### PR TITLE
[Tests-only] run webUI smoketests also on external user backends

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
@@ -8,13 +8,13 @@ Feature: admin apps settings
   Background:
     Given the administrator has browsed to the admin apps settings page
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: admin disables an app
     Given app "comments" has been enabled
     When the administrator disables app "comments" using the webUI
     Then app "comments" should be disabled
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: admin enables an app
     Given app "comments" has been disabled
     And the administrator has browsed to the disabled apps page

--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -8,7 +8,7 @@ Feature: admin general settings
     Given the administrator has changed their own email address to "admin@owncloud.com"
     And the administrator has browsed to the admin general settings page
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: administrator sets email server settings
     When the administrator sets the following email server settings using the webUI
       | setting                 | value          |
@@ -26,33 +26,33 @@ Feature: admin general settings
       If you received this email, the settings seem to be correct.
       """
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: administrator sets legal URLs
     When the administrator sets the value of imprint url to "imprinturl.html" using the webUI
     And the administrator logs out of the webUI
     Then the imprint url on the login page should link to "imprinturl.html"
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: administrator sets legal URLs
     When the administrator sets the value of privacy policy url to "privacy_policy.html" using the webUI
     And the administrator logs out of the webUI
     Then the privacy policy url on the login page should link to "privacy_policy.html"
 
-  @smokeTest @skipOnDockerContainerTesting
+  @smokeTest @skipOnDockerContainerTesting @TestAlsoOnExternalUserBackend
   Scenario: administrator sets update channel
     Given the administrator has invoked occ command "config:app:set core OC_Channel --value git"
     When the user reloads the current page of the webUI
     And the administrator sets the value of update channel to "daily" using the webUI
     Then the update channel should be "daily"
 
-  @smokeTest @skipOnFIREFOX @skipOnDockerContainerTesting
+  @smokeTest @skipOnFIREFOX @skipOnDockerContainerTesting @TestAlsoOnExternalUserBackend
   Scenario: administrator changes the cron job
     Given the administrator has invoked occ command "config:app:set core backgroundjobs_mode --value ajax"
     When the user reloads the current page of the webUI
     And the administrator sets the value of cron job to "webcron" using the webUI
     Then the background jobs mode should be "webcron"
 
-  @smokeTest @skipOnDockerContainerTesting
+  @smokeTest @skipOnDockerContainerTesting @TestAlsoOnExternalUserBackend
   Scenario: administrator changes the log level
     Given the administrator has invoked occ command "config:system:set loglevel --value 0"
     When the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -4,7 +4,7 @@ Feature: admin sharing settings
   I want to be able to manage sharing settings on the ownCloud server
   So that I can enable, disable, allow or restrict different sharing behaviour
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: disable share API
     Given the administrator has browsed to the admin sharing settings page
     When the administrator disables the share API using the webUI
@@ -67,7 +67,7 @@ Feature: admin sharing settings
     When the administrator enables restrict users to only share with their group members using the webUI
     Then the "share_with_group_members_only" capability of files sharing app should be "1"
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: enable share API
     Given parameter "shareapi_enabled" of app "core" has been set to "no"
     And the administrator has browsed to the admin sharing settings page

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -8,7 +8,7 @@ Feature: browse directly to details tab
     Given user "user1" has been created with default attributes and skeleton files
     And user "user1" has logged in using the webUI
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario Outline: Browse directly to the sharing details of a file
     When the user browses directly to display the "sharing" details of file "<file>" in folder "<folder>"
     Then the thumbnail should be visible in the details panel

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -10,7 +10,7 @@ Feature: Hide file/folders
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: create a hidden folder
     When the user creates a folder with the name ".xyz" using the webUI
     Then folder ".xyz" should not be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -10,7 +10,7 @@ Feature: Search
     And user "user1" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: Simple search
     When the user searches for "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -16,12 +16,12 @@ Feature: login users
     When user "user1" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: admin login
     When the administrator logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @smokeTest
+  @smokeTest @TestAlsoOnExternalUserBackend
   Scenario: admin login with invalid password
     Given the user has browsed to the login page
     When the administrator tries to login with an invalid password "%regular%" using the webUI


### PR DESCRIPTION
## Description
make all smoke tests (that make sense) to run on LDAP

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #36951

## How Has This Been Tested?
tests ran on LDAP https://drone.owncloud.com/owncloud/user_ldap/2293

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
