### PR TITLE
[Tests-Only] Adjust OccAppManagementContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/OccAppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/OccAppManagementContext.php
@@ -198,9 +198,9 @@ class OccAppManagementContext implements Context {
 			Assert::assertContains(
 				$app,
 				$lastOutputApps,
-				"The apps: "
-				. $lastOutputApps
-				. "returned by the occ command were expected to include {$app}, but does not"
+				"The apps: '"
+				. \implode(', ', $lastOutputApps)
+				. "' returned by the occ command were expected to include '$app', but does not"
 			);
 		}
 	}

--- a/tests/acceptance/features/bootstrap/OccAppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/OccAppManagementContext.php
@@ -117,7 +117,12 @@ class OccAppManagementContext implements Context {
 	public function theAppNameReturnedByTheOccCommandShouldBe($appName) {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputArray = \json_decode($lastOutput, true);
-		Assert::assertEquals($appName, \key($lastOutputArray['apps']));
+		Assert::assertEquals(
+			$appName,
+			\key($lastOutputArray['apps']),
+			"The app name expected to be returned by the occ command is {$appName} but got "
+			. \key($lastOutputArray['apps'])
+		);
 	}
 
 	/**
@@ -167,7 +172,11 @@ class OccAppManagementContext implements Context {
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputArray = \json_decode($lastOutput, true);
 		$actualAppEnabledStatus = $lastOutputArray['apps'][$appName]['enabled'];
-		Assert::assertEquals($appStatus, $actualAppEnabledStatus);
+		Assert::assertEquals(
+			$appStatus,
+			$actualAppEnabledStatus,
+			"The app enabled status of app {$appName} was expected to be {$appStatus}, but the actual status is {$actualAppEnabledStatus}"
+		);
 	}
 
 	/**
@@ -186,7 +195,11 @@ class OccAppManagementContext implements Context {
 		$appsSimplified = $this->featureContext->simplifyArray($apps);
 
 		foreach ($appsSimplified as $app) {
-			Assert::assertContains($app, $lastOutputApps);
+			Assert::assertContains(
+				$app,
+				$lastOutputApps,
+				"The apps: {$lastOutputApps} returned by the occ command were expected to include {$app}, but does not"
+			);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/OccAppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/OccAppManagementContext.php
@@ -198,7 +198,9 @@ class OccAppManagementContext implements Context {
 			Assert::assertContains(
 				$app,
 				$lastOutputApps,
-				"The apps: {$lastOutputApps} returned by the occ command were expected to include {$app}, but does not"
+				"The apps: "
+				. $lastOutputApps
+				. "returned by the occ command were expected to include {$app}, but does not"
 			);
 		}
 	}


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the OccAppManagementContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
