### PR TITLE
[Tests-Only] Change acceptance test steps to consistently say 'in the trashbin'

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -95,8 +95,8 @@ Feature: sharing
     Then the HTTP status code should be "204"
     And as "user1" file "/shared/shared_file.txt" should not exist
     And as "user0" file "/shared/shared_file.txt" should not exist
-    And as "user0" file "/shared_file.txt" should exist in trash
-    And as "user1" file "/shared_file.txt" should exist in trash
+    And as "user0" file "/shared_file.txt" should exist in the trashbin
+    And as "user1" file "/shared_file.txt" should exist in the trashbin
 
   @files_trashbin-app-required
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
@@ -111,10 +111,10 @@ Feature: sharing
     Then the HTTP status code should be "204"
     And as "user1" folder "/shared/sub" should not exist
     And as "user0" folder "/shared/sub" should not exist
-    And as "user0" folder "/sub" should exist in trash
-    And as "user0" file "/sub/shared_file.txt" should exist in trash
-    And as "user1" folder "/sub" should exist in trash
-    And as "user1" file "/sub/shared_file.txt" should exist in trash
+    And as "user0" folder "/sub" should exist in the trashbin
+    And as "user0" file "/sub/shared_file.txt" should exist in the trashbin
+    And as "user1" folder "/sub" should exist in the trashbin
+    And as "user1" file "/sub/shared_file.txt" should exist in the trashbin
 
   @smokeTest
   Scenario: unshare from self

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -30,7 +30,7 @@ Feature: sharing
     When user "user1" moves file "/shared_renamed/shared_file.txt" to "/taken_out.txt" using the WebDAV API
     Then as "user1" file "/taken_out.txt" should exist
     And as "user0" file "/shared/shared_file.txt" should not exist
-    And as "user0" file "/shared_file.txt" should exist in trash
+    And as "user0" file "/shared_file.txt" should exist in the trashbin
     Examples:
       | dav-path-version |
       | old              |
@@ -47,8 +47,8 @@ Feature: sharing
     When user "user1" moves folder "/shared_renamed/sub" to "/taken_out" using the WebDAV API
     Then as "user1" file "/taken_out" should exist
     And as "user0" folder "/shared/sub" should not exist
-    And as "user0" folder "/sub" should exist in trash
-    And as "user0" file "/sub/shared_file.txt" should exist in trash
+    And as "user0" folder "/sub" should exist in the trashbin
+    And as "user0" file "/sub/shared_file.txt" should exist in the trashbin
     Examples:
       | dav-path-version |
       | old              |

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -19,11 +19,11 @@ Feature: files and folders can be deleted from the trashbin
     Given using <dav-path> DAV path
     And user "user0" has deleted file "/textfile0.txt"
     And user "user0" has deleted file "/textfile1.txt"
-    And as "user0" file "/textfile0.txt" should exist in trash
-    And as "user0" file "/textfile1.txt" should exist in trash
+    And as "user0" file "/textfile0.txt" should exist in the trashbin
+    And as "user0" file "/textfile1.txt" should exist in the trashbin
     When user "user0" empties the trashbin using the trashbin API
-    Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
-    And as "user0" the file with original path "/textfile1.txt" should not exist in trash
+    Then as "user0" the file with original path "/textfile0.txt" should not exist in the trashbin
+    And as "user0" the file with original path "/textfile1.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -37,10 +37,10 @@ Feature: files and folders can be deleted from the trashbin
     And user "user0" has deleted file "/PARENT/CHILD/child.txt"
     When user "user0" deletes the file with original path "textfile1.txt" from the trashbin using the trashbin API
     Then the HTTP status code should be "204"
-    And as "user0" the file with original path "/textfile1.txt" should not exist in trash
-    But as "user0" the file with original path "/textfile0.txt" should exist in trash
-    And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
-    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+    And as "user0" the file with original path "/textfile1.txt" should not exist in the trashbin
+    But as "user0" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "user0" the file with original path "/PARENT/parent.txt" should exist in the trashbin
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
 
   @smokeTest
   Scenario: delete multiple files from the trashbin and make sure the correct ones are gone
