### PR TITLE
[Tests-only] Wait for ajax call to finish when restoring files from trashbin

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -410,9 +410,11 @@ class FileRow extends OwncloudPage {
 	/**
 	 * restore the current deleted file and folder by clicking on the restore link
 	 *
+	 * @param Session $session
+	 *
 	 * @return void
 	 */
-	public function restore() {
+	public function restore($session) {
 		$rowElement = $this->rowElement->find('xpath', $this->restoreLinkXpath);
 		$this->assertElementNotNull(
 			$rowElement,
@@ -421,6 +423,7 @@ class FileRow extends OwncloudPage {
 			" could not find restore link to '" . $this->getNameAsString() . "'"
 		);
 		$rowElement->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/TrashbinPage.php
+++ b/tests/acceptance/features/lib/TrashbinPage.php
@@ -148,7 +148,7 @@ class TrashbinPage extends FilesPageBasic {
 	 */
 	public function restore($fname, Session $session) {
 		$row = $this->findFileRowByName($fname, $session);
-		$row->restore();
+		$row->restore($session);
 	}
 
 	/**


### PR DESCRIPTION


<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR makes acceptance tests wait for the ajax call to finish when restoring files from the trashbin.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/admin_audit/issues/301

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

