### PR TITLE
[Tests-Only] skipOnEncryption password reset test due to issue-36985

### DIFF
--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -26,6 +26,7 @@ Feature: reset user password
       Use the following link to reset your password: <a href=
       """
 
+  @skipOnEncryption @issue-36985
   Scenario: user should get email when the administrator changes their password and specifies to also send email
     Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |


### PR DESCRIPTION
## Description
Skip the password reset test when encryption is on - see details in the issue.

This will help to get core CLI acceptance tests passing in the encryption app.

## Related Issue
#36985 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
