### PR TITLE
[Tests-Only] Scenario for deleting file from folder with dots in the path

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
@@ -32,3 +32,25 @@ Feature: delete file
       | dav_version |
       | old         |
       | new         |
+
+  Scenario Outline: delete file from folder with dots in the path
+    Given using <dav_version> DAV path
+    And user "user0" has created folder "<folder_name>"
+    And user "user0" has uploaded file with content "uploaded content for file name with dots" to "<folder_name>/<file_name>"
+    When user "user0" deletes file "<folder_name>/<file_name>" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "user0" file "<folder_name>/<file_name>" should not exist
+    Examples:
+      | dav_version | folder_name   | file_name   |
+      | old         | /upload.      | abc.        |
+      | old         | /upload.      | abc .       |
+      | old         | /upload.1     | abc.txt     |
+      | old         | /upload...1.. | abc...txt.. |
+      | old         | /...          | ...         |
+      | new         | /upload.      | abc.        |
+      | new         | /upload.      | abc .       |
+      | new         | /upload.1     | abc.txt     |
+      | new         | /upload...1.. | abc...txt.. |
+      | new         | /...          | ...         |
+      | new         | /..upload     | abc         |
+      | new         | /..upload     | ..abc       |


### PR DESCRIPTION
## Description
Scenario for deleting file from folder with dots in the path

## Related Issue
https://github.com/owncloud/core/issues/34442

## Motivation and Context

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
