### PR TITLE
[Tests-Only] Enable correct testing of ocis-reva#22

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -7,19 +7,11 @@ Feature: dav-versions
     And using new DAV path
     And user "user0" has been created with default attributes and without skeleton files
 
-  @skipOnOcis @issue-ocis-reva-22
   Scenario: Upload file and no version is available
     When user "user0" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" using the WebDAV API
     Then the version folder of file "/davtest.txt" for user "user0" should contain "0" elements
 
-  @skipOnOcV10 @issue-ocis-reva-22
-  #after fixing all issues delete this Scenario and use the one above
-  Scenario: Upload file and no version is available
-    When user "user0" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" using the WebDAV API
-    And user "user0" tries to get versions of file "davtest.txt" from "user0"
-    Then the HTTP status code should be "500"
-
-  @skipOnOcis @issue-ocis-reva-22
+  @skipOnOcis @issue-ocis-reva-17 @issue-ocis-reva-56
   Scenario: Upload file and no version is available using various chunking methods
     When user "user0" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms using the WebDAV API
     Then the version folder of file "/davtest.txt-olddav-regular" for user "user0" should contain "0" elements
@@ -27,7 +19,16 @@ Feature: dav-versions
     Then the version folder of file "/davtest.txt-olddav-oldchunking" for user "user0" should contain "0" elements
     Then the version folder of file "/davtest.txt-newdav-newchunking" for user "user0" should contain "0" elements
 
-  @skipOnOcis @issue-ocis-reva-22
+  @skipOnOcV10 @issue-ocis-reva-17 @issue-ocis-reva-56
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario: Upload file and no version is available using various chunking methods
+    When user "user0" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms using the WebDAV API
+    Then the version folder of file "/davtest.txt-olddav-regular" for user "user0" should contain "0" elements
+    Then the version folder of file "/davtest.txt-newdav-regular" for user "user0" should contain "0" elements
+    And as "user0" file "/davtest.txt-olddav-oldchunking" should not exist
+    And as "user0" file "/davtest.txt-newdav-newchunking" should not exist
+
+  @skipOnOcis @issue-ocis-reva-56
   Scenario: Upload file and no version is available using async upload
     Given the administrator has enabled async operations
     When user "user0" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 3 chunks with new chunking and using the WebDAV API


### PR DESCRIPTION
enables https://github.com/owncloud/ocis-reva/issues/22
which is fixed by updating reva in https://github.com/owncloud/ocis-reva/pull/91