### PR TITLE
[Tests-Only] Adjust TrashbinContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -83,7 +83,7 @@ class TrashbinContext implements Context {
 		Assert::assertEquals(
 			204,
 			$response->getStatusCode(),
-			__METHOD__ . "Expected status code was '204' but got '" . $response->getStatusCode() . "'"
+			__METHOD__ . " Expected status code was '204' but got '" . $response->getStatusCode() . "'"
 		);
 	}
 
@@ -458,7 +458,7 @@ class TrashbinContext implements Context {
 		Assert::assertTrue(
 			$found,
 			__METHOD__
-			. "Could not find expected resource '$path' in the trash"
+			. " Could not find expected resource '$path' in the trash"
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -81,7 +81,9 @@ class TrashbinContext implements Context {
 		$response = $this->emptyTrashbin($user);
 
 		Assert::assertEquals(
-			204, $response->getStatusCode()
+			204,
+			$response->getStatusCode(),
+			__METHOD__ . "Expected status code was '204' but got '" . $response->getStatusCode() . "'"
 		);
 	}
 
@@ -423,7 +425,10 @@ class TrashbinContext implements Context {
 
 		$firstEntry = $this->findFirstTrashedEntry($user, \trim($sections[0], '/'));
 
-		Assert::assertNotNull($firstEntry);
+		Assert::assertNotNull(
+			$firstEntry,
+			"The first trash entry is found null unexpectedly"
+		);
 
 		if (\count($sections) !== 1) {
 			// TODO: handle deeper structures
@@ -450,7 +455,11 @@ class TrashbinContext implements Context {
 			}
 		}
 
-		Assert::assertTrue($found);
+		Assert::assertTrue(
+			$found,
+			__METHOD__
+			. "Could not find expected resource '$path' in the trash"
+		);
 	}
 
 	/**
@@ -601,10 +610,9 @@ class TrashbinContext implements Context {
 	 */
 	public function elementInTrashHasBeenRestored($user, $originalPath) {
 		$this->restoreElement($user, $originalPath);
-		Assert::assertFalse(
-			$this->isInTrash($user, $originalPath),
-			"File previously located at $originalPath is still in the trashbin"
-		);
+		if ($this->isInTrash($user, $originalPath)) {
+			throw new Exception("File previously located at $originalPath is still in the trashbin");
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the TrashbinContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
