### PR TITLE
[Tests-Only] skipOnOcV10.4.0 things fixed for 10.4.1

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -211,7 +211,7 @@ Feature: get file properties
       | /TestFolder/test1.txt | status    | HTTP/1.1 200 OK |
 
   @issue-36920
-  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-57
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcis @issue-ocis-reva-57
   Scenario: add multiple properties to files inside a folder and do a propfind of the parent folder
     Given user "user0" has created folder "/TestFolder"
     And user "user0" has uploaded file with content "test data one" to "/TestFolder/test1.txt"

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -261,6 +261,7 @@ Feature: Sharing files and folders with internal users
     And the content of "textfile.txt" should be the same as the local "textfile.txt"
     And it should not be possible to share file "textfile.txt" using the webUI
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0
   Scenario: reshare indicators of public links to the original share owner
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -276,6 +277,7 @@ Feature: Sharing files and folders with internal users
     And the user opens the public link share tab
     Then a public link share with name "Public link" should be visible on the webUI
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0
   Scenario: reshare indicators of multiple public links with same name to the original share owner
     Given these users have been created with default attributes and without skeleton files:
       | username |


### PR DESCRIPTION
## Description
Now `latest` is `10.4.0` - we need to skip test scenarios for bugs that have been fixed since 10.4.0

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
