### PR TITLE
[Tests-Only] Acceptance tests when incoming and outgoing federated share settings are enabled or disabled

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -869,14 +869,14 @@ Feature: federated
       | 1               |
       | 2               |
 
-  Scenario Outline: Incoming and Outgoing federation shares are enabled
+  Scenario Outline: Both Incoming and Outgoing federation shares are allowed
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
-    And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
-    And user "user1" from server "LOCAL" has shared "file-to-share" with user "user0" from server "REMOTE"
-    And user "user0" from server "REMOTE" has accepted the last pending share
     And using OCS API version "<ocs-api-version>"
-    When using server "REMOTE"
+    When user "user1" uploads file with content "thisContentIsVisible" to "/file-to-share" using the WebDAV API
+    And user "user1" from server "LOCAL" shares "file-to-share" with user "user0" from server "REMOTE" using the sharing API
+    And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
+    And using server "REMOTE"
     Then as "user0" file "/file-to-share" should exist
     And the content of file "/file-to-share" for user "user0" should be "thisContentIsVisible"
     When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
@@ -890,14 +890,14 @@ Feature: federated
       | 1               |
       | 2               |
 
-  Scenario Outline: Incoming federation shares are enabled but outgoing federation shares are disabled
+  Scenario Outline: Incoming federation shares are allowed but outgoing federation shares are restricted
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
     And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
     And using OCS API version "<ocs-api-version>"
     When user "user1" from server "LOCAL" shares "file-to-share" with user "user0" from server "REMOTE" using the sharing API
     And using server "REMOTE"
-    Then user "user0" should have no last pending federated cloud share
+    Then user "user0" should not have any pending federated cloud share
     And as "user0" file "/file-to-share" should not exist
     When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
     And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
@@ -909,7 +909,7 @@ Feature: federated
       | 1               |
       | 2               |
 
-  Scenario Outline: Incoming federation shares are disabled but outgoing federation shares are enabled
+  Scenario Outline: Incoming federation shares are restricted but outgoing federation shares are allowed
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
     And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
@@ -921,33 +921,33 @@ Feature: federated
     When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
     And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
     And using server "LOCAL"
-    Then user "user1" should have no last pending federated cloud share
+    Then user "user1" should not have any pending federated cloud share
     And as "user1" file "/newFile" should not exist
     Examples:
       | ocs-api-version |
       | 1               |
       | 2               |
 
-  Scenario Outline: Incoming and outgoing federation shares are disabled
+  Scenario Outline: Both Incoming and outgoing federation shares are restricted
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
     And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
     And using OCS API version "<ocs-api-version>"
     When user "user1" from server "LOCAL" shares "/file-to-share" with user "user0" from server "REMOTE" using the sharing API
     And using server "REMOTE"
-    Then user "user0" should have no last pending federated cloud share
+    Then user "user0" should not have any pending federated cloud share
     And as "user0" file "/file-to-share" should not exist
     When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
     And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
     And using server "LOCAL"
-    Then user "user1" should have no last pending federated cloud share
+    Then user "user1" should not have any pending federated cloud share
     And as "user1" file "/newFile" should not exist
     Examples:
       | ocs-api-version |
       | 1               |
       | 2               |
 
-  Scenario Outline: Incoming and outgoing federation shares are enabled for local server but incoming federation shares is disabled for remote server
+  Scenario Outline: Incoming and outgoing federation shares are enabled for local server but incoming federation shares are restricted for remote server
     Given using server "REMOTE"
     And parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
@@ -958,7 +958,7 @@ Feature: federated
     And using OCS API version "<ocs-api-version>"
     When user "user1" from server "LOCAL" shares "/file-to-share" with user "user0" from server "REMOTE" using the sharing API
     And using server "REMOTE"
-    Then user "user0" should have no last pending federated cloud share
+    Then user "user0" should not have any pending federated cloud share
     And as "user0" file "/file-to-share" should not exist
     When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
     And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
@@ -970,7 +970,7 @@ Feature: federated
       | 1               |
       | 2               |
 
-  Scenario Outline: Incoming and outgoing federation shares are enabled for local server but outgoing federation shares is disabled for remote server
+  Scenario Outline: Incoming and outgoing federation shares are enabled for local server but outgoing federation shares are restricted for remote server
     Given using server "REMOTE"
     And parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
@@ -986,7 +986,7 @@ Feature: federated
     When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
     And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
     And using server "LOCAL"
