### PR TITLE
[Tests-Only] Add acceptance tests to rename the received share which is shared without change permission

### DIFF
--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -61,3 +61,33 @@ Feature: sharing
       | ?abc=oc #     | ?abc=oc g%rp#   | # oc?test=oc&a  |
       | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d    |
 
+  Scenario: receiver renames a received share with share, read, change permissions
+    Given user "user0" has created folder "folderToShare"
+    And user "user0" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
+    And user "user0" has shared folder "folderToShare" with user "user1" with permissions "share,read,change"
+    When user "user1" moves folder "folderToShare" to "myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user1" folder "myFolder" should exist
+    But as "user0" folder "myFolder" should not exist
+    When user "user1" moves file "/myFolder/fileInside" to "/myFolder/renamedFile" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "user1" file "/myFolder/renamedFile" should exist
+    And as "user0" file "/folderToShare/renamedFile" should exist
+    But as "user0" file "/folderToShare/fileInside" should not exist
+
+  @issue-30325
+  Scenario: receiver tries to rename a received share with share, read permissions
+    Given user "user0" has created folder "folderToShare"
+    And user "user0" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
+    And user "user0" has shared folder "folderToShare" with user "user1" with permissions "share,read"
+    When user "user1" moves folder "folderToShare" to "myFolder" using the WebDAV API
+    Then the HTTP status code should be "403"
+#    Then the HTTP status code should be "201"
+    And as "user1" folder "myFolder" should not exist
+#    And as "user1" folder "myFolder" should exist
+    But as "user0" folder "myFolder" should not exist
+#    When user "user1" moves file "/myFolder/fileInside" to "/myFolder/renamedFile" using the WebDAV API
+    When user "user1" moves file "/folderToShare/fileInside" to "/folderToShare/renamedFile" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "user1" file "/folderToShare/renamedFile" should not exist
+    But as "user1" file "/folderToShare/fileInside" should exist

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -120,3 +120,29 @@ Feature: rename folders
     And user "user1" has logged in using the webUI
     When the user renames folder "a-folder" to "a.part" using the webUI
     Then near folder "a-folder" a tooltip with the text '"a.part" has a forbidden file type/extension.' should be displayed on the webUI
+
+  Scenario: Rename a folder which is received as a share (without change permission)
+    Given user "user2" has been created with default attributes and without skeleton files
+    And user "user2" has created folder "RandomFolder"
+    And user "user2" has uploaded file with content "thisIsFileInsideFolder" to "/RandomFolder/newFile"
+    And user "user2" has shared folder "RandomFolder" with user "user1" with permissions "read, share"
+    And user "user1" has logged in using the webUI
+    When the user renames folder "RandomFolder" to "renamedFolder" using the webUI
+    Then a notification should be displayed on the webUI with the text 'Could not rename "RandomFolder"'
+    When the user opens folder "/RandomFolder" using the webUI
+    Then the option to rename file "newFile" should not be available on the webUI
+
+  Scenario: Rename a folder which is received as a share (with change permission)
+    Given user "user2" has been created with default attributes and without skeleton files
+    And user "user2" has created folder "RandomFolder"
+    And user "user2" has uploaded file with content "thisIsFileInsideFolder" to "/RandomFolder/newFile"
+    And user "user2" has shared folder "RandomFolder" with user "user1" with permissions "read, share, change"
+    And user "user1" has logged in using the webUI
+    When the user renames folder "RandomFolder" to "renamedFolder" using the webUI
+    Then folder "renamedFolder" should be listed on the webUI
+    But folder "RandomFolder" should not be listed on the webUI
+    When the user opens folder "/renamedFolder" using the webUI
+    Then the option to rename file "newFile" should be available on the webUI
+    When the user renames file "newFile" to "renamedFile" using the webUI
+    Then file "renamedFile" should be listed on the webUI
+    But file "newFile" should not be listed on the webUI

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -121,6 +121,7 @@ Feature: rename folders
     When the user renames folder "a-folder" to "a.part" using the webUI
     Then near folder "a-folder" a tooltip with the text '"a.part" has a forbidden file type/extension.' should be displayed on the webUI
 
+  @issue-30325
   Scenario: Rename a folder which is received as a share (without change permission)
     Given user "user2" has been created with default attributes and without skeleton files
     And user "user2" has created folder "RandomFolder"
@@ -128,8 +129,10 @@ Feature: rename folders
     And user "user2" has shared folder "RandomFolder" with user "user1" with permissions "read, share"
     And user "user1" has logged in using the webUI
     When the user renames folder "RandomFolder" to "renamedFolder" using the webUI
+#   Then folder "renamedFolder" should be listed on the webUI
     Then a notification should be displayed on the webUI with the text 'Could not rename "RandomFolder"'
     When the user opens folder "/RandomFolder" using the webUI
+#   When the user opens folder "/renamedFolder" using the webUI
     Then the option to rename file "newFile" should not be available on the webUI
 
   Scenario: Rename a folder which is received as a share (with change permission)


### PR DESCRIPTION
## Description
Add acceptance test to rename the received share which is shared with only read and share permissions.

## Related Issue
#30325 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
