### PR TITLE
Initialize the user before transfer-ownership

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -121,12 +121,6 @@ class TransferOwnership extends Command {
 				null,
 				InputOption::VALUE_REQUIRED,
 				'selectively provide the path to transfer. For example --path="folder_name"'
-			)
-			->addOption(
-				'force-user-init',
-				null,
-				InputOption::VALUE_NONE,
-				'force the initialization of the destination user if he hasn\'t logged in yet'
 			);
 	}
 
@@ -149,16 +143,11 @@ class TransferOwnership extends Command {
 
 		// target user has to be ready
 		if ($destinationUserObject->getLastLogin() === 0) {
-			if ($input->getOption('force-user-init')) {
-				// based on \OC\User\Session->prepareUserLogin
-				\OC_Util::setupFS($this->destinationUser);
-				$userFolder = $this->rootFolder->getUserFolder($this->destinationUser);
-				\OC_Util::copySkeleton($this->destinationUser, $userFolder);  // exceptions might be thrown here
-				\OC_Util::tearDownFS();
-			} else {
-				$output->writeln("<error>Cannot transfer to $this->destinationUser because the user hasn't logged in</error>");
-				return 1;
-			}
+			// based on \OC\User\Session->prepareUserLogin
+			\OC_Util::setupFS($this->destinationUser);
+			$userFolder = $this->rootFolder->getUserFolder($this->destinationUser);
+			\OC_Util::copySkeleton($this->destinationUser, $userFolder);  // exceptions might be thrown here
+			\OC_Util::tearDownFS();
 		}
 		if (!$this->encryptionManager->isReadyForUser($this->destinationUser)) {
 			$output->writeln("<error>The target user is not ready to accept files. The user has at least to be logged in once.</error>");

--- a/apps/files/tests/Command/TransferOwnershipTest.php
+++ b/apps/files/tests/Command/TransferOwnershipTest.php
@@ -228,22 +228,11 @@ class TransferOwnershipTest extends TestCase {
 		$this->assertCount($expectedTargetShareCount, $targetShares);
 	}
 
-	public function testTransferToUnloggedUser() {
+	public function testTransferAllFilesToUnlogged() {
 		$this->encryptionManager->method('isReadyForUser')->willReturn(true);
 		$input = [
 			'source-user' => $this->sourceUser->getUID(),
 			'destination-user' => $this->unloggedUser->getUID(),
-		];
-		$this->commandTester->execute($input);
-		$this->assertSame(1, $this->commandTester->getStatusCode());
-	}
-
-	public function testTransferAllFilesToUnloggedUserForcing() {
-		$this->encryptionManager->method('isReadyForUser')->willReturn(true);
-		$input = [
-			'source-user' => $this->sourceUser->getUID(),
-			'destination-user' => $this->unloggedUser->getUID(),
-			'--force-user-init' => null,
 		];
 		$this->commandTester->execute($input);
 		$this->assertSame(0, $this->commandTester->getStatusCode());

--- a/apps/files/tests/Command/TransferOwnershipTest.php
+++ b/apps/files/tests/Command/TransferOwnershipTest.php
@@ -25,6 +25,7 @@ use OC\Encryption\Manager;
 use OC\Share20\ProviderFactory;
 use OCA\Files\Command\TransferOwnership;
 use OCP\Files\Mount\IMountManager;
+use OCP\Files\IRootFolder;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Share;
@@ -58,6 +59,8 @@ class TransferOwnershipTest extends TestCase {
 	 * @var IMountManager
 	 */
 	private $mountManager;
+	/** @var IRootFolder */
+	private $rootFolder;
 
 	/**
 	 * @var Manager | MockObject
@@ -89,11 +92,13 @@ class TransferOwnershipTest extends TestCase {
 		$this->userManager = \OC::$server->getUserManager();
 		$this->shareManager = \OC::$server->getShareManager();
 		$this->mountManager = \OC::$server->getMountManager();
+		$this->rootFolder = \OC::$server->getRootFolder();
 		$this->encryptionManager = $this->createMock(Manager::class);
 		$this->providerFactory = new ProviderFactory(\OC::$server);
 
 		$this->sourceUser = $this->createUser('source-user');
 		$this->targetUser = $this->createUser('target-user');
+		$this->unloggedUser = $this->createUser('unlogged-user');
 		$this->loginAsUser('source-user');
 		$this->logout();
 		$this->loginAsUser('target-user');
@@ -105,6 +110,7 @@ class TransferOwnershipTest extends TestCase {
 			$this->userManager,
 			$this->shareManager,
 			$this->mountManager,
+			$this->rootFolder,
 			$this->encryptionManager,
 			$this->providerFactory
 		);
@@ -115,6 +121,7 @@ class TransferOwnershipTest extends TestCase {
 		$this->shareManager->userDeleted('share-receiver');
 		$this->shareManager->userDeleted($this->sourceUser->getUID());
 		$this->shareManager->userDeleted($this->targetUser->getUID());
+		$this->shareManager->userDeleted($this->unloggedUser->getUID());
 		parent::tearDown();
 	}
 
@@ -219,5 +226,33 @@ class TransferOwnershipTest extends TestCase {
 		$targetShares = $this->shareManager->getSharesBy($this->targetUser->getUID(), Share::SHARE_TYPE_USER);
 		$this->assertCount($expectedSourceShareCount, $sourceShares);
 		$this->assertCount($expectedTargetShareCount, $targetShares);
+	}
+
+	public function testTransferToUnloggedUser() {
+		$this->encryptionManager->method('isReadyForUser')->willReturn(true);
+		$input = [
+			'source-user' => $this->sourceUser->getUID(),
+			'destination-user' => $this->unloggedUser->getUID(),
+		];
+		$this->commandTester->execute($input);
+		$this->assertSame(1, $this->commandTester->getStatusCode());
+	}
+
+	public function testTransferAllFilesToUnloggedUserForcing() {
+		$this->encryptionManager->method('isReadyForUser')->willReturn(true);
+		$input = [
+			'source-user' => $this->sourceUser->getUID(),
+			'destination-user' => $this->unloggedUser->getUID(),
+			'--force-user-init' => null,
+		];
+		$this->commandTester->execute($input);
+		$this->assertSame(0, $this->commandTester->getStatusCode());
+		$output = $this->commandTester->getDisplay();
+
+		$this->assertStringContainsString('Transferring files to unlogged-user', $output);
+		$sourceShares = $this->shareManager->getSharesBy($this->sourceUser->getUID(), Share::SHARE_TYPE_USER);
+		$targetShares = $this->shareManager->getSharesBy($this->unloggedUser->getUID(), Share::SHARE_TYPE_USER);
+		$this->assertCount(0, $sourceShares);
+		$this->assertCount(4, $targetShares);
 	}
 }

--- a/changelog/unreleased/37038
+++ b/changelog/unreleased/37038
@@ -1,0 +1,9 @@
+Bugfix: Initialize the user before the transfer command
+
+Trying to transfer the ownership of files to a user who hadn't logged in was causing problems
+because the FS of such user wasn't initialized and it wasn't possible to move the files there.
+The command appeared to work, but the files weren't moved.
+
+Now such user has the FS initialized so the transfer can be completed normally.
+
+https://github.com/owncloud/core/pull/37038


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Initialize the user's FS if he hasn't logged in yet before transferring files to him.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/enterprise/issues/3819

## Motivation and Context
Transfer was failing silently. The command output didn't show any error but the transfer failed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

2. Create 2 users, user1 and user2 (local users)
3. Upload some files to user1
4. Without having logged in once with user2, execute `occ files:transfer-ownership user1 user2`
5. Files are transferred correctly to the user2

Checked also with master-key encryption **but not user-key encryption**

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
