### PR TITLE
[Tests-Only] Unset skeletondirectory after UtilTest exception

### DIFF
--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -16,6 +16,8 @@ use OCP\App\IAppManager;
  * @group DB
  */
 class UtilTest extends \Test\TestCase {
+	public $skeletonDirectoryWasSet = false;
+
 	public function testGetVersion() {
 		$version = \OCP\Util::getVersion();
 		$this->assertIsArray($version);
@@ -377,10 +379,9 @@ class UtilTest extends \Test\TestCase {
 
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('skeletondirectory', '/not/existing/Directory');
+		$this->skeletonDirectoryWasSet = true;
 		$userFolder = $this->createMock(Folder::class);
 		\OC_Util::copySkeleton('testuser', $userFolder);
-
-		$config->deleteSystemValue('skeletondirectory');
 	}
 
 	/**
@@ -400,10 +401,9 @@ class UtilTest extends \Test\TestCase {
 		\chmod($skeletonDir, 0);
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('skeletondirectory', $skeletonDir);
+		$this->skeletonDirectoryWasSet = true;
 		$userFolder = $this->createMock(Folder::class);
 		\OC_Util::copySkeleton('testuser', $userFolder);
-
-		$config->deleteSystemValue('skeletondirectory');
 	}
 
 	/**
@@ -423,10 +423,9 @@ class UtilTest extends \Test\TestCase {
 		\chmod($skeletonDir . '/a-file', 0);
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('skeletondirectory', $skeletonDir);
+		$this->skeletonDirectoryWasSet = true;
 		$userFolder = $this->createMock(Folder::class);
 		\OC_Util::copySkeleton('testuser', $userFolder);
-
-		$config->deleteSystemValue('skeletondirectory');
 	}
 
 	protected function setUp(): void {
@@ -440,6 +439,11 @@ class UtilTest extends \Test\TestCase {
 
 		\OC_Util::$scripts = [];
 		\OC_Util::$styles = [];
+
+		if ($this->skeletonDirectoryWasSet) {
+			$config = \OC::$server->getConfig();
+			$config->deleteSystemValue('skeletondirectory');
+		}
 	}
 
 	public function testAddScript() {


### PR DESCRIPTION
## Description
See https://github.com/owncloud/core/pull/37038#issuecomment-592005411

`tests/lib/UtilTest.php` has some tests that purposely create a skeleton directory with no read access. They expect an exception when trying to create a user with skeleton. At the end of the test they (try) to delete the skeleton directory setting (cleanup the mess they purposely made).

But the expected exception is thrown before that point, so the "cleanup" code never runs. This leaves a bad skeleton directory setting that might cause later tests to fail.

Move the cleanup code into the `tearDown()` method so that it gets run after the expected exception has happened.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [x] Unit tests added (changed)
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
