### PR TITLE
[Tests-Only] Adjust WebUIAdminSharingSettingsContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -157,8 +157,14 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	 * @return void
 	 */
 	public function expirationDateForUserSharesShouldBeSetToXDays($days) {
-		$expectedDays = $this->adminSharingSettingsPage->getUserShareExpirationDays();
-		Assert::assertEquals($days, $expectedDays);
+		$expirationDays = $this->adminSharingSettingsPage->getUserShareExpirationDays();
+		Assert::assertEquals(
+			$days,
+			$expirationDays,
+			__METHOD__
+			. " The expiration date for user shares was expected to be set to '$days' days, "
+			. "but was actually set to '$expirationDays' days"
+		);
 	}
 
 	/**
@@ -169,8 +175,14 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	 * @return void
 	 */
 	public function expirationDateForGroupSharesShouldBeSetToXDays($days) {
-		$expectedDays = $this->adminSharingSettingsPage->getGroupShareExpirationDays();
-		Assert::assertEquals($days, $expectedDays);
+		$expirationDays = $this->adminSharingSettingsPage->getGroupShareExpirationDays();
+		Assert::assertEquals(
+			$days,
+			$expirationDays,
+			__METHOD__
+			. " The expiration date for group shares was expected to be set to '$days' days, "
+			. "but was actually set to '$expirationDays' days"
+		);
 	}
 
 	/**
@@ -484,7 +496,12 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	 */
 	public function aErrorMessageForTrustedServerShouldContain($text) {
 		$msg = $this->adminSharingSettingsPage->getTrustedServerErrorMsg();
-		Assert::assertContains($text, $msg);
+		Assert::assertContains(
+			$text,
+			$msg,
+			__METHOD__
+			. " The text in the trusted server error message was expected to be '$text', but got '$msg' instead "
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the WebUIAdminSharingSettingsContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
