### PR TITLE
[Tests-Only] skipOnOcV10.3 new webUI sharing tests from PR 36915

### DIFF
--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -109,6 +109,7 @@ Feature: Sharing files and folders with internal groups
     When the user re-logs in as "user2" using the webUI
     Then folder "simple-folder" should be marked as shared with "User1" by "User Three" on the webUI
 
+  @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions of the group
 	Given these users have been created with default attributes and without skeleton files:
 	  | username |
@@ -143,6 +144,7 @@ Feature: Sharing files and folders with internal groups
 	  | share_with  | user1          |
 	  | permissions | 7              |
 
+  @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions of the user
 	Given these users have been created with default attributes and without skeleton files:
 	  | username |
@@ -177,6 +179,7 @@ Feature: Sharing files and folders with internal groups
 	  | share_with  | user1          |
 	  | permissions | 31             |
 
+  @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions of both user and group
 	Given these users have been created with default attributes and without skeleton files:
 	  | username |
@@ -212,6 +215,7 @@ Feature: Sharing files and folders with internal groups
 	  | share_with  | user1          |
 	  | permissions | 23             |
 
+  @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions and expiration date of the group
 	Given these users have been created with default attributes and without skeleton files:
 	  | username |
@@ -246,6 +250,7 @@ Feature: Sharing files and folders with internal groups
 	  | permissions | 31             |
 	  | expiration  |                |
 
+  @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions and expiration date of the user
 	Given these users have been created with default attributes and without skeleton files:
 	  | username |
@@ -280,6 +285,7 @@ Feature: Sharing files and folders with internal groups
 	  | permissions | 31             |
 	  | expiration  |                |
 
+  @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions and expiration date of both user and group
 	Given these users have been created with default attributes and without skeleton files:
 	  | username |


### PR DESCRIPTION
## Description
These new test scenarios are only relevant/work on 10.4. They fail when run against 10.3 (e.g. in file_primary_s3 nightly - https://drone.owncloud.com/owncloud/files_primary_s3/1487/58/19 )

Skip them for 10.3

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
