### PR TITLE
Add non-zero exit code for non-writable config dir and missing app-di…

### DIFF
--- a/changelog/unreleased/37148
+++ b/changelog/unreleased/37148
@@ -1,0 +1,7 @@
+Bugfix: Fix CLI zero exit code on startup errors
+
+Zero exit code was returned on startup with a missing app directory
+or a non-writable config directory. Now exit code is 1.
+
+https://github.com/owncloud/core/issues/37098
+https://github.com/owncloud/core/pull/37148

--- a/lib/base.php
+++ b/lib/base.php
@@ -251,7 +251,7 @@ class OC {
 				echo $l->t('This can usually be fixed by giving the webserver write access to the config directory')."\n";
 				echo "\n";
 				echo $l->t('See %s', [ $urlGenerator->linkToDocs('admin-dir_permissions') ])."\n";
-				exit;
+				exit(1);
 			} else {
 				OC_Template::printErrorPage(
 					$l->t('Cannot write into "config" directory!'),
@@ -530,7 +530,7 @@ class OC {
 			// we can't use the template error page here, because this needs the
 			// DI container which isn't available yet
 			print($e->getMessage());
-			exit();
+			exit(1);
 		}
 
 		// setup the basic server


### PR DESCRIPTION
…r (CLI only)

## Description
[CLI] Add non-zero exit code for the non-writable config dir or missing app-dir

## Related Issue
- Fixes https://github.com/owncloud/core/issues/37098


## How Has This Been Tested?
https://github.com/owncloud/core/issues/37098#issue-578314141

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
