### PR TITLE
[Tests-Only] skipOnOcV10.3 test scenario for issue 36920

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -211,7 +211,7 @@ Feature: get file properties
       | /TestFolder/test1.txt | status    | HTTP/1.1 200 OK |
 
   @issue-36920
-  @skipOnOcis @issue-ocis-reva-57
+  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-57
   Scenario: add multiple properties to files inside a folder and do a propfind of the parent folder
     Given user "user0" has created folder "/TestFolder"
     And user "user0" has uploaded file with content "test data one" to "/TestFolder/test1.txt"


### PR DESCRIPTION
## Description
PR #37058 fixed the issue and adjusted the test scenario. So now the test scenario works on `master` but not on an old `10.3`  system. So add `skipOnOcV10.3` tag.

## Related Issue
#36920 

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
