### PR TITLE
[Tests-Only] Adjust WebUIPersonalSecuritySettingsContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
@@ -92,28 +92,16 @@ class WebUIPersonalSecuritySettingsContext extends RawMinkContext implements Con
 		$appTr = $this->personalSecuritySettingsPage->getLinkedAppByName(
 			$this->appName
 		);
-		Assert::assertNotEmpty($appTr);
+		Assert::assertNotEmpty(
+			$appTr,
+			__METHOD__
+			. " No apps are listed in the app passwords list on the webUI."
+		);
 		$disconnectButton
 			= $this->personalSecuritySettingsPage->getDisconnectButton($appTr);
-		Assert::assertNotEmpty($disconnectButton);
-	}
-
-	/**
-	 * @Then the user display name and the app password should be displayed on the webUI
-	 *
-	 * @return void
-	 */
-	public function theUserDisplayNameAndAppPasswordShouldBeDisplayedOnTheWebUI() {
-		$result = $this->personalSecuritySettingsPage->getAppPasswordResult();
-		Assert::assertEquals(
-			$this->featureContext->getCurrentUser(),
-			$result[0]->getValue()
-		);
-
-		Assert::assertEquals(
-			1, \preg_match(
-				'/(([A-Z]){5}-){3}([A-Z]){5}/', $result[1]->getValue()
-			)
+		Assert::assertNotEmpty(
+			$disconnectButton,
+			" Disconnect button is not present for the new app."
 		);
 	}
 


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the WebUIPersonalSecuritySettingsContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
