### PR TITLE
empty extension of Google drive file should not cause dot to be appended to file name

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -286,7 +286,11 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 						if ($child->getMimeType() === self::MAP) {
 							continue; // No method known to transfer map files, ignore it
 						} elseif ($child->getMimeType() !== self::FOLDER) {
-							$name .= '.'.$this->getGoogleDocExtension($child->getMimeType());
+							$extension = $this->getGoogleDocExtension($child->getMimeType());
+							// don't append an empty extension as they will create broken paths
+							if ($extension !== '') {
+								$name .= ".{$extension}";
+							}
 						}
 					}
 					if ($path === '') {

--- a/changelog/unreleased/37044
+++ b/changelog/unreleased/37044
@@ -1,0 +1,7 @@
+Bugfix: Google drive files without extension 404
+
+Google Drive files without a file extension (".git/HEAD" for example) would result in a 404 response from the Web UI or desktop client.
+The problem has been fixed.
+
+https://github.com/owncloud/core/issues/37044
+https://github.com/owncloud/core/pull/37045


### PR DESCRIPTION
## Description
This is a squashed version of PR #37045 with the changelog edited to have a shorter description.
See that PR for the details and discussion.

## Related Issue
- Fixes #37044 

## How Has This Been Tested?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
