### PR TITLE
Add index on addressbookid

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20200114181454.php
+++ b/apps/dav/appinfo/Migrations/Version20200114181454.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\dav\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Add index to oc_cards_properties to assist with searching with large numbers of rows
+ */
+class Version20200114181454 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		$table = $schema->getTable("${prefix}cards_properties");
+		// Check for existing index spanning these columns
+		foreach ($table->getIndexes() as $index) {
+			// Check if we have a matching index already
+			if (empty(\array_diff($index->getColumns(), ['addressbookid', 'name', 'value']))) {
+				return;
+			}
+		}
+		// Add the index if we dont have one spanning this column already
+		$table->addIndex(['addressbookid', 'name', 'value'], 'carddata_aid_n_v_idx');
+	}
+}

--- a/changelog/unreleased/37152
+++ b/changelog/unreleased/37152
@@ -1,0 +1,7 @@
+Change: Add index on addressbookid
+
+Added index for addressbookid_name_value that allows to improve
+scan performance of search addressbook query when medial search is off
+
+https://github.com/owncloud/enterprise/issues/3625
+https://github.com/owncloud/core/pull/37152


### PR DESCRIPTION
Fixes owncloud/enterprise#3625. The work should add index for `'addressbookid' 'name' 'value'` that allows to improve scan performance of search addressbook query when e.g. end of term wildcard (term%) is used.

Please note combinations that allow to fully utilize index according to https://github.com/owncloud/core/pull/36225, and comment explaining why index cannot be utilized in these cases https://github.com/owncloud/enterprise/issues/3625#issuecomment-573861541:
- `accounts.enable_medial_search=true` - `%value%` - index ignored
- `accounts.enable_medial_search=false` - `value%` - index used

However, query with this index should be faster in general too regardles of wildcard on `value`, due to index on `'addressbookid', 'name'`, that will prefilter search

Targeting 10.5 (@micbar )