### PR TITLE
[Tests-Only] Acceptance test to assert the sharer can unshare and the receiver no longer sees the federated share

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -687,3 +687,14 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
+  Scenario: sharer unshares the federated share and the receiver no longer sees the files/folders
+    Given user "user1" has created folder "/PARENT/RandomFolder"
+    And user "user1" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
+    And user "user1" from server "LOCAL" has shared "/PARENT/RandomFolder" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using OCS API version "1"
+    When user "user1" deletes the last share using the sharing API
+    And using server "REMOTE"
+    Then as "user0" file "/RandomFolder/file-to-share" should not exist
+    And as "user0" folder "/RandomFolder" should not exist


### PR DESCRIPTION

## Description
Acceptance test to assert the sharer can unshare and the receiver no longer sees the federated share

## Related Issue
https://github.com/owncloud/core/issues/34149

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
