### PR TITLE
[Tests-Only] Adjust unit tests for the future

### DIFF
--- a/apps/dav/tests/unit/DAV/CopyPluginTest.php
+++ b/apps/dav/tests/unit/DAV/CopyPluginTest.php
@@ -24,6 +24,7 @@ namespace OCA\DAV\Tests\unit\DAV;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\DAV\CopyPlugin;
+use OCA\DAV\Meta\MetaFile;
 use Sabre\DAV\ICollection;
 use Sabre\DAV\IFile;
 use Sabre\DAV\Server;
@@ -90,7 +91,7 @@ class CopyPluginTest extends TestCase {
 
 	public function testCopyPluginReturnFalse() {
 		$destinationNode = $this->createMock(File::class);
-		$sourceNode = $this->createMock([IFile::class, ICopySource::class]);
+		$sourceNode = $this->createMock(MetaFile::class);
 
 		$this->tree->expects($this->once())->method('getNodeForPath')->willReturn($sourceNode);
 		$this->server->expects($this->once())->method('getCopyAndMoveInfo')->willReturn([
@@ -125,7 +126,7 @@ class CopyPluginTest extends TestCase {
 		$this->expectExceptionMessage('Test exception');
 
 		$destinationNode = $this->createMock(File::class);
-		$sourceNode = $this->createMock([ICopySource::class, IFile::class]);
+		$sourceNode = $this->createMock(MetaFile::class);
 
 		$this->tree->expects($this->once())->method('getNodeForPath')->willReturn($sourceNode);
 		$this->server->expects($this->once())->method('getCopyAndMoveInfo')->willReturn([

--- a/apps/dav/tests/unit/Files/FileLocksBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileLocksBackendTest.php
@@ -38,6 +38,9 @@ use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\ObjectTree;
 use OC\Files\View;
 
+interface IPersistentLockingStorageTest extends IPersistentLockingStorage, IStorage {
+}
+
 class FileLocksBackendTest extends TestCase {
 	const CREATION_TIME = 164419200;
 	const CURRENT_TIME = 164419800;
@@ -52,7 +55,7 @@ class FileLocksBackendTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->storageOfFileToBeLocked = $this->createMock([IPersistentLockingStorage::class, IStorage::class]);
+		$this->storageOfFileToBeLocked = $this->createMock(IPersistentLockingStorageTest::class);
 
 		$timeFactory = $this->createMock(ITimeFactory::class);
 		$timeFactory->method('getTime')->willReturn(self::CURRENT_TIME);
@@ -61,7 +64,7 @@ class FileLocksBackendTest extends TestCase {
 		$this->tree->method('getNodeForPath')->willReturnCallback(function ($uri) {
 			// root node
 			if ($uri === '') {
-				$storage = $this->createMock([IPersistentLockingStorage::class, IStorage::class]);
+				$storage = $this->createMock(IPersistentLockingStorageTest::class);
 				$storage->method('instanceOfStorage')->willReturn(true);
 				$storage->method('getLocks')->willReturn([]);
 				$fileInfo = $this->createMock(FileInfo::class);
@@ -86,7 +89,7 @@ class FileLocksBackendTest extends TestCase {
 				return $file;
 			}
 			if ($uri === 'locked-file.txt') {
-				$storage = $this->createMock([IPersistentLockingStorage::class, IStorage::class]);
+				$storage = $this->createMock(IPersistentLockingStorageTest::class);
 				$storage->method('instanceOfStorage')->willReturn(true);
 				$storage->method('getLocks')->willReturnCallback(function () {
 					$lock = new Lock();
@@ -121,7 +124,7 @@ class FileLocksBackendTest extends TestCase {
 			}
 
 			if ($uri === 'locked-collection-infinite') {
-				$storage = $this->createMock([IPersistentLockingStorage::class, IStorage::class]);
+				$storage = $this->createMock(IPersistentLockingStorageTest::class);
 				$storage->method('instanceOfStorage')->willReturn(true);
 				$storage->method('getLocks')->willReturnCallback(function () {
 					$lock = new Lock();
@@ -224,7 +227,7 @@ class FileLocksBackendTest extends TestCase {
 		$lock->setTimeout(1000);
 		$lock->setCreatedAt(self::CREATION_TIME);
 
-		$storage = $this->createMock([IPersistentLockingStorage::class, IStorage::class]);
+		$storage = $this->createMock(IPersistentLockingStorageTest::class);
 		$storage->method('instanceOfStorage')->willReturn(true);
 		$storage->method('getLocks')
 			->with($storageGetLocksPath)

--- a/apps/dav/tests/unit/Files/FileLocksBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileLocksBackendTest.php
@@ -38,6 +38,9 @@ use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\ObjectTree;
 use OC\Files\View;
 
+// ToDo: phpunit9 createMock will no longer allow an array of interface names.
+//       A dummy interface has been created here for the tests.
+//       Find a better solution.
 interface IPersistentLockingStorageTest extends IPersistentLockingStorage, IStorage {
 }
 

--- a/apps/dav/tests/unit/Files/PreviewPluginTest.php
+++ b/apps/dav/tests/unit/Files/PreviewPluginTest.php
@@ -19,6 +19,7 @@
 
 namespace OCA\DAV\Tests\Unit\Files;
 
+use OC\Files\Node\File;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Files\IFileNode;
 use OCA\DAV\Files\PreviewPlugin;
@@ -62,7 +63,7 @@ class PreviewPluginTest extends TestCase {
 		$this->previewManager = $this->createMock(IPreview::class);
 		$this->previewManager->method('isAvailable')->willReturn(true);
 
-		$this->previewNode = $this->createMock([IPreviewNode::class, FileInfo::class]);
+		$this->previewNode = $this->createMock(File::class);
 
 		$this->request = $this->createMock(RequestInterface::class);
 		/** @var ResponseInterface | MockObject $response */

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,6 +26,4 @@ if (\OCP\Util::needUpgrade()) {
 // load all enabled apps
 \OC_App::loadApps();
 
-PHPUnit\Framework\Error\Deprecated::$enabled = false;
-
 OC_Hook::clear();

--- a/tests/lib/Files/MetaVersionCollectionTest.php
+++ b/tests/lib/Files/MetaVersionCollectionTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\Files;
 
+use OC\Files\Storage\Common;
 use Test\TestCase;
 use OCP\Files\Node;
 use OC\Files\Meta\MetaVersionCollection;
@@ -53,7 +54,7 @@ class MetaVersionCollectionTest extends TestCase {
 	private $collection;
 
 	/**
-	 * @var IStorage|IVersionedStorage
+	 * @var Common
 	 */
 	private $storage;
 
@@ -62,7 +63,7 @@ class MetaVersionCollectionTest extends TestCase {
 
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->node = $this->createMock(Node::class);
-		$this->storage = $this->createMock([IStorage::class, IVersionedStorage::class]);
+		$this->storage = $this->createMock(Common::class);
 		$this->node->method('getStorage')->willReturn($this->storage);
 		$this->collection = new MetaVersionCollection($this->rootFolder, $this->node);
 	}

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -34,6 +34,9 @@ use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IVersionedObjectStorage;
 use Test\TestCase;
 
+interface IObjectStoreTest extends IObjectStore, IVersionedObjectStorage {
+}
+
 /**
  * Class ObjectStoreTest
  *
@@ -43,14 +46,14 @@ use Test\TestCase;
  */
 class ObjectStoreTest extends TestCase {
 
-	/** @var IObjectStore | IVersionedObjectStorage | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IObjectStoreTest | \PHPUnit\Framework\MockObject\MockObject */
 	private $impl;
 	/** @var ObjectStoreStorage | \PHPUnit\Framework\MockObject\MockObject */
 	private $objectStore;
 
 	public function setUp(): void {
 		parent::setUp();
-		$this->impl = $this->createMock([IObjectStore::class, IVersionedObjectStorage::class]);
+		$this->impl = $this->createMock(IObjectStoreTest::class);
 		$this->impl->expects($this->any())
 			->method('getStorageId')
 			->willReturn('object-store-test');

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -34,6 +34,9 @@ use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IVersionedObjectStorage;
 use Test\TestCase;
 
+// ToDo: phpunit9 createMock will no longer allow an array of interface names.
+//       A dummy interface has been created here for the tests.
+//       Find a better solution.
 interface IObjectStoreTest extends IObjectStore, IVersionedObjectStorage {
 }
 

--- a/tests/lib/Files/Storage/Wrapper/JailTest.php
+++ b/tests/lib/Files/Storage/Wrapper/JailTest.php
@@ -8,6 +8,7 @@
 
 namespace Test\Files\Storage\Wrapper;
 
+use OC\Files\Storage\Common;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IVersionedStorage;
 
@@ -66,7 +67,7 @@ class JailTest extends \Test\Files\Storage\Storage {
 	 * @dataProvider providesVersionMethods
 	 */
 	public function testCallsSourceVersionMethods($method, $extraArg = null) {
-		$sourceStorage = $this->createMock([IStorage::class, IVersionedStorage::class]);
+		$sourceStorage = $this->createMock(Common::class);
 		$instance = new \OC\Files\Storage\Wrapper\Jail([
 			'storage' => $sourceStorage,
 			'root' => 'foo'

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -38,6 +38,11 @@ use OCP\User\IProvidesUserNameBackend;
 use OCP\UserInterface;
 use Test\TestCase;
 
+interface IUserInterfaceWithQuotaBackendTest extends UserInterface, IProvidesQuotaBackend {
+}
+interface IUserInterfaceWithUserNameBackendTest extends UserInterface, IProvidesUserNameBackend {
+}
+
 class SyncServiceTest extends TestCase {
 
 	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
@@ -83,7 +88,7 @@ class SyncServiceTest extends TestCase {
 	public function testSetupNewAccount() {
 		$mapper = $this->createMock(AccountMapper::class);
 		// Create a mapper which supports providing a home
-		$backend = $this->createMock([UserInterface::class, \OCP\User\IProvidesHomeBackend::class]);
+		$backend = $this->createMock(UserInterface::class);
 		$config = $this->createMock(IConfig::class);
 		$logger = $this->createMock(ILogger::class);
 		$account = $this->createMock(Account::class);
@@ -120,7 +125,7 @@ class SyncServiceTest extends TestCase {
 	 * Pass in a backend that has new users anc check that they accounts are inserted
 	 */
 	public function testSetupNewAccountLogsErrorOnException() {
-		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
+		/** @var UserInterface | \PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->createMock(UserInterface::class);
 
 		$backendUids = ['thisuserhasntbeenseenbefore'];
@@ -139,8 +144,8 @@ class SyncServiceTest extends TestCase {
 
 	public function testSyncHomeLogsWhenBackendDiffersFromExisting() {
 
-		/** @var UserInterface | IProvidesHomeBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
-		$backend = $this->createMock([UserInterface::class, IProvidesHomeBackend::class]);
+		/** @var Database | \PHPUnit\Framework\MockObject\MockObject $backend */
+		$backend = $this->createMock(Database::class);
 		$a = $this->getMockBuilder(Account::class)->setMethods(['getHome'])->getMock();
 
 		// Account returns existing home
@@ -253,8 +258,8 @@ class SyncServiceTest extends TestCase {
 		$a = $this->getMockBuilder(Account::class)->setMethods(['setQuota'])->getMock();
 
 		if ($backendProvidesQuota) {
-			/** @var UserInterface | IProvidesQuotaBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
-			$backend = $this->createMock([UserInterface::class, IProvidesQuotaBackend::class]);
+			/** @var IUserInterfaceWithQuotaBackendTest | \PHPUnit\Framework\MockObject\MockObject $backend */
+			$backend = $this->createMock(IUserInterfaceWithQuotaBackendTest::class);
 			$backend->expects($this->exactly(1))->method('getQuota')->willReturn($backendQuota);
 		} else {
 			$backend = $this->createMock(UserInterface::class);
@@ -283,8 +288,8 @@ class SyncServiceTest extends TestCase {
 		$a = $this->createMock(Account::class);
 		$a->method('__call')->with('getUserId')->willReturn('user1');
 
-		/** @var UserInterface | IProvidesUserNameBackend | \PHPUnit\Framework\MockObject\MockObject $backend */
-		$backend = $this->createMock([UserInterface::class, IProvidesUserNameBackend::class]);
+		/** @var IUserInterfaceWithUserNameBackendTest | \PHPUnit\Framework\MockObject\MockObject $backend */
+		$backend = $this->createMock(IUserInterfaceWithUserNameBackendTest::class);
 		$backend->expects($this->once())
 			->method('getUserName')
 			->willReturn('userName1');

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -38,6 +38,9 @@ use OCP\User\IProvidesUserNameBackend;
 use OCP\UserInterface;
 use Test\TestCase;
 
+// ToDo: phpunit9 createMock will no longer allow an array of interface names.
+//       Dummy interfaces have been created here for the tests.
+//       Find a better solution.
 interface IUserInterfaceWithQuotaBackendTest extends UserInterface, IProvidesQuotaBackend {
 }
 interface IUserInterfaceWithUserNameBackendTest extends UserInterface, IProvidesUserNameBackend {


### PR DESCRIPTION
## Description
These are some changes that can be made now to PHP unit tests.
`phpunit` 8 reports various deprecations. See example PR #37168 

1) Remove undeclared property PHPUnit\Framework\Error\Deprecated - not valid/needed any more with phpunit8 - we will also be fine removing this now for phpunit7, if people write new unit test code it will be useful to have the new unit test code fail if it uses things that have been deprecated,

2) Stop using assertAttributeEquals in tests/lib/ConfigTest.php - that assert is deprecated and being removed. I wrote a function that does an `assertEquals` for each item.

3) Adjust createMock calls to remove deprecated array of interface names - `createMock()` can only be passed a single class/interface. phpunit8 reports:
```
Passing an array of interface names to createMock() for creating a test double that implements multiple interfaces is deprecated and will no longer be supported in PHPUnit 9.
Passing an array of interface names to getMockBuilder() for creating a test double that implements multiple interfaces is deprecated and will no longer be supported in PHPUnit 9.
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
