### PR TITLE
[Tests-Only] Do not leave behind empty ZipArchive in unit tests

### DIFF
--- a/tests/lib/Archive/TestBase.php
+++ b/tests/lib/Archive/TestBase.php
@@ -109,6 +109,10 @@ abstract class TestBase extends \Test\TestCase {
 		$this->instance->remove('/test');
 		$this->assertFalse($this->instance->fileExists('/test'));
 		$this->assertFalse($this->instance->fileExists('/test/'));
+		// leave the archive with something in it, otherwise PHP ZipArchive cleanup emits:
+		// PHP Warning: Unknown: Cannot destroy the zip context: Can't remove file: No such file or directory in Unknown on line 0
+		// which can cause the unit test run to finish with error status
+		$this->instance->addFolder('/test');
 	}
 	public function testExtract() {
 		$textFile = $this->getArchiveTestDataDir() . '/lorem.txt';
@@ -132,6 +136,10 @@ abstract class TestBase extends \Test\TestCase {
 		$this->assertStringEqualsFile($textFile, $this->instance->getFile('target.txt'));
 		$this->instance->remove('target.txt');
 		$this->assertFalse($this->instance->fileExists('target.txt'));
+		// leave the archive with something in it, otherwise PHP ZipArchive cleanup emits:
+		// PHP Warning: Unknown: Cannot destroy the zip context: Can't remove file: No such file or directory in Unknown on line 0
+		// which can cause the unit test run to finish with error status
+		$this->instance->addFile('lorem.txt', $textFile);
 	}
 	public function testRecursive() {
 		$this->instance=$this->getNew();


### PR DESCRIPTION
## Description
https://www.php.net/manual/en/class.ziparchive.php#118392
```
Warning: Unknown: Cannot destroy the zip context in Unknown on line 0
```
"It happens when the zip archive is empty."
"So, don't forget to put at least one file to your zip archive."

There are 2 Zip Archive tests that test removing files/folders from an archive. They were leaving an empty archive at the end of the test. PHP `ZipArchive` cleans up, but unfortunately if the archive that is being cleaned up is empty then that warning message is emitted. In later PHP+phpunit that is causing a fail status of the unit test suite.

Adjust those unit tests so that they put something back in the archive before they finish.

## Related Issue
Fixes #37110 

## How Has This Been Tested?
Run CI with PHP 7.2 - see #37118 - it passes, and the output does not have any warning about `Cannot destroy the zip context`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
