### PR TITLE
Better handling of DB timeouts on long downloads

### DIFF
--- a/changelog/unreleased/36978
+++ b/changelog/unreleased/36978
@@ -1,0 +1,10 @@
+Bugfix: Avoid unneeded DB connections after a long download
+
+After a long download, we needed to return the filesize, which needed a connection
+to the DB. The DB could have ended the connection due to an inactivity timeout.
+Now, the filesize is fetched before starting the download, so this timeout shouldn't
+happen any longer.
+We still need to update the checksum after the download is finished. In this case,
+we just log an error message and keep going.
+
+https://github.com/owncloud/core/pull/36978

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -472,11 +472,11 @@ class View {
 		$handle = $this->fopen($path, 'rb');
 		if ($handle) {
 			$chunkSize = 8192; // 8 kB chunks
+			$size = $this->filesize($path);
 			while (!\feof($handle)) {
 				echo \fread($handle, $chunkSize);
 				\flush();
 			}
-			$size = $this->filesize($path);
 			return $size;
 		}
 		return false;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Try to avoid hitting the DB after a long download, which could cause a failure if the DB connection timed out

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/enterprise/issues/3538

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked after setting a 10 sec DB timeout and then downloading a big file through a slow network.
The first time, we still need to hit the DB to update the checksum (currently we're logging a message and keep working), but once the checksum is there, there won't be any error.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
