### PR TITLE
Show pending remote shares at the 'Shared with you' tab

### DIFF
--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -107,6 +107,11 @@ $application->registerRoutes($this, [
 			'verb' => 'GET'
 		],
 		[
+			'name' => 'RemoteOcs#getAllShares',
+			'url' => '/api/v1/remote_shares/all',
+			'verb' => 'GET'
+		],
+		[
 			'name' => 'RemoteOcs#getOpenShares',
 			'url' => '/api/v1/remote_shares/pending',
 			'verb' => 'GET'

--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -101,6 +101,36 @@ $application->registerRoutes($this, [
 			'url' => '/api/v1/notification/notify-public-link-by-email',
 			'verb' => 'POST'
 		],
+		[
+			'name' => 'RemoteOcs#getShares',
+			'url' => '/api/v1/remote_shares',
+			'verb' => 'GET'
+		],
+		[
+			'name' => 'RemoteOcs#getOpenShares',
+			'url' => '/api/v1/remote_shares/pending',
+			'verb' => 'GET'
+		],
+		[
+			'name' => 'RemoteOcs#acceptShare',
+			'url' => '/api/v1/remote_shares/pending/{id}',
+			'verb' => 'POST'
+		],
+		[
+			'name' => 'RemoteOcs#declineShare',
+			'url' => '/api/v1/remote_shares/pending/{id}',
+			'verb' => 'DELETE'
+		],
+		[
+			'name' => 'RemoteOcs#getShare',
+			'url' => '/api/v1/remote_shares/{id}',
+			'verb' => 'GET'
+		],
+		[
+			'name' => 'RemoteOcs#unshare',
+			'url' => '/api/v1/remote_shares/{id}',
+			'verb' => 'DELETE'
+		],
 	]
 ]);
 
@@ -118,36 +148,3 @@ $this->create('sharing_external_shareinfo', '/shareinfo')
 	->actionInclude('files_sharing/ajax/shareinfo.php');
 $this->create('sharing_external_add', '/external')
 	->actionInclude('files_sharing/ajax/external.php');
