### PR TITLE
[Tests-Only] Acceptance tests to export the local storages mounts to a file

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1913,6 +1913,32 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * @When the administrator creates a file :path with the last exported content using the testing API
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function theAdministratorCreatesFileWithLastExportedContent(
+		$path
+	) {
+		$commandOutput = $this->getStdOutOfOccCommand();
+		$user = $this->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->getBaseUrl(),
+			$user,
+			$this->getAdminPassword(),
+			'POST',
+			"/apps/testing/api/v1/file",
+			[
+				'file' => "/$path",
+				'content' => $commandOutput
+			],
+			$this->getOcsApiVersion()
+		);
+	}
+
+	/**
 	 * @Given the administrator has created file :path with content :content in local storage :mountPount
 	 *
 	 * @param string $path
@@ -2120,6 +2146,18 @@ class FeatureContext extends BehatVariablesContext {
 			$fileContent,
 			"The content of the file does not match with '{$content}'"
 		);
+	}
+
+	/**
+	 * @Then the file :path with the last exported content should exist in the server root
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function theFileWithLastExportedContentShouldExistInTheServerRoot($path) {
+		$lastExportedContent = $this->getStdOutOfOccCommand();
+		$this->theFileWithContentShouldExistInTheServerRoot($path, $lastExportedContent);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1939,6 +1939,34 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * @When the administrator has created a file :path with the last exported content using the testing API
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasCreatedAFileWithLastExportedContent(
+		$path
+	) {
+		$commandOutput = $this->getStdOutOfOccCommand();
+		$user = $this->getAdminUsername();
+		$response = OcsApiHelper::sendRequest(
+			$this->getBaseUrl(),
+			$user,
+			$this->getAdminPassword(),
+			'POST',
+			"/apps/testing/api/v1/file",
+			[
+				'file' => "/$path",
+				'content' => $commandOutput
+			],
+			$this->getOcsApiVersion()
+		);
+		$lastExportedContent = $this->getStdOutOfOccCommand();
+		$this->theFileWithContentShouldExistInTheServerRoot($path, $lastExportedContent);
+	}
+
+	/**
 	 * @Given the administrator has created file :path with content :content in local storage :mountPount
 	 *
 	 * @param string $path

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1913,33 +1913,7 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @When the administrator creates a file :path with the last exported content using the testing API
-	 *
-	 * @param string $path
-	 *
-	 * @return void
-	 */
-	public function theAdministratorCreatesFileWithLastExportedContent(
-		$path
-	) {
-		$commandOutput = $this->getStdOutOfOccCommand();
-		$user = $this->getAdminUsername();
-		$response = OcsApiHelper::sendRequest(
-			$this->getBaseUrl(),
-			$user,
-			$this->getAdminPassword(),
-			'POST',
-			"/apps/testing/api/v1/file",
-			[
-				'file' => "/$path",
-				'content' => $commandOutput
-			],
-			$this->getOcsApiVersion()
-		);
-	}
-
-	/**
-	 * @When the administrator has created a file :path with the last exported content using the testing API
+	 * @Given the administrator has created a file :path with the last exported content using the testing API
 	 *
 	 * @param string $path
 	 *
@@ -2174,18 +2148,6 @@ class FeatureContext extends BehatVariablesContext {
 			$fileContent,
 			"The content of the file does not match with '{$content}'"
 		);
-	}
-
-	/**
-	 * @Then the file :path with the last exported content should exist in the server root
-	 *
-	 * @param string $path
-	 *
-	 * @return void
-	 */
-	public function theFileWithLastExportedContentShouldExistInTheServerRoot($path) {
-		$lastExportedContent = $this->getStdOutOfOccCommand();
-		$this->theFileWithContentShouldExistInTheServerRoot($path, $lastExportedContent);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1891,6 +1891,34 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @When the administrator has deleted local storage :folder using the occ command
+	 *
+	 * @param string $folder
+	 *
+	 * @return integer
+	 * @throws Exception
+	 */
+	public function administratorHasDeletedFolder($folder) {
+		$createdLocalStorage = [];
+		$this->listLocalStorageMount();
+		$commandOutput = \json_decode($this->featureContext->getStdOutOfOccCommand());
+		foreach ($commandOutput as $i) {
+			$createdLocalStorage[$i->mount_id] = \ltrim($i->mount_point, '/');
+		}
+		foreach ($createdLocalStorage as $key => $value) {
+			if ($value === $folder) {
+				$mount_id = $key;
+			}
+		}
+		if (!isset($mount_id)) {
+			throw  new Exception("Id not found for folder to be deleted");
+		}
+		$this->invokingTheCommand('files_external:delete --yes ' . $mount_id);
+		$this->theCommandShouldHaveBeenSuccessful();
+		return (int) $mount_id;
+	}
+
+	/**
 	 * @When the administrator exports the local storage mounts using the occ command
 	 *
 	 * @return void
@@ -1898,6 +1926,29 @@ class OccContext implements Context {
 	 */
 	public function theAdministratorExportsTheMountsUsingTheOccCommand() {
 		$this->invokingTheCommand('files_external:export');
+	}
+
+	/**
+	 * @When the administrator imports the local storage mount from file :file using the occ command
+	 *
+	 * @param $file
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorImportsTheMountFromFileUsingTheOccCommand($file) {
+		$this->invokingTheCommand('files_external:import ' . $file);
+	}
+
+	/**
+	 * @When the administrator has exported the local storage mounts using the occ command
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorHasExportedTheMountsUsingTheOccCommand() {
+		$this->invokingTheCommand('files_external:export');
+		$this->theCommandShouldHaveBeenSuccessful();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -370,6 +370,20 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Given the administrator has set the system language to :defaultLanguage
+	 *
+	 * @param $defaultLanguage
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorHasSetTheSystemLanguagaeTo($defaultLanguage) {
+		$this->runOcc(
+			["config:system:set default_language --value $defaultLanguage"]
+		);
+	}
+
+	/**
 	 *
 	 * @param string $path
 	 *

--- a/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
@@ -15,3 +15,12 @@ Feature: export created local storage mounts from the command line
       | /local_storage2    | Local   | None               | datadir:      |                      | All             |                  |
       | /new_local_storage | Local   | None               | datadir:      |                      | All             |                  |
       | /local_storage     | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
+    
+  Scenario: export the created mounts to a file
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has created the local storage mount "new_local_storage"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    And the administrator has uploaded file with content "new file" to "/new_local_storage/new-file"
+    When the administrator exports the local storage mounts using the occ command
+    And the administrator creates a file "data/exportedMounts.json" with the last exported content using the testing API
+    Then the file "data/exportedMounts.json" with the last exported content should exist in the server root

--- a/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
@@ -17,3 +17,13 @@ Feature: export created local storage mounts from the command line
       | /local_storage2    | Local   | None               | datadir:      |                      | All             |                  |
       | /new_local_storage | Local   | None               | datadir:      |                      | All             |                  |
       | /local_storage     | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
+
+  @issue-37054
+  Scenario: export the created mounts when the system language is "de"
+    Given the administrator has set the system language to "de"
+    When the administrator exports the local storage mounts using the occ command
+    Then the following local storage should be listed:
+      | MountPoint         | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage2    | Lokal   | Keine              | datadir:      |                      | All             |                  |
+      | /new_local_storage | Lokal   | Keine              | datadir:      |                      | All             |                  |
+      | /local_storage     | Lokal   | Keine              | datadir:      | enable_sharing: true | All             |                  |

--- a/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
@@ -4,23 +4,21 @@ Feature: export created local storage mounts from the command line
   I want to export all created local storage mounts from the command line
   So that I can view available local storage mounts
 
-  Scenario: export the created mounts
+  Background:
     Given the administrator has created the local storage mount "local_storage2"
     And the administrator has created the local storage mount "new_local_storage"
     And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
     And the administrator has uploaded file with content "new file" to "/new_local_storage/new-file"
+
+  Scenario: export the created mounts
     When the administrator exports the local storage mounts using the occ command
     Then the following local storage should be listed:
       | MountPoint         | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
       | /local_storage2    | Local   | None               | datadir:      |                      | All             |                  |
       | /new_local_storage | Local   | None               | datadir:      |                      | All             |                  |
       | /local_storage     | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
-    
+
   Scenario: export the created mounts to a file
-    Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has created the local storage mount "new_local_storage"
-    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
-    And the administrator has uploaded file with content "new file" to "/new_local_storage/new-file"
     When the administrator exports the local storage mounts using the occ command
     And the administrator creates a file "data/exportedMounts.json" with the last exported content using the testing API
     Then the file "data/exportedMounts.json" with the last exported content should exist in the server root

--- a/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
@@ -17,8 +17,3 @@ Feature: export created local storage mounts from the command line
       | /local_storage2    | Local   | None               | datadir:      |                      | All             |                  |
       | /new_local_storage | Local   | None               | datadir:      |                      | All             |                  |
       | /local_storage     | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
-
-  Scenario: export the created mounts to a file
-    When the administrator exports the local storage mounts using the occ command
-    And the administrator creates a file "data/exportedMounts.json" with the last exported content using the testing API
-    Then the file "data/exportedMounts.json" with the last exported content should exist in the server root

--- a/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
@@ -1,0 +1,16 @@
+@cli @skipOnLDAP @local_storage
+Feature: import exported local storage mounts from the command line
+  As an admin
+  I want to import exported local storage mounts from the command line
+  So that I can create previously exported local storage mounts
+
+  @issue-37054
+  Scenario: export the created mounts to a file
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    And the administrator has exported the local storage mounts using the occ command
+    And the administrator has created a file "data/exportedMounts.json" with the last exported content using the testing API
+    And the administrator has deleted local storage "local_storage2" using the occ command
+    When the administrator imports the local storage mount from file "data/exportedMounts.json" using the occ command
+    # change the then step once the issue is fixed and the import works well
+    Then the command output should contain the text "An unhandled exception has been thrown:"

--- a/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
@@ -5,12 +5,12 @@ Feature: import exported local storage mounts from the command line
   So that I can create previously exported local storage mounts
 
   @issue-37054
-  Scenario: export the created mounts to a file
+  Scenario: import local storage mounts from a file
     Given the administrator has created the local storage mount "local_storage2"
     And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
     And the administrator has exported the local storage mounts using the occ command
     And the administrator has created a file "data/exportedMounts.json" with the last exported content using the testing API
     And the administrator has deleted local storage "local_storage2" using the occ command
     When the administrator imports the local storage mount from file "data/exportedMounts.json" using the occ command
-    # change the then step once the issue is fixed and the import works well
+    # change the then step once the issue is fixed, and the import works well
     Then the command output should contain the text "An unhandled exception has been thrown:"


### PR DESCRIPTION
## Description
Add acceptance tests to export the local storages mounts to a file

## Related Issue
#36704 
#37054 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