@@ -54,10 +54,10 @@ Feature: files and folders can be deleted from the trashbin
     And user "user0" has deleted file "/PARENT/CHILD/child.txt"
     When user "user0" deletes the file with original path "/PARENT/textfile0.txt" from the trashbin using the trashbin API
     And user "user0" deletes the file with original path "/PARENT/CHILD/child.txt" from the trashbin using the trashbin API
-    Then as "user0" the file with original path "/PARENT/textfile0.txt" should not exist in trash
-    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should not exist in trash
-    But as "user0" the file with original path "/textfile0.txt" should exist in trash
-    And as "user0" the file with original path "/PARENT/child.txt" should exist in trash
+    Then as "user0" the file with original path "/PARENT/textfile0.txt" should not exist in the trashbin
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should not exist in the trashbin
+    But as "user0" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "user0" the file with original path "/PARENT/child.txt" should exist in the trashbin
 
   @skipOnOcV10.3
   Scenario: User tries to delete another user's trashbin
@@ -68,10 +68,10 @@ Feature: files and folders can be deleted from the trashbin
     And user "user0" has deleted file "/PARENT/CHILD/child.txt"
     When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the trashbin API
     Then the HTTP status code should be "401"
-    And as "user0" the file with original path "/textfile1.txt" should exist in trash
-    And as "user0" the file with original path "/textfile0.txt" should exist in trash
-    And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
-    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+    And as "user0" the file with original path "/textfile1.txt" should exist in the trashbin
+    And as "user0" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "user0" the file with original path "/PARENT/parent.txt" should exist in the trashbin
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
 
   Scenario: User tries to delete trashbin file using invalid password
     Given user "user1" has been created with default attributes and without skeleton files
@@ -81,10 +81,10 @@ Feature: files and folders can be deleted from the trashbin
     And user "user0" has deleted file "/PARENT/CHILD/child.txt"
     When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the password "invalid" and the trashbin API
     Then the HTTP status code should be "401"
-    And as "user0" the file with original path "/textfile1.txt" should exist in trash
-    And as "user0" the file with original path "/textfile0.txt" should exist in trash
-    And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
-    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+    And as "user0" the file with original path "/textfile1.txt" should exist in the trashbin
+    And as "user0" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "user0" the file with original path "/PARENT/parent.txt" should exist in the trashbin
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
 
   Scenario: User tries to delete trashbin file using no password
     Given user "user1" has been created with default attributes and without skeleton files
@@ -94,7 +94,7 @@ Feature: files and folders can be deleted from the trashbin
     And user "user0" has deleted file "/PARENT/CHILD/child.txt"
     When user "user1" tries to delete the file with original path "textfile1.txt" from the trashbin of user "user0" using the password "" and the trashbin API
     Then the HTTP status code should be "401"
-    And as "user0" the file with original path "/textfile1.txt" should exist in trash
-    And as "user0" the file with original path "/textfile0.txt" should exist in trash
-    And as "user0" the file with original path "/PARENT/parent.txt" should exist in trash
-    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in trash
+    And as "user0" the file with original path "/textfile1.txt" should exist in the trashbin
+    And as "user0" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "user0" the file with original path "/PARENT/parent.txt" should exist in the trashbin
+    And as "user0" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -13,7 +13,7 @@ Feature: files and folders exist in the trashbin after being deleted
   Scenario Outline: deleting a file moves it to trashbin
     Given using <dav-path> DAV path
     When user "user0" deletes file "/textfile0.txt" using the WebDAV API
-    Then as "user0" file "/textfile0.txt" should exist in trash
+    Then as "user0" file "/textfile0.txt" should exist in the trashbin
     But as "user0" file "/textfile0.txt" should not exist
     Examples:
       | dav-path |
@@ -25,7 +25,7 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "user0" has created folder "/tmp"
     When user "user0" deletes folder "/tmp" using the WebDAV API
