### PR TITLE
[Tests-Only] [10.4.1] Add skipOnBruteForceProtection test tags due to issue 112

### DIFF
--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -6,6 +6,7 @@ Feature: auth
     And user "newadmin" has been added to group "admin"
 
   @smokeTest @issue-32068 @skipOnOcis @issue-ocis-reva-30 @issue-ocis-reva-65
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     When user "newadmin" requests these endpoints with "DELETE" using password "invalid" then the status codes should be as listed
       | endpoint                                                        | ocs-code | http-code |

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -185,6 +185,7 @@ Feature: auth
 
   @skipOnOcis
   @issue-ocis-reva-65
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as admin user with wrong password
     Given user "newadmin" has been created with default attributes and without skeleton files
     And user "newadmin" has been added to group "admin"

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -8,6 +8,7 @@ Feature: auth
   @skipOnOcis
   @issue-ocis-reva-30
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT request to OCS endpoints as admin with wrong password
     When user "newadmin" requests these endpoints with "PUT" including body using password "invalid" then the status codes should be as listed
       | endpoint                                         | ocs-code | http-code | body          |


### PR DESCRIPTION
## Description
Port of #37204 to `release-10.4.1` branch.

Adding these `skipOnBruteForceProtection` tags will give us the flexibility to skip these test scenarios when the system-under-test has the current `brute_force_protection` app enabled, which gives inconsistent results.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
