### PR TITLE
fix remaining time estimation for public link uploads

### DIFF
--- a/changelog/unreleased/37053
+++ b/changelog/unreleased/37053
@@ -1,0 +1,7 @@
+Bugfix: Fix public link upload remaining time estimation
+
+Public link upload wrong remaining time estimation problem has been resolved.
+Also, the remaining time calculation logic has been changed for smoother performance.
+
+https://github.com/owncloud/core/pull/37053
+https://github.com/owncloud/core/issues/25053


### PR DESCRIPTION
## Description
Currently, remaining time estimation is relies on `new Date().getMilliseconds();` difference between the two `fileupload.fileuploadprogressall` events. When time second change there is no meaning in this milliseconds difference. We are using Jquery-file-upload package in file-upload and the package is already providing bitrate for upload. With this PR the code will use this bitrate. 

In addition, to provide a smooth experience, the code is using a buffer mechanism. But, in the first bufferSize(20) events, since the buffer is empty, time estimation is wrong. The remaining time is rapidly increasing at the beginning. This problem resolved by dividing bufferTotal to the filled buffer size. Also, this buffer logic explained by adding a comment line.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/25053
- Fixes https://github.com/owncloud/enterprise/issues/3827

## Motivation and Context
Fixing bugs.

## How Has This Been Tested?
Test 1:
- Upload a 5 GB file via a public link
- Look at the estimated upload time (Previously it was wrong on Chrome)

Test 2:
- Upload a 5 GB file as user
- Look at the estimated upload time

I repeated tests with IE, Opera, Chrome and Firefox browsers. All of them look okay.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