-    Then user "user1" should have no last pending federated cloud share
+    Then user "user1" should not have any pending federated cloud share
     And as "user1" file "/newFile" should not exist
     Examples:
       | ocs-api-version |

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -868,3 +868,127 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
+  Scenario Outline: Incoming and Outgoing federation shares are enabled
+    Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
+    And user "user1" from server "LOCAL" has shared "file-to-share" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And using OCS API version "<ocs-api-version>"
+    When using server "REMOTE"
+    Then as "user0" file "/file-to-share" should exist
+    And the content of file "/file-to-share" for user "user0" should be "thisContentIsVisible"
+    When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
+    And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    When user "user1" from server "LOCAL" accepts the last pending share using the sharing API
+    Then as "user1" file "/newFile" should exist
+    And the content of file "/newFile" for user "user1" should be "thisFileIsShared"
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Incoming federation shares are enabled but outgoing federation shares are disabled
+    Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
+    And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
+    And using OCS API version "<ocs-api-version>"
+    When user "user1" from server "LOCAL" shares "file-to-share" with user "user0" from server "REMOTE" using the sharing API
+    And using server "REMOTE"
+    Then user "user0" should have no last pending federated cloud share
+    And as "user0" file "/file-to-share" should not exist
+    When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
+    And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    When user "user1" from server "LOCAL" accepts the last pending share using the sharing API
+    Then as "user1" file "/newFile" should exist
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Incoming federation shares are disabled but outgoing federation shares are enabled
+    Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
+    And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
+    And using OCS API version "<ocs-api-version>"
+    When user "user1" from server "LOCAL" shares "/file-to-share" with user "user0" from server "REMOTE" using the sharing API
+    And using server "REMOTE"
+    And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
+    Then as "user0" file "/file-to-share" should exist
+    When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
+    And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    Then user "user1" should have no last pending federated cloud share
+    And as "user1" file "/newFile" should not exist
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Incoming and outgoing federation shares are disabled
+    Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
+    And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
+    And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
+    And using OCS API version "<ocs-api-version>"
+    When user "user1" from server "LOCAL" shares "/file-to-share" with user "user0" from server "REMOTE" using the sharing API
+    And using server "REMOTE"
+    Then user "user0" should have no last pending federated cloud share
+    And as "user0" file "/file-to-share" should not exist
+    When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
+    And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    Then user "user1" should have no last pending federated cloud share
+    And as "user1" file "/newFile" should not exist
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Incoming and outgoing federation shares are enabled for local server but incoming federation shares is disabled for remote server
+    Given using server "REMOTE"
+    And parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
+    And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And using server "LOCAL"
+    And parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
+    And using OCS API version "<ocs-api-version>"
+    When user "user1" from server "LOCAL" shares "/file-to-share" with user "user0" from server "REMOTE" using the sharing API
+    And using server "REMOTE"
+    Then user "user0" should have no last pending federated cloud share
+    And as "user0" file "/file-to-share" should not exist
+    When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
+    And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    And user "user1" from server "LOCAL" accepts the last pending share using the sharing API
+    Then as "user1" file "/newFile" should exist
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  Scenario Outline: Incoming and outgoing federation shares are enabled for local server but outgoing federation shares is disabled for remote server
+    Given using server "REMOTE"
+    And parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
+    And using server "LOCAL"
+    And parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
+    And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
+    And using OCS API version "<ocs-api-version>"
+    When user "user1" from server "LOCAL" shares "/file-to-share" with user "user0" from server "REMOTE" using the sharing API
+    And using server "REMOTE"
+    And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
+    Then as "user0" file "/file-to-share" should exist
+    When user "user0" uploads file with content "thisFileIsShared" to "/newFile" using the WebDAV API
+    And user "user0" from server "REMOTE" shares "/newFile" with user "user1" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    Then user "user1" should have no last pending federated cloud share
+    And as "user1" file "/newFile" should not exist
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -873,8 +873,8 @@ Feature: federated
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
     And using OCS API version "<ocs-api-version>"
-    When user "user1" uploads file with content "thisContentIsVisible" to "/file-to-share" using the WebDAV API
-    And user "user1" from server "LOCAL" shares "file-to-share" with user "user0" from server "REMOTE" using the sharing API
+    And user "user1" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
+    When user "user1" from server "LOCAL" shares "file-to-share" with user "user0" from server "REMOTE" using the sharing API
     And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
     And using server "REMOTE"
     Then as "user0" file "/file-to-share" should exist

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -25,6 +25,7 @@
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use TestHelpers\SharingHelper;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -199,6 +200,24 @@ class FederationContext implements Context {
 			'GET',
 			"/apps/files_sharing/api/v1/remote_shares/{$share_id}",
 			null
+		);
+	}
+
+	/**
+	 * @Then user :user should have no last pending federated cloud share
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userShouldHaveNoLastPendingFederatedCloudShare($user) {
+		$this->userGetsTheListOfPendingFederatedCloudShares($user);
+		$responseXml = $this->featureContext->getResponseXml();
+		$xmlPart = $responseXml->xpath("//data/element[last()]/id");
+		Assert::assertTrue(
+			!\is_array($xmlPart) || (\count($xmlPart) === 0),
+			__METHOD__
+			. " No pending federated cloud shares were expected, but got unexpectedly."
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -204,7 +204,7 @@ class FederationContext implements Context {
 	}
 
 	/**
-	 * @Then user :user should have no last pending federated cloud share
+	 * @Then user :user should not have any pending federated cloud share
 	 *
 	 * @param string $user
 	 *


### PR DESCRIPTION
## Description
Add acceptance tests for different permutations of incoming and outgoing federated share settings enabled or disabled

## Related Issue
- Related to #34149 
- Fixes #32066

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
