### PR TITLE
[Tests-Only] Adjust WebDavPropertiesContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -613,10 +613,9 @@ class WebDavPropertiesContext implements Context {
 			$user,
 			$path
 		);
-		Assert::assertNotNull(
-			$this->storedETAG[$user][$path],
-			'Expected stored etag to be some string but found null!'
-		);
+		if ($this->storedETAG[$user][$path] === null) {
+			throw new Exception("Expected stored etag to be some string but found null!");
+		}
 	}
 
 	/**
@@ -626,11 +625,11 @@ class WebDavPropertiesContext implements Context {
 	 * @throws \Exception
 	 */
 	public function thePropertiesResponseShouldContainAnEtag() {
-		if (!$this->featureContext->isEtagValid()) {
-			throw new \Exception(
-				"getetag not found in response"
-			);
-		}
+		Assert::assertTrue(
+			$this->featureContext->isEtagValid(),
+			__METHOD__
+			. " getetag not found in response"
+		);
 	}
 
 	/**
@@ -673,7 +672,9 @@ class WebDavPropertiesContext implements Context {
 			}
 			Assert::assertEquals(
 				$col["value"],
-				$xmlPart[0]
+				$xmlPart[0],
+				__METHOD__
+				. " Expected '" . $col["value"] . "' but got '" . $xmlPart[0] . "'"
 			);
 		}
 	}
@@ -693,7 +694,13 @@ class WebDavPropertiesContext implements Context {
 		);
 		Assert::assertEquals(
 			$this->storedETAG[$user][$path],
-			$this->featureContext->getEtagFromResponseXmlObject()
+			$this->featureContext->getEtagFromResponseXmlObject(),
+			__METHOD__
+			. " The etag of element '$path' of user '$user' was not expected to change. The stored etag was '"
+			. $this->storedETAG[$user][$path]
+			. "' but got '"
+			. $this->featureContext->getEtagFromResponseXmlObject()
+			. "' from the response"
 		);
 	}
 
@@ -712,7 +719,13 @@ class WebDavPropertiesContext implements Context {
 		);
 		Assert::assertNotEquals(
 			$this->storedETAG[$user][$path],
-			$this->featureContext->getEtagFromResponseXmlObject()
+			$this->featureContext->getEtagFromResponseXmlObject(),
+			__METHOD__
+			. " The etag of element '$path' of user '$user' was expected to change. The stored etag was '"
+			. $this->storedETAG[$user][$path]
+			. "' and got '"
+			. $this->featureContext->getEtagFromResponseXmlObject()
+			. "' from the response"
 		);
 	}
 


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the WebDavPropertiesContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
