### PR TITLE
[Tests-only] Corrected data type for varible 'type'

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1476,7 +1476,7 @@ class OccContext implements Context {
 			);
 		}
 	}
-	
+
 	/**
 	 * @Then the following backend types should be listed:
 	 *
@@ -2137,7 +2137,7 @@ class OccContext implements Context {
 	 *
 	 * @param string $key
 	 * @param string $value
-	 * @param boolean $type
+	 * @param string $type
 	 *
 	 * @return void
 	 * @throws Exception
@@ -2158,7 +2158,7 @@ class OccContext implements Context {
 	 *
 	 * @param string $key
 	 * @param string $value
-	 * @param boolean $type
+	 * @param string $type
 	 *
 	 * @return void
 	 * @throws Exception

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -27,7 +27,6 @@ use Guzzle\Http\Exception\BadResponseException;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use TestHelpers\OcsApiHelper;
-use TestHelpers\OcisHelper;
 use TestHelpers\SetupHelper;
 use TestHelpers\UploadHelper;
 use TestHelpers\WebDavHelper;


### PR DESCRIPTION

## Description
Corrected data type for varible `type` from boolean to string in documentation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
