### PR TITLE
fix OCS Share API response for requests contain "include_tags" parameter

### DIFF
--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -207,42 +207,28 @@ class Helper {
 	/**
 	 * Populate the result set with file tags
 	 *
-	 * @param array $fileList
-	 * @param string $fileIdentifier identifier attribute name for values in $fileList
-	 * @return array file list populated with tags
+	 * @param array $shareList
+	 * @return array share list populated with tags
 	 */
-	public static function populateTags(array $fileList, $fileIdentifier = 'fileid') {
-		$filesById = [];
-		foreach ($fileList as $fileData) {
-			$filesById[$fileData[$fileIdentifier]] = $fileData;
+	public static function populateTagsForShares($shareList) {
+		$fileIdList = [];
+		foreach ($shareList as $share) {
+			$fileIdList[] = $share['file_source'];
 		}
+		$fileIdList = \array_unique($fileIdList);
 		$tagger = \OC::$server->getTagManager()->load('files');
-		$tags = $tagger->getTagsForObjects(\array_keys($filesById));
-
+		$tags = $tagger->getTagsForObjects($fileIdList);
 		if (!\is_array($tags)) {
 			throw new \UnexpectedValueException('$tags must be an array');
 		}
 
-		if (!empty($tags)) {
-			foreach ($tags as $fileId => $fileTags) {
-				$filesById[$fileId]['tags'] = $fileTags;
-			}
-
-			foreach ($filesById as $key => $fileWithTags) {
-				foreach ($fileList as $key2 => $file) {
-					if ($file[$fileIdentifier] == $key) {
-						$fileList[$key2] = $fileWithTags;
-					}
-				}
-			}
-
-			foreach ($fileList as $key => $file) {
-				if (!\array_key_exists('tags', $file)) {
-					$fileList[$key]['tags'] = [];
-				}
+		foreach ($shareList as $key => $share) {
+			$shareList[$key]['tags'] = [];
+			if (\array_key_exists($share['file_source'], $tags)) {
+				$shareList[$key]['tags'] = $tags[$share['file_source']];
 			}
 		}
-		return $fileList;
+		return $shareList;
 	}
 
 	/**

--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -586,7 +586,7 @@ class Share20OcsController extends OCSController {
 		}
 
 		if ($includeTags) {
-			$formatted = \OCA\Files\Helper::populateTags($formatted, 'file_source');
+			$formatted = \OCA\Files\Helper::populateTagsForShares($formatted);
 		}
 
 		return new Result($formatted);
@@ -716,7 +716,7 @@ class Share20OcsController extends OCSController {
 		}
 
 		if ($includeTags) {
-			$formatted = \OCA\Files\Helper::populateTags($formatted, 'file_source');
+			$formatted = \OCA\Files\Helper::populateTagsForShares($formatted);
 		}
 
 		if ($path !== null) {

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -439,12 +439,15 @@ class ApiTest extends TestCase {
 
 		$share = $this->shareManager->createShare($share);
 
-		$request = $this->createRequest([]);
+		$request = $this->createRequest(['include_tags' => true]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER1);
 		$result = $ocs->getShares();
 
 		$this->assertTrue($result->succeeded());
 		$this->assertCount(1, $result->getData());
+		foreach ($result->getData() as $shareWithTags) {
+			$this->assertArrayHasKey('tags', $shareWithTags);
+		}
 
 		$this->shareManager->deleteShare($share);
 	}
@@ -469,12 +472,18 @@ class ApiTest extends TestCase {
 			->setPermissions(31);
 		$share2 = $this->shareManager->createShare($share2);
 
-		$request = $this->createRequest(['shared_with_me' => 'true']);
+		$request = $this->createRequest([
+			'shared_with_me' => 'true',
+			'include_tags' => true
+		]);
 		$ocs = $this->createOCS($request, self::TEST_FILES_SHARING_API_USER2);
 		$result = $ocs->getShares();
 
 		$this->assertTrue($result->succeeded());
 		$this->assertCount(2, $result->getData());
+		foreach ($result->getData() as $shareWithTags) {
+			$this->assertArrayHasKey('tags', $shareWithTags);
+		}
 
 		$this->shareManager->deleteShare($share1);
 		$this->shareManager->deleteShare($share2);

--- a/changelog/unreleased/37088
+++ b/changelog/unreleased/37088
@@ -1,0 +1,8 @@
+Bugfix: fix OCS Share API response for requests contain "include_tags" parameter
+
+Sending "include_tags" request parameter for OCS Share API was led to duplicated share entries in API response.
+This bug has been fixed by using share_id instead of file_id when populating tags.
+Also, the tag generation helper method simplified by customizing it for only shares.
+
+https://github.com/owncloud/core/issues/37084
+https://github.com/owncloud/core/pull/37088


### PR DESCRIPTION
## Description
This PR simplifies tag generations for shares and fixes the duplicate share entry problem described in #37084 .
`populateTags` helper method is only used for tag generation for shares. There is no other usage of it in Github organization-wide. The method had too many nested loops. I simplified this method by customizing it for only shares.

@PVince81 Can you confirm the response with this PR so that I don't miss a thing?

## Related Issue
- Fixes #37084 

## How Has This Been Tested?
- Described steps of #37084

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
