### PR TITLE
Trigger CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Build Status](https://drone.owncloud.com/api/badges/owncloud/core/status.svg?branch=master)](https://drone.owncloud.com/owncloud/core)
 [![codecov.io](https://codecov.io/github/owncloud/core/coverage.svg?branch=master)](https://codecov.io/github/owncloud/core?branch=master)
 
+Trigger CI
+
 **[ownCloud](http://ownCloud.org) gives you freedom and control over your own data.
 A personal cloud which runs on your own server.**
 


### PR DESCRIPTION
To check the results of webUI tests.

They fail with `Fatal error: Call to a member function open() on null (Behat\Testwork\Call\Exception\FatalThrowableError)` - see issue #37113 for details.