### PR TITLE
Add logging of general exception to error log in federated share polling

### DIFF
--- a/apps/federatedfilesharing/lib/AppInfo/Application.php
+++ b/apps/federatedfilesharing/lib/AppInfo/Application.php
@@ -177,6 +177,7 @@ class Application extends App {
 					$server->getDatabaseConnection(),
 					$server->getUserManager(),
 					\OC\Files\Filesystem::getLoader(),
+					$server->getLogger(),
 					$externalManager,
 					$externalMountProvider
 				);


### PR DESCRIPTION
It can happen that polling throws an exception that a bit ambigous as `Skipping external share with id "id" from remote
"https://test.test. Reason: ""`. For debugging in such cases it might be better to log such exceptions to better understand the cause.