-    Then as "user0" folder "/tmp" should exist in trash
+    Then as "user0" folder "/tmp" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -36,8 +36,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has created folder "/new-folder"
     And user "user0" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     When user "user0" deletes file "/new-folder/new-file.txt" using the WebDAV API
-    Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in trash
-    And as "user0" file "/new-file.txt" should exist in trash
+    Then as "user0" the file with original path "/new-folder/new-file.txt" should exist in the trashbin
+    And as "user0" file "/new-file.txt" should exist in the trashbin
     But as "user0" file "/new-folder/new-file.txt" should not exist
     Examples:
       | dav-path |
@@ -52,8 +52,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user0" deletes file "/shared/shared_file.txt" using the WebDAV API
-    Then as "user0" the file with original path "/shared/shared_file.txt" should exist in trash
-    And as "user0" file "/shared_file.txt" should exist in trash
+    Then as "user0" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    And as "user0" file "/shared_file.txt" should exist in the trashbin
     But as "user0" file "/shared/shared_file.txt" should not exist
     Examples:
       | dav-path |
@@ -68,7 +68,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "user0" has shared folder "/shared" with user "user1"
     When user "user0" deletes folder "/shared" using the WebDAV API
-    Then as "user0" the folder with original path "/shared" should exist in trash
+    Then as "user0" the folder with original path "/shared" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -83,7 +83,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has shared folder "/shared" with user "user1"
     And user "user1" has moved folder "/shared" to "/renamed_shared"
     When user "user1" deletes folder "/renamed_shared" using the WebDAV API
-    Then as "user1" the folder with original path "/renamed_shared" should not exist in trash
+    Then as "user1" the folder with original path "/renamed_shared" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -98,7 +98,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has shared folder "/shared" with user "user1"
     And user "user1" has moved file "/shared" to "/renamed_shared"
     When user "user1" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
-    Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in trash
+    Then as "user1" the file with original path "/renamed_shared/shared_file.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -126,11 +126,11 @@ Feature: files and folders exist in the trashbin after being deleted
       | /folderC/textfile0.txt |
       | /folderD/textfile0.txt |
     # When issue-23151 is fixed, uncomment these lines. They should pass reliably.
-    #Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
-    #And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
-    #And as "user0" the folder with original path "/folderC/textfile0.txt" should exist in trash
-    #And as "user0" the folder with original path "/folderD/textfile0.txt" should exist in trash
-    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+    #Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
+    #And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
+    #And as "user0" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
+    #And as "user0" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
+    And as "user0" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -146,9 +146,9 @@ Feature: files and folders exist in the trashbin after being deleted
     When user "user0" deletes file "/folderA/textfile0.txt" using the WebDAV API
     And user "user0" deletes file "/folderB/textfile0.txt" using the WebDAV API
     And user "user0" deletes file "/textfile0.txt" using the WebDAV API
-    Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in trash
-    And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in trash
-    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+    Then as "user0" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
+    And as "user0" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
+    And as "user0" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -163,7 +163,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     When user "user0" deletes folder "/local_storage/tmp" using the WebDAV API
-    Then as "user0" the folder with original path "/local_storage/tmp" should exist in trash
+    Then as "user0" the folder with original path "/local_storage/tmp" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -22,7 +22,7 @@ Feature: Restore deleted files/folders
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9]{1,32}"$/ |
-    And as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in trash
+    And as "user1" the file with original path "/renamed_shared/shared_file.txt" should not exist in the trashbin
     And user "user1" should see the following elements
       | /renamed_shared/                |
       | /renamed_shared/shared_file.txt |
@@ -42,12 +42,12 @@ Feature: Restore deleted files/folders
     And user "user0" has uploaded file with content "to delete" to "/textfile3.txt"
     And user "user0" has uploaded file with content "to delete" to "/textfile4.txt"
     And user "user0" has deleted file "/textfile0.txt"
-    And as "user0" file "/textfile0.txt" should exist in trash
+    And as "user0" file "/textfile0.txt" should exist in the trashbin
     When user "user0" restores the folder with original path "/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9]{1,32}"$/ |
