### PR TITLE
[Tests-Only] Web UI accept pending federated

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1973,4 +1973,22 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			$expectedCount
 		);
 	}
+
+	/**
+	 * @When the user closes the federation sharing dialog
+	 *
+	 * @return void
+	 */
+	public function theUserClosesFederationShareDialog() {
+		$this->filesPage->closeFederationDialog();
+	}
+
+	/**
+	 * @When the user accepts the pending remote share using the webUI
+	 *
+	 * @return void
+	 */
+	public function theUserAcceptsThePendingRemoteSharesUsingTheWebui() {
+		$this->sharedWithYouPage->acceptPendingShare();
+	}
 }

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -45,6 +45,7 @@ class FilesPage extends FilesPageBasic {
 	protected $folderBreadCrumbXpath = "//div[@class='breadcrumb']//a[contains(@href,'%s')]";
 	protected $uploadCreatePermissionDeniedMessageSelector = ".notCreatable.notPublic";
 	protected $sharingDialogXpath = "//h3[@data-original-title='%s']/ancestor::div[@id='app-sidebar']//div[@id='shareTabView']";
+	protected $closeOCDialogXpath = "//div/a[@class='oc-dialog-close']";
 
 	/**
 	 *
@@ -443,5 +444,21 @@ class FilesPage extends FilesPageBasic {
 	public function isNewFileIconVisible() {
 		$newFileIcon = $this->find("xpath", $this->newFileFolderButtonXpath);
 		return $newFileIcon->isVisible();
+	}
+
+	/**
+	 * Closes the federated Share dialog
+	 *
+	 * @return bool
+	 */
+	public function closeFederationDialog() {
+		$closeIcon = $this->find("xpath", $this->closeOCDialogXpath);
+		$this->assertElementNotNull(
+			$closeIcon,
+			__METHOD__ .
+			" xpath $this->closeOCDialogXpath " .
+			"could not find OC-dialog close icon."
+		);
+		$closeIcon->click();
 	}
 }

--- a/tests/acceptance/features/lib/SharedWithYouPage.php
+++ b/tests/acceptance/features/lib/SharedWithYouPage.php
@@ -38,6 +38,7 @@ class SharedWithYouPage extends FilesPageBasic {
 	protected $fileNameMatchXpath = "//span[contains(@class,'nametext') and not(contains(@class,'innernametext')) and .=%s]";
 	protected $fileListXpath = ".//div[@id='app-content-sharingin']//tbody[@id='fileList']";
 	protected $emptyContentXpath = ".//div[@id='app-content-sharingin']//div[@id='emptycontent']";
+	protected $acceptPendingFederatedXpath = "//table//a[@class='action action-accept permanent']";
 
 	/**
 	 * @return string
@@ -132,5 +133,19 @@ class SharedWithYouPage extends FilesPageBasic {
 			echo $message;
 			\error_log($message);
 		}
+	}
+
+	/**
+	 * @return void
+	 */
+	public function acceptPendingShare() {
+		$acceptShareElement = $this->find("xpath", $this->acceptPendingFederatedXpath);
+		$this->assertElementNotNull(
+			$acceptShareElement,
+			__METHOD__ .
+			" xpath $this->acceptPendingFederatedXpath " .
+			"could not find accept element."
+		);
+		$acceptShareElement->click();
 	}
 }

--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
@@ -87,3 +87,17 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
     Then user "user1" should not see the following elements
       | /lorem%20(2).txt |
+
+  Scenario: Local user accepts a pending federated share on the webUI
+    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    When the user browses to the shared-with-you page
+    And the user closes the federation sharing dialog
+    And the user accepts the pending remote share using the webUI
+    Then file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
+
+  Scenario: Federated share from Local user to remote user
+    Given user "user1" from server "LOCAL" has shared "/lorem.txt" with user "user1" from server "REMOTE"
+    And user "user1" from server "REMOTE" has accepted the last pending share
+    When the user browses to the shared-with-others page
+    Then user "user1" should see the following elements
+      | lorem.txt |


### PR DESCRIPTION
## Description
- Test for accepting federated share from remote to local user.
- Test to ensure that when a local user makes federated share with remote then, the file is listed in `shared with other` page

## Related Issue
- Fixes https://github.com/owncloud/core/issues/37140

## How Has This Been Tested?
locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
