### PR TITLE
[Test-only] reva now returns 404 when trying to delete a nonexisting file

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareWithInvalidPermissions.feature
@@ -44,14 +44,14 @@ Feature: cannot share resources with invalid permissions
     And as "user1" entry "<item>" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | item          | permissions |
-      | 1               | 996             | 200              | textfile0.txt | 0           |
-      | 2               | 996             | 200              | textfile0.txt | 0           |
-      | 1               | 996             | 200              | PARENT        | 0           |
-      | 2               | 996             | 200              | PARENT        | 0           |
-      | 1               | 996             | 200              | textfile0.txt | 32          |
-      | 2               | 996             | 200              | textfile0.txt | 32          |
-      | 1               | 996             | 200              | PARENT        | 32          |
-      | 2               | 996             | 200              | PARENT        | 32          |
+      | 1               | 400             | 200              | textfile0.txt | 0           |
+      | 2               | 400             | 200              | textfile0.txt | 0           |
+      | 1               | 400             | 200              | PARENT        | 0           |
+      | 2               | 400             | 200              | PARENT        | 0           |
+      | 1               | 400             | 200              | textfile0.txt | 32          |
+      | 2               | 400             | 200              | textfile0.txt | 32          |
+      | 1               | 400             | 200              | PARENT        | 32          |
+      | 2               | 400             | 200              | PARENT        | 32          |
 
   @skipOnOcis @issue-ocis-reva-45 @issue-ocis-reva-64
   Scenario Outline: Cannot create a share of a file with a user with only create permission
@@ -85,8 +85,8 @@ Feature: cannot share resources with invalid permissions
     And as "user1" entry "textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 996             | 200              |
-      | 2               | 996             | 200              |
+      | 1               | 100             | 200              |
+      | 2               | 100             | 200              |
 
   @skipOnOcis @issue-ocis-reva-45 @issue-ocis-reva-64
   Scenario Outline: Cannot create a share of a file with a user with only (create,delete) permission
@@ -122,10 +122,10 @@ Feature: cannot share resources with invalid permissions
     And as "user1" entry "textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | permissions   |
-      | 1               | 996             | 200              | delete        |
-      | 2               | 996             | 200              | delete        |
-      | 1               | 996             | 200              | create,delete |
-      | 2               | 996             | 200              | create,delete |
+      | 1               | 100             | 200              | delete        |
+      | 2               | 100             | 200              | delete        |
+      | 1               | 100             | 200              | create,delete |
+      | 2               | 100             | 200              | create,delete |
 
   @skipOnOcis @issue-ocis-reva-34
   Scenario Outline: Cannot create a share of a file with a group with only create permission

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -84,21 +84,21 @@ Feature: sharing
     When user "user0" shares file "textfile0.txt" with user "user1" with permissions <requested_permissions> using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the OCS status message should be "grpc stat request failed"
+    And the OCS status message should be "OK"
     Examples:
       | ocs_api_version | requested_permissions | granted_permissions | ocs_status_code |
       # Ask for full permissions. You get share plus read plus update. create and delete do not apply to shares of a file
-      | 1               | 31                    | 31                  | 996             |
-      | 2               | 31                    | 31                  | 996             |
+      | 1               | 31                    | 31                  | 100             |
+      | 2               | 31                    | 31                  | 100             |
       # Ask for read, share (17), create and delete. You get share plus read
-      | 1               | 29                    | 31                  | 996             |
-      | 2               | 29                    | 31                  | 996             |
+      | 1               | 29                    | 31                  | 100             |
+      | 2               | 29                    | 31                  | 100             |
       # Ask for read, update, create, delete. You get read plus update.
-      | 1               | 15                    | 15                  | 996             |
-      | 2               | 15                    | 15                  | 996             |
+      | 1               | 15                    | 15                  | 100             |
+      | 2               | 15                    | 15                  | 100             |
       # Ask for just update. You get exactly update (you do not get read or anything else)
-      | 1               | 2                     | 2                   | 996             |
-      | 2               | 2                     | 2                   | 996             |
+      | 1               | 2                     | 2                   | 100             |
+      | 2               | 2                     | 2                   | 100             |
 
   @skipOnOcis
   @issue-ocis-reva-45
