### PR TITLE
[Tests-Only] Set shareapi_exclude_groups_list to the empty string at the start of acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2606,7 +2606,7 @@ trait Sharing {
 				'capabilitiesParameter' => 'exclude_groups_from_sharing_list',
 				'testingApp' => 'core',
 				'testingParameter' => 'shareapi_exclude_groups_list',
-				'testingState' => null
+				'testingState' => ''
 			],
 			[
 				'capabilitiesApp' => 'files_sharing',


### PR DESCRIPTION
## Description
At the start of each acceptance test scenario we set various sharing settings to some default values. Most of those are true or false settings which end up getting the value `yes` or `no` sent through to the testing app which puts those in the core settings - all good.

`shareapi_exclude_groups_list` is a formatted string of group names that are excluded from sharing. We have been setting it to `null`. With Guzzle5 that has been getting through in the request body to the testing app as `value` the empty string, which is actually what we want.

With Guzzle6 the body gets constructed differently items like `value` that are specified `null` just do not end up at all in the request.

IMO this is an unseen bug in the current test code, so fix it now.

## Related Issue
#36942 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
