### PR TITLE
Add share type to the verifyExpirationDate hook

### DIFF
--- a/changelog/unreleased/37135
+++ b/changelog/unreleased/37135
@@ -1,0 +1,10 @@
+Bugfix: Add share type to the verifyExpirationDate hook
+
+The verifyExpirationDate hook notifies the password_policy app about proposed
+expiration dates of shares. The share type was not being passed in the hook.
+This meant that the password_policy app incorrectly processed user and group
+share expiration dates. See the linked issue for details.
+The problem has been corrected.
+
+https://github.com/owncloud/password_policy/issues/287
+https://github.com/owncloud/core/pull/37135

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -469,6 +469,7 @@ class Manager implements IManager {
 			'accepted' => &$accepted,
 			'message' => &$message,
 			'passwordSet' => $share->getPassword() !== null,
+			'shareType' => $share->getShareType(),
 		]);
 
 		if (!$accepted) {


### PR DESCRIPTION
## Description
add type of the share to the verifyExpirationDate hook

## Related Issue
- Part of the fix for https://github.com/owncloud/password_policy/issues/287

## Motivation and Context
it is not possible to distinguish public links from other share types 

## How Has This Been Tested?
1. Set public link expiration policies in the password policy app according to https://github.com/owncloud/password_policy/issues/287

2. Create a user or group share

### expected
share is created

### actual
share creation is blocked due to public link policies

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