-    And as "user0" the folder with original path "/textfile0.txt" should not exist in trash
+    And as "user0" the folder with original path "/textfile0.txt" should not exist in the trashbin
     And user "user0" should see the following elements
       | /FOLDER/           |
       | /PARENT/           |
@@ -69,7 +69,7 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted file "/new-folder/new-file.txt"
     When user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in the trashbin
     And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
       | dav-path |
@@ -85,7 +85,7 @@ Feature: Restore deleted files/folders
     When user "user0" restores the folder with original path "/new-folder" using the trashbin API
     And user "user0" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in the trashbin
     And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
       | dav-path |
@@ -103,7 +103,7 @@ Feature: Restore deleted files/folders
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9]{1,32}"$/ |
-    And as "user0" the file with original path "<delete-path>" should not exist in trash
+    And as "user0" the file with original path "<delete-path>" should not exist in the trashbin
     And as "user0" file "<restore-path>" should exist
     And as "user0" file "<delete-path>" should not exist
     Examples:
@@ -126,7 +126,7 @@ Feature: Restore deleted files/folders
     # Sometimes "/PARENT/textfile0.txt" is found in the trashbin. Should it? Or not?
     # That seems to be what happens when the restore-overwrite happens properly,
     # The original /PARENT/textfile0.txt seems to be "deleted" and so goes to the trashbin
-    #And as "user0" the file with original path "/PARENT/textfile0.txt" should not exist in trash
+    #And as "user0" the file with original path "/PARENT/textfile0.txt" should not exist in the trashbin
     And as "user0" file "/PARENT/textfile0.txt" should exist
     # sometimes the restore from trashbin does overwrite the existing file, but sometimes it does not. That is also surprising.
     # the current observed behavior is that if the original /PARENT/textfile0.txt ended up in the trashbin,
@@ -150,8 +150,8 @@ Feature: Restore deleted files/folders
     When user "user0" restores the file with original path "/textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
     #Then the HTTP status code should be "403"
-    And as "user0" the file with original path "/textfile0.txt" should not exist in trash
-    #And as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" the file with original path "/textfile0.txt" should not exist in the trashbin
+    #And as "user0" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "user0" file "/shareFolderParent/textfile0.txt" should exist
     #And as "user0" file "/shareFolderParent/textfile0.txt" should not exist
     And as "user1" file "/shareFolderParent/textfile0.txt" should exist
@@ -173,8 +173,8 @@ Feature: Restore deleted files/folders
     When user "user0" restores the file with original path "/textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
     #Then the HTTP status code should be "403"
-    And as "user0" the file with original path "/textfile0.txt" should not exist in trash
-    #And as "user0" the file with original path "/textfile0.txt" should exist in trash
+    And as "user0" the file with original path "/textfile0.txt" should not exist in the trashbin
+    #And as "user0" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "user0" file "/shareFolderParent/shareFolderChild/textfile0.txt" should exist
     #And as "user0" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     And as "user1" file "/shareFolderParent/shareFolderChild/textfile0.txt" should exist
@@ -195,7 +195,7 @@ Feature: Restore deleted files/folders
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9]{1,32}"$/ |
-    And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in trash
+    And as "user0" the file with original path "/new-folder/new-file.txt" should not exist in the trashbin
     And as "user0" file "/new-folder/new-file.txt" should exist
     Examples:
       | dav-path |
@@ -211,12 +211,12 @@ Feature: Restore deleted files/folders
     And user "user0" has created folder "/local_storage/tmp"
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
-    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in the trashbin
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9]{1,32}"$/ |
-    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And user "user0" should see the following elements
       | /local_storage/                  |
       | /local_storage/tmp/              |
@@ -236,10 +236,10 @@ Feature: Restore deleted files/folders
     And user "user0" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
-    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in the trashbin
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"
 
   @local_storage
@@ -254,10 +254,10 @@ Feature: Restore deleted files/folders
       | number | content |
       | 1      | AA      |
     And user "user0" has deleted file "/local_storage/tmp/textfile0.txt"
