### PR TITLE
Use translations from lib and not from core

### DIFF
--- a/changelog/unreleased/37039
+++ b/changelog/unreleased/37039
@@ -1,0 +1,3 @@
+Change: Respect default_language when sending email notifications
+
+https://github.com/owncloud/core/issues/37039

--- a/changelog/unreleased/37040
+++ b/changelog/unreleased/37040
@@ -1,0 +1,5 @@
+Change: Lookup email subject in correct translation context
+
+Use 'lib' instead of 'core' to get the translations.
+
+https://github.com/owncloud/core/issues/37040

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -112,12 +112,13 @@ class MailNotifications {
 	 * @param Node shared node
 	 * @param string $shareType share type
 	 * @param IUser[] $recipientList list of recipients
-	 * @throws GenericShareException
 	 * @return array list of user to whom the mail send operation failed
+	 * @throws \OCP\Files\NotFoundException
+	 * @throws GenericShareException
 	 */
-	public function sendInternalShareMail($sender, $node, $shareType, $recipientList) {
+	public function sendInternalShareMail($sender, $node, $shareType, $recipientList): array {
 		if ($this->config->getAppValue('core', 'shareapi_allow_mail_notification', 'no') !== 'yes') {
-			$message_t = $this->l->t("Internal mail notification for shared files is not allowed");
+			$message_t = $this->l->t('Internal mail notification for shared files is not allowed');
 			throw new GenericShareException($message_t, $message_t, 403);
 		}
 		$noMail = [];
@@ -162,13 +163,12 @@ class MailNotifications {
 			]);
 
 			$unescapedFilename = $filename;
-			$filename = $filter->getFile();
 			$link = $filter->getLink();
 
 			$recipientLanguageCode = $this->config->getUserValue($recipient->getUID(), 'core', 'lang', 'en');
-			$recipientL10N = \OC::$server->getL10N('core');
+			$recipientL10N = \OC::$server->getL10N('lib');
 			if ($this->l->getLanguageCode() !== $recipientLanguageCode) {
-				$recipientL10N = \OC::$server->getL10N('core', $recipientLanguageCode);
+				$recipientL10N = \OC::$server->getL10N('lib', $recipientLanguageCode);
 				$subject = (string)$recipientL10N->t('%s shared »%s« with you', [$filter->getSenderDisplayName(), $unescapedFilename]);
 			} else {
 				$subject = (string)$this->l->t('%s shared »%s« with you', [$filter->getSenderDisplayName(), $unescapedFilename]);
@@ -216,7 +216,7 @@ class MailNotifications {
 	 */
 	public function sendLinkShareMail($sender, $recipients, $link, $personalNote = null) {
 		if ($this->config->getAppValue('core', 'shareapi_allow_public_notification', 'no') !== 'yes') {
-			$message_t = $this->l->t("Public link mail notification is not allowed");
+			$message_t = $this->l->t('Public link mail notification is not allowed');
 			throw new GenericShareException($message_t, $message_t, 403);
 		}
 		$recipientsAsString = \implode(', ', $recipients);
@@ -404,7 +404,7 @@ class MailNotifications {
 			)
 		];
 	}
-		
+
 	/**
 	 * @param string $senderMailAddress
 	 * @return string

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -165,7 +165,8 @@ class MailNotifications {
 			$unescapedFilename = $filename;
 			$link = $filter->getLink();
 
-			$recipientLanguageCode = $this->config->getUserValue($recipient->getUID(), 'core', 'lang', 'en');
+			$defaultLang = $this->config->getSystemValue('default_language', 'en');
+			$recipientLanguageCode = $this->config->getUserValue($recipient->getUID(), 'core', 'lang', $defaultLang);
 			$recipientL10N = \OC::$server->getL10N('lib');
 			if ($this->l->getLanguageCode() !== $recipientLanguageCode) {
 				$recipientL10N = \OC::$server->getL10N('lib', $recipientLanguageCode);


### PR DESCRIPTION
## Description
The wrong translation context was used.
And default_language is taken into consideration

## Related Issue
- Fixes https://github.com/owncloud/core/issues/37040
- fixes https://github.com/owncloud/core/issues/37039

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
