### PR TITLE
[Tests-Only] Put the expected value first in Assert::assertEquals

### DIFF
--- a/tests/acceptance/features/bootstrap/LoggingContext.php
+++ b/tests/acceptance/features/bootstrap/LoggingContext.php
@@ -431,18 +431,18 @@ class LoggingContext implements Context {
 	/**
 	 * @Given the owncloud log backend has been set to :backend
 	 *
-	 * @param string $backend (owncloud|syslog|errorlog)
+	 * @param string $expectedBackend (owncloud|syslog|errorlog)
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function owncloudLogBackendHasBeenSetTo($backend) {
-		$this->owncloudLogBackendIsSetTo($backend);
+	public function owncloudLogBackendHasBeenSetTo($expectedBackend) {
+		$this->owncloudLogBackendIsSetTo($expectedBackend);
 		$currentBackend = LoggingHelper::getLogBackend();
 		Assert::assertEquals(
+			$expectedBackend,
 			$currentBackend,
-			$backend,
-			"The owncloud log backend was expected to be set to {$backend} but got {$currentBackend}"
+			"The owncloud log backend was expected to be set to {$expectedBackend} but got {$currentBackend}"
 		);
 	}
 
@@ -461,18 +461,18 @@ class LoggingContext implements Context {
 	/**
 	 * @Given the owncloud log timezone has been set to :timezone
 	 *
-	 * @param string $timezone
+	 * @param string $expectedTimezone
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function owncloudLogTimezoneHasBeenSetTo($timezone) {
-		$this->owncloudLogTimezoneIsSetTo($timezone);
+	public function owncloudLogTimezoneHasBeenSetTo($expectedTimezone) {
+		$this->owncloudLogTimezoneIsSetTo($expectedTimezone);
 		$currentTimezone = LoggingHelper::getLogTimezone();
 		Assert::assertEquals(
+			$expectedTimezone,
 			$currentTimezone,
-			$timezone,
-			"The owncloud log timezone was expected to be set to {$timezone}, but got {$currentTimezone}"
+			"The owncloud log timezone was expected to be set to {$expectedTimezone}, but got {$currentTimezone}"
 		);
 	}
 


### PR DESCRIPTION
## Description
The expected and actual values were around the wrong way in these `Assert::assertEquals`. That will make the automatic message confusing if the Assert fails. Fix it.

## Related Issue
- #36810 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
