### PR TITLE
[Tests-Only] Specify guzzle 5.3 for testing

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -8,6 +8,7 @@
         "jarnaiz/behat-junit-formatter": "^1.3",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.0",
-        "symfony/translation": "^3.4"
+        "symfony/translation": "^3.4",
+        "guzzlehttp/guzzle": "^5.3"
     }
 }


### PR DESCRIPTION
We need to specify Guzzle 5.3 specifically when testing with the old 10.3.2 - otherwise nowadays Guzzle6 ends up getting loaded and that will not work with the old test code.