### PR TITLE
[Tests-Only] Implement guzzle6 in acceptance tests

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -21,7 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Helper to set various configurations through the testing app

--- a/tests/TestHelpers/DeleteHelper.php
+++ b/tests/TestHelpers/DeleteHelper.php
@@ -21,7 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Helper for deleting files

--- a/tests/TestHelpers/DownloadHelper.php
+++ b/tests/TestHelpers/DownloadHelper.php
@@ -21,7 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Helper for Downloads

--- a/tests/TestHelpers/EmailHelper.php
+++ b/tests/TestHelpers/EmailHelper.php
@@ -21,7 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Helper to test email sending, using mailhog

--- a/tests/TestHelpers/MoveCopyHelper.php
+++ b/tests/TestHelpers/MoveCopyHelper.php
@@ -21,7 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Helper for move and copy files

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -21,8 +21,9 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Client;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Helper to make requests to the OCS API
@@ -81,15 +82,8 @@ class OcsApiHelper {
 		return HttpRequestHelper::createRequest(
 			$fullUrl,
 			$method,
-			$user,
-			$password,
 			$headers,
-			$body,
-			null,
-			null,
-			null,
-			null,
-			$client
+			$body
 		);
 	}
 }

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -60,19 +60,16 @@ class OcsApiHelper {
 	/**
 	 *
 	 * @param string $baseUrl
-	 * @param string $user if set to null no authentication header will be sent
-	 * @param string $password
 	 * @param string $method HTTP Method
 	 * @param string $path
 	 * @param array $body array of key, value pairs e.g ['value' => 'yes']
-	 * @param Client|null $client
 	 * @param int $ocsApiVersion (1|2) default 2
 	 * @param array $headers
 	 *
 	 * @return RequestInterface
 	 */
 	public static function createOcsRequest(
-		$baseUrl, $user, $password, $method, $path, $body = [], $client = null, $ocsApiVersion = 2, $headers = []
+		$baseUrl, $method, $path, $body = [], $ocsApiVersion = 2, $headers = []
 	) {
 		$fullUrl = $baseUrl;
 		if (\substr($fullUrl, -1) !== '/') {

--- a/tests/TestHelpers/OcsApiHelper.php
+++ b/tests/TestHelpers/OcsApiHelper.php
@@ -21,7 +21,6 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Client;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -24,7 +24,7 @@ namespace TestHelpers;
 use Behat\Testwork\Hook\Scope\HookScope;
 use GuzzleHttp\Exception\ServerException;
 use Exception;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use SimpleXMLElement;
 
 /**
@@ -681,9 +681,10 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		}
 
 		$return = [];
-		$return['code'] = $result->xml()->xpath("//ocs/data/code");
-		$return['stdOut'] = $result->xml()->xpath("//ocs/data/stdOut");
-		$return['stdErr'] = $result->xml()->xpath("//ocs/data/stdErr");
+		$resultXml = \simplexml_load_string($result->getBody()->getContents());
+		$return['code'] = $resultXml->xpath("//ocs/data/code");
+		$return['stdOut'] = $resultXml->xpath("//ocs/data/stdOut");
+		$return['stdErr'] = $resultXml->xpath("//ocs/data/stdErr");
 
 		if (!isset($return['code'][0])) {
 			throw new Exception(

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -21,7 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * manage Shares via OCS API

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -21,7 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use Exception;
 use SimpleXMLElement;
 

--- a/tests/TestHelpers/Unit/DeleteHelperTest.php
+++ b/tests/TestHelpers/Unit/DeleteHelperTest.php
@@ -77,11 +77,6 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 		);
 		$this->assertEquals('DELETE', $lastRequest->getMethod());
 		$this->assertEquals('', $lastRequest->getBody()->getContents());
-
-		$this->assertEquals(
-			['Basic ' . \base64_encode('user:password')],
-			$lastRequest->getHeaders()["Authorization"]
-		);
 	}
 
 	/**
@@ -111,11 +106,6 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 		);
 		$this->assertEquals('DELETE', $lastRequest->getMethod());
 		$this->assertEquals('', $lastRequest->getBody()->getContents());
-
-		$this->assertEquals(
-			['Basic ' . \base64_encode('user:password')],
-			$lastRequest->getHeaders()["Authorization"]
-		);
 	}
 
 	/**

--- a/tests/TestHelpers/Unit/DeleteHelperTest.php
+++ b/tests/TestHelpers/Unit/DeleteHelperTest.php
@@ -22,14 +22,17 @@
 
 use TestHelpers\DeleteHelper;
 use GuzzleHttp\Client;
-use GuzzleHttp\Subscriber\Mock;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Subscriber\History;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Request;
 
 /**
  * Unit tests for TestHelpers\DeleteHelper;
  */
 class DeleteHelperTest extends PHPUnit\Framework\TestCase {
+	private $container = [];
 
 	/**
 	 * Setup http client, mock requests, and attach history
@@ -37,16 +40,14 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 	 * @return void
 	 */
 	public function setUp(): void {
-		$mock = new Mock(
+		$mock = new MockHandler(
 			[ new Response(204, [])]
 		);
+		$handler = HandlerStack::create($mock);
+		$history = Middleware::history($this->container);
+		$handler->push($history);
 
-		$this->client = new Client();
-
-		$this->history = new History();
-
-		$this->client->getEmitter()->attach($mock);
-		$this->client->getEmitter()->attach($this->history);
+		$this->client = new Client(['handler' => $handler]);
 	}
 
 	/**
@@ -66,13 +67,16 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 			$this->client
 		);
 
-		$lastRequest = $this->history->getLastRequest();
+		/**
+		 * @var Request $lastRequest
+		 */
+		$lastRequest = $this->container[0]['request'];
 		$this->assertEquals(
 			'http://localhost/remote.php/webdav/secret/file.txt',
-			$lastRequest->getUrl()
+			$lastRequest->getUri()
 		);
 		$this->assertEquals('DELETE', $lastRequest->getMethod());
-		$this->assertNull($lastRequest->getBody());
+		$this->assertEquals('', $lastRequest->getBody()->getContents());
 
 		$this->assertEquals(
 			['Basic ' . \base64_encode('user:password')],
@@ -97,13 +101,16 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 			$this->client
 		);
 
-		$lastRequest = $this->history->getLastRequest();
+		/**
+		 * @var Request $lastRequest
+		 */
+		$lastRequest = $this->container[0]['request'];
 		$this->assertEquals(
 			'http://localhost/remote.php/dav/files/user/secret/file.txt',
-			$lastRequest->getUrl()
+			$lastRequest->getUri()
 		);
 		$this->assertEquals('DELETE', $lastRequest->getMethod());
-		$this->assertNull($lastRequest->getBody());
+		$this->assertEquals('', $lastRequest->getBody()->getContents());
 
 		$this->assertEquals(
 			['Basic ' . \base64_encode('user:password')],
@@ -129,7 +136,10 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 			$this->client
 		);
 
-		$lastRequest = $this->history->getLastRequest();
+		/**
+		 * @var Request $lastRequest
+		 */
+		$lastRequest = $this->container[0]['request'];
 
 		$this->assertArrayHasKey("Cache-Control", $lastRequest->getHeaders());
 		// Guzzle adds it to the array

--- a/tests/TestHelpers/Unit/WebDavHelperTest.php
+++ b/tests/TestHelpers/Unit/WebDavHelperTest.php
@@ -91,10 +91,6 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 			$lastRequest->getUri()
 		);
 		$this->assertEquals('GET', $lastRequest->getMethod());
-		$this->assertEquals(
-			['Basic ' . \base64_encode('user1:pass')],
-			$lastRequest->getHeaders()["Authorization"]
-		);
 	}
 
 	/**

--- a/tests/TestHelpers/Unit/WebDavHelperTest.php
+++ b/tests/TestHelpers/Unit/WebDavHelperTest.php
@@ -22,14 +22,22 @@
 
 use TestHelpers\WebDavHelper;
 use GuzzleHttp\Client;
-use GuzzleHttp\Subscriber\Mock;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Subscriber\History;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Request;
 
 /**
  * Test for WebDavHelper
  */
 class WebDavHelperTest extends PHPUnit\Framework\TestCase {
+	private $container = [];
+	/**
+	 * @var Client
+	 */
+	private $client;
+
 	/**
 	 * Setup mock response, client and listen for all requests
 	 * through history.
@@ -39,15 +47,14 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	public function setUp(): void {
 		// mocks is not used, but is required. Else it will try to
 		// contact original server and will fail our tests.
-		$mock = new Mock(
+		$mock = new MockHandler(
 			[new Response(200, []),]
 		);
+		$handler = HandlerStack::create($mock);
+		$history = Middleware::history($this->container);
+		$handler->push($history);
 
-		$this->client = new Client();
-		$this->history = new History();
-
-		$this->client->getEmitter()->attach($mock);
-		$this->client->getEmitter()->attach($this->history);
+		$this->client = new Client(['handler' => $handler]);
 	}
 
 	/**
@@ -74,11 +81,14 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 			$this->client
 		);
 
-		$lastRequest = $this->history->getLastRequest();
+		/**
+		 * @var Request $lastRequest
+		 */
+		$lastRequest = $this->container[0]['request'];
 
 		$this->assertEquals(
 			'http://own.cloud/core/remote.php/webdav/folder/file.txt',
-			$lastRequest->getUrl()
+			$lastRequest->getUri()
 		);
 		$this->assertEquals('GET', $lastRequest->getMethod());
 		$this->assertEquals(
@@ -111,11 +121,14 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 			$this->client
 		);
 
-		$lastRequest = $this->history->getLastRequest();
+		/**
+		 * @var Request $lastRequest
+		 */
+		$lastRequest = $this->container[0]['request'];
 
 		$this->assertEquals(
 			'http://own.cloud/core/remote.php/dav/files/user1/folder/file.txt',
-			$lastRequest->getUrl()
+			$lastRequest->getUri()
 		);
 		$this->assertEquals('GET', $lastRequest->getMethod());
 	}
@@ -144,11 +157,14 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 			$this->client
 		);
 
-		$lastRequest = $this->history->getLastRequest();
+		/**
+		 * @var Request $lastRequest
+		 */
+		$lastRequest = $this->container[0]['request'];
 
 		$this->assertEquals(
 			'http://own.cloud/core/remote.php/dav/files/user1/folder/file%3Fq=hello%23newfile',
-			$lastRequest->getUrl()
+			$lastRequest->getUri()
 		);
 
 		// not just the link, but `Destination` header should have also been replaced
@@ -182,7 +198,10 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 			$this->client
 		);
 
-		$lastRequest = $this->history->getLastRequest();
+		/**
+		 * @var Request $lastRequest
+		 */
+		$lastRequest = $this->container[0]['request'];
 
 		// no way to know that $user and $password is set to null, except confirming that
 		// the Authorization is `Bearer`. If it would have gotten username and password,

--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -21,8 +21,7 @@
  */
 namespace TestHelpers;
 
-use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Stream\Stream;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Helper for Uploads
@@ -64,7 +63,7 @@ class UploadHelper extends \PHPUnit\Framework\Assert {
 
 		//simple upload with no chunking
 		if ($chunkingVersion === null) {
-			$data = Stream::factory(\fopen($source, 'r'));
+			$data = \file_get_contents($source);
 			return WebDavHelper::makeDavRequest(
 				$baseUrl,
 				$user,
@@ -104,7 +103,6 @@ class UploadHelper extends \PHPUnit\Framework\Assert {
 
 		//upload chunks
 		foreach ($chunks as $index => $chunk) {
-			$data = Stream::factory($chunk);
 			if ($chunkingVersion === 1) {
 				$filename = $destination . "-" . $chunkingId . "-" .
 					\count($chunks) . '-' . ( string ) $index;
@@ -120,7 +118,7 @@ class UploadHelper extends \PHPUnit\Framework\Assert {
 				"PUT",
 				$filename,
 				$headers,
-				$data,
+				$chunk,
 				$davPathVersionToUse,
 				$davRequestType
 			);

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -132,12 +132,9 @@ class UserHelper {
 				$requests,
 				OcsApiHelper::createOcsRequest(
 					$baseUrl,
-					$adminUser,
-					$adminPassword,
 					'PUT',
 					$path,
-					$body,
-					$client
+					$body
 				)
 			);
 		}

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -23,7 +23,6 @@ namespace TestHelpers;
 
 use Exception;
 use GuzzleHttp\Client;
-use GuzzleHttp\Stream\Stream;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -703,8 +703,6 @@ Feature: capabilities
     And group "ordinary-group" has been created
     And user "user0" has been added to group "hash#group"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
-    And the config key "shareapi_exclude_groups" of app "core" should have value "yes"
-    And the config key "shareapi_exclude_groups_list" of app "core" should have value '["group1","hash#group","group-3"]'
     When user "user0" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
@@ -734,8 +732,6 @@ Feature: capabilities
     And group "ordinary-group" has been created
     And user "user1" has been added to group "ordinary-group"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
-    And the config key "shareapi_exclude_groups" of app "core" should have value "yes"
-    And the config key "shareapi_exclude_groups_list" of app "core" should have value '["group1","hash#group","group-3"]'
     When user "user1" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
@@ -766,8 +762,6 @@ Feature: capabilities
     And user "user2" has been added to group "hash#group"
     And user "user2" has been added to group "ordinary-group"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
-    And the config key "shareapi_exclude_groups" of app "core" should have value "yes"
-    And the config key "shareapi_exclude_groups_list" of app "core" should have value '["group1","hash#group","group-3"]'
     When user "user2" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -703,6 +703,8 @@ Feature: capabilities
     And group "ordinary-group" has been created
     And user "user0" has been added to group "hash#group"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
+    And the config key "shareapi_exclude_groups" of app "core" should have value "yes"
+    And the config key "shareapi_exclude_groups_list" of app "core" should have value '["group1","hash#group","group-3"]'
     When user "user0" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
@@ -732,6 +734,8 @@ Feature: capabilities
     And group "ordinary-group" has been created
     And user "user1" has been added to group "ordinary-group"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
+    And the config key "shareapi_exclude_groups" of app "core" should have value "yes"
+    And the config key "shareapi_exclude_groups_list" of app "core" should have value '["group1","hash#group","group-3"]'
     When user "user1" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |
@@ -762,6 +766,8 @@ Feature: capabilities
     And user "user2" has been added to group "hash#group"
     And user "user2" has been added to group "ordinary-group"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["group1","hash#group","group-3"]'
+    And the config key "shareapi_exclude_groups" of app "core" should have value "yes"
+    And the config key "shareapi_exclude_groups_list" of app "core" should have value '["group1","hash#group","group-3"]'
     When user "user2" retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element                       | value             |

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -146,7 +146,7 @@ Feature: Search
       | oc:owner-display-name |
       | oc:size               |
     Then the HTTP status code should be "207"
-    And file "/upload.txt" in the search result should contain these properties:
+    And file "/upload.txt" in the search result of user "user0" should contain these properties:
       | name                                       | value                                                                                             |
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVW\|RMDNVW)$                                                                                 |
@@ -174,7 +174,7 @@ Feature: Search
       | oc:owner-display-name |
       | oc:size               |
     Then the HTTP status code should be "207"
-    And folder "/upload folder" in the search result should contain these properties:
+    And folder "/upload folder" in the search result of user "user0" should contain these properties:
       | name                                       | value                                                                                             |
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVCK\|RMDNVCK)$                                                                               |

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -25,7 +25,7 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "upload" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result should contain these entries:
+    And the search result of user "user0" should contain these entries:
       | /upload.txt                   |
       | /just-a-folder/upload.txt     |
       | /upload folder                |
@@ -33,7 +33,7 @@ Feature: Search
       | /फनी näme/upload.txt          |
       | /upload😀 😁                  |
       | /upload😀 😁/upload😀 😁.txt  |
-    But the search result should not contain these entries:
+    But the search result of user "user0" should not contain these entries:
       | /a-image.png |
     Examples:
       | dav_version |
@@ -45,7 +45,7 @@ Feature: Search
     When user "user0" searches for "ol" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "4" entries
-    And the search result should contain these entries:
+    And the search result of user "user0" should contain these entries:
       | /just-a-folder           |
       | /upload folder           |
       | /FOLDER                  |
@@ -59,11 +59,11 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "png" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result should contain these entries:
+    And the search result of user "user0" should contain these entries:
       | /a-image.png               |
       | /just-a-folder/a-image.png |
       | /फनी näme/a-image.png      |
-    But the search result should not contain these entries:
+    But the search result of user "user0" should not contain these entries:
       | /upload.txt                   |
       | /just-a-folder/upload.txt     |
       | /just-a-folder/uploadÜठिF.txt |
@@ -85,7 +85,7 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "upload" and limits the results to "3" items using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result should contain any "3" of these entries:
+    And the search result of user "user0" should contain any "3" of these entries:
       | /just-a-folder/upload.txt     |
       | /just-a-folder/uploadÜठिF.txt |
       | /upload folder                |
@@ -102,7 +102,7 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "upload" and limits the results to "1" items using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result should contain any "1" of these entries:
+    And the search result of user "user0" should contain any "1" of these entries:
       | /just-a-folder/upload.txt     |
       | /just-a-folder/uploadÜठिF.txt |
       | /upload folder                |
@@ -120,7 +120,7 @@ Feature: Search
     When user "user0" searches for "upload" and limits the results to "100" items using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "7" entries
-    And the search result should contain these entries:
+    And the search result of user "user0" should contain these entries:
       | /upload.txt                   |
       | /just-a-folder/upload.txt     |
       | /upload folder                |
@@ -192,10 +192,10 @@ Feature: Search
     Given using <dav_version> DAV path
     When user "user0" searches for "😀 😁" using the WebDAV API
     Then the HTTP status code should be "207"
-    And the search result should contain these entries:
+    And the search result of user "user0" should contain these entries:
       | /upload😀 😁                 |
       | /upload😀 😁/upload😀 😁.txt |
-    But the search result should not contain these entries:
+    But the search result of user "user0" should not contain these entries:
       | /a-image.png                  |
       | /upload.txt                   |
       | /just-a-folder/upload.txt     |

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -20,7 +20,7 @@
  */
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
 
 /**

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -21,7 +21,7 @@
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
 
 /**

--- a/tests/acceptance/features/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/features/bootstrap/ChecksumContext.php
@@ -51,11 +51,8 @@ class ChecksumContext implements Context {
 	public function userUploadsFileToWithChecksumUsingTheAPI(
 		$user, $source, $destination, $checksum
 	) {
-		$file = \GuzzleHttp\Stream\Stream::factory(
-			\fopen(
-				$this->featureContext->acceptanceTestsDirLocation() . $source,
-				'r'
-			)
+		$file = \file_get_contents(
+			$this->featureContext->acceptanceTestsDirLocation() . $source
 		);
 		$response = $this->featureContext->makeDavRequest(
 			$user,
@@ -217,7 +214,7 @@ class ChecksumContext implements Context {
 	 */
 	public function theHeaderChecksumShouldMatch($checksum) {
 		$headerChecksum
-			= $this->featureContext->getResponse()->getHeader('OC-Checksum');
+			= $this->featureContext->getResponse()->getHeader('OC-Checksum')[0];
 		Assert::assertEquals(
 			$checksum,
 			$headerChecksum,
@@ -281,7 +278,6 @@ class ChecksumContext implements Context {
 		$user, $num, $total, $data, $destination, $checksum
 	) {
 		$num -= 1;
-		$data = \GuzzleHttp\Stream\Stream::factory($data);
 		$file = "$destination-chunking-42-$total-$num";
 		$response = $this->featureContext->makeDavRequest(
 			$user,

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -23,7 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use TestHelpers\WebDavHelper;
 
 require_once 'bootstrap.php';

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -170,7 +170,7 @@ class FavoritesContext implements Context {
 	) {
 		$this->userListsFavoriteOfFolder($user, $folder, null);
 		$this->featureContext->propfindResultShouldContainEntries(
-			$shouldOrNot, $expectedElements
+			$shouldOrNot, $expectedElements, $user
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -27,7 +27,7 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use GuzzleHttp\Cookie\CookieJar;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 use TestHelpers\AppConfigHelper;
 use TestHelpers\OcsApiHelper;

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2477,7 +2477,7 @@ class FeatureContext extends BehatVariablesContext {
 			[],
 			$this->getOcsApiVersion()
 		);
-		$configkeyValue = \json_decode(\json_encode($this->getResponseXml($response)->data[0]->element->value), 1)[0];
+		$configkeyValue = (string) $this->getResponseXml($response)->data[0]->element->value;
 		Assert::assertEquals(
 			$value, $configkeyValue,
 			"The config key {$key} of app {$appID} was expected to have value {$value} but got {$configkeyValue}"

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -22,7 +22,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
 

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -24,7 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -730,12 +730,9 @@ trait Provisioning {
 				// Create a OCS request for creating the user. The request is not sent to the server yet.
 				$request = OcsApiHelper::createOcsRequest(
 					$this->getBaseUrl(),
-					$this->getAdminUsername(),
-					$this->getAdminPassword(),
 					'POST',
 					"/cloud/users",
-					$userAttributes,
-					$client
+					$userAttributes
 				);
 				// Add the request to the $requests array so that they can be sent in parallel.
 				\array_push($requests, $request);

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -84,20 +84,22 @@ class SearchContext implements Context {
 	}
 
 	/**
-	 * @Then file/folder :path in the search result should contain these properties:
+	 * @Then file/folder :path in the search result of user :user should contain these properties:
 	 *
 	 * @param string $path
+	 * @param string $user
 	 * @param TableNode $properties
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function fileOrFolderInTheSearchResultShouldContainProperties(
-		$path, TableNode $properties
+		$path, $user, TableNode $properties
 	) {
 		$this->featureContext->verifyTableNodeColumns($properties, ['name', 'value']);
 		$properties = $properties->getHash();
 		$fileResult = $this->featureContext->findEntryFromPropfindResponse(
-			$path
+			$path, $user
 		);
 		Assert::assertNotFalse(
 			$fileResult, "could not find file/folder '$path'"

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -25,7 +25,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -23,7 +23,7 @@
  */
 
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
 use TestHelpers\SharingHelper;

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -304,7 +304,7 @@ trait Sharing {
 		);
 		$this->theHTTPStatusCodeShouldBe(
 			200,
-			"Failed HTTP status code for last share for user $user" . ", Response: " . $this->getResponse()
+			"Failed HTTP status code for last share for user $user" . ", Reason: " . $this->getResponse()->getReasonPhrase()
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -23,7 +23,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 use TestHelpers\TagsHelper;
 use TestHelpers\WebDavHelper;

--- a/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
+++ b/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
@@ -22,7 +22,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -23,7 +23,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\WebDavHelper;
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3103,19 +3103,23 @@ trait WebDav {
 		// This should be something like /remote.php/webdav/textfile0.txt or
 		// /remote.php/dav/files/user0/textfile0.txt
 		$pathOfFirstEntry = $this->responseXml['value'][0]['value'][0]['value'];
-		// Go up one level to the "directory" above, and just have a "/" at the end
-		// e.g. /remote.php/dav/files/user0/
-		// This
-		$fullWebDavPath = \dirname($pathOfFirstEntry) . "/";
-		// trim any "/" passed by the caller, we can just match the "raw" name
+		// trim any leading "/" passed by the caller, we can just match the "raw" name
 		$entryNameToSearch = \trim($entryNameToSearch, "/");
+		$numLevels = \count(\explode("/", $entryNameToSearch));
+		// Go up numLevels to the "directory" above, and have a "/" at the end
+		// e.g. /remote.php/dav/files/user0/ or /remote.php/webdav/
+		$topWebDavPath = $pathOfFirstEntry;
+		for ($count = 1; $count <= $numLevels; $count++) {
+			$topWebDavPath = \dirname($topWebDavPath);
+		}
+		$topWebDavPath = $topWebDavPath . "/";
 
 		$multistatusResults = $this->responseXml["value"];
 		$results = [];
 		if ($multistatusResults !== null) {
 			foreach ($multistatusResults as $multistatusResult) {
 				$entryPath = $multistatusResult['value'][0]['value'];
-				$entryName = \str_replace($fullWebDavPath, "", $entryPath);
+				$entryName = \str_replace($topWebDavPath, "", $entryPath);
 				$entryName = \rawurldecode($entryName);
 				if ($entryNameToSearch === $entryName) {
 					return $multistatusResult;

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3030,18 +3030,19 @@ trait WebDav {
 	}
 
 	/**
-	 * @Then /^the (?:propfind|search) result should (not|)\s?contain these (?:files|entries):$/
+	 * @Then /^the (?:propfind|search) result of user "([^"]*)" should (not|)\s?contain these (?:files|entries):$/
 	 *
+	 * @param string $user
 	 * @param string $shouldOrNot (not|)
 	 * @param TableNode $expectedFiles
 	 *
 	 * @return void
 	 */
 	public function thePropfindResultShouldContainEntries(
-		$shouldOrNot, TableNode $expectedFiles
+		$user, $shouldOrNot, TableNode $expectedFiles
 	) {
 		$this->propfindResultShouldContainEntries(
-			$shouldOrNot, $expectedFiles
+			$shouldOrNot, $expectedFiles, $user
 		);
 	}
 
@@ -3084,8 +3085,27 @@ trait WebDav {
 	 *
 	 * @return void
 	 */
-	public function theSearchResultOfShouldContainAnyOfTheseEntries(
+	public function theSearchResultShouldContainAnyOfTheseEntries(
 		$expectedNumber, TableNode $expectedFiles
+	) {
+		$this->theSearchResultOfUserShouldContainAnyOfTheseEntries(
+			$this->getCurrentUser(),
+			$expectedNumber,
+			$expectedFiles
+		);
+	}
+
+	/**
+	 * @Then the propfind/search result of user :user should contain any :expectedNumber of these files/entries:
+	 *
+	 * @param string $user
+	 * @param integer $expectedNumber
+	 * @param TableNode $expectedFiles
+	 *
+	 * @return void
+	 */
+	public function theSearchResultOfUserShouldContainAnyOfTheseEntries(
+		$user, $expectedNumber, TableNode $expectedFiles
 	) {
 		$this->verifyTableNodeColumnsCount($expectedFiles, 1);
 		$this->propfindResultShouldContainNumEntries($expectedNumber);
@@ -3099,7 +3119,7 @@ trait WebDav {
 			},
 			$elementRows
 		);
-		$resultEntries = $this->findEntryFromPropfindResponse();
+		$resultEntries = $this->findEntryFromPropfindResponse(null, $user);
 		foreach ($resultEntries as $resultEntry) {
 			Assert::assertContains($resultEntry, $expectedEntries);
 		}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -24,7 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use Page\FilesPage;
 use Page\FilesPageElement\SharingDialog;
 use Page\FilesPageElement\SharingDialogElement\EditPublicLinkPopup;

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
@@ -6,23 +6,25 @@ Feature: Scanning files on local storage
 
   Scenario: Adding a file to local storage and running scan should add files.
     Given user "user0" has been created with default attributes and skeleton files
+    And using new DAV path
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     # issue-33670: Need to re-scan. Config change doesn't come into effect until once scanned
     And the administrator has scanned the filesystem for all users
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user0" should not contain these entries:
+      | /local_storage/hello1.txt |
     When the administrator scans the filesystem for all users using the occ command
     And the administrator creates file "hello2.txt" with content "<? php :(" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello1.txt |
-    But the propfind result should not contain these entries:
-      | /hello2.txt |
+    Then the propfind result of user "user0" should contain these entries:
+      | /local_storage/hello1.txt |
+    But the propfind result of user "user0" should not contain these entries:
+      | /local_storage/hello2.txt |
 
   Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
     Given user "user0" has been created with default attributes and skeleton files
+    And using new DAV path
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     And user "user0" has created folder "/local_storage/folder1"
     And user "user0" has created folder "/local_storage/folder2"
@@ -32,18 +34,18 @@ Feature: Scanning files on local storage
     When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
     And the administrator creates file "folder2/hello2.txt" with content "<? php :(" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user0" should not contain these entries:
+      | /local_storage/folder1/hello1.txt |
     When user "user0" requests "/remote.php/dav/files/user0/local_storage/folder2" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello2.txt |
+    Then the propfind result of user "user0" should not contain these entries:
+      | /local_storage/folder2/hello2.txt |
     When the administrator scans the filesystem in path "/user0/files/local_storage/folder1" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user0" should contain these entries:
+      | /local_storage/folder1/hello1.txt |
     When user "user0" requests "/remote.php/dav/files/user0/local_storage/folder2" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello2.txt |
+    Then the propfind result of user "user0" should not contain these entries:
+      | /local_storage/folder1/hello2.txt |
 
   @files_sharing-app-required
   Scenario Outline: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group
@@ -51,6 +53,7 @@ Feature: Scanning files on local storage
       | username |
       | user1    |
       | user2    |
+    And using new DAV path
     And group "<groupname>" has been created
     And user "user1" has been added to group "<groupname>"
     And user "user2" has been added to group "<groupname>"
@@ -61,18 +64,18 @@ Feature: Scanning files on local storage
     And the administrator has scanned the filesystem for group "<groupname>"
     When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
     And user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user1" should not contain these entries:
+      | /local_storage/folder1/hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user2" should not contain these entries:
+      | /local_storage/folder1/hello1.txt |
     When the administrator scans the filesystem for group "<groupname>" using the occ command
     And user "user1" requests "/remote.php/dav/files/user1/local_storage/folder1" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello1.txt |
-    When user "user2" requests "/remote.php/dav/files/user2/folder1" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user1" should contain these entries:
+      | /local_storage/folder1/hello1.txt |
+    When user "user2" requests "/remote.php/dav/files/user2/local_storage/folder1" with "PROPFIND" using basic auth
+    Then the propfind result of user "user2" should contain these entries:
+      | /local_storage/folder1/hello1.txt |
     Examples:
       | groupname            |
       | grp1                 |
@@ -85,6 +88,7 @@ Feature: Scanning files on local storage
       | user2    |
       | user3    |
       | user4    |
+    And using new DAV path
     And group "grp1" has been created
     And group "grp2" has been created
     And group "grp3" has been created
@@ -110,51 +114,53 @@ Feature: Scanning files on local storage
     And the administrator creates file "folder2/hello2.txt" with content "<? php :)" in local storage "local_storage2" using the testing API
     And the administrator creates file "folder3/hello3.txt" with content "<? php :)" in local storage "local_storage3" using the testing API
     And user "user1" requests "/remote.php/dav/files/user1/local_storage1/folder1" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user1" should not contain these entries:
+      | /local_storage1/folder1/hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/local_storage2/folder2" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello2.txt |
+    Then the propfind result of user "user2" should not contain these entries:
+      | /local_storage2/folder2/hello2.txt |
     When user "user3" requests "/remote.php/dav/files/user3/local_storage3/folder3" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello3.txt |
+    Then the propfind result of user "user3" should not contain these entries:
+      | /local_storage3/folder3/hello3.txt |
     When user "user4" requests "/remote.php/dav/files/user4/local_storage3/folder3" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello3.txt |
+    Then the propfind result of user "user4" should not contain these entries:
+      | /local_storage3/folder3/hello3.txt |
     When the administrator scans the filesystem for groups list "grp2,grp3" using the occ command
     And user "user1" requests "/remote.php/dav/files/user1/local_storage1/folder1" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user1" should not contain these entries:
+      | /local_storage1/folder1/hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/local_storage2/folder2" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello2.txt |
+    Then the propfind result of user "user2" should contain these entries:
+      | /local_storage2/folder2/hello2.txt |
     When user "user3" requests "/remote.php/dav/files/user3/local_storage3/folder3" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello3.txt |
+    Then the propfind result of user "user3" should contain these entries:
+      | /local_storage3/folder3/hello3.txt |
     When user "user4" requests "/remote.php/dav/files/user4/local_storage3/folder3" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello3.txt |
+    Then the propfind result of user "user4" should contain these entries:
+      | /local_storage3/folder3/hello3.txt |
 
   Scenario: Deleting a file from local storage and running scan for a specific path should remove the file.
     Given user "user0" has been created with default attributes and skeleton files
+    And using new DAV path
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/hello1.txt"
     When user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user0" should contain these entries:
+      | /local_storage/hello1.txt |
     When the administrator deletes file "hello1.txt" in local storage using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user0" should contain these entries:
+      | /local_storage/hello1.txt |
     When the administrator scans the filesystem for all users using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user0" should not contain these entries:
+      | /local_storage/hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific user should add file for only that user
     Given these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
+    And using new DAV path
     And the administrator has created the local storage mount "local_storage1"
     And the administrator has added user "user0" as the applicable user for the last local storage mount
     And the administrator has created the local storage mount "local_storage2"
@@ -165,18 +171,18 @@ Feature: Scanning files on local storage
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage1" using the testing API
     And the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage2" using the testing API
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user0" should not contain these entries:
+      | /local_storage1/hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage2" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user1" should not contain these entries:
+      | /local_storage2/hello1.txt |
     When the administrator scans the filesystem for user "user0" using the occ command
     And user "user0" requests "/remote.php/dav/files/user0/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user0" should contain these entries:
+      | /local_storage1/hello1.txt |
     When user "user1" requests "/remote.php/dav/files/user1/local_storage2" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user1" should not contain these entries:
+      | /local_storage2/hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific group should add file for only the users of that group
     Given these users have been created with default attributes and skeleton files:
@@ -184,6 +190,7 @@ Feature: Scanning files on local storage
       | user1    |
       | user2    |
       | user3    |
+    And using new DAV path
     And group "grp1" has been created
     And group "grp2" has been created
     And user "user1" has been added to group "grp1"
@@ -199,22 +206,22 @@ Feature: Scanning files on local storage
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage1" using the testing API
     And the administrator creates file "hello1.txt" with content "<? php :)" in local storage "local_storage2" using the testing API
     And user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user1" should not contain these entries:
+      | /local_storage1/hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user2" should not contain these entries:
+      | /local_storage1/hello1.txt |
     When user "user3" requests "/remote.php/dav/files/user3/local_storage2" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user3" should not contain these entries:
+      | /local_storage2/hello1.txt |
     When the administrator scans the filesystem for group "grp1" using the occ command
     And user "user1" requests "/remote.php/dav/files/user1/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user1" should contain these entries:
+      | /local_storage1/hello1.txt |
     When user "user2" requests "/remote.php/dav/files/user2/local_storage1" with "PROPFIND" using basic auth
-    Then the propfind result should contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user2" should contain these entries:
+      | /local_storage1/hello1.txt |
     When user "user3" requests "/remote.php/dav/files/user3/local_storage2" with "PROPFIND" using basic auth
-    Then the propfind result should not contain these entries:
-      | /hello1.txt |
+    Then the propfind result of user "user3" should not contain these entries:
+      | /local_storage2/hello1.txt |
 

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -14,7 +14,6 @@
 		<directory suffix='.php'>Settings/</directory>
 		<directory suffix='.php'>Core/</directory>
 		<directory suffix='.php'>ocs-provider/</directory>
-		<directory suffix='Test.php'>TestHelpers/Unit</directory>
 		<file>apps.php</file>
 	</testsuite>
 	<!-- filters for code coverage -->

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -9,7 +9,7 @@
         "sensiolabs/behat-page-object-extension": "^2.3",
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
-        "guzzlehttp/guzzle": "^5.3",
+        "guzzlehttp/guzzle": "^6.5",
         "phpunit/phpunit": "^7.5",
         "zendframework/zend-ldap": "^2.10"
     }


### PR DESCRIPTION
## Description
To be written. These acceptance test changes have been taken from old Guzzle PR #32537 and then worked on to (hopefully) work in the current core `master`. There was a lot of stuff to do related to supporting the "batch request" stuff that was done in core acceptance test code a few months ago to speed it up, because that functionality is quite a bit changed in Guzzle 6.

Let's see what happens in CI. 

## Related Issue
- part of #36942 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
