### PR TITLE
[Tests-Only] Add acceptance test to manage options for local storage mount

### DIFF
--- a/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
@@ -1,0 +1,28 @@
+@cli @skipOnLDAP @local_storage
+Feature: manage options for a mount using occ command
+  As an admin
+  I want to add options for a local storage mount
+  So that I can manage options for the mount
+
+  Background:
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has created the local storage mount "local_storage3"
+    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage.txt"
+    And the administrator has uploaded file with content "this is a file in local storage3" to "/local_storage3/new-file"
+
+  Scenario: add options for a local storage mount
+    When the administrator adds an option with key "enable_sharing" and value "true" for the local storage mount "local_storage2"
+    And the administrator adds an option with key "read-only" and value "1" for the local storage mount "local_storage2"
+    And the administrator adds an option with key "enable_sharing" and value "false" for the local storage mount "local_storage3"
+    And the administrator adds an option with key "read-only" and value "1" for the local storage mount "local_storage3"
+    And the administrator lists the local storage using the occ command
+    Then the following should be included in the options of local storage "/local_storage2":
+       | options              |
+       | enable_sharing: true |
+       | read-only: 1         |
+    And the following should be included in the options of local storage "/local_storage3":
+       | options               |
+       | read-only: 1          |
+    But the following should not be included in the options of local storage "/local_storage3":
+      | options               |
+      | enable_sharing: false |


### PR DESCRIPTION
## Description
Add acceptance test to add options for local storage mount using occ command

## Related Issue
#36704 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
