### PR TITLE
[Tests-Only] Combine test scenario for issue 29599 into examples table

### DIFF
--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -132,6 +132,7 @@ Feature: upload file using new chunking
     And the content of file "/<file-name>" for user "user0" should be "AAAAABBBBBCCCCC"
     Examples:
       | file-name |
+      | 0         |
       | &#?       |
       | TIÄFÜ     |
 
@@ -155,18 +156,6 @@ Feature: upload file using new chunking
       | file-name |
       | &#?       |
       | TIÄFÜ     |
-
-  # The bug for this scenario was fixed by https://github.com/owncloud/core/pull/33276
-  # The fix is released in 10.1 - all 10.0.* versions will fail this scenario
-  @skipOnOcV10.0
-  Scenario: Upload a file called "0" using new chunking
-    When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "user0" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
-    And user "user0" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
-    And user "user0" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
-    And user "user0" moves new chunk file with id "chunking-42" to "/0" using the WebDAV API
-    And as "user0" file "/0" should exist
-    And the content of file "/0" for user "user0" should be "AAAAABBBBBCCCCC"
 
   Scenario: Upload a file to a filename that is banned by default using new chunking
     When user "user0" creates a new chunking upload with id "chunking-42" using the WebDAV API


### PR DESCRIPTION
## Description
PR #31724 unskipped tests related to chunking upload of filename "0".
We can combine the special scenario for new chunking into the examples table of a scenario outline above. We do not need to have special skipping for OcV10.0 any more. (The scenario for old chunking got included into a scenario outline a while ago)

## Related Issue
- Fixes #29599

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
