### PR TITLE
Remove full-stop from reset password success message

### DIFF
--- a/changelog/unreleased/36984
+++ b/changelog/unreleased/36984
@@ -1,0 +1,8 @@
+Bugfix: Remove full-stop from end of reset password message
+
+When doing occ user:resetpassword username --password-from-env --send-email
+the message "Successfully reset password for username" had a full-stop at the
+end. Without --send-email there was no full-stop. The full-stop has been
+removed to make the messages consistent.
+
+https://github.com/owncloud/core/pull/36984

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -186,7 +186,7 @@ class ResetPassword extends Command {
 			$this->config->setUserValue($userId, 'owncloud', 'lostpassword', $this->timeFactory->getTime() . ':' . $token);
 			$success = $this->lostController->setPassword($token, $userId, $password, false);
 			if (\is_array($success) && isset($success['status']) && $success['status'] === 'success') {
-				$output->writeln("<info>Successfully reset password for {$username}.</info>");
+				$output->writeln("<info>Successfully reset password for {$username}</info>");
 				return 0;
 			} else {
 				$output->writeln("<error>Error while resetting password!</error>");

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -291,7 +291,7 @@ class ResetPasswordTest extends TestCase {
 
 			$output->expects($this->once())
 				->method('writeln')
-				->with("<info>Successfully reset password for foo.</info>");
+				->with("<info>Successfully reset password for foo</info>");
 		} else {
 			$this->lostController->expects($this->never())
 				->method('setPassword');


### PR DESCRIPTION
## Description
When doing occ user:resetpassword username --password-from-env --send-email
the message "Successfully reset password for username" had a full-stop at the
end. Without --send-email there was no full-stop. The full-stop has been
removed to make the messages consistent.

```
$ php occ user:resetpassword testuser --password-from-env --send-email
Successfully reset password for testuser.
$ php occ user:resetpassword testuser --password-from-env
Successfully reset password for testuser
```

(I noticed this while investigating some password reset scenarios that were failing with encryption)

## How Has This Been Tested?
The commands now output:
```
$ php occ user:resetpassword testuser --password-from-env --send-email
Successfully reset password for testuser
$ php occ user:resetpassword testuser --password-from-env
Successfully reset password for testuser
```

Both commands now give the same output (no full-stop)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
