### PR TITLE
[Tests-Only] Do not leave behind empty ZipArchive in unit tests

### DIFF
--- a/tests/lib/Archive/TestBase.php
+++ b/tests/lib/Archive/TestBase.php
@@ -25,6 +25,18 @@ abstract class TestBase extends \Test\TestCase {
 	 */
 	abstract protected function getNew();
 
+	protected function tearDown(): void {
+		// when the archive is empty, getFiles() can return an empty array or an array with [0] => bool(false)
+		$files = $this->instance->getFiles();
+		if ((\count($files) === 0) || ($files[0] === false)) {
+			// make sure to leave the archive with something in it, otherwise PHP ZipArchive cleanup emits:
+			// PHP Warning: Unknown: Cannot destroy the zip context: Can't remove file: No such file or directory in Unknown on line 0
+			// which can cause the unit test run to finish with error status
+			$textFile = $this->getArchiveTestDataDir() . '/lorem.txt';
+			$this->instance->addFile('lorem.txt', $textFile);
+		}
+		parent::tearDown();
+	}
 	protected function getArchiveTestDataDir() {
 		return \OC::$SERVERROOT . '/tests/data/archive';
 	}


### PR DESCRIPTION
## Description
https://www.php.net/manual/en/class.ziparchive.php#118392
```
Warning: Unknown: Cannot destroy the zip context in Unknown on line 0
```
"It happens when the zip archive is empty."
"So, don't forget to put at least one file to your zip archive."

There are 2 Zip Archive tests that test removing files/folders from an archive. They were leaving an empty archive at the end of the test. PHP `ZipArchive` cleans up, but unfortunately if the archive that is being cleaned up is empty then that warning message is emitted. In later PHP+phpunit that is causing a fail status of the unit test suite.

Add a `tearDown()` that puts something in the archive if it is empty.

## Related Issue
Fixes #37110 

## How Has This Been Tested?
Run CI with PHP 7.2 - see #37118 - it passes, and the output does not have any warning about `Cannot destroy the zip context`

https://drone.owncloud.com/owncloud/core/23905/14/9 - the drone unit test run of this PR does not have any mention of `Cannot destroy the zip context in Unknown`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
