### PR TITLE
Test with dot in database name

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1287,7 +1287,7 @@ def acceptance():
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.1'],
-		'databases': ['postgres:10.3'],
+		'databases': ['postgres:9.4'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
 		'logLevel': '2',

--- a/.drone.star
+++ b/.drone.star
@@ -1287,7 +1287,7 @@ def acceptance():
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.1'],
-		'databases': ['mariadb:10.3'],
+		'databases': ['mariadb:10.4'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
 		'logLevel': '2',

--- a/.drone.star
+++ b/.drone.star
@@ -1287,7 +1287,7 @@ def acceptance():
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.1'],
-		'databases': ['mariadb:10.4'],
+		'databases': ['mysql:5.5'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
 		'logLevel': '2',

--- a/.drone.star
+++ b/.drone.star
@@ -1287,7 +1287,7 @@ def acceptance():
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.1'],
-		'databases': ['mariadb:10.2'],
+		'databases': ['postgres:10.3'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
 		'logLevel': '2',

--- a/.drone.star
+++ b/.drone.star
@@ -1287,7 +1287,7 @@ def acceptance():
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.1'],
-		'databases': ['mysql:5.7'],
+		'databases': ['mysql:8.0'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
 		'logLevel': '2',

--- a/.drone.star
+++ b/.drone.star
@@ -1774,7 +1774,7 @@ def getDbUsername(db):
 	if name == 'oracle':
 		return 'system'
 
-	return 'owncloud'
+	return 'owncloud.user'
 
 def getDbPassword(db):
 	name = getDbName(db)
@@ -1793,7 +1793,7 @@ def getDbDatabase(db):
 	if name == 'oracle':
 		return 'XE'
 
-	return 'owncloud'
+	return 'own.cloud.database'
 
 def getDbType(db):
 	dbName = getDbName(db)

--- a/.drone.star
+++ b/.drone.star
@@ -1287,7 +1287,7 @@ def acceptance():
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.1'],
-		'databases': ['mysql:5.5'],
+		'databases': ['mysql:5.7'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
 		'logLevel': '2',

--- a/.drone.star
+++ b/.drone.star
@@ -1287,7 +1287,7 @@ def acceptance():
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.1'],
-		'databases': ['postgres:9.4'],
+		'databases': ['mariadb:10.3'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
 		'logLevel': '2',

--- a/.drone.star
+++ b/.drone.star
@@ -1287,7 +1287,7 @@ def acceptance():
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.1'],
-		'databases': ['mysql:8.0'],
+		'databases': ['oracle'],
 		'federatedServerNeeded': False,
 		'filterTags': '',
 		'logLevel': '2',

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -72,9 +72,6 @@ abstract class AbstractDatabase {
 		} elseif (empty($config['dbname'])) {
 			$errors[] = $this->trans->t("%s enter the database name.", [$this->dbprettyname]);
 		}
-		if (\substr_count($config['dbname'], '.') >= 1) {
-			$errors[] = $this->trans->t("%s you may not use dots in the database name", [$this->dbprettyname]);
-		}
 		return $errors;
 	}
 

--- a/tests/drone/install-server.sh
+++ b/tests/drone/install-server.sh
@@ -22,13 +22,13 @@ declare -x DB_PREFIX
 [[ -z "${DB_PREFIX}" ]] && DB_PREFIX="oc_"
 
 declare -x DB_USERNAME
-[[ -z "${DB_USERNAME}" ]] && DB_USERNAME="owncloud"
+[[ -z "${DB_USERNAME}" ]] && DB_USERNAME="owncloud.user"
 
 declare -x DB_PASSWORD
 [[ -z "${DB_PASSWORD}" ]] && DB_PASSWORD="owncloud"
 
 declare -x DB_NAME
-[[ -z "${DB_NAME}" ]] && DB_NAME="owncloud"
+[[ -z "${DB_NAME}" ]] && DB_NAME="own.cloud.database"
 
 PLUGIN_DB_TIMEOUT=45
 plugin_wait_for_oracle() {


### PR DESCRIPTION
Demonstrate that a database name like `own.cloud.database` works, firstly with `mariadb:10.2` (which is what we use by default in acceptance tests)

Ref: PR #37020 

Working OK with:
- [x] mariadb:10.2 https://drone.owncloud.com/owncloud/core/23567
- [x] mariadb:10.3 https://drone.owncloud.com/owncloud/core/23573
- [x] mariadb:10.4 https://drone.owncloud.com/owncloud/core/23574
- [x] postgres:9.4 https://drone.owncloud.com/owncloud/core/23570
- [x] postgres:10.3 https://drone.owncloud.com/owncloud/core/23568
- [x] mysql:5.5 https://drone.owncloud.com/owncloud/core/23576 Note: putting emojis in comments fails https://drone.owncloud.com/owncloud/core/23576/37/13 - that is an existing problem, I expect that mysql:5.5 does not support those Unicode Emoji... characters that are in the test scenarios. Update: mysql:5.5 is not officially supported any more, so this is not an issue at all.
- [x] mysql:5.7 https://drone.owncloud.com/owncloud/core/23577
- [x] mysql:8.0 https://drone.owncloud.com/owncloud/core/23579
- [x] oracle https://drone.owncloud.com/owncloud/core/23580
(see #37025 for a run of current master acceptance tests with Oracle - the issues are existing, unrelated to "dot in database name")

(This is a chance to run the acceptance test suites with each database to anyway know that they are passing OK)