### PR TITLE
[Tests-Only] Add acceptance test for translated response messages

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -101,6 +101,7 @@ config = {
 				'apiShareUpdate',
 				'apiTags',
 				'apiTrashbin',
+				'apiTranslation',
 				'apiVersions',
 				'apiWebdavLocks',
 				'apiWebdavLocks2',

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -388,6 +388,13 @@ default:
         - OccContext:
         - PublicWebDavContext:
 
+    apiTranslation:
+      paths:
+        - '%paths.base%/../features/apiTranslation'
+      context: *common_ldap_suite_context
+      contexts:
+        - FeatureContext: *common_feature_context_params
+
     cliAppManagement:
       paths:
         - '%paths.base%/../features/cliAppManagement'

--- a/tests/acceptance/features/apiTranslation/translation.feature
+++ b/tests/acceptance/features/apiTranslation/translation.feature
@@ -1,0 +1,30 @@
+@api
+Feature: translate messages in api response to preferred language
+  As a user
+  I want response messages to be translated in preferred language
+  So that I can see and understand the response messages in my language
+
+  Scenario Outline: user tries to get non existing share and uses some preferred language
+    Given user "user0" has been created with default attributes and without skeleton files
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+    And using <dav_version> DAV path
+    And user "user1" has shared file "textfile0.txt" with user "user2"
+    When user "user0" gets the info of the last share in language "de-DE" using the sharing API
+    Then the OCS status code should be "404"
+    And the OCS status message should be "Fehlerhafte Freigabe-ID, Freigabe existiert nicht"
+    When user "user0" gets the info of the last share in language "zh-CN" using the sharing API
+    Then the OCS status code should be "404"
+    And the OCS status message should be "错误的共享 ID，共享不存在"
+    When user "user0" gets the info of the last share in language "fr-FR" using the sharing API
+    Then the OCS status code should be "404"
+    And the OCS status message should be "Mauvais ID de partage, le partage n'existe pas"
+    When user "user0" gets the info of the last share in language "es-ES" using the sharing API
+    Then the OCS status code should be "404"
+    And the OCS status message should be "El ID del recurso compartido no es correcto, el recurso compartido no existe"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -114,11 +114,12 @@ class OCSContext implements Context {
 	 * @param string $url
 	 * @param TableNode|null $body
 	 * @param string|null $password
+	 * @param array $headers
 	 *
 	 * @return void
 	 */
 	public function userSendsHTTPMethodToOcsApiEndpointWithBody(
-		$user, $verb, $url, $body = null, $password = null
+		$user, $verb, $url, $body = null, $password = null, $headers = null
 	) {
 		/**
 		 * array of the data to be sent in the body.
@@ -143,7 +144,7 @@ class OCSContext implements Context {
 
 		$response = OcsApiHelper::sendRequest(
 			$this->featureContext->getBaseUrl(), $user, $password, $verb,
-			$url, $bodyArray, $this->featureContext->getOcsApiVersion()
+			$url, $bodyArray, $this->featureContext->getOcsApiVersion(), $headers
 		);
 		$this->featureContext->setResponse($response);
 	}

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1528,16 +1528,18 @@ trait Sharing {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" gets the info of the last share in language "([^"]*)" using the sharing API$/
 	 * @When /^user "([^"]*)" gets the info of the last share using the sharing API$/
 	 *
 	 * @param string $user
+	 * @param string $language
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userGetsInfoOfLastShareUsingTheSharingApi($user) {
+	public function userGetsInfoOfLastShareUsingTheSharingApi($user, $language=null) {
 		$share_id = $this->getLastShareIdOf($user);
-		$this->getShareData($user, $share_id);
+		$this->getShareData($user, $share_id, $language);
 	}
 
 	/**
@@ -1604,13 +1606,18 @@ trait Sharing {
 	 *
 	 * @param string $user
 	 * @param int $share_id
+	 * @param string $language
 	 *
 	 * @return void
 	 */
-	public function getShareData($user, $share_id) {
+	public function getShareData($user, $share_id, $language=null) {
 		$url = $this->getSharesEndpointPath("/$share_id");
+		$headers = [];
+		if ($language !== null) {
+			$headers['Accept-Language'] = $language;
+		}
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
-			$user, "GET", $url, null
+			$user, "GET", $url, null, null, $headers
 		);
 	}
 


### PR DESCRIPTION
## Description
This PR adds acceptance test for the translated error messages when the Accept-Language header is set to some preferred language.

## Related Issue
# https://github.com/owncloud/QA/issues/608

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
