### PR TITLE
[Tests-Only] Add acceptance test to show available backends using the occ command

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -433,6 +433,41 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * List available backends
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function listAvailableBackends() {
+		$this->invokingTheCommand('files_external:backends --output=json');
+	}
+
+	/**
+	 * List available backends of type
+	 *
+	 * @param String $type
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function listAvailableBackendsOfType($type) {
+		$this->invokingTheCommand('files_external:backends ' . $type . ' --output=json');
+	}
+
+	/**
+	 * List backend of type
+	 *
+	 * @param String $type
+	 * @param String $backend
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function listBackendOfType($type, $backend) {
+		$this->invokingTheCommand('files_external:backends ' . $type . ' ' . $backend . ' --output=json');
+	}
+
+	/**
 	 * List created local storage mount with --show-password
 	 *
 	 * @return void
@@ -1274,6 +1309,41 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @When the administrator lists the available backends using the occ command
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminListsAvailableBackendsUsingTheOccCommand() {
+		$this->listAvailableBackends();
+	}
+
+	/**
+	 * @When the administrator lists the available backends of type :type using the occ command
+	 *
+	 * @param String $type
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminListsAvailableBackendsOfTypeUsingTheOccCommand($type) {
+		$this->listAvailableBackendsOfType($type);
+	}
+
+	/**
+	 * @When the adminstrator lists the :backend backend of type :backendType using the occ command
+	 *
+	 * @param String $backend
+	 * @param String $backendType
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminListsBackendOfTypeUsingTheOccCommand($backend, $backendType) {
+		$this->listBackendOfType($backendType, $backend);
+	}
+
+	/**
 	 * @When the administrator lists configurations with the existing key :key for the local storage mount :localStorage
 	 *
 	 * @param string $key
@@ -1403,6 +1473,108 @@ class OccContext implements Context {
 				$i['localStorage'],
 				$createdLocalStorage,
 				"{$i['localStorage']} exists but was not expected to exist"
+			);
+		}
+	}
+	
+	/**
+	 * @Then the following backend types should be listed:
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theFollowingBackendTypesShouldBeListed($table) {
+		$expectedBackendTypes = $table->getColumnsHash();
+		foreach ($expectedBackendTypes as $expectedBackendTypeEntry) {
+			Assert::assertArrayHasKey(
+				'backend-type',
+				$expectedBackendTypeEntry,
+				__METHOD__
+				. " The provided expected backend type entry '"
+				. \implode(', ', $expectedBackendTypeEntry)
+				. "' do not have key 'backend-type'"
+			);
+		}
+		$commandOutput = \json_decode($this->featureContext->getStdOutOfOccCommand());
+		$keys = \array_keys((array) $commandOutput);
+		foreach ($expectedBackendTypes as $backendTypesEntry) {
+			Assert::assertContains(
+				$backendTypesEntry['backend-type'],
+				$keys,
+				__METHOD__
+				. " ${backendTypesEntry['backend-type']} is not contained in '"
+				. \implode(', ', $keys)
+				. "' but was expected to be."
+			);
+		}
+	}
+
+	/**
+	 * @Then the following authentication/storage backends should be listed:
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theFollowingBackendsShouldBeListed($table) {
+		$expectedBackends = $table->getColumnsHash();
+		foreach ($expectedBackends as $expectedBackendEntry) {
+			Assert::assertArrayHasKey(
+				'backends',
+				$expectedBackendEntry,
+				__METHOD__
+				. " The provided expected backend entry '"
+				. \implode(', ', $expectedBackendEntry)
+				. "' do not have key 'backends'"
+			);
+		}
+		$commandOutput = \json_decode($this->featureContext->getStdOutOfOccCommand());
+		$keys = \array_keys((array) $commandOutput);
+		foreach ($expectedBackends as $backendsEntry) {
+			Assert::assertContains(
+				$backendsEntry['backends'],
+				$keys,
+				__METHOD__
+				. " ${backendsEntry['backends']} is not contained in '"
+				. \implode(', ', $keys)
+				. "' but was expected to be."
+			);
+		}
+	}
+
+	/**
+	 * @Then the following authentication/storage backend keys should be listed:
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theFollowingBackendKeysOfTypeShouldBeListed($table) {
+		$expectedBackendKeys = $table->getColumnsHash();
+		foreach ($expectedBackendKeys as $expectedBackendKeyEntry) {
+			Assert::assertArrayHasKey(
+				'backend-keys',
+				$expectedBackendKeyEntry,
+				__METHOD__
+				. " The provided expected backend key entry '"
+				. \implode(', ', $expectedBackendKeyEntry)
+				. "' do not have key 'backend-keys'"
+			);
+		}
+		$commandOutput = \json_decode($this->featureContext->getStdOutOfOccCommand());
+		$keys = \array_keys((array) $commandOutput);
+		foreach ($expectedBackendKeys as $backendKeysEntry) {
+			Assert::assertContains(
+				$backendKeysEntry['backend-keys'],
+				$keys,
+				__METHOD__
+				. " ${backendKeysEntry['backend-keys']} is not contained in '"
+				. \implode(', ', $keys)
+				. "' but was expected to be."
 			);
 		}
 	}

--- a/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
+++ b/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
@@ -1,0 +1,83 @@
+@cli @skipOnLDAP @local_storage
+Feature: show available backends using occ command
+  As an admin
+  I want to list backends
+  So that I can manage available backends for created local storage
+
+  Background:
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "file in local storage" to "/local_storage2/file-in-local-storage.txt"
+
+  Scenario: list available backends for created local storage
+    When the administrator lists the available backends using the occ command
+    Then the following backend types should be listed:
+      | backend-type   |
+      | authentication |
+      | storage        |
+
+  Scenario: list available backends of type authentication for created local storage
+    When the administrator lists the available backends of type "authentication" using the occ command
+    Then the following authentication backends should be listed:
+      | backends                     |
+      | password::sessioncredentials |
+      | null::null                   |
+      | builtin::builtin             |
+      | password::password           |
+      | oauth1::oauth1               |
+      | oauth2::oauth2               |
+      | publickey::rsa               |
+      | openstack::openstack         |
+      | openstack::rackspace         |
+
+  Scenario: list available backends of type storage for created local storage
+    When the administrator lists the available backends of type "storage" using the occ command
+    Then the following storage backends should be listed:
+      | backends                   |
+      | dav                        |
+      | owncloud                   |
+      | sftp                       |
+      | googledrive                |
+      | \OC\Files\Storage\SFTP_Key |
+      | smb                        |
+      | \OC\Files\Storage\SMB_OC   |
+      | local                      |
+
+  Scenario Outline: list specific backend of type storage for created local storage
+    When the adminstrator lists the "<backend>" backend of type "storage" using the occ command
+    Then the following storage backend keys should be listed:
+      | backend-keys                      |
+      | name                              |
+      | identifier                        |
+      | configuration                     |
+      | storage_class                     |
+      | supported_authentication_backends |
+      | authentication_configuration      |
+    Examples:
+      | backend                    |
+      | dav                        |
+      | owncloud                   |
+      | sftp                       |
+      | googledrive                |
+      | \OC\Files\Storage\SFTP_Key |
+      | smb                        |
+      | \OC\Files\Storage\SMB_OC   |
+      | local                      |
+
+  Scenario Outline: list specific backend of type authentication for created local storage
+    When the adminstrator lists the "<backend>" backend of type "authentication" using the occ command
+    Then the following authentication backend keys should be listed:
+      | backend-keys  |
+      | name          |
+      | identifier    |
+      | configuration |
+    Examples:
+      | backend                      |
+      | password::sessioncredentials |
+      | null::null                   |
+      | builtin::builtin             |
+      | password::password           |
+      | oauth1::oauth1               |
+      | oauth2::oauth2               |
+      | publickey::rsa               |
+      | openstack::openstack         |
+      | openstack::rackspace         |


### PR DESCRIPTION
## Description
This PR adds acceptance test to show available authentication and storage backends using the occ command

## Related Issue
#36704 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
