### PR TITLE
Fixes #36570 - write crash log in case of config.php parse error

### DIFF
--- a/changelog/unreleased/36570
+++ b/changelog/unreleased/36570
@@ -1,0 +1,3 @@
+Change: Write crash log in case of parse error in config.php
+
+https://github.com/owncloud/core/issues/36570

--- a/lib/base.php
+++ b/lib/base.php
@@ -1010,10 +1010,15 @@ class OC {
 	 *
 	 * Note: This is mainly for internal purposes. You're encouraged to use the ownCloud's logger
 	 * for anything you need to log.
+	 *
+	 * @param Throwable $ex
 	 */
-	public static function crashLog(\Throwable $ex) {
-		$dataDir = self::$config->getValue('datadirectory', self::$SERVERROOT . '/data');
-		$crashDir = self::$config->getValue('crashdirectory', $dataDir);
+	public static function crashLog(\Throwable $ex): void {
+		$crashDir = self::$SERVERROOT . '/data';
+		if (self::$config) {
+			$dataDir = self::$config->getValue('datadirectory', self::$SERVERROOT . '/data');
+			$crashDir = self::$config->getValue('crashdirectory', $dataDir);
+		}
 
 		$filename = "${crashDir}/crash-" . \date('Y-m-d') . '.log';
 
@@ -1025,7 +1030,7 @@ class OC {
 			'id' => $currentEntryId,
 			'class' => \get_class($ex),
 			'message' => $ex->getMessage(),
-			'stacktrace' => \array_map(function ($elem) {
+			'stacktrace' => \array_map(static function ($elem) {
 				unset($elem['args'], $elem['type']);
 				return $elem;
 			}, $ex->getTrace()),
@@ -1041,7 +1046,7 @@ class OC {
 				'id' => $currentEntryId,
 				'class' => \get_class($ex),
 				'message' => $ex->getMessage(),
-				'stacktrace' => \array_map(function ($elem) {
+				'stacktrace' => \array_map(static function ($elem) {
 					unset($elem['args'], $elem['type']);
 					return $elem;
 				}, $ex->getTrace()),


### PR DESCRIPTION
## Description
Crash log is now written in case of parse error in config.php

## Related Issue
- Fixes #36570 

## How Has This Been Tested?
- :hand: 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
