### PR TITLE
[Tests-Only] Add acceptance test to assert that original content can all be seen by federated share receiver

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -586,3 +586,30 @@ Feature: federated
     When the administrator sets parameter "autoAddServers" of app "federation" to "0"
     And user "user0" from server "REMOTE" shares "/textfile1.txt" with user "user1" from server "LOCAL" using the sharing API
     And as "user1" file "textfile1 (2).txt" should not exist
+
+  Scenario Outline: federated share receiver sees the original content of a received file
+    Given using server "REMOTE"
+    And user "user0" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
+    And user "user0" from server "REMOTE" has shared "file-to-share" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    When using OCS API version "<ocs-api-version>"
+    And using server "LOCAL"
+    Then the content of file "/file-to-share" for user "user1" should be "thisContentIsVisible"
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: federated share receiver sees the original content of a received file in multiple levels of folders
+    Given using server "REMOTE"
+    And user "user0" has created folder "/PARENT/RandomFolder"
+    And user "user0" has uploaded file with content "thisContentIsVisible" to "/PARENT/RandomFolder/file-to-share"
+    And user "user0" from server "REMOTE" has shared "/PARENT/RandomFolder/file-to-share" with user "user1" from server "LOCAL"
+    And user "user1" from server "LOCAL" has accepted the last pending share
+    When using OCS API version "<ocs-api-version>"
+    And using server "LOCAL"
+    Then the content of file "/file-to-share" for user "user1" should be "thisContentIsVisible"
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -592,8 +592,8 @@ Feature: federated
     And user "user0" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
     And user "user0" from server "REMOTE" has shared "file-to-share" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
-    When using OCS API version "<ocs-api-version>"
-    And using server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
+    When using server "LOCAL"
     Then the content of file "/file-to-share" for user "user1" should be "thisContentIsVisible"
     Examples:
       | ocs-api-version |
@@ -606,8 +606,8 @@ Feature: federated
     And user "user0" has uploaded file with content "thisContentIsVisible" to "/PARENT/RandomFolder/file-to-share"
     And user "user0" from server "REMOTE" has shared "/PARENT/RandomFolder/file-to-share" with user "user1" from server "LOCAL"
     And user "user1" from server "LOCAL" has accepted the last pending share
-    When using OCS API version "<ocs-api-version>"
-    And using server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
+    When using server "LOCAL"
     Then the content of file "/file-to-share" for user "user1" should be "thisContentIsVisible"
     Examples:
       | ocs-api-version |


### PR DESCRIPTION
## Description
Add acceptance test to assert that original content can all be seen by federated share receiver(files in root, files in multiple levels of folders)

## Related Issue
https://github.com/owncloud/core/issues/34149

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
