### PR TITLE
Remove unecessary constraint on database name

### DIFF
--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -72,9 +72,6 @@ abstract class AbstractDatabase {
 		} elseif (empty($config['dbname'])) {
 			$errors[] = $this->trans->t("%s enter the database name.", [$this->dbprettyname]);
 		}
-		if (\substr_count($config['dbname'], '.') >= 1) {
-			$errors[] = $this->trans->t("%s you may not use dots in the database name", [$this->dbprettyname]);
-		}
 		return $errors;
 	}
 


### PR DESCRIPTION
## Description

Installation of owncloud prevents database name to have dots inside.

This is not a limitation of database (Postgres and Mysql supports this).

Owncloud is adding an artificial barrier here. 

https://github.com/owncloud/core/issues/19390
https://github.com/owncloud/core/issues/20381

## Related Issue

This topic was mentioned a few time in issues, but these are locked and closed. 
- Fixes #19390
- Fixes #20381

## Motivation and Context

I'm installing broad list of services, and none of them have ever decided to enforce their own naming constraints by preventing their installation if we don't follow them. I'm using in my example the domain name of the service as database name (as another reporter of this bug did).

## How Has This Been Tested?
Installation works out of the box with dotted domain on postgres on my install... for broader tests, I don't have the time right now.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
