### PR TITLE
[Tests-Only] Added acceptance test to search for shared and tagged resources using REPORT

### DIFF
--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -126,3 +126,4 @@ Feature: Assign tags to file/folder
       | name        | type                |
       | MyFirstTag  | normal              |
       | MySecondTag | not user-assignable |
+

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -27,3 +27,10 @@ Feature: tags
       | name      | type   |
       | StaticTag | static |
     And the HTTP status when user "user1" requests tags for file "/myFileToTag.txt" owned by "user0" should be "404"
+
+  Scenario: Retrieve tag on a resource using REPORT method
+    Given the administrator has created a "normal" tag with name "NormalTag"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "myFileToTag.txt"
+    And user "user0" has added tag "NormalTag" to file "myFileToTag.txt"
+    When user reports for tag "NormalTag" using the webDAV API
+    Then as user "user0" the response should contain file "myFileToTag.txt"

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -27,10 +27,3 @@ Feature: tags
       | name      | type   |
       | StaticTag | static |
     And the HTTP status when user "user1" requests tags for file "/myFileToTag.txt" owned by "user0" should be "404"
-
-  Scenario: Retrieve tag on a resource using REPORT method
-    Given the administrator has created a "normal" tag with name "NormalTag"
-    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "myFileToTag.txt"
-    And user "user0" has added tag "NormalTag" to file "myFileToTag.txt"
-    When user reports for tag "NormalTag" using the webDAV API
-    Then as user "user0" the response should contain file "myFileToTag.txt"

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -222,3 +222,28 @@ Feature: Search
     Then the HTTP status code should be "207"
     And the search result by tags for user "user0" should contain these entries:
       | upload.txt |
+
+  Scenario: share a tagged resource to another internal user and sharee search for tag using REPORT method
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has created a "normal" tag with name "JustARegularTag1"
+    And user "user0" has created a "normal" tag with name "JustARegularTag2"
+    And user "user0" has added tag "JustARegularTag1" to folder "फनी näme"
+    And user "user0" has added tag "JustARegularTag1" to file "upload.txt"
+    And user "user0" has added tag "JustARegularTag2" to file "upload.txt"
+    And user "user0" has shared file "फनी näme" with user "user1"
+    And user "user0" has shared file "upload.txt" with user "user1"
+    When user "user1" searches for tag "JustARegularTag1" using the webDAV API
+    Then the HTTP status code should be "207"
+    And the search result by tags for user "user1" should contain these entries:
+      | फनी näme   |
+      | upload.txt |
+    When user "user1" searches for tag "JustARegularTag2" using the webDAV API
+    Then the HTTP status code should be "207"
+    And the search result by tags for user "user1" should contain these entries:
+      | upload.txt |
+    When user "user1" searches for following tag using the webDAV API
+      | JustARegularTag1 |
+      | JustARegularTag2 |
+    Then the HTTP status code should be "207"
+    And as user "user1" the response should contain file "upload.txt"
+    And as user "user1" the response should not contain file "फनी näme"

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -213,17 +213,17 @@ Feature: Search
     And user "user0" has added tag "JustARegularTag1" to folder "फनी näme"
     And user "user0" has added tag "JustARegularTag1" to file "upload.txt"
     And user "user0" has added tag "JustARegularTag2" to file "upload.txt"
-    When user "user0" searches for tag "JustARegularTag1" using the webDAV API
+    When user "user0" searches for resources tagged with tag "JustARegularTag1" using the webDAV API
     Then the HTTP status code should be "207"
     And the search result by tags for user "user0" should contain these entries:
       | फनी näme   |
       | upload.txt |
-    When user "user0" searches for tag "JustARegularTag2" using the webDAV API
+    When user "user0" searches for resources tagged with tag "JustARegularTag2" using the webDAV API
     Then the HTTP status code should be "207"
     And the search result by tags for user "user0" should contain these entries:
       | upload.txt |
 
-  Scenario: share a tagged resource to another internal user and sharee search for tag using REPORT method
+  Scenario: share a tagged resource to another internal user and sharee searches for tag using REPORT method
     Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has created a "normal" tag with name "JustARegularTag1"
     And user "user0" has created a "normal" tag with name "JustARegularTag2"
@@ -232,16 +232,16 @@ Feature: Search
     And user "user0" has added tag "JustARegularTag2" to file "upload.txt"
     And user "user0" has shared file "फनी näme" with user "user1"
     And user "user0" has shared file "upload.txt" with user "user1"
-    When user "user1" searches for tag "JustARegularTag1" using the webDAV API
+    When user "user1" searches for resources tagged with tag "JustARegularTag1" using the webDAV API
     Then the HTTP status code should be "207"
     And the search result by tags for user "user1" should contain these entries:
       | फनी näme   |
       | upload.txt |
-    When user "user1" searches for tag "JustARegularTag2" using the webDAV API
+    When user "user1" searches for resources tagged with tag "JustARegularTag2" using the webDAV API
     Then the HTTP status code should be "207"
     And the search result by tags for user "user1" should contain these entries:
       | upload.txt |
-    When user "user1" searches for following tag using the webDAV API
+    When user "user1" searches for resources tagged with all of the following tags using the webDAV API
       | JustARegularTag1 |
       | JustARegularTag2 |
     Then the HTTP status code should be "207"

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -1672,6 +1672,37 @@ class TagsContext implements Context {
 	}
 
 	/**
+	 * @When user reports for tag :tagName using the webDAV API
+	 *
+	 * @param $tagName
+	 *
+	 * @return void
+	 */
+	public function userReportsForTagsOnFileUsingTheWebDavApi($tagName) {
+		$this->userSearchesForTagUsingWebDavAPI(
+			$this->featureContext->getCurrentUser(),
+			$tagName
+		);
+	}
+
+	/**
+	 * @Then as user :user the response should contain file/folder :path
+	 *
+	 * @param $user
+	 * @param $path
+	 *
+	 * @return void
+	 */
+	public function asUserFileShouldBeTaggedWithTagName($user, $path) {
+		$responseResourcesArray = $this->featureContext->findEntryFromReportResponse($user);
+		Assert::assertTrue(
+			\in_array($path, $responseResourcesArray),
+			"Expected: $path to be present in last response, but not found! \n" .
+			"Resource from response: " . \implode(",", $responseResourcesArray)
+		);
+	}
+
+	/**
 	 * @AfterScenario
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -1659,7 +1659,7 @@ class TagsContext implements Context {
 			} else {
 				throw new Error(
 					"Expected: Tag with name $tagName[0] to be in created list, but not found!" .
-					"List of created Tags: " . \implode(",", $tagNames)
+					"List of created Tags: " . \implode(",", $createdTagNames)
 				);
 			}
 		}
@@ -1677,7 +1677,7 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @When user :user searches for following tag using the webDAV API
+	 * @When user :user searches for resources tagged with all of the following tags using the webDAV API
 	 *
 	 * @param string $user
 	 * @param TableNode $tagNames
@@ -1692,7 +1692,7 @@ class TagsContext implements Context {
 	}
 
 	/**
-	 * @When user :user searches for tag :tagName using the webDAV API
+	 * @When user :user searches for resources tagged with tag :tagName using the webDAV API
 	 *
 	 * @param string $user
 	 * @param string $tagName


### PR DESCRIPTION
## Description
When some tagged resource is shared with another user, then sharee should get those resources with same tags. This PR adds acceptance test for retrieving tagged and shared resources for users 
Draft because created on top of https://github.com/owncloud/core/pull/37147

## Related Issue
- Part of https://github.com/owncloud/QA/issues/634

## Motivation and Context


## How Has This Been Tested?
- :robot: 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
