### PR TITLE
[Tests-Only] Use newadmin for invalid auth tests

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -185,7 +185,9 @@ Feature: CORS headers
   Scenario Outline: CORS headers should be returned when invalid password is used (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
     And the administrator has added "https://aphno.badal" to the list of personal CORS domains
-    When the administrator sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers using password "invalid"
+    And user "newadmin" has been created with default attributes and without skeleton files
+    And user "newadmin" has been added to group "admin"
+    When user "newadmin" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers using password "invalid"
       | header | value               |
       | Origin | https://aphno.badal |
     Then the OCS status code should be "<ocs-code>"

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -1,9 +1,13 @@
 @api @TestAlsoOnExternalUserBackend @files_sharing-app-required
 Feature: auth
 
+  Background:
+    Given user "newadmin" has been created with default attributes and without skeleton files
+    And user "newadmin" has been added to group "admin"
+
   @smokeTest @issue-32068 @skipOnOcis @issue-ocis-reva-30 @issue-ocis-reva-65
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
-    When the administrator requests these endpoints with "DELETE" using password "invalid" then the status codes should be as listed
+    When user "newadmin" requests these endpoints with "DELETE" using password "invalid" then the status codes should be as listed
       | endpoint                                                        | ocs-code | http-code |
       | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       |
       | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/123 | 997      | 401       |
@@ -26,7 +30,7 @@ Feature: auth
   @smokeTest @skipOnOcV10 @issue-ocis-reva-30 @issue-ocis-reva-65
    #after fixing all issues delete this Scenario and use the one above
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
-    When the administrator requests these endpoints with "DELETE" using password "invalid" then the status codes should be as listed
+    When user "newadmin" requests these endpoints with "DELETE" using password "invalid" then the status codes should be as listed
       | endpoint                                                        | http-code |
       | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/123 | 401       |
       | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/123 | 401       |

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -186,7 +186,9 @@ Feature: auth
   @skipOnOcis
   @issue-ocis-reva-65
   Scenario: using OCS as admin user with wrong password
-    When the administrator requests these endpoints with "GET" using password "invalid" then the status codes should be as listed
+    Given user "newadmin" has been created with default attributes and without skeleton files
+    And user "newadmin" has been added to group "admin"
+    When user "newadmin" requests these endpoints with "GET" using password "invalid" then the status codes should be as listed
       | endpoint                                                    | ocs-code | http-code |
       | /ocs/v1.php/apps/files_external/api/v1/mounts               | 997      | 401       |
       | /ocs/v2.php/apps/files_external/api/v1/mounts               | 997      | 401       |

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -1,11 +1,15 @@
 @api @TestAlsoOnExternalUserBackend @files_sharing-app-required
 Feature: auth
 
+  Background:
+    Given user "newadmin" has been created with default attributes and without skeleton files
+    And user "newadmin" has been added to group "admin"
+
   @skipOnOcis
   @issue-ocis-reva-30
   @smokeTest
   Scenario: send PUT request to OCS endpoints as admin with wrong password
-    When the administrator requests these endpoints with "PUT" with body using password "invalid" then the status codes should be as listed
+    When user "newadmin" requests these endpoints with "PUT" including body using password "invalid" then the status codes should be as listed
       | endpoint                                         | ocs-code | http-code | body          |
       | /ocs/v1.php/cloud/users/user0                    | 997      | 401       | doesnotmatter |
       | /ocs/v2.php/cloud/users/user0                    | 997      | 401       | doesnotmatter |
@@ -21,7 +25,7 @@ Feature: auth
   @smokeTest
   #after fixing all issues delete this Scenario and use the one above
   Scenario: send PUT request to OCS endpoints as admin with wrong password
-    When the administrator requests these endpoints with "PUT" with body using password "invalid" then the status codes should be as listed
+    When user "newadmin" requests these endpoints with "PUT" including body using password "invalid" then the status codes should be as listed
       | endpoint                                         | http-code | body          |
       | /ocs/v1.php/cloud/users/user0                    | 401       | doesnotmatter |
       | /ocs/v2.php/cloud/users/user0                    | 401       | doesnotmatter |


### PR DESCRIPTION
## Description
If we use the built-in admin account for tests that purposely send an invalid password to API endpoints then there is the risk that the built-in admin account might get locked out. If the built-in admin account gets locked out during a test run then later `AfterScenario` and `BeforeScenario` actions will fail just because a previous test scenario "messed up" the built-in admin account.

For example, this can happen when running core acceptance tests while the `brute_force_protection` app is enabled.

Change these sort of scenarios so that they create a new user that is in the `admin` group, and use that user. That user can get locked-out in a scenario, and it will not break the built-in admin account.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