@@ -125,8 +125,8 @@ Feature: sharing
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "user0 file" to "randomfile.txt"
     When user "user0" shares file "randomfile.txt" with user "user1" with permissions "0" using the sharing API
-    Then the OCS status code should be "996"
-    And the OCS status message should be "grpc stat request failed"
+    Then the OCS status code should be "400"
+    And the OCS status message should be "permissions 0 out of range 1 - 31"
     And the HTTP status code should be "<http_status_code>"
     And as "user1" file "randomfile.txt" should not exist
     Examples:
@@ -142,8 +142,8 @@ Feature: sharing
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "user0 file" to "randomfile.txt"
     When user "user0" shares file "/randomfile.txt" with user "user1" using the sharing API
-    Then the OCS status code should be "998"
-    And the OCS status message should be "not found"
+    Then the OCS status code should be "100"
+    And the OCS status message should be "OK"
     And the HTTP status code should be "<http_status_code>"
     And as "user1" file "randomfile.txt" should not exist
     Examples:
@@ -222,8 +222,8 @@ Feature: sharing
     And user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created folder "/afolder"
     When user "user0" shares folder "afolder" with user "user1" with permissions "0" using the sharing API
-    Then the OCS status code should be "996"
-    And the OCS status message should be "grpc stat request failed"
+    Then the OCS status code should be "400"
+    And the OCS status message should be "permissions 0 out of range 1 - 31"
     And the HTTP status code should be "<http_status_code>"
     And as "user1" folder "afolder" should not exist
     Examples:
@@ -274,12 +274,12 @@ Feature: sharing
     And user "user0" has created folder "/FOLDER"
     When user "user0" shares folder "/FOLDER" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
-    And the OCS status message should be "not found"
+    And the OCS status message should be "OK"
     And the HTTP status code should be "200"
     Examples:
       | ocs_api_version | ocs_status_code |
-      | 1               | 998             |
-      | 2               | 998             |
+      | 1               | 100             |
+      | 2               | 100             |
 
   @skipOnOcis @issue-ocis-reva-34
   Scenario Outline: Creating a share of a file with a group, the default permissions are read(1)+update(2)+can-share(16)
@@ -620,7 +620,7 @@ Feature: sharing
       | /common/sub/textfile0.txt |
       | /textfile0.txt            |
 
-  @issue-enterprise-3896
+  @skipOnOcis @issue-enterprise-3896
   Scenario: sharing back to resharer is allowed
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -635,7 +635,7 @@ Feature: sharing
 #    Then the HTTP status code should be "405"
     And as "user1" folder "userOneFolder" should not exist
 
-  @issue-enterprise-3896
+  @skipOnOcis @issue-enterprise-3896
   Scenario: sharing back to original sharer is allowed
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1275,20 +1275,14 @@ trait WebDav {
 			$this->getPasswordForUser($user), 'GET', $path,
 			[], null, 2, $type
 		);
-		$actualCode = $response->getStatusCode();
-		$message = "$entry '$path' expected to not exist " .
-				   "(status code {$actualCode}, expected ";
-
-		if (OcisHelper::isTestingOnOcis()) {
-			//OCIS currently shows error 500 when accessing a not existing file
-			//https://github.com/owncloud/ocis-reva/issues/13
-			Assert::assertEquals(500, $actualCode, $message . "500)");
-		} else {
-			$message .= "401 - 404)";
-			Assert::assertGreaterThanOrEqual(401, $actualCode, $message);
-			Assert::assertLessThanOrEqual(404, $actualCode, $message);
+		
+		if ($response->getStatusCode() < 401 || $response->getStatusCode() > 404) {
+			throw new \Exception(
+				"$entry '$path' expected to not exist " .
+				"(status code {$response->getStatusCode()}, expected 401 - 404)"
+			);
 		}
-
+		
 		return $response;
 	}
 


### PR DESCRIPTION
I reverted these changes:
https://github.com/owncloud/core/commit/12752e778bbd2cae2e6f40b9452049592cd80426#diff-76a3f5f23003d99750d877daa045562aL1239-L1243

see https://github.com/cs3org/reva/pull/588
and https://github.com/owncloud/ocis-reva/pull/113
