### PR TITLE
[Tests-Only] User can update the permission in share when max expiry date is enforced

### DIFF
--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -247,3 +247,30 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  Scenario Outline: user can update the role in an existing share after the system maximum expiry date has been reduced
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "user1" has been created with default attributes and without skeleton files
+    When user "user0" creates a share using the sharing API with settings
+      | path        | textfile0.txt |
+      | shareType   | user          |
+      | shareWith   | user1         |
+      | permissions | read,share    |
+      | expireDate  | +30 days      |
+    Then the HTTP status code should be "200"
+    When the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "5"
+    And user "user0" updates the last share using the sharing API with
+      | permissions | read |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    When user "user0" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
+      | permissions | read     |
+      | expiration  | +30 days |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |


### PR DESCRIPTION
## Description
API test is added for updating the permission in the share  when max expiry date is enforced and the existing expiry date pasts the maximum enforced date.

## Motivation and Context
An error message is displayed while updating the date to a date more than max enforced date. But while modifying the permission only, the update is successful without any feedback message.

## How Has This Been Tested?
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
