### PR TITLE
Add force option to delete user home folder

### DIFF
--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -247,6 +247,37 @@ class SyncService {
 	}
 
 	/**
+	 * Delete the card owned by the user if the userId is unique
+	 * Returns:
+	 *   - true if the card is deleted (the user was unique)
+	 *   - false if there are 2 or more cards found with the same uid
+	 *   - null if no card was found with that uid
+	 * @param string $userId the user Id
+	 * @return bool|null
+	 */
+	public function deleteUserByUidIfUnique($userId) {
+		$systemAddressBook = $this->getLocalSystemAddressBook();
+		$contacts = $this->backend->searchEx(
+			$systemAddressBook['id'],
+			$userId,
+			['UID'],
+			['matchMode' => 'EXACT'],
+			2
+		);
+
+		$contactsFound = \count($contacts);
+		switch ($contactsFound) {
+			case 1:
+				// if there is only one contact found, delete it
+				$this->backend->deleteCard($systemAddressBook['id'], $contacts[0]['uri']);
+				return true;
+			case 2:
+				// if there are 2 or more (search was limited to 2 results), do nothing and return false
+				return false;
+		}
+	}
+
+	/**
 	 * @return array|null
 	 */
 	public function getLocalSystemAddressBook() {

--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -103,6 +103,10 @@ class HookManager {
 		$uid = $params['uid'];
 		if (isset($this->usersToDelete[$uid])) {
 			$this->syncService->deleteUser($this->usersToDelete[$uid]);
+		} else {
+			// the user wasn't found in the userManager. Assume it was deleted before
+			// and try to delete from the syncService if it's the only one.
+			$this->syncService->deleteUserByUidIfUnique($uid);  // not interested in the result
 		}
 
 		foreach ($this->calendarsToDelete as $calendar) {

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -118,6 +118,87 @@ class SyncServiceTest extends TestCase {
 		$ss->deleteUser($user);
 	}
 
+	public function testDeleteUserByUidIfUnique() {
+		$logger = $this->createMock('OCP\ILogger');
+		$userManager = $this->createMock('OCP\IUserManager');
+
+		$backend = $this->createMock(CardDavBackend::class);
+		$backend->method('getAddressBooksByUri')->willReturn([
+			'id'  => 40,
+			'uri' => 'contacts',
+			'principaluri' => 'principals/users/admin',
+			'{DAV:}displayname' => 'Contacts',
+			'{urn:ietf:params:xml:ns:carddav}addressbook-description' => null,
+			'{http://calendarserver.org/ns/}getctag' => 1,
+			'{http://sabredav.org/ns}sync-token' => 1,
+		]);
+		$backend->method('searchEx')->willReturn([
+			[
+				'uri' => 'backend:userId.vcf',
+				'carddata' => "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 3.4.8//EN\r\nUID:userId\r\nFN:userId\r\nN:userId;;;;\r\nEND:VCARD\r\n\r\n"
+			]
+		]);
+		$backend->expects($this->once())
+			->method('deleteCard')
+			->with(40, 'backend:userId.vcf');
+
+		$ss = new SyncService($backend, $userManager, $logger);
+		$this->assertTrue($ss->deleteUserByUidIfUnique('userId'));
+	}
+
+	public function testDeleteUserByUidIfUniqueNoData() {
+		$logger = $this->createMock('OCP\ILogger');
+		$userManager = $this->createMock('OCP\IUserManager');
+
+		$backend = $this->createMock(CardDavBackend::class);
+		$backend->method('getAddressBooksByUri')->willReturn([
+			'id'  => 40,
+			'uri' => 'contacts',
+			'principaluri' => 'principals/users/admin',
+			'{DAV:}displayname' => 'Contacts',
+			'{urn:ietf:params:xml:ns:carddav}addressbook-description' => null,
+			'{http://calendarserver.org/ns/}getctag' => 1,
+			'{http://sabredav.org/ns}sync-token' => 1,
+		]);
+		$backend->method('searchEx')->willReturn([]);
+		$backend->expects($this->never())
+			->method('deleteCard');
+
+		$ss = new SyncService($backend, $userManager, $logger);
+		$this->assertNull($ss->deleteUserByUidIfUnique('userId'));
+	}
+
+	public function testDeleteUserByUidIfUniqueMultiple() {
+		$logger = $this->createMock('OCP\ILogger');
+		$userManager = $this->createMock('OCP\IUserManager');
+
+		$backend = $this->createMock(CardDavBackend::class);
+		$backend->method('getAddressBooksByUri')->willReturn([
+			'id'  => 40,
+			'uri' => 'contacts',
+			'principaluri' => 'principals/users/admin',
+			'{DAV:}displayname' => 'Contacts',
+			'{urn:ietf:params:xml:ns:carddav}addressbook-description' => null,
+			'{http://calendarserver.org/ns/}getctag' => 1,
+			'{http://sabredav.org/ns}sync-token' => 1,
+		]);
+		$backend->method('searchEx')->willReturn([
+			[
+				'uri' => 'backend:userId.vcf',
+				'carddata' => "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 3.4.8//EN\r\nUID:userId\r\nFN:userId\r\nN:userId;;;;\r\nEND:VCARD\r\n\r\n"
+			],
+			[
+				'uri' => 'backend2:userId.vcf',
+				'carddata' => "BEGIN:VCARD\r\nVERSION:3.0\r\nPRODID:-//Sabre//Sabre VObject 3.4.8//EN\r\nUID:userId\r\nFN:userId\r\nN:userId;;;;\r\nEND:VCARD\r\n\r\n"
+			]
+		]);
+		$backend->expects($this->never())
+			->method('deleteCard');
+
+		$ss = new SyncService($backend, $userManager, $logger);
+		$this->assertFalse($ss->deleteUserByUidIfUnique('userId'));
+	}
+
 	/**
 	 * @param int $createCount
 	 * @param int $updateCount

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -588,9 +588,9 @@ class Share20OcsControllerTest extends TestCase {
 		$group->method('getGID')->willReturn('groupId');
 
 		$this->userManager->method('get')->will($this->returnValueMap([
-			['userId', $user],
-			['initiatorId', $initiator],
-			['ownerId', $owner],
+			['userId', false, $user],
+			['initiatorId', false, $initiator],
+			['ownerId', false, $owner],
 		]));
 		$this->groupManager->method('get')->will($this->returnValueMap([
 			['group', $group],
@@ -2345,9 +2345,9 @@ class Share20OcsControllerTest extends TestCase {
 				'mail_send' => 0,
 				'mimetype' => 'myMimeType',
 			], $share, [
-				['owner', $owner],
-				['initiator', $initiator],
-				['recipient', $recipient],
+				['owner', false, $owner],
+				['initiator', false, $initiator],
+				['recipient', false, $recipient],
 			], false
 		];
 
@@ -2726,9 +2726,9 @@ class Share20OcsControllerTest extends TestCase {
 		$recipient->method('getEMailAddress')->willReturn('email@example.com');
 
 		$this->userManager->method('get')->will($this->returnValueMap([
-			['initiator', $initiator],
-			['recipient', $recipient],
-			['owner', $owner],
+			['initiator', false, $initiator],
+			['recipient', false, $recipient],
+			['owner', false, $owner],
 		]));
 
 		$ocs = new Share20OcsController(

--- a/apps/files_sharing/tests/NotifierTest.php
+++ b/apps/files_sharing/tests/NotifierTest.php
@@ -311,8 +311,8 @@ class NotifierTest extends \Test\TestCase {
 
 		$this->userManager->method('get')
 			->will($this->returnValueMap([
-				[$subjectParams[0], $user1],
-				[$subjectParams[1], $user2],
+				[$subjectParams[0], false, $user1],
+				[$subjectParams[1], false, $user2],
 		]));
 
 		$this->config->method('getAppValue')

--- a/changelog/unreleased/37103
+++ b/changelog/unreleased/37103
@@ -1,0 +1,12 @@
+Bugfix: Add force option to delete user home folder
+
+When the command:
+./occ user:delete -f foo
+
+If the user foo is not available then the command would
+check if the home folder exists for the user foo, when 
+-f or force option is provided. If so then it would
+delete the home folder of foo.
+
+https://github.com/owncloud/core/pull/37103
+

--- a/changelog/unreleased/37103
+++ b/changelog/unreleased/37103
@@ -1,12 +1,15 @@
-Bugfix: Add force option to delete user home folder
+Bugfix: Add force option to delete user even if the user doesn't exist
 
 When the command:
 ./occ user:delete -f foo
 
-If the user foo is not available then the command would
-check if the home folder exists for the user foo, when 
--f or force option is provided. If so then it would
-delete the home folder of foo.
+If the user foo doesn't exist, the "force" option will try to delete
+any remnant that such user could have in the system. This includes data,
+shares, preferences, etc.
+This situation has been detected with some setups after the upgrade of
+ownCloud 9 to 10 with user_ldap active.
+Note that normal user deletion behaviour will still be used if the user
+exists even if the "force" option is used.
 
 https://github.com/owncloud/core/pull/37103
 

--- a/core/Command/User/Delete.php
+++ b/core/Command/User/Delete.php
@@ -25,8 +25,7 @@
 namespace OC\Core\Command\User;
 
 use OC\User\DeletedUser;
-use OCP\IURLGenerator;
-use OCP\IConfig;
+use OC\User\Manager;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -37,19 +36,13 @@ use Symfony\Component\Console\Input\InputArgument;
 class Delete extends Command {
 	/** @var IUserManager */
 	private $userManager;
-	/** @var IConfig */
-	private $config;
-	/** @var IURLGenerator */
-	private $urlGenerator;
 
 	/**
 	 * @param IUserManager $userManager
 	 * @param IRootFolder $rootFolder
 	 */
-	public function __construct(IUserManager $userManager, IConfig $config, IURLGenerator $urlGenerator) {
+	public function __construct(IUserManager $userManager) {
 		$this->userManager = $userManager;
-		$this->config = $config;
-		$this->urlGenerator = $urlGenerator;
 		parent::__construct();
 	}
 
@@ -74,7 +67,7 @@ class Delete extends Command {
 		$user = $this->userManager->get($uid);
 		if ($user === null) {
 			if ($input->getOption('force')) {
-				$deletedUser = new DeletedUser($this->userManager, $this->config, $this->urlGenerator, $uid);
+				$deletedUser = $this->userManager->get($uid, true);
 				$deletedUser->delete();
 				$output->writeln("<info>User deleted.</info>");
 				return 0;

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -148,7 +148,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	);
 
 	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager(), \OC::$server->getMailer()));
-	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager(), \OC::$server->getRootFolder()));
 	$application->add(new OC\Core\Command\User\Disable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Inactive(\OC::$server->getUserManager()));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -148,7 +148,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	);
 
 	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager(), \OC::$server->getMailer()));