-    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in the trashbin
     When user "user0" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in trash
+    And as "user0" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the downloaded content when downloading file "/local_storage/tmp/textfile0.txt" for user "user0" with range "bytes=0-1" should be "AA"
 
   @smokeTest @skipOnOcV10.3
@@ -267,7 +267,7 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted file "/textfile0.txt"
     When user "user1" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the trashbin API
     Then the HTTP status code should be "401"
-    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/textfile0.txt" should exist in the trashbin
     And user "user0" should not see the following elements
       | /textfile0.txt |
     Examples:
@@ -282,7 +282,7 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted file "/textfile0.txt"
     When user "user0" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the password "invalid" and the trashbin API
     Then the HTTP status code should be "401"
-    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/textfile0.txt" should exist in the trashbin
     And user "user0" should not see the following elements
       | /textfile0.txt |
     Examples:
@@ -297,7 +297,7 @@ Feature: Restore deleted files/folders
     And user "user0" has deleted file "/textfile0.txt"
     When user "user0" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "user0" using the password "" and the trashbin API
     Then the HTTP status code should be "401"
-    And as "user0" the folder with original path "/textfile0.txt" should exist in trash
+    And as "user0" the folder with original path "/textfile0.txt" should exist in the trashbin
     And user "user0" should not see the following elements
       | /textfile0.txt |
     Examples:

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -410,7 +410,7 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" (?:file|folder|entry) "([^"]*)" should exist in trash$/
+	 * @Then /^as "([^"]*)" (?:file|folder|entry) "([^"]*)" should exist in the trashbin$/
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -463,7 +463,7 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * Function to check if an element is in trashbin
+	 * Function to check if an element is in the trashbin
 	 *
 	 * @param string $user
 	 * @param string $originalPath
@@ -631,7 +631,7 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (?:file|folder|entry) with original path "([^"]*)" should exist in trash$/
+	 * @Then /^as "([^"]*)" the (?:file|folder|entry) with original path "([^"]*)" should exist in the trashbin$/
 	 *
 	 * @param string $user
 	 * @param string $originalPath
@@ -648,7 +648,7 @@ class TrashbinContext implements Context {
 	}
 
 	/**
-	 * @Then /^as "([^"]*)" the (?:file|folder|entry) with original path "([^"]*)" should not exist in trash$/
+	 * @Then /^as "([^"]*)" the (?:file|folder|entry) with original path "([^"]*)" should not exist in the trashbin/
 	 *
 	 * @param string $user
 	 * @param string $originalPath

--- a/tests/acceptance/features/cliTrashbin/trashbin.feature
+++ b/tests/acceptance/features/cliTrashbin/trashbin.feature
@@ -12,9 +12,9 @@ Feature: files and folders can be deleted from the trashbin
     When the administrator empties the trashbin of user "user0" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Remove deleted files of   user0'
-    Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
-    And as "user0" the file with original path "/textfile1.txt" should not exist in trash
-    And as "user0" the folder with original path "/PARENT" should not exist in trash
+    Then as "user0" the file with original path "/textfile0.txt" should not exist in the trashbin
+    And as "user0" the file with original path "/textfile1.txt" should not exist in the trashbin
+    And as "user0" the folder with original path "/PARENT" should not exist in the trashbin
 
   Scenario: delete files and folder of all user from the trashbin
     Given user "user0" has been created with default attributes and skeleton files
@@ -25,6 +25,6 @@ Feature: files and folders can be deleted from the trashbin
     When the administrator empties the trashbin of all users using the occ command
     Then the command should have been successful
     And the command output should contain the text "Remove all deleted files"
-    Then as "user0" the file with original path "/textfile0.txt" should not exist in trash
-    And as "user1" the file with original path "/textfile1.txt" should not exist in trash
-    And as "user1" the folder with original path "/PARENT" should not exist in trash
+    Then as "user0" the file with original path "/textfile0.txt" should not exist in the trashbin
+    And as "user1" the file with original path "/textfile1.txt" should not exist in the trashbin
+    And as "user1" the folder with original path "/PARENT" should not exist in the trashbin

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -17,10 +17,10 @@ Feature: files and folders exist in the trashbin after being deleted
       | lorem.txt                             |
       | strängé नेपाली folder                 |
       | strängé filename (duplicate #2 &).txt |
-    Then as "user1" folder "simple-folder" should exist in trash
-    And as "user1" file "lorem.txt" should exist in trash
-    And as "user1" folder "strängé नेपाली folder" should exist in trash
-    And as "user1" file "strängé filename (duplicate #2 &).txt" should exist in trash
+    Then as "user1" folder "simple-folder" should exist in the trashbin
+    And as "user1" file "lorem.txt" should exist in the trashbin
+    And as "user1" folder "strängé नेपाली folder" should exist in the trashbin
+    And as "user1" file "strängé filename (duplicate #2 &).txt" should exist in the trashbin
     And the deleted elements should be listed in the trashbin on the webUI
     And file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
@@ -52,10 +52,10 @@ Feature: files and folders exist in the trashbin after being deleted
       | data.zip      |
       | lorem.txt     |
       | simple-folder |
-    Then as "user1" file "data.zip" should exist in trash
-    And as "user1" file "lorem.txt" should exist in trash
-    And as "user1" folder "simple-folder" should exist in trash
-    And as "user1" file "simple-folder/lorem.txt" should exist in trash
+    Then as "user1" file "data.zip" should exist in the trashbin
+    And as "user1" file "lorem.txt" should exist in the trashbin
+    And as "user1" folder "simple-folder" should exist in the trashbin
+    And as "user1" file "simple-folder/lorem.txt" should exist in the trashbin
     And the deleted elements should be listed in the trashbin on the webUI
     And file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
@@ -63,8 +63,8 @@ Feature: files and folders exist in the trashbin after being deleted
     When the user creates a folder with the name "my-empty-folder" using the webUI
     And the user creates a folder with the name "my-other-empty-folder" using the webUI
     And the user deletes folder "my-empty-folder" using the webUI
-    Then as "user1" folder "my-empty-folder" should exist in trash
-    But as "user1" the folder with original path "my-other-empty-folder" should not exist in trash
+    Then as "user1" folder "my-empty-folder" should exist in the trashbin
+    But as "user1" the folder with original path "my-other-empty-folder" should not exist in the trashbin
     And folder "my-empty-folder" should be listed in the trashbin on the webUI
     But folder "my-other-empty-folder" should not be listed in the trashbin on the webUI
     When the user opens trashbin folder "my-empty-folder" using the webUI
@@ -83,9 +83,9 @@ Feature: files and folders exist in the trashbin after being deleted
     And the user deletes the following elements using the webUI
       | name      |
       | lorem.txt |
-    Then as "user1" the file with original path "lorem.txt" should exist in trash
-    And as "user1" the file with original path "simple-folder/lorem.txt" should exist in trash
-    And as "user1" the file with original path "strängé नेपाली folder/lorem.txt" should exist in trash
+    Then as "user1" the file with original path "lorem.txt" should exist in the trashbin
+    And as "user1" the file with original path "simple-folder/lorem.txt" should exist in the trashbin
+    And as "user1" the file with original path "strängé नेपाली folder/lorem.txt" should exist in the trashbin
     Then the deleted elements should be listed in the trashbin on the webUI
     And file "lorem.txt" with path "./lorem.txt" should be listed in the trashbin on the webUI
     And file "lorem.txt" with path "simple-folder/lorem.txt" should be listed in the trashbin on the webUI


### PR DESCRIPTION
## Description
Some acceptance test steps talk about "in the trashbin" but some just say "in trash". Make them consistently say "in the trashbin". Then they will be easier to find.

(I was doing some work in data_exporter for trashbin import and was looking for core steps, and it was annoying having the 2 different styles of words)

Note: admin_audit and ransomware_protection are the only apps that use the effected steps. I will make PRs for those also)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
