### PR TITLE
[Tests-Only] Run federated acceptance tests against multiple older core releases

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -125,7 +125,7 @@ config = {
 				'apiFederation',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['daily-master-qa', '10.2.1']
+			'federatedServerVersions': ['daily-master-qa', 'latest', '10.2.1']
 		},
 		'cli': {
 			'suites': [
@@ -148,7 +148,7 @@ config = {
 				'cliExternalStorage',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['daily-master-qa', '10.2.1']
+			'federatedServerVersions': ['daily-master-qa', 'latest', '10.2.1']
 		},
 		'webUI': {
 			'suites': {
@@ -201,7 +201,7 @@ config = {
 				'webUISharingExternal2': 'webUISharingExt2',
 			},
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['daily-master-qa', '10.2.1']
+			'federatedServerVersions': ['daily-master-qa', 'latest', '10.2.1']
 		},
 		'webUIFirefox': {
 			'suites': {


### PR DESCRIPTION
## Description
I noticed that the federated acceptance tests have been running against federated servers with ieht `10.2.1` or `daily-qa-master`. But `10.3.2` has been out for some time and is currently linked as `latest`.

I added `latest` to the list of federated server versions that we test against.

I think we should test against the latest patch release of each minor version, for a few minor versions back, because as people upgrade their installations they will have transition times when their federated cloud will have different versions running. e.g. when 10.4.0 is released and becomes `latest` we can test against `10.2.1` `10.3.2` `latest` and `master`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
