### PR TITLE
Bump Graffino/Browser-Update v2.0.2 to v2.0.5

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -15,7 +15,7 @@
     "@bower_components/blueimp-md5": "blueimp/JavaScript-MD5#1.0.1",
     "@bower_components/bootstrap": "twbs/bootstrap#3.4.1",
     "@bower_components/bowser": "ded/bowser#1.9.4",
-    "@bower_components/browser-update": "Graffino/Browser-Update#v2.0.2",
+    "@bower_components/browser-update": "Graffino/Browser-Update#v2.0.5",
     "@bower_components/clipboard": "zenorocha/clipboard.js#v2.0.4",
     "@bower_components/davclient.js": "owncloud/davclient.js#0.1.3",
     "@bower_components/es6-promise": "components/es6-promise#4.2.4",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -29,9 +29,9 @@
   version "1.9.4"
   resolved "https://codeload.github.com/ded/bowser/tar.gz/1fb99ced0e8834fd9662604bad7e0f0c3eba2786"
 
-"@bower_components/browser-update@Graffino/Browser-Update#v2.0.2":
-  version "2.0.2"
-  resolved "https://codeload.github.com/Graffino/Browser-Update/tar.gz/0edda8c7f53ad2cbe68538c00b8c790513096d60"
+"@bower_components/browser-update@Graffino/Browser-Update#v2.0.5":
+  version "2.0.5"
+  resolved "https://codeload.github.com/Graffino/Browser-Update/tar.gz/76efd225894bf77c411aa8cced870fe6327ac259"
 
 "@bower_components/clipboard@zenorocha/clipboard.js#v2.0.4":
   version "2.0.4"

--- a/changelog/unreleased/36976
+++ b/changelog/unreleased/36976
@@ -1,0 +1,4 @@
+Change: Update Graffino/Browser-Update from 2.0.2 to 2.0.5
+
+https://github.com/owncloud/core/issues/36976
+https://github.com/owncloud/core/pull/36981


### PR DESCRIPTION
## Description
cherry-pick of #36981 to `release-10.4.0` branch, in case we want to have it there also.

(see the other PR for details of what this is about)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
