### PR TITLE
[Tests-Only] Add shareapi_allow_mail_notification to default sharing settings for tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2786,6 +2786,13 @@ trait Sharing {
 			],
 			[
 				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'user@@@send_mail',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_allow_mail_notification',
+				'testingState' => false
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
 				'capabilitiesParameter' => 'user@@@expire_date@@@enabled',
 				'testingApp' => 'core',
 				'testingParameter' => 'shareapi_default_expire_date_user_share',


### PR DESCRIPTION
## Description
Add the setting `shareapi_allow_mail_notification` to the list of default sharing settings that are put in place at the beginning of acceptance test scenarios. This setting was missing from the list, so when running tests locally then the setting might not be in the expected state.

## How Has This Been Tested?
1) have a local ownCloud and in Admin Sharing Settings enable "Allow users to send mail notification for shared files to other users"
2) run a test that cares, e.g. capabilities:
```
$ make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiCapabilities/capabilities.feature:38
Running apiCapabilities tests tagged ~@skipOnOcV10&&~@skipOnOcV10.4&&~@skipOnOcV10.4.0&&@api&&~@skip 
@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41
Feature: capabilities

  Background:                       # /home/phil/git/owncloud/core/tests/acceptance/features/apiCapabilities/capabilities.feature:4
    Given using OCS API version "1" # FeatureContext::usingOcsApiVersion()

  @smokeTest
  Scenario: getting default capabilities with admin user                         # /home/phil/git/owncloud/core/tests/acceptance/features/apiCapabilities/capabilities.feature:38
    When the administrator retrieves the capabilities using the capabilities API # AppConfigurationContext::theAdministratorGetsCapabilities()
    Then the capabilities should contain                                         # CapabilitiesContext::checkCapabilitiesResponse()
      | capability    | path_to_element                           | value             |
      | core          | pollinterval                              | 60                |
      | core          | webdav-root                               | remote.php/webdav |
      | core          | status@@@edition                          | %edition%         |
      | core          | status@@@productname                      | %productname%     |
      | core          | status@@@version                          | %version%         |
      | core          | status@@@versionstring                    | %versionstring%   |
      | files_sharing | api_enabled                               | 1                 |
      | files_sharing | default_permissions                       | 31                |
      | files_sharing | search_min_length                         | 2                 |
      | files_sharing | public@@@enabled                          | 1                 |
      | files_sharing | public@@@multiple                         | 1                 |
      | files_sharing | public@@@upload                           | 1                 |
      | files_sharing | public@@@supports_upload_only             | 1                 |
      | files_sharing | public@@@send_mail                        | EMPTY             |
      | files_sharing | public@@@social_share                     | 1                 |
      | files_sharing | public@@@enforced                         | EMPTY             |
      | files_sharing | public@@@enforced_for@@@read_only         | EMPTY             |
      | files_sharing | public@@@enforced_for@@@read_write        | EMPTY             |
      | files_sharing | public@@@enforced_for@@@upload_only       | EMPTY             |
      | files_sharing | public@@@enforced_for@@@read_write_delete | EMPTY             |
      | files_sharing | public@@@expire_date@@@enabled            | EMPTY             |
      | files_sharing | public@@@defaultPublicLinkShareName       | Public link       |
      | files_sharing | resharing                                 | 1                 |
      | files_sharing | federation@@@outgoing                     | 1                 |
      | files_sharing | federation@@@incoming                     | 1                 |
      | files_sharing | group_sharing                             | 1                 |
      | files_sharing | share_with_group_members_only             | EMPTY             |
      | files_sharing | share_with_membership_groups_only         | EMPTY             |
      | files_sharing | auto_accept_share                         | 1                 |
      | files_sharing | user_enumeration@@@enabled                | 1                 |
      | files_sharing | user_enumeration@@@group_members_only     | EMPTY             |
      | files_sharing | user@@@send_mail                          | EMPTY             |
      | files         | bigfilechunking                           | 1                 |
      Failed field files_sharing user@@@send_mail
      Failed asserting that two strings are equal.
      --- Expected
      +++ Actual
      @@ @@
      -''
      +'1'

--- Failed scenarios:

    /home/phil/git/owncloud/core/tests/acceptance/features/apiCapabilities/capabilities.feature:38

1 scenario (1 failed)
3 steps (2 passed, 1 failed)
```
The test fails.

3) Apply the code in this PR and run the test again. It passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
