### PR TITLE
Fix the user:sync command for single user in case the --re-enable option is …

### DIFF
--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -267,18 +267,17 @@ class SyncBackend extends Command {
 		$dummy = new Account(); // to prevent null pointer when writing messages
 
 		if ($userToSync !== null) {
-			// Run the sync using the internal username if mapped
-			$syncService->run($backend, new \ArrayIterator([$userToSync]));
+			if ($input->getOption('re-enable') && !$userToSync->isEnabled()) {
+				$this->reEnableUsers([$uid => $dummy], $output);
+			} else {
+				// Run the sync using the internal username if mapped
+				$syncService->run($backend, new \ArrayIterator([$userToSync]));
+			}
 		} else {
 			// Not found
 			$this->handleRemovedUsers([$uid => $dummy], $input, $output, $missingAccountsAction);
 		}
-
 		$output->writeln('');
-
-		if ($input->getOption('re-enable')) {
-			$this->reEnableUsers([$uid => $dummy], $output);
-		}
 	}
 	/**
 	 * @param $backend


### PR DESCRIPTION
…being used

## Description
Currently, when running the user:sync command for a single user with the `-r` option and given the user has been disabled on the AD/LDAP, the command is wrongly re-enabling the user. This is how it currently looks like:

Step 1 (correct):

```
- occ ldap:search testuser --> correct
- occ user:sync "OCA\User_LDAP\User_Proxy" -m disable -u testuser
Syncing testuser ...
Disabling accounts:
testuser, testuser disabled --> correct
```

Step 2 (wrong):

```
- occ user:sync "OCA\User_LDAP\User_Proxy" -m disable -r -u testuser
Syncing testuser ...
Disabling accounts:
testuser, testuser, already disabled --> correct

Re-enabling accounts:
testuser, testuser enabled --> wrong
```

As can be seen, in the very last step the user is getting re-enabled, which is wrong since the user is still disabled on the LDAP/AD side. Note: This only affects single user sync and not multiple users sync.

## How Has This Been Tested?

- Disable a user on the LDAP/AD side or moving him outside of the configured LDAP filters
- Run the `user:sync` command for the single user with the `-r` option and be sure the user still stays disabled on the oC side.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised