### PR TITLE
Check the file in the primary storage and allow remove it from the

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -25,6 +25,7 @@
 	</background-jobs>
 
 	<commands>
+		<command>OCA\Files\Command\CheckCache</command>
 		<command>OCA\Files\Command\Scan</command>
 		<command>OCA\Files\Command\DeleteOrphanedFiles</command>
 		<command>OCA\Files\Command\TransferOwnership</command>

--- a/apps/files/lib/Command/CheckCache.php
+++ b/apps/files/lib/Command/CheckCache.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Juan Pablo Villafañez Ramos <jvillafanez@solidgeargroup.com>
+ * @author Juan Pablo Villafáñez Ramos <jvillafanez@solidgeargroup.com>
  *
  * @copyright Copyright (c) 2020, ownCloud GmbH
  * @license AGPL-3.0

--- a/apps/files/lib/Command/CheckCache.php
+++ b/apps/files/lib/Command/CheckCache.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @author Juan Pablo Villafañez Ramos <jvillafanez@solidgeargroup.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Command;
+
+use OCP\Files\IHomeStorage;
+use OCP\Files\IRootFolder;
+use OCP\Files\File;
+use OCP\Files\NotFoundException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CheckCache extends Command {
+	const ERROR_MISSING_FILE = 1;
+	const ERROR_NOT_A_FILE = 2;
+	const ERROR_CANNOT_OPEN = 3;
+
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	public function __construct(IRootFolder $rootFolder) {
+		parent::__construct();
+		$this->rootFolder = $rootFolder;
+	}
+
+	protected function configure() {
+		$this->setName('files:check-cache')
+			->setDescription('Check if the target file exists in the primary storage')
+			->addArgument(
+				'uid',
+				InputArgument::REQUIRED,
+				'The user (user id) who owns the file'
+			)
+			->addArgument(
+				'target-file',
+				InputArgument::REQUIRED,
+				'The file we want to check'
+			)->addOption(
+				'remove',
+				null,
+				InputOption::VALUE_NONE,
+				'Remove the file from the cache if it\'s missing in the backend'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$uid = $input->getArgument('uid');
+		$userFolder = $this->rootFolder->getUserFolder($uid);  // might throw a NoUserException
+
+		try {
+			$targetFile = $input->getArgument('target-file');
+			$node = $userFolder->get($targetFile);
+		} catch (NotFoundException $ex) {
+			$output->writeln("<error>$targetFile not found within user $uid</error>");
+			return self::ERROR_MISSING_FILE;
+		}
+
+		if ($node->isShared() || !($node->getStorage()->instanceOfStorage(IHomeStorage::class))) {
+			$output->writeln("<comment>Ignoring $targetFile because it is shared or not inside the primary storage</comment>");
+			return 0;
+		}
+
+		if (!($node instanceof File)) {
+			$output->writeln("<error>$targetFile isn't a file</error>");
+			return self::ERROR_NOT_A_FILE;
+		}
+
+		$stream = @$node->fopen('rb');  // errors are expected if the file is missing
+		if (!$stream) {
+			if ($input->getOption('remove')) {
+				$node->delete();
+				$output->writeln("$targetFile has been deleted");
+			} else {
+				$output->writeln("<error>Cannot open the file. Verify the file is missing in the primary storage before attempting to remove it</error>");
+				return self::ERROR_CANNOT_OPEN;
+			}
+		} else {
+			$output->writeln("$targetFile has been accessed properly");
+			\fclose($stream);
+		}
+	}
+}

--- a/apps/files/tests/Command/CheckCacheTest.php
+++ b/apps/files/tests/Command/CheckCacheTest.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez Ramos <jvillafanez@solidgeargroup.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Tests\Command;
+
+use OCA\Files\Command\CheckCache;
+use OCP\Files\IRootFolder;
+use OCP\Files\Folder;
+use OCP\Files\File;
+use OCP\Files\NotFoundException;
+use OCP\Files\Storage\IStorage;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ *
+ * @package OCA\Files\Tests\Command
+ */
+class CheckCacheTest extends TestCase {
+	/** @var IRootFolder */
+	private $rootFolder;
+	/** @var CheckCache */
+	private $command;
+	/**@var CommandTester */
+	private $commandTester;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+
+		$this->command = new CheckCache($this->rootFolder);
+		$this->commandTester = new CommandTester($this->command);
+	}
+
+	public function testMissingTargetFile() {
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')
+			->will($this->throwException(new NotFoundException()));
+
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$this->commandTester->execute([
+			'uid' => 'testUser1',
+			'target-file' => 'non-existing.txt'
+		]);
+		$this->assertSame(CheckCache::ERROR_MISSING_FILE, $this->commandTester->getStatusCode());
+	}
+
+	public function testTargetFileIsShared() {
+		$targetFile = $this->createMock(File::class);
+		$targetFile->method('isShared')->willReturn(true);
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($targetFile);
+
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$this->commandTester->execute([
+			'uid' => 'testUser1',
+			'target-file' => 'target.txt'
+		]);
+		$this->assertSame(0, $this->commandTester->getStatusCode());
+	}
+
+	public function testTargetFileNotHome() {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('instanceOfStorage')->willReturn(false);
+
+		$targetFile = $this->createMock(File::class);
+		$targetFile->method('isShared')->willReturn(false);
+		$targetFile->method('getStorage')->willReturn($storage);
+		$targetFile->expects($this->never())
+			->method('delete');
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($targetFile);
+
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$this->commandTester->execute([
+			'uid' => 'testUser1',
+			'target-file' => 'target.txt'
+		]);
+		$this->assertSame(0, $this->commandTester->getStatusCode());
+	}
+
+	public function testTargetFileNotFile() {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('instanceOfStorage')->willReturn(true);
+
+		$targetFile = $this->createMock(Folder::class);
+		$targetFile->method('isShared')->willReturn(false);
+		$targetFile->method('getStorage')->willReturn($storage);
+		$targetFile->expects($this->never())
+			->method('delete');
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($targetFile);
+
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$this->commandTester->execute([
+			'uid' => 'testUser1',
+			'target-file' => 'target.txt'
+		]);
+		$this->assertSame(CheckCache::ERROR_NOT_A_FILE, $this->commandTester->getStatusCode());
+	}
+
+	public function testTargetFileStillAccessible() {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('instanceOfStorage')->willReturn(true);
+
+		$resource = \fopen('php://memory', 'rb');
+
+		$targetFile = $this->createMock(File::class);
+		$targetFile->method('isShared')->willReturn(false);
+		$targetFile->method('getStorage')->willReturn($storage);
+		$targetFile->method('fopen')->willReturn($resource);
+		$targetFile->expects($this->never())
+			->method('delete');
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($targetFile);
+
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$this->commandTester->execute([
+			'uid' => 'testUser1',
+			'target-file' => 'target.txt'
+		]);
+		$this->assertSame(0, $this->commandTester->getStatusCode());
+	}
+
+	public function testTargetFileCannotOpen() {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('instanceOfStorage')->willReturn(true);
+
+		$targetFile = $this->createMock(File::class);
+		$targetFile->method('isShared')->willReturn(false);
+		$targetFile->method('getStorage')->willReturn($storage);
+		$targetFile->method('fopen')->willReturn(false);
+		$targetFile->expects($this->never())
+			->method('delete');
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($targetFile);
+
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$this->commandTester->execute([
+			'uid' => 'testUser1',
+			'target-file' => 'target.txt'
+		]);
+		$this->assertSame(CheckCache::ERROR_CANNOT_OPEN, $this->commandTester->getStatusCode());
+	}
+
+	public function testTargetFileCannotOpenDelete() {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('instanceOfStorage')->willReturn(true);
+
+		$targetFile = $this->createMock(File::class);
+		$targetFile->method('isShared')->willReturn(false);
+		$targetFile->method('getStorage')->willReturn($storage);
+		$targetFile->method('fopen')->willReturn(false);
+		$targetFile->expects($this->once())
+			->method('delete');
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($targetFile);
+
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$this->commandTester->execute([
+			'uid' => 'testUser1',
+			'target-file' => 'target.txt',
+			'--remove' => null,
+		]);
+		$this->assertSame(0, $this->commandTester->getStatusCode());
+	}
+}

