### PR TITLE
[Tests-Only] Skip on encryption more test scenarios

### DIFF
--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
@@ -10,6 +10,7 @@ Feature: create local storage from the command line
       | user0    |
       | user1    |
 
+  @skipOnEncryptionType:user-keys @issue-encryption-181
   Scenario: create local storages that are available to specific users
     Given the administrator has created the local storage mount "local_storage2"
     And the administrator has created the local storage mount "local_storage3"
@@ -34,6 +35,7 @@ Feature: create local storage from the command line
     And the content of file "/local_storage3/file-in-local-storage3.txt" for user "user1" should be "this is a file in local storage3"
     But as "user1" folder "/local_storage2" should not exist
 
+  @skipOnEncryptionType:user-keys @issue-encryption-181
   Scenario: create local storage that is available for more than one user
     And these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/cliMain/filesChecksum.feature
+++ b/tests/acceptance/features/cliMain/filesChecksum.feature
@@ -1,19 +1,23 @@
 @cli @local_storage @TestAlsoOnExternalUserBackend
 Feature: files checksum command
 
+  @skipOnEncryptionType:user-keys @issue-encryption-182
   Scenario: Administrator verifies the checksum of all the files
     When the administrator invokes occ command "files:checksum:verify"
     Then the command should have been successful
 
+  @skipOnEncryptionType:user-keys @issue-encryption-182
   Scenario: Administrator fixes the mismatched checksums
     When the administrator invokes occ command "files:checksum:verify -r"
     Then the command should have been successful
 
+  @skipOnEncryptionType:user-keys @issue-encryption-182
   Scenario: Administrator verifies the checksum of all the files of a user
     Given user "user0" has been created with default attributes and skeleton files
     When the administrator invokes occ command "files:checksum:verify --user=user0"
     Then the command should have been successful
 
+  @skipOnEncryptionType:user-keys @issue-encryption-182
   Scenario: Administrator fixes the mismatched checksums of all the files of a user
     Given user "user0" has been created with default attributes and skeleton files
     When the administrator invokes occ command "files:checksum:verify -r --user=user0"


### PR DESCRIPTION
## Description
`skipOnEncryptionType:user-keys` for CLI acceptance test scenarios that do not work with user-key encryption. See the issues for details.

This will get https://github.com/owncloud/encryption/pull/179 passing, so we can regularly run core CLI acceptance tests in drone.

## Related Issue
https://github.com/owncloud/encryption/issues/181
https://github.com/owncloud/encryption/issues/182

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
