### PR TITLE
[Tests-Only] Adjust WebUIAdminGeneralSettingsContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -210,7 +210,14 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	public function theVersionOfOwncloudInstallationShouldBeDisplayedOnTheAdminGeneralSettingsPage() {
 		$actualVersion = $this->adminGeneralSettingsPage->getOwncloudVersion();
 		$expectedVersion = SetupHelper::getSystemConfigValue('version');
-		Assert::assertEquals(\trim($expectedVersion), $actualVersion);
+		Assert::assertEquals(
+			\trim($expectedVersion),
+			$actualVersion,
+			__METHOD__
+			. " The expected version to be displayed was '"
+			. \trim($expectedVersion)
+			. "' but got '$actualVersion' instead"
+		);
 	}
 
 	/**
@@ -221,7 +228,14 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	public function theVersionStringOfTheOwncloudInstallationShouldBeDisplayedOnTheAdminGeneralSettingsPage() {
 		$actualVersion = $this->adminGeneralSettingsPage->getOwncloudVersionString();
 		$expectedVersion = SetupHelper::runOcc(['-V'])['stdOut'];
-		Assert::assertStringEndsWith($actualVersion, \trim($expectedVersion));
+		Assert::assertStringEndsWith(
+			$actualVersion,
+			\trim($expectedVersion),
+			__METHOD__
+			. " Expected version string is '"
+			. \trim($expectedVersion)
+			. "and it does not end with '$actualVersion'"
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the WebUIAdminGeneralSettingsContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
