### PR TITLE
[Tests-only] Add acceptance test to share subfolder to invisible user in share chain

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -649,3 +649,20 @@ Feature: sharing
     Then the HTTP status code should be "200"
 #    Then the HTTP status code should be "405"
     And as "user0" folder "userOneFolder" should not exist
+
+  @skipOnOcis @issue-enterprise-3896
+  Scenario: sharing a subfolder to a user that already received parent folder share
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
+      | user3    |
+    And user "user0" has created folder "userZeroFolder"
+    And user "user0" has shared folder "userZeroFolder" with user "user1"
+    And user "user0" has shared folder "userZeroFolder" with user "user2"
+    And user "user1" has created folder "userZeroFolder/userOneFolder"
+    When user "user1" shares folder "userZeroFolder/userOneFolder" with user "user3" with permissions "read, share" using the sharing API
+    And user "user3" shares folder "userOneFolder" with user "user2" using the sharing API
+    Then the HTTP status code should be "200"
+#    Then the HTTP status code should be "405"
+    And as "user2" folder "userOneFolder" should not exist


### PR DESCRIPTION


<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds acceptance test to share a subfolder to a user that already received parent folder share but is invisible in the share chain
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/enterprise/issues/3896

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

