### PR TITLE
Respect sharing.federation.allowHttpFallback config option

### DIFF
--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -330,15 +330,15 @@ class Notifications {
 		$try = 0;
 
 		while ($result['success'] === false && $try < 2) {
-			if ($useOcm) {
-				$endpoint = $this->discoveryManager->getOcmShareEndpoint($protocol . $remoteDomain);
-				$endpoint .= $urlSuffix;
-			} else {
-				$relativePath = $this->discoveryManager->getShareEndpoint($protocol . $remoteDomain);
-				$endpoint = $protocol . $remoteDomain . $relativePath . $urlSuffix . '?format=' . self::RESPONSE_FORMAT;
-			}
-
 			try {
+				if ($useOcm) {
+					$endpoint = $this->discoveryManager->getOcmShareEndpoint($protocol . $remoteDomain);
+					$endpoint .= $urlSuffix;
+				} else {
+					$relativePath = $this->discoveryManager->getShareEndpoint($protocol . $remoteDomain);
+					$endpoint = $protocol . $remoteDomain . $relativePath . $urlSuffix . '?format=' . self::RESPONSE_FORMAT;
+				}
+
 				$options = [
 					'timeout' => 10,
 					'connect_timeout' => 10,
@@ -364,6 +364,7 @@ class Notifications {
 				if ($e->getCode() === Http::STATUS_INTERNAL_SERVER_ERROR) {
 					throw $e;
 				}
+
 				$allowHttpFallback = $this->config->getSystemValue('sharing.federation.allowHttpFallback', false) === true;
 				if (!$allowHttpFallback) {
 					break;

--- a/changelog/unreleased/37153
+++ b/changelog/unreleased/37153
@@ -1,0 +1,6 @@
+Bugfix: Respect sharing.federation.allowHttpFallback config option
+
+Federated share can be created for server without SSL, by setting config
+option sharing.federation.allowHttpFallback=true.
+
+https://github.com/owncloud/core/pull/37153


### PR DESCRIPTION
This MR in general help local testing for federated sharing :
- catches exception that allow fallback from https->http 
- add some more unit tests testing `tryHttpPostToShareEndpoint`

Reasons:
- without this MR, exception is shown to the user:
`cURL error 60: SSL certificate problem: self signed certificate`
- now, better exception is shown as request gets properly handled:
`server cannot be reached`
- now, with the config `sharing.federation.allowHttpFallback` set, allows to create federated share.


Do we need some documentation for this config (developer docs) ?
```
occ config:system:set sharing.federation.allowHttpFallback --value true --type boolean
```