### PR TITLE
[Tests-Only] Adjust tests of files_external:list

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1468,20 +1468,32 @@ class OccContext implements Context {
 						);
 					}
 					if (isset($expectedStorageEntry['ApplicableUsers'])) {
-						Assert::assertEquals(
-							$expectedStorageEntry['ApplicableUsers'],
-							$listedStorageEntry->applicable_users,
-							"ApplicableUsers column does not have the expected value for storage "
-							. $expectedStorageEntry['MountPoint']
-						);
+						$listedApplicableUsers = \explode(', ', $listedStorageEntry->applicable_users);
+						$expectedApplicableUsers = \explode(', ', $expectedStorageEntry['ApplicableUsers']);
+						foreach ($expectedApplicableUsers as $expectedApplicableUserEntry) {
+							Assert::assertContains(
+								$expectedApplicableUserEntry,
+								$listedApplicableUsers,
+								__METHOD__
+								. " '$expectedApplicableUserEntry' is not listed in '"
+								. \implode(', ', $listedApplicableUsers)
+								. "'"
+							);
+						}
 					}
 					if (isset($expectedStorageEntry['ApplicableGroups'])) {
-						Assert::assertEquals(
-							$expectedStorageEntry['ApplicableGroups'],
-							$listedStorageEntry->applicable_groups,
-							"ApplicableGroups column does not have the expected value for storage "
-							. $expectedStorageEntry['MountPoint']
-						);
+						$listedApplicableGroups = \explode(', ', $listedStorageEntry->applicable_groups);
+						$expectedApplicableGroups = \explode(', ', $expectedStorageEntry['ApplicableGroups']);
+						foreach ($expectedApplicableGroups as $expectedApplicableGroupEntry) {
+							Assert::assertContains(
+								$expectedApplicableGroupEntry,
+								$listedApplicableGroups,
+								__METHOD__
+								. " '$expectedApplicableGroupEntry' is not listed in '"
+								. \implode(', ', $listedApplicableGroups)
+								. "'"
+							);
+						}
 					}
 					if (isset($expectedStorageEntry['Type'])) {
 						Assert::assertEquals(
@@ -1492,9 +1504,10 @@ class OccContext implements Context {
 						);
 					}
 					$isStorageEntryListed = true;
+					break;
 				}
 			}
-			Assert::assertTrue($isStorageEntryListed, "Expected local storage {$expectedStorageEntry['MountPoint']} not found");
+			Assert::assertTrue($isStorageEntryListed, __METHOD__ . " Expected local storage {$expectedStorageEntry['MountPoint']} not found");
 		}
 	}
 


### PR DESCRIPTION
## Description
This PR adjusts the functions used in the tests for files_external:list such that the list of users and groups is accepted in any order.

## Related Issue
- Fixes #37023 

## Motivation and Context
The expected applicable users and groups in the test scenarios of files_external:list can be returned in any order. For instance, on PostgreSQL 9.4 the "applicable users/groups" for the local storage mount gets listed in the opposite order. In this case, the test fails just because of the listed order of users/groups even though all the expeceted users/groups are listed. So, the tests need to be adjusted to accept users/groups in any order.

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
