### PR TITLE
[Tests-Only] Added test scenario to retrieve comments details

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -252,8 +252,8 @@ class WebDavHelper {
 	) {
 		$propertyBody = "";
 		foreach ($propertiesArray as $propertyArray) {
-			$property = $propertyArray["property"];
-			$value = $propertyArray["value"];
+			$property = $propertyArray["propertyName"];
+			$value = $propertyArray["propertyValue"];
 			[$namespacePrefix, $namespace, $property] = self::getPropertyWithNamespaceInfo(
 				$namespaceString,
 				$property

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -14,9 +14,49 @@ Feature: Comments
       | user  | comment          |
       | user0 | My first comment |
     When the user gets the following properties of folder "/myFileToComment.txt" using the WebDAV API
+      | propertyName       |
       | oc:comments-href   |
       | oc:comments-count  |
       | oc:comments-unread |
     Then the single response should contain a property "oc:comments-count" with value "1"
     And the single response should contain a property "oc:comments-unread" with value "0"
     And the single response should contain a property "oc:comments-href" with value "%a_comment_url%"
+
+  Scenario: Getting more info about comments using REPORT method
+    Given as user "user0"
+    And the user has uploaded file "filesForUpload/textfile.txt" to "myFileToComment.txt"
+    And the user has commented with content "My first comment" on file "myFileToComment.txt"
+    When the user gets all information about the comments on file "myFileToComment.txt" using the WebDAV REPORT API
+    Then the following comment properties should be listed
+      | propertyName     | propertyValue    |
+      | verb             | comment          |
+      | actorType        | users            |
+      | actorId          | user0            |
+      | objectType       | files            |
+      | isUnread         | false            |
+      | actorDisplayName | User Zero        |
+      | message          | My first comment |
+
+  Scenario: Getting more info about comments using PROPFIND method
+    Given as user "user0"
+    And the user has uploaded file "filesForUpload/textfile.txt" to "myFileToComment.txt"
+    And the user has commented with content "My first comment" on file "myFileToComment.txt"
+    When the user gets the following comment properties of file "myFileToComment.txt" using the WebDAV PROPFIND API
+      | propertyName        |
+      | oc:verb             |
+      | oc:actorType        |
+      | oc:actorId          |
+      | oc:objectType       |
+      | oc:isUnread         |
+      | oc:actorDisplayName |
+      | oc:message          |
+    Then the HTTP status code should be success
+    And the following comment properties should be listed
+      | propertyName     | propertyValue    |
+      | verb             | comment          |
+      | actorType        | users            |
+      | actorId          | user0            |
+      | objectType       | files            |
+      | isUnread         | false            |
+      | actorDisplayName | User Zero        |
+      | message          | My first comment |

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -13,6 +13,7 @@ Feature: sharing
     Given using <dav-path> DAV path
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     When user "user0" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
@@ -25,6 +26,7 @@ Feature: sharing
     And user "user0" has uploaded file with content "foo" to "/tmp.txt"
     And user "user0" has shared file "/tmp.txt" with user "user1"
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
@@ -43,6 +45,7 @@ Feature: sharing
       | permissions | share,update,read |
       | shareWith   | grp1              |
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "19"
     Examples:
@@ -73,6 +76,7 @@ Feature: sharing
       | permissions | update,read |
       | shareWith   | grp1        |
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "3"
     Examples:
@@ -103,6 +107,7 @@ Feature: sharing
       | permissions | share,read |
       | shareWith   | grp1       |
     When user "user1" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "17"
     Examples:
@@ -114,6 +119,7 @@ Feature: sharing
     Given using <dav-path> DAV path
     And user "user0" has created folder "/tmp"
     When user "user0" gets the following properties of folder "/" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
@@ -126,6 +132,7 @@ Feature: sharing
     And user "user0" has created folder "/tmp"
     And user "user0" has shared file "/tmp" with user "user1"
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
@@ -143,6 +150,7 @@ Feature: sharing
       | shareType | group |
       | shareWith | grp1  |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "31"
     Examples:
@@ -173,6 +181,7 @@ Feature: sharing
       | shareWith   | grp1                     |
       | permissions | share,delete,create,read |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "29"
     Examples:
@@ -203,6 +212,7 @@ Feature: sharing
       | shareWith   | grp1                     |
       | permissions | share,delete,update,read |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "27"
     Examples:
@@ -233,6 +243,7 @@ Feature: sharing
       | shareWith   | grp1                     |
       | permissions | share,create,update,read |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "23"
     Examples:
@@ -263,6 +274,7 @@ Feature: sharing
       | shareWith   | grp1   |
       | permissions | change |
     When user "user1" gets the following properties of folder "/tmp" using the WebDAV API
+      | propertyName          |
       | ocs:share-permissions |
     Then the single response should contain a property "ocs:share-permissions" with value "15"
     Examples:

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -98,6 +98,7 @@ Feature: lock folders
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
     When user "user0" gets the following properties of folder "PARENT" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "<lock-root>"
     And the value of the item "//d:locktoken/d:href" in the response should match "/^opaquelocktoken:[a-z0-9-]+$/"

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -9,6 +9,7 @@ Feature: LOCKDISCOVERY for public links
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the item "//d:locktoken/d:href" in the response should not exist
@@ -23,6 +24,7 @@ Feature: LOCKDISCOVERY for public links
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the item "//d:locktoken/d:href" in the response should not exist
@@ -37,6 +39,7 @@ Feature: LOCKDISCOVERY for public links
     And user "user0" has locked folder "PARENT/CHILD" setting following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
     And the item "//d:locktoken/d:href" in the response should not exist
@@ -51,6 +54,7 @@ Feature: LOCKDISCOVERY for public links
     And user "user0" has locked folder "PARENT/CHILD" setting following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
     And the item "//d:locktoken/d:href" in the response should not exist
@@ -65,6 +69,7 @@ Feature: LOCKDISCOVERY for public links
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the item "//d:locktoken/d:href" in the response should not exist
@@ -79,6 +84,7 @@ Feature: LOCKDISCOVERY for public links
     And user "user0" has locked folder "PARENT/CHILD/child.txt" setting following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD\/child.txt$/"
     And the item "//d:locktoken/d:href" in the response should not exist
@@ -93,6 +99,7 @@ Feature: LOCKDISCOVERY for public links
     And user "user0" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/child.txt" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the item "//d:locktoken/d:href" in the response should not exist

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -10,12 +10,15 @@ Feature: set timeouts of LOCKS
       | lockscope | shared    |
       | timeout   | <timeout> |
     And user "user0" gets the following properties of folder "PARENT" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     When user "user0" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     When user "user0" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     Examples:
@@ -40,12 +43,15 @@ Feature: set timeouts of LOCKS
       | lockscope | shared    |
       | timeout   | <timeout> |
     And user "user1" gets the following properties of folder "PARENT (2)" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     When user "user1" gets the following properties of folder "PARENT (2)/CHILD" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     When user "user1" gets the following properties of folder "PARENT (2)/parent.txt" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     Examples:
@@ -70,12 +76,15 @@ Feature: set timeouts of LOCKS
       | lockscope | shared    |
       | timeout   | <timeout> |
     And user "user0" gets the following properties of folder "PARENT" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     When user "user0" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     When user "user0" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     Examples:
@@ -99,12 +108,15 @@ Feature: set timeouts of LOCKS
       | lockscope | shared    |
       | timeout   | <timeout> |
     And the public gets the following properties of entry "/" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     When the public gets the following properties of entry "/parent.txt" in the last created public link using the WebDAV API
+      | propertyName    |
       | d:lockdiscovery |
     Then the value of the item "//d:timeout" in the response should match "<result>"
     Examples:

--- a/tests/acceptance/features/apiWebdavProperties/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties/createFolder.feature
@@ -35,6 +35,7 @@ Feature: create folder
     Given using <dav_version> DAV path
     And user "user0" has created folder "/test_folder"
     When user "user0" gets the following properties of folder "/test_folder" using the WebDAV API
+      | propertyName   |
       | d:resourcetype |
     Then the single response should contain a property "d:resourcetype" with a child property "d:collection"
     Examples:
@@ -46,6 +47,7 @@ Feature: create folder
     Given using <dav_version> DAV path
     And user "user0" has created folder "/test_folder:5"
     When user "user0" gets the following properties of folder "/test_folder:5" using the WebDAV API
+      | propertyName   |
       | d:resourcetype |
     Then the single response should contain a property "d:resourcetype" with a child property "d:collection"
     Examples:

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -62,6 +62,7 @@ Feature: get file properties
     Given using <dav_version> DAV path
     And user "user0" has created folder "/test"
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
+      | propertyName   |
       | oc:share-types |
     Then the response should contain an empty property "oc:share-types"
     Examples:
@@ -81,6 +82,7 @@ Feature: get file properties
       | permissions | all   |
       | shareWith   | user1 |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
+      | propertyName   |
       | oc:share-types |
     Then the response should contain a share-types property with
       | 0 |
@@ -101,6 +103,7 @@ Feature: get file properties
       | permissions | all   |
       | shareWith   | grp1  |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
+      | propertyName   |
       | oc:share-types |
     Then the response should contain a share-types property with
       | 1 |
@@ -118,6 +121,7 @@ Feature: get file properties
       | path        | test |
       | permissions | all  |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
+      | propertyName   |
       | oc:share-types |
     Then the response should contain a share-types property with
       | 3 |
@@ -147,6 +151,7 @@ Feature: get file properties
       | path        | test |
       | permissions | all  |
     When user "user0" gets the following properties of folder "/test" using the WebDAV API
+      | propertyName   |
       | oc:share-types |
     Then the response should contain a share-types property with
       | 0 |
@@ -174,6 +179,7 @@ Feature: get file properties
     Given using <dav_version> DAV path
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     When user "user0" gets the following properties of file "/somefile.txt" using the WebDAV API
+      | propertyName   |
       | oc:privatelink |
     Then the single response should contain a property "oc:privatelink" with value like "%(/(index.php/)?f/[0-9]*)%"
     Examples:
@@ -196,19 +202,19 @@ Feature: get file properties
     Given user "user0" has created folder "/TestFolder"
     And user "user0" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
     And user "user0" has set the following properties of file "/TestFolder/test1.txt" using the WebDav API
-      | property  | value |
-      | testprop1 | AAAAA |
-      | testprop2 | BBBBB |
+      | propertyName | propertyValue |
+      | testprop1    | AAAAA         |
+      | testprop2    | BBBBB         |
     When user "user0" gets the following properties of file "/TestFolder/test1.txt" using the WebDAV API
-      | property     |
+      | propertyName |
       | oc:testprop1 |
       | oc:testprop2 |
     Then the HTTP status code should be success
     And as user "user0" the last response should have the following properties
-      | resource              | property  | value           |
-      | /TestFolder/test1.txt | testprop1 | AAAAA           |
-      | /TestFolder/test1.txt | testprop2 | BBBBB           |
-      | /TestFolder/test1.txt | status    | HTTP/1.1 200 OK |
+      | resource              | propertyName | propertyValue   |
+      | /TestFolder/test1.txt | testprop1    | AAAAA           |
+      | /TestFolder/test1.txt | testprop2    | BBBBB           |
+      | /TestFolder/test1.txt | status       | HTTP/1.1 200 OK |
 
   @issue-36920
   @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcis @issue-ocis-reva-57
@@ -217,22 +223,22 @@ Feature: get file properties
     And user "user0" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
     And user "user0" has uploaded file with content "test data two" to "/TestFolder/test2.txt"
     And user "user0" has set the following properties of file "/TestFolder/test1.txt" using the WebDav API
-      | property  | value |
-      | testprop1 | AAAAA |
-      | testprop2 | BBBBB |
+      | propertyName | propertyValue |
+      | testprop1    | AAAAA         |
+      | testprop2    | BBBBB         |
     And user "user0" has set the following properties of file "/TestFolder/test2.txt" using the WebDav API
-      | property  | value |
-      | testprop1 | CCCCC |
-      | testprop2 | DDDDD |
+      | propertyName | propertyValue |
+      | testprop1    | CCCCC         |
+      | testprop2    | DDDDD         |
     When user "user0" gets the following properties of folder "/TestFolder" using the WebDAV API
-      | property     |
+      | propertyName |
       | oc:testprop1 |
       | oc:testprop2 |
     Then the HTTP status code should be success
     And as user "user0" the last response should have the following properties
-      | resource              | property  | value                  |
-      | /TestFolder/test1.txt | testprop1 | AAAAA                  |
-      | /TestFolder/test1.txt | testprop2 | BBBBB                  |
-      | /TestFolder/test2.txt | testprop1 | CCCCC                  |
-      | /TestFolder/test2.txt | testprop2 | DDDDD                  |
-      | /TestFolder/          | status    | HTTP/1.1 404 Not Found |
+      | resource              | propertyName | propertyValue          |
+      | /TestFolder/test1.txt | testprop1    | AAAAA                  |
+      | /TestFolder/test1.txt | testprop2    | BBBBB                  |
+      | /TestFolder/test2.txt | testprop1    | CCCCC                  |
+      | /TestFolder/test2.txt | testprop2    | DDDDD                  |
+      | /TestFolder/          | status       | HTTP/1.1 404 Not Found |

--- a/tests/acceptance/features/apiWebdavProperties/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getQuota.feature
@@ -40,6 +40,7 @@ Feature: get quota
       | permissions | all       |
       | shareWith   | user0     |
     When user "user0" gets the following properties of folder "/testquota" using the WebDAV API
+      | propertyName            |
       | d:quota-available-bytes |
     Then the single response should contain a property "d:quota-available-bytes" with value "10485406"
     Examples:
@@ -52,6 +53,7 @@ Feature: get quota
     And the quota of user "user0" has been set to "1 KB"
     And user "user0" has uploaded file "/prueba.txt" of size 93 bytes
     When user "user0" gets the following properties of folder "/" using the WebDAV API
+      | propertyName            |
       | d:quota-available-bytes |
     Then the single response should contain a property "d:quota-available-bytes" with value "577"
     Examples:
@@ -67,6 +69,7 @@ Feature: get quota
     And user "user0" has uploaded file "/user0.txt" of size 93 bytes
     And user "user0" has shared file "user0.txt" with user "user1"
     When user "user1" gets the following properties of folder "/" using the WebDAV API
+      | propertyName            |
       | d:quota-available-bytes |
     Then the single response should contain a property "d:quota-available-bytes" with value "670"
     Examples:


### PR DESCRIPTION
## Description
Added test scenario to assert all data-items returned by REPORT method on file comments api.

## Related Issue
- Part of #36821

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
