### PR TITLE
PHP 7.4 20200221

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -26,6 +26,7 @@ config = {
 		'allDatabases' : {
 			'phpVersions': [
 				'7.1',
+				'7.4',
 			]
 		},
 		'reducedDatabases' : {
@@ -41,7 +42,7 @@ config = {
 		},
 		'external-samba-windows' : {
 			'phpVersions': [
-				'7.1',
+				'7.4',
 			],
 			'databases': [
 				'sqlite',
@@ -60,7 +61,7 @@ config = {
 		},
 		'external-other' : {
 			'phpVersions': [
-				'7.1',
+				'7.4',
 			],
 			'databases': [
 				'sqlite',
@@ -589,7 +590,7 @@ def phpstan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.1'],
+		'phpVersions': ['7.4'],
 		'logLevel': '2',
 	}
 
@@ -666,7 +667,7 @@ def phan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3', '7.4'],
 		'logLevel': '2',
 	}
 
@@ -743,7 +744,7 @@ def litmus():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.1'],
+		'phpVersions': ['7.4'],
 		'logLevel': '2'
 	}
 
@@ -908,7 +909,7 @@ def dav():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.1'],
+		'phpVersions': ['7.4'],
 		'logLevel': '2'
 	}
 
@@ -1006,7 +1007,7 @@ def javascript():
 	default = {
 		'coverage': True,
 		'logLevel': '2',
-		'phpVersion': '7.1'
+		'phpVersion': '7.4'
 	}
 
 	if 'defaults' in config:
@@ -1102,7 +1103,7 @@ def phptests(testType):
 	errorFound = False
 
 	default = {
-		'phpVersions': ['7.1', '7.2', '7.3'],
+		'phpVersions': ['7.1', '7.2', '7.3', '7.4'],
 		'databases': [
 			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mariadb:10.4', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'postgres:10.3', 'oracle'
 		],
@@ -1286,7 +1287,7 @@ def acceptance():
 	default = {
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
-		'phpVersions': ['7.1'],
+		'phpVersions': ['7.4'],
 		'databases': ['mariadb:10.2'],
 		'federatedServerNeeded': False,
 		'filterTags': '',

--- a/.drone.star
+++ b/.drone.star
@@ -1308,6 +1308,7 @@ def acceptance():
 		'includeKeyInMatrixName': False,
 		'runAllSuites': False,
 		'numberOfParts': 1,
+		'federatedPhpVersion': '7.2',
 	}
 
 	if 'defaults' in config:
@@ -1447,7 +1448,7 @@ def acceptance():
 										yarnInstall(phpVersion) +
 										installServer(phpVersion, db, params['logLevel'], params['federatedServerNeeded'], params['proxyNeeded']) +
 										(
-											installFederated(federatedServerVersion, phpVersion, params['logLevel'], protocol, db, federationDbSuffix) +
+											installFederated(federatedServerVersion, params['federatedPhpVersion'], params['logLevel'], protocol, db, federationDbSuffix) +
 											owncloudLog('federated', 'federated') if params['federatedServerNeeded'] else []
 										) +
 										installExtraApps(phpVersion, extraAppsDict) +
@@ -1481,7 +1482,7 @@ def acceptance():
 										params['extraServices'] +
 										owncloudService(phpVersion, 'server', '/drone/src', params['useHttps']) +
 										((
-											owncloudService(phpVersion, 'federated', '/drone/federated', params['useHttps']) +
+											owncloudService(params['federatedPhpVersion'], 'federated', '/drone/federated', params['useHttps']) +
 											databaseServiceForFederation(db, federationDbSuffix)
 										) if params['federatedServerNeeded'] else []),
 									'depends_on': [],

--- a/.drone.star
+++ b/.drone.star
@@ -667,7 +667,7 @@ def phan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.1', '7.2', '7.3', '7.4'],
+		'phpVersions': ['7.1', '7.2', '7.3'],
 		'logLevel': '2',
 	}
 

--- a/console.php
+++ b/console.php
@@ -41,9 +41,9 @@ if (\version_compare(PHP_VERSION, '7.1.0') === -1) {
 	exit(1);
 }
 
-// Show warning if PHP 7.4 or later is used as ownCloud is not compatible with PHP 7.4
-if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
-	echo 'This version of ownCloud is not compatible with PHP 7.4' . PHP_EOL;
+// Show warning if PHP 7.5 or later is used as ownCloud is not compatible with PHP 7.5
+if (\version_compare(PHP_VERSION, '7.5.0alpha1') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 7.5' . PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '.' . PHP_EOL;
 	exit(1);
 }

--- a/index.php
+++ b/index.php
@@ -35,9 +35,9 @@ if (\version_compare(PHP_VERSION, '7.1.0') === -1) {
 	return;
 }
 
-// Show warning if PHP 7.4 or later is used as ownCloud is not compatible with PHP 7.4
-if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
-	echo 'This version of ownCloud is not compatible with PHP 7.4<br/>';
+// Show warning if PHP 7.5 or later is used as ownCloud is not compatible with PHP 7.5
+if (\version_compare(PHP_VERSION, '7.5.0alpha1') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 7.5<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '.';
 	return;
 }

--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -64,7 +64,7 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 			if (\method_exists($param, 'getType')) {
 				$type = $param->getType();
 				if ($type !== null) {
-					$this->types[$param->getName()] = (string) $type;
+					$this->types[$param->getName()] = $type->getName();
 				}
 			}
 

--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -63,6 +63,7 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 			// over phpdoc annotations
 			if (\method_exists($param, 'getType')) {
 				$type = $param->getType();
+				'@phan-var \ReflectionNamedType $type';
 				if ($type !== null) {
 					$this->types[$param->getName()] = $type->getName();
 				}

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -111,7 +111,7 @@ class Cache implements ICache {
 	 * get the stored metadata of a file or folder
 	 *
 	 * @param string | int $file either the path of a file or folder or the file id for a file or folder
-	 * @return ICacheEntry|false the cache entry as array of false if the file is not found in the cache
+	 * @return ICacheEntry|false the cache entry as array or false if the file is not found in the cache
 	 */
 	public function get($file) {
 		if (\is_string($file) or $file == '') {

--- a/tests/lib/Cache/FileCacheTest.php
+++ b/tests/lib/Cache/FileCacheTest.php
@@ -84,8 +84,8 @@ class FileCacheTest extends TestCache {
 	}
 
 	protected function tearDown(): void {
-		if ($this->instance) {
-			$this->instance->remove('hack', 'hack');
+		if ($this->instance->get('hack') !== null) {
+			$this->instance->remove('hack');
 		}
 
 		parent::tearDown();

--- a/tests/lib/Command/Integrity/SignAppTest.php
+++ b/tests/lib/Command/Integrity/SignAppTest.php
@@ -221,23 +221,23 @@ class SignAppTest extends TestCase {
 			->expects($this->at(1))
 			->method('getOption')
 			->with('privateKey')
-			->will($this->returnValue('privateKey'));
+			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key'));
 		$inputInterface
 			->expects($this->at(2))
 			->method('getOption')
 			->with('certificate')
-			->will($this->returnValue('certificate'));
+			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt'));
 
 		$this->fileAccessHelper
 			->expects($this->at(0))
 			->method('file_get_contents')
-			->with('privateKey')
-			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key'));
+			->with(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key')
+			->will($this->returnValue(\file_get_contents(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key')));
 		$this->fileAccessHelper
 			->expects($this->at(1))
 			->method('file_get_contents')
-			->with('certificate')
-			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt'));
+			->with(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt')
+			->will($this->returnValue(\file_get_contents(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt')));
 
 		$this->checker
 			->expects($this->once())

--- a/tests/lib/Command/Integrity/SignCoreTest.php
+++ b/tests/lib/Command/Integrity/SignCoreTest.php
@@ -172,12 +172,12 @@ class SignCoreTest extends TestCase {
 			->expects($this->at(0))
 			->method('getOption')
 			->with('privateKey')
-			->will($this->returnValue('privateKey'));
+			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key'));
 		$inputInterface
 			->expects($this->at(1))
 			->method('getOption')
 			->with('certificate')
-			->will($this->returnValue('certificate'));
+			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt'));
 		$inputInterface
 				->expects($this->at(2))
 				->method('getOption')
@@ -187,13 +187,13 @@ class SignCoreTest extends TestCase {
 		$this->fileAccessHelper
 			->expects($this->at(0))
 			->method('file_get_contents')
-			->with('privateKey')
-			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key'));
+			->with(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key')
+			->will($this->returnValue(\file_get_contents(\OC::$SERVERROOT . '/tests/data/integritycheck/core.key')));
 		$this->fileAccessHelper
 			->expects($this->at(1))
 			->method('file_get_contents')
-			->with('certificate')
-			->will($this->returnValue(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt'));
+			->with(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt')
+			->will($this->returnValue(\file_get_contents(\OC::$SERVERROOT . '/tests/data/integritycheck/core.crt')));
 
 		$this->checker
 			->expects($this->once())

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -248,8 +248,12 @@ class CacheTest extends TestCase {
 
 		// clean up
 		$this->cache->remove('');
-		$this->cache->remove($dir1);
-		$this->cache->remove($dir2);
+		if ($this->cache->get($dir1)) {
+			$this->cache->remove($dir1);
+		}
+		if ($this->cache->get($dir2)) {
+			$this->cache->remove($dir2);
+		}
 
 		$this->assertFalse($this->cache->inCache($dir1));
 		$this->assertFalse($this->cache->inCache($dir2));

--- a/tests/lib/Files/Cache/HomeCacheTest.php
+++ b/tests/lib/Files/Cache/HomeCacheTest.php
@@ -102,9 +102,15 @@ class HomeCacheTest extends \Test\TestCase {
 
 		// clean up
 		$this->cache->remove('');
-		$this->cache->remove('files');
-		$this->cache->remove($dir1);
-		$this->cache->remove($dir2);
+		if ($this->cache->get('files')) {
+			$this->cache->remove('files');
+		}
+		if ($this->cache->get($dir1)) {
+			$this->cache->remove($dir1);
+		}
+		if ($this->cache->get($dir2)) {
+			$this->cache->remove($dir2);
+		}
 
 		$this->assertFalse($this->cache->inCache('files'));
 		$this->assertFalse($this->cache->inCache($dir1));
@@ -132,7 +138,9 @@ class HomeCacheTest extends \Test\TestCase {
 
 		// clean up
 		$this->cache->remove('');
-		$this->cache->remove($dir1);
+		if ($this->cache->get($dir1)) {
+			$this->cache->remove($dir1);
+		}
 
 		$this->assertFalse($this->cache->inCache($dir1));
 	}

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -30,6 +30,12 @@ class CacheJailTest extends CacheTest {
 		$this->cache = new \OC\Files\Cache\Wrapper\CacheJail($this->sourceCache, 'foo');
 	}
 
+	protected function tearDown(): void {
+		if ($this->sourceCache) {
+			$this->sourceCache->clear();
+		}
+	}
+
 	public function testSearchOutsideJail() {
 		$file1 = 'foo/foobar';
 		$file2 = 'folder/foobar';

--- a/tests/lib/Util/User/MemoryAccountMapper.php
+++ b/tests/lib/Util/User/MemoryAccountMapper.php
@@ -76,7 +76,7 @@ class MemoryAccountMapper extends AccountMapper {
 			return self::$accounts;
 		}
 		$match = \array_filter(self::$accounts, function (Account $a) use ($pattern) {
-			return \stripos($a->getUserId(), $pattern);
+			return \stripos($a->getUserId(), (string) $pattern);
 		});
 
 		return $match;


### PR DESCRIPTION
This is code so far for supporting PHP 7.4

~This PR is on top of #36999 which implements Guzzle6 for acceptance tests. That can help developers who have PHP 7.4 - they can run acceptance tests against some ownCloud system-under-test (ownCloud10 itself, or OCIS or...)~

PR #36999 "Guzzle6 for acceptance tests" is now in master. I have rebased this PR.

There are a lot of adjustments to `phpunit` tests still to be done - but I think the actual run-time back-end works.