### PR TITLE
[Tests-Only] Add space after __METHOD__ in acceptance test messages

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -147,7 +147,7 @@ class AppConfigurationContext implements Context {
 		if ($statusCode !== 200) {
 			throw new \Exception(
 				__METHOD__
-				. "user $username returned unexpected status $statusCode"
+				. " user $username returned unexpected status $statusCode"
 			);
 		}
 	}
@@ -408,7 +408,7 @@ class AppConfigurationContext implements Context {
 		if ($status !== 201) {
 			throw new \Exception(
 				__METHOD__ .
-				"Could not add trusted server " . $this->getUrlStringForMessage($url)
+				" Could not add trusted server " . $this->getUrlStringForMessage($url)
 				. ". The request failed with status $status"
 			);
 		}
@@ -484,7 +484,7 @@ class AppConfigurationContext implements Context {
 			$contents = $this->featureContext->getResponse()->getBody()->getContents();
 			throw new \Exception(
 				__METHOD__
-				. "Failed to clear all trusted servers" . $contents
+				. " Failed to clear all trusted servers" . $contents
 			);
 		}
 	}

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -89,7 +89,7 @@ class AppManagementContext implements Context {
 		if (!empty($resp['stdErr'])) {
 			throw new \Exception(
 				__METHOD__
-				. "Expected to set app path but failed due to error: " . $resp['stdErr']
+				. " Expected to set app path but failed due to error: " . $resp['stdErr']
 			);
 		}
 	}
@@ -159,7 +159,7 @@ class AppManagementContext implements Context {
 		if (!\array_key_exists($appId, $appsDisabled)) {
 			throw new \Exception(
 				__METHOD__
-				. 'Expected: ' . $appId . 'to be present in apps(disabled) list, but not found'
+				. ' Expected: ' . $appId . 'to be present in apps(disabled) list, but not found'
 			);
 		}
 	}

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3233,7 +3233,7 @@ class FeatureContext extends BehatVariablesContext {
 		} elseif ($server === 'REMOTE') {
 			$url = $this->getRemoteBaseUrl();
 		} else {
-			throw new \Exception(__METHOD__ . "Invalid value for server : $server");
+			throw new \Exception(__METHOD__ . " Invalid value for server : $server");
 		}
 		$adminUser = $this->getAdminUsername();
 		$response = OcsApiHelper::sendRequest(

--- a/tests/acceptance/features/bootstrap/OccAppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/OccAppManagementContext.php
@@ -157,7 +157,7 @@ class OccAppManagementContext implements Context {
 		}
 
 		// if it's neither in the default location, nor in `apps_paths`, where it could be?
-		throw new Exception(__METHOD__ . "App path $appPath was not found in the config.");
+		throw new Exception(__METHOD__ . " App path $appPath was not found in the config.");
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1476,8 +1476,8 @@ class OccContext implements Context {
 				$element,
 				\array_map('trim', $ResultArray),
 				__METHOD__
-				. \implode(', ', $element)
-				. "was expected to be listed, but is not listed in the mount configuration information"
+				. " '" . \implode(', ', $element)
+				. "' was expected to be listed, but is not listed in the mount configuration information"
 			);
 		}
 	}

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -518,7 +518,7 @@ class OccUsersGroupsContext implements Context {
 			$language,
 			\trim($responseLanguage),
 			__METHOD__
-			. "Expected: the language of user '$username' to be '$language', but got '$responseLanguage'"
+			. " Expected: the language of user '$username' to be '$language', but got '$responseLanguage'"
 		);
 	}
 
@@ -548,13 +548,13 @@ class OccUsersGroupsContext implements Context {
 				$row['uid'],
 				$result,
 				__METHOD__
-				. "Failed asserting that key '${row['uid']}' exists"
+				. " Failed asserting that key '${row['uid']}' exists"
 			);
 			Assert::assertContains(
 				$row['display name'],
 				$result,
 				__METHOD__
-				. "Failed asserting that ${row['display name']} exists"
+				. " Failed asserting that ${row['display name']} exists"
 			);
 		}
 	}
@@ -623,7 +623,7 @@ class OccUsersGroupsContext implements Context {
 				$row['group'],
 				$lastOutputGroups,
 				__METHOD__
-				. "Failed asserting that '${row['group']}' exists in '"
+				. " Failed asserting that '${row['group']}' exists in '"
 				. \implode(', ', $lastOutputGroups)
 				. "'"
 			);