-	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getURLGenerator()));
+	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Disable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Inactive(\OC::$server->getUserManager()));

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -148,7 +148,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	);
 
 	$application->add(new OC\Core\Command\User\Add(\OC::$server->getUserManager(), \OC::$server->getGroupManager(), \OC::$server->getMailer()));
-	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager(), \OC::$server->getRootFolder()));
+	$application->add(new OC\Core\Command\User\Delete(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getURLGenerator()));
 	$application->add(new OC\Core\Command\User\Disable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Enable(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\Inactive(\OC::$server->getUserManager()));

--- a/lib/private/User/DeletedUser.php
+++ b/lib/private/User/DeletedUser.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\User;
+
+use OC\Files\Cache\Storage;
+use OC\Hooks\Emitter;
+use OC\User\Manager;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IConfig;
+use OCP\Files\NotFoundException;
+
+/**
+ * Class representing a deleted user.
+ * This class is intended to be used internally.
+ */
+class DeletedUser implements IUser {
+	/** @var Emitter */
+	private $emitter;
+	/** @var IConfig */
+	private $config;
+	/** @var IURLGenerator */
+	private $urlGenerator;
+	/** @var string */
+	private $uid;
+
+	public function __construct(Manager $userManager, IConfig $config, IURLGenerator $urlGenerator, $uid) {
+		$this->emitter = $userManager;  // use the userManager as event emitter
+		// this is required because there could be listeners listening in the
+		// userManager class, and we want to trigger the same
+		// (this behaviour is copied from \OC\User\Manager::getUserObject)
+		$this->config = $config;
+		$this->urlGenerator = $urlGenerator;
+		$this->uid = $uid;
+	}
+
+	public function getAccountId() {
+		return $this->uid;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getUID() {
+		return $this->uid;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getUserName() {
+		return $this->config->getUserValue($this->uid, 'core', 'username', $this->uid);
+	}
+
+	public function setUserName($userName) {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	/**
+	 * Return the uid as displayname. Consider the account table's information deleted.
+	 * @return string
+	 */
+	public function getDisplayName() {
+		return $this->uid;
+	}
+
+	public function setDisplayName($displayName) {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	/**
+	 * Consider the user didn't login (return 0)
+	 * @return int
+	 */
+	public function getLastLogin() {
+		return 0;
+	}
+
+	/**
+	 * Match \OC\User\User implementation returning true on first update, but
+	 * don't do anything
+	 */
+	public function updateLastLoginTimestamp() {
+		return true;
+	}
+
+	/**
+	 * This is mostly copied from \OC\User\User, but taking into account the
+	 * account info is missing
+	 */
+	public function delete() {
+		if ($this->emitter) {
+			$this->emitter->emit('\OC\User', 'preDelete', [$this]);
+		}
+
+		// account deletion in the backend must have been performed out of here, otherwise
+		// we shouldn't have reached this point. Skip the account deletion in the backend
+
+		// FIXME: Feels like an hack - suggestions?
+
+		// We have to delete the user from all groups
+		foreach (\OC::$server->getGroupManager()->getUserGroups($this) as $group) {
+			$group->removeUser($this);
+		}
+		// Delete the user's keys in preferences
+		\OC::$server->getConfig()->deleteAllUserValues($this->getUID());
+
+		// Delete all mount points for user
+		\OC::$server->getUserStoragesService()->deleteAllMountsForUser($this);
+		//Delete external storage or remove user from applicableUsers list
+		\OC::$server->getGlobalStoragesService()->deleteAllForUser($this);
+
+		// Delete user files in /data/
+		try {
+			$userFolder = \OC::$server->getRootFolder()->get("/{$this->uid}");
+			$userFolder->delete();
+		} catch (NotFoundException $e) {
+			// Do nothing if the folder doesn't exist
+		}
+
+		// Delete the users entry in the storage table
+		Storage::remove('home::' . $this->getUID());
+		Storage::remove('object::user:' . $this->getUID());
+
+		\OC::$server->getCommentsManager()->deleteReferencesOfActor('users', $this->getUID());
+		\OC::$server->getCommentsManager()->deleteReadMarksFromUser($this);
+
+		if ($this->emitter) {
+			$this->emitter->emit('\OC\User', 'postDelete', [$this]);
+		}
+		return true;
+	}
+
+	public function setPassword($password, $recoveryPassword = null) {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	public function getHome() {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	public function getBackendClassName() {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	public function canChangeAvatar() {
+		return false;
+	}
+
+	public function canChangePassword() {
+		return false;
+	}
+
+	public function canChangeDisplayName() {
+		return false;
+	}
+
+	public function isEnabled() {
+		return false;
+	}
+
+	public function setEnabled($enabled) {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getEMailAddress() {
+		return null;
+	}
+
+	public function getAvatarImage($size) {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	public function getCloudId() {
+		$server = $this->urlGenerator->getAbsoluteURL('/');
+		return $this->uid . '@' . \rtrim($this->removeProtocolFromUrl($server), '/');
+	}
+
+	/**
+	 * Copied from \OC\User\User
+	 */
+	private function removeProtocolFromUrl($url) {
+		if (\strpos($url, 'https://') === 0) {
+			return \substr($url, \strlen('https://'));
+		} elseif (\strpos($url, 'http://') === 0) {
+			return \substr($url, \strlen('http://'));
+		}
+
+		return $url;
+	}
+
+	public function setEMailAddress($mailAddress) {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	public function getQuota() {
+		return 'default';
+	}
+
+	public function setQuota($quota) {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	public function setSearchTerms(array $terms) {
+		throw new \Exception("Not Implemented", 1);
+	}
+
+	public function getSearchTerms() {
+		return [];
+	}
+}

--- a/lib/private/User/DeletedUser.php
+++ b/lib/private/User/DeletedUser.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgeargroup.com>
  *
  * @copyright Copyright (c) 2020, ownCloud GmbH
  * @license AGPL-3.0

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -74,10 +74,12 @@ interface IUserManager {
 	 * get a user by user id
 	 *
 	 * @param string $uid
+	 * @param bool $evenMissing get an IUser instance even if the user doesn't exist
+	 * The instance will contain basic information, and most operations won't be implemented
 	 * @return \OCP\IUser|null Either the user or null if the specified user does not exist
 	 * @since 8.0.0
 	 */
-	public function get($uid);
+	public function get($uid, $evenMissing = false);
 
 	/**
 	 * check if a user exists

--- a/tests/Core/Command/User/DeleteTest.php
+++ b/tests/Core/Command/User/DeleteTest.php
@@ -24,6 +24,8 @@ namespace Tests\Core\Command\User;
 
 use OC\Core\Command\User\Delete;
 use OCP\Files\IRootFolder;
+use OCP\IURLGenerator;
+use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Files\Node;
 use Symfony\Component\Console\Application;
@@ -33,9 +35,11 @@ use Test\TestCase;
 class DeleteTest extends TestCase {
 
 	/** @var \PHPUnit\Framework\MockObject\MockObject|IUserManager */
-	protected $userManager;
-	/** @var \PHPUnit\Framework\MockObject\MockObject|IRootFolder */
-	protected $rootFolder;
+	private $userManager;
+	/** @var \PHPUnit\Framework\MockObject\MockObject|IConfig */
+	private $config;
+	/** @var IURLGenerator */
+	private $urlGenerator;
 
 	/** @var CommandTester */
 	private $commandTester;
@@ -45,9 +49,10 @@ class DeleteTest extends TestCase {
 		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 
-		$command = new Delete($this->userManager, $this->rootFolder);
+		$command = new Delete($this->userManager, $this->config, $this->urlGenerator);
 		$command->setApplication(new Application());
 		$this->commandTester = new CommandTester($command);
 	}
@@ -110,14 +115,8 @@ class DeleteTest extends TestCase {
 			->with('user')
 			->willReturn(null);
 
-		$node = $this->createMock(Node::class);
-		$node->expects($this->once())
-			->method('delete');
-		$this->rootFolder
-			->method('get')
-			->willReturn($node);
 		$this->commandTester->execute(['uid' => 'user', '--force' => true]);
 		$output = $this->commandTester->getDisplay();
-		$this->assertStringContainsString('User folder is deleted.', $output);
+		$this->assertStringContainsString('User deleted.', $output);
 	}
 }

--- a/tests/Core/Command/User/DeleteTest.php
+++ b/tests/Core/Command/User/DeleteTest.php
@@ -23,9 +23,7 @@
 namespace Tests\Core\Command\User;
 
 use OC\Core\Command\User\Delete;
-use OCP\Files\IRootFolder;
-use OCP\IURLGenerator;
-use OCP\IConfig;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Files\Node;
 use Symfony\Component\Console\Application;
@@ -36,10 +34,6 @@ class DeleteTest extends TestCase {
 
 	/** @var \PHPUnit\Framework\MockObject\MockObject|IUserManager */
 	private $userManager;
-	/** @var \PHPUnit\Framework\MockObject\MockObject|IConfig */
-	private $config;
-	/** @var IURLGenerator */
-	private $urlGenerator;
 
 	/** @var CommandTester */
 	private $commandTester;
@@ -49,10 +43,8 @@ class DeleteTest extends TestCase {
 		$this->userManager = $this->getMockBuilder('OCP\IUserManager')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->config = $this->createMock(IConfig::class);
-		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 
-		$command = new Delete($this->userManager, $this->config, $this->urlGenerator);
+		$command = new Delete($this->userManager);
 		$command->setApplication(new Application());
 		$this->commandTester = new CommandTester($command);
 	}
@@ -110,10 +102,13 @@ class DeleteTest extends TestCase {
 	}
 
 	public function testForceDeleteUser() {
-		$this->userManager->expects($this->once())
+		$this->userManager->expects($this->exactly(2))
 			->method('get')
-			->with('user')
-			->willReturn(null);
+			->withConsecutive(
+				['user', false],
+				['user', true]
+			)
+			->will($this->onConsecutiveCalls(null, $this->createMock(IUser::class)));
 
 		$this->commandTester->execute(['uid' => 'user', '--force' => true]);
 		$output = $this->commandTester->getDisplay();

--- a/tests/Core/Controller/AvatarControllerTest.php
+++ b/tests/Core/Controller/AvatarControllerTest.php
@@ -116,7 +116,7 @@ class AvatarControllerTest extends TestCase {
 		$this->userMock->expects($this->any())->method('getDisplayName')->willReturn('displayName');
 		$this->userMock->expects($this->any())->method('getUID')->willReturn('userId');
 		$this->userManager->expects($this->any())->method('get')
-			->willReturnMap([['userId', $this->userMock]]);
+			->willReturnMap([['userId', false, $this->userMock]]);
 		$this->userSession->expects($this->any())->method('getUser')->willReturn($this->userMock);
 
 		$this->avatarFile = $this->createMock('OCP\Files\File');

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -364,8 +364,8 @@ class LostControllerTest extends TestCase {
 			->method('get')
 			->willReturnMap(
 				[
-					['test@example.com', null],
-					['ExistingUser', $this->existingUser]
+					['test@example.com', false, null],
+					['ExistingUser', false, $this->existingUser]
 				]
 			);
 		$this->userManager

--- a/tests/lib/Command/User/SyncBackendTest.php
+++ b/tests/lib/Command/User/SyncBackendTest.php
@@ -356,7 +356,7 @@ class SyncBackendTest extends TestCase {
 		//$reappearedUser = $this->createMock(IUser::class);
 
 		$this->userManager->method('get')->willReturnMap([
-			['removed-uid', $removedUser],
+			['removed-uid', false, $removedUser],
 			//['reappeared-uid', $reappearedUser]
 		]);
 
@@ -448,7 +448,7 @@ class SyncBackendTest extends TestCase {
 		$removedUser->method('delete')->willReturn(true);
 
 		$this->userManager->method('get')->willReturnMap([
-			['removed-uid', $removedUser],
+			['removed-uid', false, $removedUser],
 		]);
 		$removedUser->expects($this->once())->method($method)->willReturn($isEnabled);
 		if ($setEnabled !== null) {

--- a/tests/lib/Group/GroupTest.php
+++ b/tests/lib/Group/GroupTest.php
@@ -29,9 +29,9 @@ class GroupTest extends \Test\TestCase {
 		$userManager->expects($this->any())
 			->method('get')
 			->will($this->returnValueMap([
-				['user1', $user1],
-				['user2', $user2],
-				['user3', $user3]
+				['user1', false, $user1],
+				['user2', false, $user2],
+				['user3', false, $user3]
 			]));
 		return $userManager;
 	}

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -1027,9 +1027,9 @@ class DefaultShareProviderTest extends TestCase {
 		$initiator->method('getUID')->willReturn('sharedBy');
 
 		$this->userManager->method('get')->willReturnMap([
-			['sharedWith', $user],
-			['shareOwner', $owner],
-			['sharedBy', $initiator],
+			['sharedWith', false, $user],
+			['shareOwner', false, $owner],
+			['sharedBy', false, $initiator],
 		]);
 		$this->groupManager->method('getUserGroups')->with($user)->willReturn($groups);
 		$this->groupManager->method('get')->with('sharedWith')->willReturn($group);
@@ -1121,9 +1121,9 @@ class DefaultShareProviderTest extends TestCase {
 		$initiator->method('getUID')->willReturn('sharedBy');
 
 		$this->userManager->method('get')->willReturnMap([
-			['user', $user],
-			['shareOwner', $owner],
-			['sharedBy', $initiator],
+			['user', false, $user],
+			['shareOwner', false, $owner],
+			['sharedBy', false, $initiator],
 		]);
 		$this->groupManager->method('getUserGroups')->with($user)->willReturn($groups);
 		$this->groupManager->method('get')->with('sharedWith')->willReturn($group);
@@ -1203,8 +1203,8 @@ class DefaultShareProviderTest extends TestCase {
 		$user1->method('getUID')->willReturn('user1');
 
 		$this->userManager->method('get')->willReturnMap([
-			['user0', $user0],
-			['user1', $user1],
+			['user0', false, $user0],
+			['user1', false, $user1],
 		]);
 
 		$group0 = $this->createMock(IGroup::class);
@@ -1243,8 +1243,8 @@ class DefaultShareProviderTest extends TestCase {
 		$user1->method('getUID')->willReturn('user1');
 
 		$this->userManager->method('get')->willReturnMap([
-			['user0', $user0],
-			['user1', $user1],
+			['user0', false, $user0],
+			['user1', false, $user1],
 		]);
 
 		for ($i = 0; $i < 105; $i++) {
@@ -1295,8 +1295,8 @@ class DefaultShareProviderTest extends TestCase {
 		$user1->method('getUID')->willReturn('user1');
 
 		$this->userManager->method('get')->willReturnMap([
-			['user0', $user0],
-			['user1', $user1],
+			['user0', false, $user0],
+			['user1', false, $user1],
 		]);
 
 		$group0 = $this->createMock(IGroup::class);
@@ -1408,9 +1408,9 @@ class DefaultShareProviderTest extends TestCase {
 
 		// Setup mocking
 		$this->userManager->method('get')->willReturnMap([
-			['user1', $user1],
-			['user2', $user2],
-			['meow', $userMeow],
+			['user1', false, $user1],
+			['user2', false, $user2],
+			['meow', false, $userMeow],
 		]);
 
 		$this->rootFolder->method('getUserFolder')->with('user2')->will($this->returnSelf());
@@ -1491,8 +1491,8 @@ class DefaultShareProviderTest extends TestCase {
 
 		// Setup mocking
 		$this->userManager->method('get')->willReturnMap([
-			['user1', $user1],
-			['user2', $user2],
+			['user1', false, $user1],
+			['user2', false, $user2],
 		]);
 
 		$this->rootFolder->method('getUserFolder')->with('user1')->will($this->returnSelf());
@@ -1589,9 +1589,9 @@ class DefaultShareProviderTest extends TestCase {
 		$initiator->method('getUID')->willReturn('sharedBy');
 
 		$this->userManager->method('get')->willReturnMap([
-			['sharedWith', $user],
-			['shareOwner', $owner],
-			['sharedBy', $initiator],
+			['sharedWith', false, $user],
+			['shareOwner', false, $owner],
+			['sharedBy', false, $initiator],
 		]);
 		$this->groupManager->method('getUserGroups')->with($user)->willReturn($groups);
 		$this->groupManager->method('get')->with('sharedWith')->willReturn($group);
@@ -1905,8 +1905,8 @@ class DefaultShareProviderTest extends TestCase {
 		$user2 = $this->createMock(IUser::class);
 		$user2->method('getUID')->willReturn('user2');
 		$this->userManager->method('get')->will($this->returnValueMap([
-			['user1', $user1],
-			['user2', $user2],
+			['user1', false, $user1],
+			['user2', false, $user2],
 		]));
 
 		$group = $this->createMock(IGroup::class);
@@ -1979,8 +1979,8 @@ class DefaultShareProviderTest extends TestCase {
 		$user2 = $this->createMock(IUser::class);
 		$user2->method('getUID')->willReturn('user2');
 		$this->userManager->method('get')->will($this->returnValueMap([
-			['user1', $user1],
-			['user2', $user2],
+			['user1', false, $user1],
+			['user2', false, $user2],
 		]));
 
 		$group = $this->createMock(IGroup::class);
@@ -2041,8 +2041,8 @@ class DefaultShareProviderTest extends TestCase {
 		$user2 = $this->createMock(IUser::class);
 		$user2->method('getUID')->willReturn('user2');
 		$this->userManager->method('get')->will($this->returnValueMap([
-			['user1', $user1],
-			['user2', $user2],
+			['user1', false, $user1],
+			['user2', false, $user2],
 		]));
 
 		$group = $this->createMock(IGroup::class);
@@ -2619,8 +2619,8 @@ class DefaultShareProviderTest extends TestCase {
 		$this->groupManager->method('get')->with('group0')->willReturn($group0);
 
 		$this->userManager->method('get')->will($this->returnValueMap([
-			['user0', $user0],
-			['user1', $user1],
+			['user0', false, $user0],
+			['user1', false, $user1],
 		]));
 
 		$folder = $this->createMock(Folder::class);
@@ -2678,8 +2678,8 @@ class DefaultShareProviderTest extends TestCase {
 		$this->groupManager->method('get')->with('group0')->willReturn($group0);
 
 		$this->userManager->method('get')->will($this->returnValueMap([
-			['user0', $user0],
-			['user1', $user1],
+			['user0', false, $user0],
+			['user1', false, $user1],
 		]));
 
 		$folder = $this->createMock(Folder::class);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1273,8 +1273,8 @@ class ManagerTest extends \Test\TestCase {
 			);
 
 		$this->userManager->method('get')->will($this->returnValueMap([
-			['sharedBy', $sharedBy],
-			['sharedWith', $sharedWith],
+			['sharedBy', false, $sharedBy],
+			['sharedWith', false, $sharedWith],
 		]));
 
 		$this->config
@@ -1306,8 +1306,8 @@ class ManagerTest extends \Test\TestCase {
 			);
 
 		$this->userManager->method('get')->will($this->returnValueMap([
-			['sharedBy', $sharedBy],
-			['sharedWith', $sharedWith],
+			['sharedBy', false, $sharedBy],
+			['sharedWith', false, $sharedWith],
 		]));
 
 		$this->config
@@ -2069,8 +2069,8 @@ class ManagerTest extends \Test\TestCase {
 		$this->userManager->expects($this->any())
 			->method('get')
 			->will($this->returnValueMap([
-				['user1', $user1],
-				['user2', $user2]
+				['user1', false, $user1],
+				['user2', false, $user2]
 			]));
 
 		if ($sharetype === 'user') {
@@ -2186,8 +2186,8 @@ class ManagerTest extends \Test\TestCase {
 			->getMock();
 		$this->userManager->method('get')
 			->will($this->returnValueMap([
-				['user1', $this->createMock(IUser::class)],
-				['user2', null]
+				['user1', false, $this->createMock(IUser::class)],
+				['user2', false, null]
 			]));
 		$share = $this->createShare('23', \OCP\Share::SHARE_TYPE_USER,
 			'/foo', 'user2', 'user1', 'user1',
@@ -2207,7 +2207,7 @@ class ManagerTest extends \Test\TestCase {
 			->getMock();
 		$this->userManager->method('get')
 			->will($this->returnValueMap([
-				['user1', $this->createMock(IUser::class)],
+				['user1', false, $this->createMock(IUser::class)],
 			]));
 		$share = $this->createShare('23', \OCP\Share::SHARE_TYPE_USER,
 			'/foo', 'user2', 'user1', 'user1',
@@ -2227,8 +2227,8 @@ class ManagerTest extends \Test\TestCase {
 			->getMock();
 		$this->userManager->method('get')
 			->will($this->returnValueMap([
-				['user1', $this->createMock(IUser::class)],
-				['user2', $this->createMock(IUser::class)],
+				['user1', false, $this->createMock(IUser::class)],
+				['user2', false, $this->createMock(IUser::class)],
 			]));
 		$this->view->expects($this->once())
 			->method('file_exists')

--- a/tests/lib/User/DeletedUserTest.php
+++ b/tests/lib/User/DeletedUserTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * @author Juan Pablo Villafáñez <jvillafanez@solidgeargroup.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\User;
+
+use OC\User\DeletedUser;
+use OC\User\Manager;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+use Test\TestCase;
+
+/**
+ *
+ * @package Test\User
+ */
+class DeletedUserTest extends TestCase {
+	/** @var Manager */
+	private $manager;
+	/** @var IConfig */
+	private $config;
+	/** @var IURLGenerator */
+	private $urlGenerator;
+	/** @var DeletedUser */
+	private $deletedUser;
+
+	protected function setUp(): void {
+		$this->manager = $this->createMock(Manager::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+
+		$this->deletedUser = new DeletedUser($this->manager, $this->config, $this->urlGenerator, 'theTestUser');
+	}
+
+	public function testGetAccountId() {
+		$this->assertSame('theTestUser', $this->deletedUser->getAccountId());
+	}
+
+	public function testGetUID() {
+		$this->assertSame('theTestUser', $this->deletedUser->getUID());
+	}
+
+	public function testGetUserName() {
+		$this->config->method('getUserValue')
+			->with('theTestUser', 'core', 'username', 'theTestUser')
+			->willReturn('theUserName');
+
+		$this->assertSame('theUserName', $this->deletedUser->getUserName());
+	}
+
+	public function testSetUserName() {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->setUserName('newUsername');
+	}
+
+	public function testGetDisplayName() {
+		$this->assertSame('theTestUser', $this->deletedUser->getDisplayName());
+	}
+
+	public function testSetDisplayName() {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->setDisplayName('newDisplayname');
+	}
+
+	public function testGetLastLogin() {
+		$this->assertSame(0, $this->deletedUser->getLastLogin());
+	}
+
+	public function testUpdateLastLoginTimestamp() {
+		$this->assertTrue($this->deletedUser->updateLastLoginTimestamp());
+	}
+
+	// TODO: "delete" method can't be unittested
+
+	public function passwordProvider() {
+		return [
+			['password', null],
+			['password', 'recovery'],
+		];
+	}
+
+	/**
+	 * @dataProvider passwordProvider
+	 */
+	public function testSetPassword($password, $recovery) {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->setPassword($password, $recovery);
+	}
+
+	public function testGetHome() {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->getHome();
+	}
+
+	public function testGetBackendClassName() {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->getBackendClassName();
+	}
+
+	public function testCanChangeAvatar() {
+		$this->assertFalse($this->deletedUser->canChangeAvatar());
+	}
+
+	public function testCanChangePassword() {
+		$this->assertFalse($this->deletedUser->canChangePassword());
+	}
+
+	public function testCanChangeDisplayName() {
+		$this->assertFalse($this->deletedUser->canChangeDisplayName());
+	}
+
+	public function testIsEnabled() {
+		$this->assertFalse($this->deletedUser->isEnabled());
+	}
+
+	public function setEnabledProvider() {
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	/**
+	 * @dataProvider setEnabledProvider
+	 */
+	public function testSetEnabled($state) {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->setEnabled($state);
+	}
+
+	public function testGetEMailAddress() {
+		$this->assertNull($this->deletedUser->getEMailAddress());
+	}
+
+	public function testGetAvatarImage() {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->getAvatarImage(50);
+	}
+
+	public function testGetCloudId() {
+		$this->urlGenerator->method('getAbsoluteURL')
+			->willReturn('https://demo.memo:9999/owncloud');
+
+		$this->assertSame('theTestUser@demo.memo:9999/owncloud', $this->deletedUser->getCloudId());
+	}
+
+	public function testSetEMailAddress() {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->setEMailAddress('dummy@example.com');
+	}
+
+	public function testGetQuota() {
+		$this->assertSame('default', $this->deletedUser->getQuota());
+	}
+
+	public function setQuotaProvider() {
+		return [
+			['default'],
+			['none'],
+			['500'],
+			['500MB'],
+		];
+	}
+
+	/**
+	 * @dataProvider setQuotaProvider
+	 */
+	public function testSetQuota($quota) {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->setQuota($quota);
+	}
+
+	public function testSetSearchTerms() {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Not Implemented');
+
+		$this->deletedUser->setSearchTerms([]);
+	}
+
+	public function testGetSearchTerms() {
+		$this->assertSame([], $this->deletedUser->getSearchTerms());
+	}
+}

--- a/tests/lib/User/TokenAuthModuleTest.php
+++ b/tests/lib/User/TokenAuthModuleTest.php
@@ -76,7 +76,7 @@ class TokenAuthModuleTest extends TestCase {
 
 		$this->manager->expects($this->any())->method('get')
 			->willReturnMap([
-				['user1', $this->user],
+				['user1', false, $this->user],
 			]);
 	}
 


### PR DESCRIPTION
Add a force option to the user delete command
in order to delete the users home folder if
exists.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Add force option for the `user:delete` command, to delete the home folder of the user if available.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/enterprise/issues/2969

## Motivation and Context
Its been noticed that when users upgrade from 9.1.5 to 10 of core, the accounts table does not have the user details and neither the home entry added to it. Now if the backend had deleted a user before upgrade then oC admin will not be able to delete the oc user mapped to the ldap backend. Because the entry is missing in the accounts table. Under such condition it would be handy to delete the home folder of those users (i.e, for missing backend users).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Install oC 9.1.5
- Create LDAP users
- Now enable user_ldap app
- Configure it with the oC as admin
- Make sure the LDAP users are synced. You can see the result in the Users page.
- Now try to login to few users who are mapped with the LDAP.
- Delete the users in the LDAP.
- Upgrade to oC 10.4.0
- Now try to run `user:delete` with uid and --force, where uid is the user unavailable in the LDAP or say the deleted one.
- The home folder ( i.e, the remains ) should be deleted.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
