### PR TITLE
[Tests-Only]Try to update date and permission at the same time when max date is enforced

### DIFF
--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -274,3 +274,32 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  Scenario Outline: user cannot update the role and date in an existing share after the system maximum expiry date has been reduced
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "user1" has been created with default attributes and without skeleton files
+    When user "user0" creates a share using the sharing API with settings
+      | path        | textfile0.txt |
+      | shareType   | user          |
+      | shareWith   | user1         |
+      | permissions | read,share    |
+      | expireDate  | +30 days      |
+    Then the HTTP status code should be "200"
+    When the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "10"
+    And user "user0" updates the last share using the sharing API with
+      | permissions | read |
+      | expireDate  | +28  |
+    Then the OCS status message should be "Expiration date is in the past"
+    And the HTTP status code should be "<http_status_code>"
+    And the OCS status code should be "404"
+    When user "user0" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
+      | permissions | read, share |
+      | expiration  | +30 days    |
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -275,24 +275,25 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @issue-37217
   Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "user1" has been created with default attributes and without skeleton files
-    When user "user0" creates a share using the sharing API with settings
+    And user "user0" has created a share with settings
       | path        | textfile0.txt |
       | shareType   | user          |
       | shareWith   | user1         |
       | permissions | read,share    |
       | expireDate  | +30 days      |
-    Then the HTTP status code should be "200"
     When the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "10"
     And user "user0" updates the last share using the sharing API with
       | permissions | read |
       | expireDate  | +28  |
     Then the OCS status message should be "Expiration date is in the past"
+#    Then the OCS status message should be "Cannot set expiration date more than 10 days in the future"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "404"
     When user "user0" gets the info of the last share using the sharing API

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -275,7 +275,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: user cannot update the role and date in an existing share after the system maximum expiry date has been reduced
+  Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"


### PR DESCRIPTION
## Description
API test added for testing if user can update the permission and date at the same time when the new date is more than the new enforced max date.

## Related Issue
Demonstrates https://github.com/owncloud/core/issues/37217

## Motivation and Context
An error message is generated saying `Expiration date is in the past`

## How Has This Been Tested?
locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
