### PR TITLE
Bump core version to 10.4.1

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 4, 0, 4];
+$OC_Version = [10, 4, 1, 0];
 
 // The human readable string
-$OC_VersionString = '10.4.0';
+$OC_VersionString = '10.4.1prealpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
`release-10.4.0` branch has been merged back to `master`.
`master` also has other changes/fixes... for the next release, which currently would be numbered `10.4.1`
We want to be able to tag acceptance test scenarios for bugs fixed in `master` with `skipOnOcV10.4.0` when the scenario is something that will pass in `master` but will not pass against a `10.4.0`  system. So we need `master` to be the next "likely" release version.

IMO we don't make a changelog entry for this?

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
