### PR TITLE
[Tests-Only] Add scenario outline for scenario in which sharer unshares the federated share and receiver no longer sees the share

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -809,13 +809,17 @@ Feature: federated
       | 1               |
       | 2               |
 
-  Scenario: sharer unshares the federated share and the receiver no longer sees the files/folders
+  Scenario Outline: sharer unshares the federated share and the receiver no longer sees the files/folders
     Given user "user1" has created folder "/PARENT/RandomFolder"
     And user "user1" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
     And user "user1" from server "LOCAL" has shared "/PARENT/RandomFolder" with user "user0" from server "REMOTE"
     And user "user0" from server "REMOTE" has accepted the last pending share
-    And using OCS API version "1"
+    And using OCS API version "<ocs-api-version>"
     When user "user1" deletes the last share using the sharing API
     And using server "REMOTE"
     Then as "user0" file "/RandomFolder/file-to-share" should not exist
     And as "user0" folder "/RandomFolder" should not exist
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |


### PR DESCRIPTION
## Description
 Add scenario outline for the scenario in which sharer unshares the federated share and receiver no longer sees the share

## Related Issue
#34149 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
