### PR TITLE
[Tests-Only] skip acceptDeclineFederatedShares new scenario on old core versions

### DIFF
--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
@@ -88,6 +88,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then user "user1" should not see the following elements
       | /lorem%20(2).txt |
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0
   Scenario: Local user accepts a pending federated share on the webUI
     Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
     When the user browses to the shared-with-you page


### PR DESCRIPTION
## Description
https://drone.owncloud.com/owncloud/files_primary_s3/1599/56/19
https://drone.owncloud.com/owncloud/encryption/1179/180/17

This new scenario drives the webUI in ways that do not work on older core versions. So skip the new scenario in that case.
The scenario was added in https://github.com/owncloud/core/pull/37146

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
