### PR TITLE
[Tests-Only] Pin behat/mink to version 1.7.1

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -4,7 +4,7 @@
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
         "behat/mink-goutte-driver": "^1.2",
-        "behat/mink-selenium2-driver": "dev-master",
+        "behat/mink-selenium2-driver": "^1.4",
         "jarnaiz/behat-junit-formatter": "^1.3",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.3",

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
         "behat/behat": "^3.6",
+        "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "dev-master",


### PR DESCRIPTION
## Description
New versions of `MinkSelenium2Driver` and `Mink` were released overnight. Our Behat acceptance tests `vendor-bin/Behat/composer.json` automagically sucks in the new changes. And "stuff failed" (see the issue for details).

https://github.com/minkphp/MinkSelenium2Driver/releases/tag/v1.4.0
https://github.com/minkphp/Mink/releases/tag/v1.8.1

`MinkSelenium2Driver` `1.4.0` is working fine. So we can use that rather than relying on `dev-master` - good.

But `Mink` 1.8.0 or 1.8.1 causes the problem. It might be related to https://github.com/minkphp/Mink/pull/705 which changed the way that sessions get started (e.g. to selenium) - I will look at that later. For now, specify Mink 1.7.1 to get things working. (dependencies in other Behat-Mink things were causing later Mink code to get loaded)

## Related Issue
- #37113 

## How Has This Been Tested?
Local acceptance test run and CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
