### PR TITLE
[Tests-Only] Adjust words for cliExternalStorage scenarios

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2733,7 +2733,7 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * gets every created storages and deletes them
+	 * deletes all created storages
 	 *
 	 * @return void
 	 * @throws Exception

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -411,7 +411,7 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator lists all local storages mount points using the occ command
+	 * @When the administrator lists all local storage mount points using the occ command
 	 *
 	 * List created local storage mount with --short
 	 *
@@ -2071,7 +2071,7 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator creates an external mount point with following configuration using the occ command
+	 * @When the administrator creates an external mount point with the following configuration using the occ command
 	 *
 	 * @param TableNode $settings
 	 *
@@ -2120,37 +2120,37 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator has created an external mount point with following configuration using the occ command
+	 * @Given the administrator has created an external mount point with the following configuration using the occ command
 	 *
 	 * @param TableNode $settings
 	 *
 	 * @return void
 	 */
-	public function userHasCreatedAnExternalMountPointWithFollowingConfigUsingTheOccCommand(TableNode $settings) {
+	public function adminHasCreatedAnExternalMountPointWithFollowingConfigUsingTheOccCommand(TableNode $settings) {
 		$this->createExternalMountPointUsingTheOccCommand($settings);
 		$this->theCommandShouldHaveBeenSuccessful();
 	}
 
 	/**
-	 * @When administrator deletes external storage with mount point :mountPoint
+	 * @When the administrator deletes external storage with mount point :mountPoint
 	 *
 	 * @param string $mountPoint
 	 *
 	 * @return void
 	 */
-	public function deleteExternalMountPoint($mountPoint) {
+	public function adminDeletesExternalMountPoint($mountPoint) {
 		$mount_id = $this->administratorDeletesFolder($mountPoint);
 		$this->featureContext->popStorageId($mount_id);
 	}
 
 	/**
-	 * @Then mount point :mountPoint should not be listed as created external storages
+	 * @Then mount point :mountPoint should not be listed as an external storage
 	 *
 	 * @param string $mountPoint
 	 *
 	 * @return void
 	 */
-	public function mountPointShouldNotBeListedAsCreatedExternalStorage($mountPoint) {
+	public function mountPointShouldNotBeListedAsAnExternalStorage($mountPoint) {
 		$commandOutput = \json_decode($this->featureContext->getStdOutOfOccCommand());
 		foreach ($commandOutput as $entry) {
 			Assert::assertNotEquals($mountPoint, $entry->mount_point);

--- a/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
+++ b/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
@@ -12,7 +12,7 @@ So that I can extend my storage service
     And using server "LOCAL"
 
   Scenario: creating a webdav_owncloud external storage
-    When the administrator creates an external mount point with following configuration using the occ command
+    When the administrator creates an external mount point with the following configuration using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |
@@ -28,7 +28,7 @@ So that I can extend my storage service
     And as "admin" folder "TestMountPoint" should exist
 
   Scenario: using webdav_owncloud as external storage
-    Given the administrator has created an external mount point with following configuration using the occ command
+    Given the administrator has created an external mount point with the following configuration using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |
@@ -46,7 +46,7 @@ So that I can extend my storage service
     Given using server "REMOTE"
     And user "user1" has created folder "TestMnt1"
     And using server "LOCAL"
-    And the administrator creates an external mount point with following configuration using the occ command
+    And the administrator creates an external mount point with the following configuration using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt1           |
       | secure                 | false              |
@@ -55,7 +55,7 @@ So that I can extend my storage service
       | storage_backend        | owncloud           |
       | mount_point            | TestMountPoint1    |
       | authentication_backend | password::password |
-    When administrator deletes external storage with mount point "TestMountPoint1"
+    When the administrator deletes external storage with mount point "TestMountPoint1"
     Then the command should have been successful
-    When the administrator lists all local storages mount points using the occ command
-    Then mount point "/TestMountPoint1" should not be listed as created external storages
+    When the administrator lists all local storage mount points using the occ command
+    Then mount point "/TestMountPoint1" should not be listed as an external storage


### PR DESCRIPTION
## Description
PR #36857 introduced some acceptance tests for external storage. This PR adjusts some of the words in the steps.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
