### PR TITLE
[Tests-Only] Add .drone.yml to .gitignore so people do not accidentally commit it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ clover.xml
 
 # CI
 .cache
+
+# Generated from .drone.star
+.drone.yml


### PR DESCRIPTION
## Description
We changed to using `.drone.star`  directly on the drone server.

If developers are locally doing `drone starlark --source .drone.star` to locally generate a  `.drone.yml` then we do not want it to get accidentally committed in a PR. (They might be doing that just to see if the starlark works...)

Add `.drone.yml` to `.gitignore`

## How Has This Been Tested?
Create `.drone.yml` locally
`git status`
It is not seen as a file to add to git

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
