### PR TITLE
[Tests-Only] add functions for the acceptance tests added for password policy expiration date

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -555,6 +555,32 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user changes the expiration of the public link :linkName of file/folder :name to :expiration
+	 *
+	 * @param string $linkName
+	 * @param string $name
+	 * @param string $expiration
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theUserChangesTheExpirationOfThePublicLinkToCertainDate($linkName, $name, $expiration) {
+		$session = $this->getSession();
+		$this->theUserOpensTheShareDialogForFileFolder($name);
+		$this->theUserHasOpenedThePublicLinkShareTab();
+		$expiration = \date('d-m-Y', \strtotime($expiration));
+		$this->publicSharingPopup = $this->publicShareTab->editLink(
+			$session,
+			$linkName,
+			null,
+			null,
+			null,
+			$expiration
+		);
+		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
 	 * @When the user opens the create public link share popup
 	 *
 	 * @return void


### PR DESCRIPTION
## Description
Add methods to edit the expiration date of previously created share.

## Related Issue
- https://github.com/owncloud/password_policy/issues/126

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
