### PR TITLE
[Tests-Only] Added method listTrashbinFileInServerRoot 

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2146,11 +2146,10 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @param string $path
 	 * @param string $content
-	 * @param bool $trash
 	 *
-	 * @return string
+	 * @return void
 	 */
-	public function theFileWithContentShouldExistInTheServerRoot($path, $content, $trash = false) {
+	public function theFileWithContentShouldExistInTheServerRoot($path, $content) {
 		$this->readFileInServerRoot($path);
 		Assert::assertSame(
 			200,
@@ -2160,10 +2159,6 @@ class FeatureContext extends BehatVariablesContext {
 		$fileContent = HttpRequestHelper::getResponseXml($this->getResponse());
 		$fileContent = (string) $fileContent->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($fileContent);
-
-		if ($trash) {
-			return $fileContent;
-		}
 
 		Assert::assertSame(
 			$content,

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2124,24 +2124,46 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * send request to list a server file
+	 *
+	 * @param string $path
+	 *
+	 * @return void
+	 */
+	public function listTrashbinFileInServerRoot($path) {
+		$response = OcsApiHelper::sendRequest(
+			$this->getBaseUrl(),
+			$this->getAdminUsername(),
+			$this->getAdminPassword(),
+			'GET',
+			"/apps/testing/api/v1/dir?dir={$path}"
+		);
+		$this->setResponse($response);
+	}
+
+	/**
 	 * @Then the file :path with content :content should exist in the server root
 	 *
 	 * @param string $path
 	 * @param string $content
+	 * @param bool $trash
 	 *
-	 * @return void
+	 * @return string
 	 */
-	public function theFileWithContentShouldExistInTheServerRoot($path, $content) {
+	public function theFileWithContentShouldExistInTheServerRoot($path, $content, $trash = false) {
 		$this->readFileInServerRoot($path);
 		Assert::assertSame(
 			200,
 			$this->getResponse()->getStatusCode(),
 			"Failed to read the file {$path}"
 		);
-
 		$fileContent = HttpRequestHelper::getResponseXml($this->getResponse());
 		$fileContent = (string) $fileContent->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($fileContent);
+
+		if ($trash) {
+			return $fileContent;
+		}
 
 		Assert::assertSame(
 			$content,


### PR DESCRIPTION
## Description
Added method `listTrashbinFileInServerRoot` and made some changes in method `theFileWithContentShouldExistInTheServerRoot` in FeatureContext.php

## Related Issue
- https://github.com/owncloud/data_exporter/pull/149

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- locally 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