@@ -651,7 +651,7 @@ class OccUsersGroupsContext implements Context {
 			$displayName,
 			$lastOutputDisplayName,
 			__METHOD__
-			. "Expected displayname to be '$displayName' but got '$lastOutputDisplayName'"
+			. " Expected displayname to be '$displayName' but got '$lastOutputDisplayName'"
 		);
 	}
 
@@ -672,7 +672,7 @@ class OccUsersGroupsContext implements Context {
 			60,
 			$delta,
 			__METHOD__
-			. "User was expected to be seen recently but wasn't"
+			. " User was expected to be seen recently but wasn't"
 		);
 	}
 
@@ -687,7 +687,7 @@ class OccUsersGroupsContext implements Context {
 			"has never logged in.",
 			$lastOutput,
 			__METHOD__
-			. "'$lastOutput' does not contain 'has never logged in.'"
+			. " '$lastOutput' does not contain 'has never logged in.'"
 		);
 	}
 
@@ -705,7 +705,7 @@ class OccUsersGroupsContext implements Context {
 			$noOfUsers,
 			$actualUsers[1],
 			__METHOD__
-			. "Expected number of users to be '$noOfUsers' but got '${actualUsers[1]}'"
+			. " Expected number of users to be '$noOfUsers' but got '${actualUsers[1]}'"
 		);
 	}
 

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -390,7 +390,7 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 		$this->assertElementNotNull(
 			$expirationDay,
 			__METHOD__ .
-			"could not find user share expiration day field"
+			" could not find user share expiration day field"
 		);
 		return $expirationDay->getValue($expirationDay);
 	}
@@ -403,7 +403,7 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 		$this->assertElementNotNull(
 			$expirationDay,
 			__METHOD__ .
-			"could not find group share expiration day field"
+			" could not find group share expiration day field"
 		);
 		return $expirationDay->getValue($expirationDay);
 	}
@@ -640,21 +640,21 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 		$btn = $this->find("xpath", $this->addTrustedServerBtnXpath);
 		$this->assertElementNotNull(
 			$btn,
-			__METHOD__ . "Could not find the button to add trusted server."
+			__METHOD__ . " Could not find the button to add trusted server."
 		);
 		$btn->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
 		$input = $this->find("xpath", $this->addTrustedServerInputXpath);
 		$this->assertElementNotNull(
 			$input,
-			__METHOD__ . "Could not find the input to add trusted server."
+			__METHOD__ . " Could not find the input to add trusted server."
 		);
 		$input->setValue($url);
 		$this->waitForAjaxCallsToStartAndFinish($session);
 		$submit = $this->find("xpath", $this->addTrustedServerConfirmBtnXpath);
 		$this->assertElementNotNull(
 			$submit,
-			__METHOD__ . "Could not find the confirm button to add trusted server."
+			__METHOD__ . " Could not find the confirm button to add trusted server."
 		);
 		$submit->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
@@ -676,7 +676,7 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 		);
 		$this->assertElementNotNull(
 			$btn,
-			__METHOD__ . "Could not find the button to delete trusted server."
+			__METHOD__ . " Could not find the button to delete trusted server."
 		);
 		$btn->click();
 		$this->waitForAjaxCallsToStartAndFinish($session);
@@ -695,7 +695,7 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 		);
 		$this->assertElementNotNull(
 			$err,
-			__METHOD__ . "Could not find the error message for trusted servers."
+			__METHOD__ . " Could not find the error message for trusted servers."
 		);
 		return $err->getText();
 	}

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -393,7 +393,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 		$this->assertElementNotNull(
 			$selectedAllFilesBtn,
 			__METHOD__ .
-			"could not find button $this->selectAllFilesCheckboxXpath to select all files"
+			" could not find button $this->selectAllFilesCheckboxXpath to select all files"
 		);
 		return $selectedAllFilesBtn;
 	}


### PR DESCRIPTION
## Description
I noticed that when some acceptance tests fail they emit messages that use `__METHOD__` in the message text (to help the reader of the message identify where it came from). But the following text is missing a space.

Always put a space in the text string after inserting `__METHOD__`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
