### PR TITLE
Handle case of ZIP Archive with no files

### DIFF
--- a/lib/private/Archive/ZIP.php
+++ b/lib/private/Archive/ZIP.php
@@ -128,7 +128,10 @@ class ZIP extends Archive {
 		$fileCount=$this->zip->numFiles;
 		$files= [];
 		for ($i=0;$i<$fileCount;$i++) {
-			$files[]=$this->zip->getNameIndex($i);
+			$name = $this->zip->getNameIndex($i);
+			if ($name !== false) {
+				$files[] = $name;
+			}
 		}
 		return $files;
 	}

--- a/tests/lib/Archive/TestBase.php
+++ b/tests/lib/Archive/TestBase.php
@@ -26,9 +26,7 @@ abstract class TestBase extends \Test\TestCase {
 	abstract protected function getNew();
 
 	protected function tearDown(): void {
-		// when the archive is empty, getFiles() can return an empty array or an array with [0] => bool(false)
-		$files = $this->instance->getFiles();
-		if ((\count($files) === 0) || ($files[0] === false)) {
+		if (\count($this->instance->getFiles()) === 0) {
 			// make sure to leave the archive with something in it, otherwise PHP ZipArchive cleanup emits:
 			// PHP Warning: Unknown: Cannot destroy the zip context: Can't remove file: No such file or directory in Unknown on line 0
 			// which can cause the unit test run to finish with error status
@@ -65,6 +63,21 @@ abstract class TestBase extends \Test\TestCase {
 		foreach ($expected as $file) {
 			$this->assertContains($file, $dirContent, 'cant find '.  $file . ' in archive');
 		}
+	}
+
+	public function testGetFilesFromEmptyArchive() {
+		$this->instance=$this->getNew();
+		$allFiles=$this->instance->getFiles();
+		$this->assertCount(0, $allFiles, 'found ' . \count($allFiles) . ' files but expected no files');
+	}
+
+	public function testGetFilesFromEmptiedArchive() {
+		$textFile = $this->getArchiveTestDataDir() . '/lorem.txt';
+		$this->instance=$this->getNew();
+		$this->instance->addFile('lorem.txt', $textFile);
+		$this->instance->remove('lorem.txt');
+		$allFiles=$this->instance->getFiles();
+		$this->assertCount(0, $allFiles, 'found ' . \count($allFiles) . ' files but expected no files');
 	}
 
 	public function testContent() {


### PR DESCRIPTION
## Description
The call directly to `$this->zip->numFiles` "internal"  variable returns `1` when a ZipArchive is actually empty. That is internals of the PHP `ZipArchive` class. When we loop through the `1` file, we get `false` returned by `$this->zip->getNameIndex(0)`, which is the documented return value when there is no file at the index. That is good. Adjust our code to check for that `false` return value.

Note: the PHP `ZipArchive` class has a `count()` method since PHP 7.2. That might be good to use, but we still support PHP 7.1, so not yet.

This code seems to only really get run from `lib/private/Installer.php`. So IMO there will not be real-life use of this in a way that ends up with an empty ZipArchive. So this fix is really just tidying up the class so it consistently returns what it claims.

## Related Issue
- Fixes #37121 


## How Has This Been Tested?
CI unit tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