-
-// OCS API
-//TODO: SET: mail notification, waiting for PR #4689 to be accepted
-
-API::register('get',
-		'/apps/files_sharing/api/v1/remote_shares',
-		['\OCA\Files_Sharing\API\Remote', 'getShares'],
-		'files_sharing');
-
-API::register('get',
-		'/apps/files_sharing/api/v1/remote_shares/pending',
-		['\OCA\Files_Sharing\API\Remote', 'getOpenShares'],
-		'files_sharing');
-
-API::register('post',
-		'/apps/files_sharing/api/v1/remote_shares/pending/{id}',
-		['\OCA\Files_Sharing\API\Remote', 'acceptShare'],
-		'files_sharing');
-
-API::register('delete',
-		'/apps/files_sharing/api/v1/remote_shares/pending/{id}',
-		['\OCA\Files_Sharing\API\Remote', 'declineShare'],
-		'files_sharing');
-
-API::register('get',
-		'/apps/files_sharing/api/v1/remote_shares/{id}',
-		['\OCA\Files_Sharing\API\Remote', 'getShare'],
-		'files_sharing');
-
-API::register('delete',
-		'/apps/files_sharing/api/v1/remote_shares/{id}',
-		['\OCA\Files_Sharing\API\Remote', 'unshare'],
-		'files_sharing');

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -244,7 +244,7 @@
 
 			if (!!this._sharedWithUser) {
 				var remoteShares = $.ajax({
-					url: OC.linkToOCS('apps/files_sharing/api/v1') + 'remote_shares',
+					url: OC.linkToOCS('apps/files_sharing/api/v1') + 'remote_shares/all',
 					/* jshint camelcase: false */
 					data: {
 						format: 'json',
@@ -339,7 +339,7 @@
 				.map(function(share) {
 					var file = {
 						shareOwner: share.owner + '@' + share.remote.replace(/.*?:\/\//g, ""),
-						shareState: share.accepted ? OC.Share.STATE_ACCEPTED : OC.Share.STATE_PENDING,
+						shareState: !!parseInt(share.accepted) ? OC.Share.STATE_ACCEPTED : OC.Share.STATE_PENDING,
 						name: OC.basename(share.mountpoint),
 						mtime: share.mtime * 1000,
 						mimetype: share.mimetype,

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -339,7 +339,7 @@
 				.map(function(share) {
 					var file = {
 						shareOwner: share.owner + '@' + share.remote.replace(/.*?:\/\//g, ""),
-						shareState: !!parseInt(share.accepted) ? OC.Share.STATE_ACCEPTED : OC.Share.STATE_PENDING,
+						shareState: !!parseInt(share.accepted, 10) ? OC.Share.STATE_ACCEPTED : OC.Share.STATE_PENDING,
 						name: OC.basename(share.mountpoint),
 						mtime: share.mtime * 1000,
 						mimetype: share.mimetype,

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -28,9 +28,12 @@
 namespace OCA\Files_Sharing\AppInfo;
 
 use OC\AppFramework\Utility\SimpleContainer;
+use OC\Files\Filesystem;
+use OCA\Files_Sharing\Controller\RemoteOcsController;
 use OCA\Files_Sharing\Controller\Share20OcsController;
 use OCA\Files_Sharing\Controllers\ExternalSharesController;
 use OCA\Files_Sharing\Controllers\ShareController;
+use OCA\Files_Sharing\External\Manager;
 use OCA\Files_Sharing\Middleware\SharingCheckMiddleware;
 use OCA\Files_Sharing\MountProvider;
 use OCA\Files_Sharing\Notifier;
@@ -94,6 +97,24 @@ class Application extends App {
 				$c->query(NotificationPublisher::class),
 				$server->getEventDispatcher(),
 				$c->query(SharingBlacklist::class)
+			);
+		});
+
+		$container->registerService('RemoteOcsController', function (SimpleContainer $c) use ($server) {
+			$user = $server->getUserSession()->getUser();
+			$uid = $user ? $user->getUID() : null;
+			return new RemoteOcsController(
+				$c->query('AppName'),
+				$server->getRequest(),
+				new Manager(
+					$server->getDatabaseConnection(),
+					Filesystem::getMountManager(),
+					Filesystem::getLoader(),
+					$server->getNotificationManager(),
+					$server->getEventDispatcher(),
+					$uid
+				),
+				$uid
 			);
 		});
 

--- a/apps/files_sharing/lib/Controller/RemoteOcsController.php
+++ b/apps/files_sharing/lib/Controller/RemoteOcsController.php
@@ -80,11 +80,14 @@ class RemoteOcsController extends OCSController {
 	public function acceptShare($id) {
 		if ($this->externalManager->acceptShare((int) $id)) {
 			$share = $this->externalManager->getShare($id);
+			// Frontend part expects a list of accepted shares having state and mountpoint at least
 			return new Result(
-				[[
-					'state' => Share::STATE_ACCEPTED,
-					'file_target' => $share['mountpoint']
-				]]
+				[
+					[
+						'state' => Share::STATE_ACCEPTED,
+						'file_target' => $share['mountpoint']
+					]
+				]
 			);
 		}
 
@@ -191,7 +194,7 @@ class RemoteOcsController extends OCSController {
 			return new Result(null, 404, 'Share does not exist');
 		}
 
-		$mountPoint = '/' . $this->uid . '/files' . $shareInfo['mountpoint'];
+		$mountPoint = "/{$this->uid}/files{$shareInfo['mountpoint']}";
 
 		if ($this->externalManager->removeShare($mountPoint) === true) {
 			return new Result(null);

--- a/apps/files_sharing/tests/Controller/RemoteOcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/RemoteOcsControllerTest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\Tests\Controller;
+
+use OCA\Files_Sharing\Controller\RemoteOcsController;
+use OCA\Files_Sharing\External\Manager;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class RemoteOcsControllerTest extends TestCase {
+	/** @var string */
+	protected $appName = 'files_sharing';
+
+	/** @var IRequest | MockObject */
+	protected $request;
+
+	/** @var Manager */
+	protected $externalManager;
+
+	/** @var RemoteOcsController */
+	protected $controller;
+
+	protected function setUp(): void {
+		$this->request = $this->createMock(IRequest::class);
+		$this->externalManager = $this->createMock(Manager::class);
+		$this->controller = new RemoteOcsController(
+			$this->appName,
+			$this->request,
+			$this->externalManager,
+			'user'
+		);
+	}
+
+	public function testGetOpenShares() {
+		$this->externalManager->expects($this->once())
+			->method('getOpenShares')
+			->willReturn([]);
+		$result = $this->controller->getOpenShares();
+		$this->assertEquals(100, $result->getStatusCode());
+	}
+
+	public function acceptShareDataProvider() {
+		return [
+			[true, false, 100],
+			[false, true, 404]
+		];
+	}
+
+	/**
+	 * @dataProvider acceptShareDataProvider
+	 *
+	 * @param bool $acceptShareResult
+	 * @param bool $processNotificationExpected
+	 * @param int $expectedStatusCode
+	 */
+	public function testAcceptShare($acceptShareResult, $processNotificationExpected, $expectedStatusCode) {
+		$shareId = 42;
+		$this->externalManager->expects($this->once())
+			->method('acceptShare')
+			->with($shareId)
+			->willReturn($acceptShareResult);
+
+		$this->externalManager->expects($this->exactly((int) $processNotificationExpected))
+			->method('processNotification')
+			->with($shareId);
+
+		$result = $this->controller->acceptShare($shareId);
+		$this->assertEquals($expectedStatusCode, $result->getStatusCode());
+	}
+
+	public function declineShareDataProvider() {
+		return [
+			[true, false, 100],
+			[false, true, 404]
+		];
+	}
+
+	/**
+	 * @dataProvider declineShareDataProvider
+	 *
+	 * @param bool $declineShareResult
+	 * @param bool $processNotificationExpected
+	 * @param int $expectedStatusCode
+	 */
+	public function testDeclineShare($declineShareResult, $processNotificationExpected, $expectedStatusCode) {
+		$shareId = 42;
+		$this->externalManager->expects($this->once())
+			->method('declineShare')
+			->with($shareId)
+			->willReturn($declineShareResult);
+
+		$this->externalManager->expects($this->exactly((int) $processNotificationExpected))
+			->method('processNotification')
+			->with($shareId);
+
+		$result = $this->controller->declineShare($shareId);
+		$this->assertEquals($expectedStatusCode, $result->getStatusCode());
+	}
+
+	public function testGetShares() {
+		$this->externalManager->expects($this->once())
+			->method('getAcceptedShares')
+			->willReturn([]);
+		$result = $this->controller->getShares();
+		$this->assertEquals(100, $result->getStatusCode());
+	}
+
+	public function getShareDataProvider() {
+		return [
+			[false, 404],
+		];
+	}
+
+	/**
+	 * @dataProvider getShareDataProvider
+	 *
+	 * @param mixed $getShareResult
+	 * @param int $expectedStatusCode
+	 */
+	public function testGetShare($getShareResult, $expectedStatusCode) {
+		$shareId = 42;
+		$this->externalManager->expects($this->once())
+			->method('getShare')
+			->with($shareId)
+			->willReturn($getShareResult);
+
+		$result = $this->controller->getShare($shareId);
+		$this->assertEquals($expectedStatusCode, $result->getStatusCode());
+	}
+
+	public function unshareDataProvider() {
+		return [
+			[false, false, false, 404],
+			[['mountpoint' => '/foobar'], true, false, 403],
+			[['mountpoint' => '/foobar'], true, true, 100],
+		];
+	}
+
+	/**
+	 * @dataProvider unshareDataProvider
+	 *
+	 * @param mixed $getShareResult
+	 * @param bool $shouldCallUnshare
+	 * @param bool $unshareResult
+	 * @param int $expectedStatusCode
+	 */
+	public function testUnshare($getShareResult, $shouldCallUnshare, $unshareResult, $expectedStatusCode) {
+		$shareId = 42;
+		$this->externalManager->expects($this->once())
+			->method('getShare')
+			->with($shareId)
+			->willReturn($getShareResult);
+
+		$this->externalManager->expects($this->exactly((int) $shouldCallUnshare))
+			->method('removeShare')
+			->willReturn($unshareResult);
+
+		$result = $this->controller->unshare($shareId);
+		$this->assertEquals($expectedStatusCode, $result->getStatusCode());
+	}
+}

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -22,10 +22,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OCA\Files_Sharing\Tests\API;
+namespace OCA\Files_Sharing\Tests\Controller;
 
 use OC\OCS\Result;
-use OC\Share\Constants;
 use OC\Share20\Manager;
 use OCA\Files_Sharing\Controller\Share20OcsController;
 use OCA\Files_Sharing\Service\NotificationPublisher;
@@ -54,8 +53,6 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IShare;
 use OCP\Share\IAttributes as IShareAttributes;
 use OCP\Share\IManager;
-use OCP\Files\File;
-use OCP\Files\Storage;
 
 /**
  * Class Share20OcsControllerTest
@@ -160,10 +157,6 @@ class Share20OcsControllerTest extends TestCase {
 			$this->eventDispatcher,
 			$this->sharingBlacklist
 		);
-	}
-
-	public function tearDown(): void {
-		parent::tearDown();
 	}
 
 	/**

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -145,7 +145,7 @@ describe('OCA.Sharing.FileList tests', function() {
 
 			expect(fakeServer.requests[1].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'remote_shares?format=json&include_tags=true'
+				'remote_shares/all?format=json&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -226,7 +226,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			);
 			expect(fakeServer.requests[1].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'remote_shares?format=json&include_tags=true'
+				'remote_shares/all?format=json&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -312,7 +312,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			);
 			expect(fakeServer.requests[1].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'remote_shares?format=json&include_tags=true'
+				'remote_shares/all?format=json&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(

--- a/changelog/unreleased/37022
+++ b/changelog/unreleased/37022
@@ -1,0 +1,5 @@
+Bugfix: Show pending remote shares at the Shared with you tab
+
+Fixed missing pending remote shares in the file list at the Shared with you tab.
+
+https://github.com/owncloud/core/pull/37022


### PR DESCRIPTION
## Description
- [x] Remove deprecated static API class usage in favor of OcsController
- [x] Display pending remote shares at the `Shared with you` tab
- [x] Adapt accept/decline process to the remote shares

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3793

## Motivation and Context
Shared with should include pending remote shares

## How Has This Been Tested?
1. A create several  federated shares
2. As a recipient browse to the `shared with you` tab and accept/decline them

## Screenshots (if appropriate):
<img width="837" alt="shared with you" src="https://user-images.githubusercontent.com/991300/76431692-03198c80-63c3-11ea-9325-ab15295740fd.png">


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
