### PR TITLE
[Tests-Only] Adjust WebUIPersonalSharingSettingsContext asserts and exceptions for then and given steps

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
@@ -102,7 +102,9 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function autoAcceptingCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageOnTheWebui() {
 		Assert::assertFalse(
-			$this->personalSharingSettingsPage->isAutoAcceptLocalSharesCheckboxDisplayed()
+			$this->personalSharingSettingsPage->isAutoAcceptLocalSharesCheckboxDisplayed(),
+			__METHOD__
+			. " User-based auto accepting checkbox is displayed on the personal sharing settings page."
 		);
 	}
 
@@ -113,7 +115,9 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function autoAcceptingFederatedCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPageOnTheWebui() {
 		Assert::assertFalse(
-			$this->personalSharingSettingsPage->isAutoAcceptFederatedSharesCheckboxDisplayed()
+			$this->personalSharingSettingsPage->isAutoAcceptFederatedSharesCheckboxDisplayed(),
+			__METHOD__
+			. " User-based auto accepting from trusted servers checkbox is displayed on the personal sharing settings page."
 		);
 	}
 
@@ -124,7 +128,9 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	 */
 	public function allowFindingYouViaAutocompleteCheckboxShouldNotBeDisplayedOnThePersonalSharingSettingsPage() {
 		Assert::assertFalse(
-			$this->personalSharingSettingsPage->isAllowFindingYouViaAutocompleteCheckboxDisplayed()
+			$this->personalSharingSettingsPage->isAllowFindingYouViaAutocompleteCheckboxDisplayed(),
+			__METHOD__
+			. " Allow finding you via autocomplete checkbox is displayed on the personal sharing settings page."
 		);
 	}
 }


### PR DESCRIPTION
## Description
This PR includes the adjustments in the asserts and exceptions for the then and given steps respectively in the WebUIPersonalSharingSettingsContext file.

## Related Issue
#36810 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
