### PR TITLE
[Tests-Only] Pass DB username, password and name from drone to install-server.sh

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1771,16 +1771,18 @@ def getDbName(db):
 def getDbUsername(db):
 	name = getDbName(db)
 
+	# The Oracle image has the Db Username hardcoded
 	if name == 'oracle':
-		return 'system'
+		return 'autotest'
 
 	return 'owncloud'
 
 def getDbPassword(db):
 	name = getDbName(db)
 
+	# The Oracle image has the Db Password hardcoded
 	if name == 'oracle':
-		return 'oracle'
+		return 'owncloud'
 
 	return 'owncloud'
 
@@ -1790,6 +1792,7 @@ def getDbRootPassword():
 def getDbDatabase(db):
 	name = getDbName(db)
 
+	# The Oracle image has the Db Name hardcoded
 	if name == 'oracle':
 		return 'XE'
 
@@ -1959,7 +1962,10 @@ def installServer(phpVersion, db, logLevel, federatedServerNeeded = False, proxy
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'environment': {
-			'DB_TYPE': getDbName(db)
+			'DB_TYPE': getDbName(db),
+			'DB_USERNAME': getDbUsername(db),
+			'DB_PASSWORD': getDbPassword(db),
+			'DB_NAME': getDbDatabase(db)
 		},
 		'commands': [
 			'bash tests/drone/install-server.sh',


### PR DESCRIPTION
## Description
Pass `DB_USERNAME` `DB_PASSWORD` and `DB_NAME` in environment variables to `install-server.sh` so that these can really be set flexibly in `.drone.star`

Note: the Oracle image has the Db username/password and Db name fixed (hardcoded)
https://github.com/owncloud-ci/oracle-xe/blob/master/latest/rootfs/owncloud.sql
`create user autotest identified by owncloud;`
So it is not possible to adjust those from the starlark. I have set them in the starlark to their hard-coded values for the `oracle` Db case. That way the correct hard-coded values for the `oracle` Db case get passed to `install-server.sh` 

## Related Issue
- Fixes #37028 

## How Has This Been Tested?
CI - see  PR #37029 which demonstrates setting different values in `.drone.star`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
