### PR TITLE
[Tests-Only] Add acceptance test to remove all for local storage mount

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1200,6 +1200,25 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @When the administrator removes all from the applicable users and groups for local storage mount :localStorage using the occ command
+	 *
+	 * @param string $localStorage
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theAdminRemovesAllForTheMountUsingOccCommand($localStorage) {
+		$mountId = $this->featureContext->getStorageId($localStorage);
+		$this->featureContext->runOcc(
+			[
+				'files_external:applicable',
+				$mountId,
+				"--remove-all"
+			]
+		);
+	}
+
+	/**
 	 * @Given /^the administrator has (added|removed) (user|group) "([^"]*)" (?:as|from) the applicable (?:user|group) for local storage mount "([^"]*)"$/
 	 *
 	 * @param string $action

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
@@ -68,3 +68,25 @@ Feature: create local storage from the command line
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user0" should be "this is a file of user0"
     And as "user1" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "user1" should be "this is a file in local storage2"
+
+  Scenario: users should get access if all the users and groups are removed from the applicable groups
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | user2    |
+      | user3    |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp2"
+    And the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
+    And the administrator has added group "grp1" as the applicable group for local storage mount "local_storage2"
+    And the administrator has added group "grp2" as the applicable group for local storage mount "local_storage2"
+    And the administrator has added user "user3" as the applicable user for local storage mount "local_storage2"
+    When the administrator removes all from the applicable users and groups for local storage mount "local_storage2" using the occ command
+    Then as "user0" folder "/local_storage2" should exist
+    And as "user1" folder "/local_storage2" should exist
+    And as "user2" folder "/local_storage2" should exist
+    And as "user3" folder "/local_storage2" should exist


### PR DESCRIPTION
## Description
Add acceptance test to remove all from the applicable users and groups for local storage mount.

## Related Issue
Related to #36704

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
