### PR TITLE
[Tests-Only] Removed redundant getter function for PROPFIND requests

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -146,55 +146,6 @@ class WebDavHelper {
 			$davPathVersionToUse, $type
 		);
 	}
-
-	/**
-	 * sends HTTP request PROPFIND method with multiple properties
-	 *
-	 * @param string $baseUrl
-	 * @param string $user
-	 * @param string $password
-	 * @param string $path
-	 * @param array $properties
-	 * @param string $namespaceString
-	 * @param int $folderDepth
-	 * @param string $type
-	 * @param int $davPathVersionToUse
-	 *
-	 * @return ResponseInterface
-	 */
-	public static function propfindWithMultipleProps(
-		$baseUrl,
-		$user,
-		$password,
-		$path,
-		$properties,
-		$namespaceString = "oc='http://owncloud.org/ns'",
-		$folderDepth = 0,
-		$type = "files",
-		$davPathVersionToUse = 2
-	) {
-		$propertyBody = "";
-		foreach ($properties as $property) {
-			[$namespacePrefix, $namespace, $property] = self::getPropertyWithNamespaceInfo(
-				$namespaceString,
-				$property
-			);
-			$propertyBody .= "\n\t\t<$namespacePrefix:$property/>";
-		}
-		$body = "<?xml version=\"1.0\"?>
-				<d:propfind
-				   xmlns:d=\"DAV:\"
-				   xmlns:oc=\"http://owncloud.org/ns\"
-				   xmlns:ocs=\"http://open-collaboration-services.org/ns\">
-				    <d:prop>$propertyBody
-				    </d:prop>
-				</d:propfind>";
-		return self::makeDavRequest(
-			$baseUrl, $user, $password, "PROPFIND", $path, null, $body,
-			$davPathVersionToUse, $type
-		);
-	}
-
 	/**
 	 *
 	 * @param string $baseUrl

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -194,15 +194,16 @@ Feature: get file properties
   @skipOnOcis @issue-ocis-reva-57
   Scenario: add, receive multiple custom meta properties to a file
     Given user "user0" has created folder "/TestFolder"
+    And using new dav path
     And user "user0" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
     And user "user0" has set the following properties of file "/TestFolder/test1.txt" using the WebDav API
       | property  | value |
       | testprop1 | AAAAA |
       | testprop2 | BBBBB |
-    When user "user0" gets the following properties of file "/TestFolder/test1.txt" using the WebDav PropFind API
-      | property  |
-      | testprop1 |
-      | testprop2 |
+    When user "user0" gets the following properties of file "/TestFolder/test1.txt" using the WebDAV API
+      | property     |
+      | oc:testprop1 |
+      | oc:testprop2 |
     Then the HTTP status code should be success
     And as user "user0" the last response should have the following properties
       | resource              | property  | value           |
@@ -224,10 +225,10 @@ Feature: get file properties
       | property  | value |
       | testprop1 | CCCCC |
       | testprop2 | DDDDD |
-    When user "user0" gets the following properties of folder "/TestFolder" using the WebDav PropFind API
-      | property  |
-      | testprop1 |
-      | testprop2 |
+    When user "user0" gets the following properties of folder "/TestFolder" using the WebDAV API
+      | property     |
+      | oc:testprop1 |
+      | oc:testprop2 |
     Then the HTTP status code should be success
     And as user "user0" the last response should have the following properties
       | resource              | property  | value                  |

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -194,7 +194,6 @@ Feature: get file properties
   @skipOnOcis @issue-ocis-reva-57
   Scenario: add, receive multiple custom meta properties to a file
     Given user "user0" has created folder "/TestFolder"
-    And using new dav path
     And user "user0" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
     And user "user0" has set the following properties of file "/TestFolder/test1.txt" using the WebDav API
       | property  | value |

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -83,7 +83,11 @@ class WebDavPropertiesContext implements Context {
 				$properties[] = $row[0];
 			}
 		}
-		$depth = \count($properties) > 1 ? 'infinity' : 0;
+		$depth = 0;
+		if (\count($properties) > 1) {
+			$depth = 'infinity';
+			$this->featureContext->usingNewDavPath();
+		}
 		$this->featureContext->setResponseXmlObject(
 			$this->featureContext->listFolder($user, $path, $depth, $properties)
 		);

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -83,8 +83,9 @@ class WebDavPropertiesContext implements Context {
 				$properties[] = $row[0];
 			}
 		}
+		$depth = \count($properties) > 1 ? 'infinity' : 0;
 		$this->featureContext->setResponseXmlObject(
-			$this->featureContext->listFolder($user, $path, 0, $properties)
+			$this->featureContext->listFolder($user, $path, $depth, $properties)
 		);
 	}
 
@@ -105,6 +106,9 @@ class WebDavPropertiesContext implements Context {
 
 	/**
 	 * @Given /^user "([^"]*)" has set the following properties of (?:file|folder|entry) "([^"]*)" using the WebDav API$/
+	 *
+	 * if no namespace prefix is provided before property, default `oc:` prefix is set for added props
+	 * only and everything rest on xml is set to prefix `d:`
 	 *
 	 * @param string $username
 	 * @param string $path
@@ -154,38 +158,6 @@ class WebDavPropertiesContext implements Context {
 				$this->featureContext->getUserPassword($user), $path,
 				$properties
 			)
-		);
-	}
-
-	/**
-	 * @When user :username gets the following properties of file/folder :path using the WebDav PropFind API
-	 *
-	 * @param string $username
-	 * @param string $path
-	 * @param TableNode $propertiesTable with single column with column header 'property'
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userGetsFollowingPropsWithNamespaceOfFileUsingWebDavAPI(
-		$username, $path, $propertiesTable
-	) {
-		$this->featureContext->verifyTableNodeColumns($propertiesTable, ["property",]);
-		$properties = [];
-		foreach ($propertiesTable->getColumnsHash() as $col) {
-			\array_push($properties, $col["property"]);
-		}
-		$this->featureContext->setResponse(
-			WebDavHelper::propfindWithMultipleProps(
-				$this->featureContext->getBaseUrl(),
-				$username,
-				$this->featureContext->getPasswordForUser($username),
-				$path,
-				$properties
-			)
-		);
-		$this->featureContext->setResponseXmlObject(
-			HttpRequestHelper::getResponseXml($this->featureContext->getResponse())
 		);
 	}
 
@@ -634,6 +606,8 @@ class WebDavPropertiesContext implements Context {
 
 	/**
 	 * @Then as user :username the last response should have the following properties
+	 *
+	 * only supports new dav version
 	 *
 	 * @param string $username
 	 * @param TableNode $expectedPropTable with following columns:


### PR DESCRIPTION
## Description
With PR #36941, a separate `getter` function for multiple-props was added which is just some modification with existing propfind getter function.
This PR removed redundant function and adds `infinity` `depth-level` if number of properties are more than one which in result `doesn't affect any existing steps` and `makes possible to assert multiple props at once`

## Related Issue
- #36821 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
