### PR TITLE
[Tests-Only] Run 5 apiProxy pipelines instead of 3 to reduce the elapsed run time

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -238,7 +238,7 @@ config = {
 			'useHttps': False,
 			'filterTags': '@smokeTest&&~@notifications-app-required',
 			'runAllSuites': True,
-			'numberOfParts': 3,
+			'numberOfParts': 5,
 		},
 	}
 }


### PR DESCRIPTION
## Description
The existing 3 `apiProxy` pipelines for running the smoke tests with a proxy in front of the system-under-test are taking a while to finish. In particular the 3rd pipeline is often taking >50 minutes to finish. It is often the last pipeline to finish, and so is delaying green CI for PRs.

Split into 5 parts - that will reduce the elapsed run time of each part.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
