### PR TITLE
[Tests-Only] skipOnEncryptionType:user-keys password change test

### DIFF
--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -4,6 +4,7 @@ Feature: reset user password
   I want to be able to reset a user's password
   So that I can secure individual access to resources on the ownCloud server
 
+  @skipOnEncryptionType:user-keys
   Scenario: reset user password
     Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |


### PR DESCRIPTION
## Description
I missed skipping this in the PRs yesterday.

This scenario does not work with user-key encryption. It forces a password change with an `occ` command (in a situation where the command wants to warn the user about data loss...) And indeed there is data loss if an admin does this:

https://drone.owncloud.com/owncloud/encryption/1132/86/11

```
Feature: reset user password
  As an admin
  I want to be able to reset a user's password
  So that I can secure individual access to resources on the ownCloud server

  Scenario: reset user password                                                                                                                      # /var/www/owncloud/testrunner/tests/acceptance/features/cliProvisioning/resetUserPassword.feature:7
    Given these users have been created with skeleton files:                                                                                         # FeatureContext::theseUsersHaveBeenCreated()
      | username       | password  | displayname | email                    |
      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
    When the administrator resets the password of user "brand-new-user" to "%alt1%" using the occ command                                            # OccUsersGroupsContext::resetUserPasswordUsingTheOccCommand()
    Then the command should have been successful                                                                                                     # OccContext::theCommandShouldHaveBeenSuccessful()
    And the command output should contain the text "Successfully reset password for brand-new-user"                                                  # OccContext::theCommandOutputContainsTheText()
    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line # FeatureContext::contentOfFileForUserUsingPasswordShouldBePlusEndOfLine()
      The downloaded content was expected to be 'ownCloud test text file 0
      ', but actually is '<?xml version="1.0" encoding="utf-8"?>
      <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
        <s:exception>Sabre\DAV\Exception\Forbidden</s:exception>
        <s:message>Encryption not ready: Private Key missing for user: please try to log-out and log-in again</s:message>
      </d:error>
      '.
      Failed asserting that two strings are equal.
      --- Expected
      +++ Actual
      @@ @@
      -'ownCloud test text file 0\n
      +'<?xml version="1.0" encoding="utf-8"?>\n
      +<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">\n
      +  <s:exception>Sabre\DAV\Exception\Forbidden</s:exception>\n
      +  <s:message>Encryption not ready: Private Key missing for user: please try to log-out and log-in again</s:message>\n
      +</d:error>\n
       '
```

So skip the test.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