--- a/changelog/unreleased/37067
+++ b/changelog/unreleased/37067
@@ -1,0 +1,17 @@
+Enhancement: Add new occ command to check the cache for primary storages
+
+This is a new occ command mainly for objectstores (objectstore and files_primary_s3 apps)
+as primary storages, but it can be used also for local primary storage.
+
+The use case is when a file is deleted directly from the primary storage without going
+through ownCloud. This is a scenario that shouldn't happen (modifying the primary
+storage outside of ownCloud isn't supported).
+
+The command will check if the target file can be accessed, and if not you can delete
+the information that ownCloud has (the command provides an option for this).
+
+The command will only work for the primary storage. It will ignore files that are
+accessible through a share (they need to be accessed directly), or files that are
+in an external storage.
+
+https://github.com/owncloud/core/pull/37067


### PR DESCRIPTION
cache if it's missing

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Files in the primary storage could be deleted outside of ownCloud, leaving information in the ownCloud's file cache. This command intends to check if the target file can be read from the backend storage, and it not, it allows you to remove the information cached.

Main goal is to clean the cache for objectstores (objectstore and files_primary_S3 apps) as primary storage, but the behaviour has been homogenized, so it can be used for local storage as long as the same conditions apply.

Note that removing files directly from the primary storage isn't supported and shouldn't happen. As such, the cases where you need to run this command should be extremely weird. This is why we only provide a command to check for only one file instead of scanning for the whole ownCloud's FS

## Related Issue
https://github.com/owncloud/enterprise/issues/3801

## Motivation and Context
Provide a tool to clean up stored information in the ownCloud's filecache in case a file disappears from the primary storage

## How Has This Been Tested?
Check both with local storage and objectstore app (files_primary_S3 not tested but expected to behave the same as with objectstore)
1. Upload some files into the primary storage through ownCloud
2. Remove one of those files directly from the storage (bypassing ownCloud)
3. Run the command

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
