### PR TITLE
[Tests-Only] [10.4.1] Fix webUI acceptance test page title checks

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -61,7 +61,7 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	/**
 	 * @return string
 	 */
-	private function getLoginSuccessPageTitle() {
+	private function getExpectedLoginSuccessPageTitle() {
 		// When the login succeeds, we end up on the Files page
 		return "Files - " . $this->featureContext->getProductNameFromStatus();
 	}
@@ -72,18 +72,16 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function webUILoginShouldHaveBeenSuccessful() {
-		$actualTitle = $this->getLoginSuccessPageTitle();
-		$expectedTitle = 'Files - ownCloud';
 		Assert::assertEquals(
-			$expectedTitle,
-			$actualTitle
+			$this->getExpectedLoginSuccessPageTitle(),
+			$this->filesPage->getPageTitle()
 		);
 	}
 
 	/**
 	 * @return string
 	 */
-	private function getLoginFailedPageTitle() {
+	private function getExpectedLoginFailedPageTitle() {
 		// When the login fails, we end up at a page with a title that is the
 		// themed product name, e.g. "ownCloud"
 		return $this->featureContext->getProductNameFromStatus();
@@ -93,11 +91,9 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function webUILoginShouldHaveBeenUnsuccessful() {
-		$actualTitle = $this->getLoginFailedPageTitle();
-		$expectedTitle = 'ownCloud';
 		Assert::assertEquals(
-			$expectedTitle,
-			$actualTitle
+			$this->getExpectedLoginFailedPageTitle(),
+			$this->loginPage->getPageTitle()
 		);
 	}
 
@@ -460,14 +456,14 @@ class WebUILoginContext extends RawMinkContext implements Context {
 				$username, $password
 			);
 			$this->webUIGeneralContext->theUserShouldBeRedirectedToAWebUIPageWithTheTitle(
-				$this->getLoginSuccessPageTitle()
+				$this->getExpectedLoginSuccessPageTitle()
 			);
 		} else {
 			$this->userLogInWithUsernameAndInvalidPasswordUsingTheWebUI(
 				$username, $password
 			);
 			$this->webUIGeneralContext->theUserShouldBeRedirectedToAWebUIPageWithTheTitle(
-				$this->getLoginFailedPageTitle()
+				$this->getExpectedLoginFailedPageTitle()
 			);
 		}
 	}


### PR DESCRIPTION
## Description
Backport #37182 to `release-10.4.1` branch.

This is needed so that the UI acceptance tests will pass nicely when used with a themed system-under-test that has a different product name.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
