### PR TITLE
[Tests-Only] [10.4.1] Acceptance test typos 10.4.1

### DIFF
--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -12,7 +12,7 @@ Feature: upload to a public link share
       | path        | FOLDER |
       | permissions | create |
     When the public uploads file "test.txt" with content "test" using the old public WebDAV API
-    And the public uploads file "test.txt" with content "test2" with autorename mode using the old public WebDAV API
+    And the public uploads file "test.txt" with content "test2" with auto-rename mode using the old public WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9]{1,32}"$/ |

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1941,7 +1941,7 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @Given the administrator has created file :path with content :content in local storage :mountPount
+	 * @Given the administrator has created file :path with content :content in local storage :mountPoint
 	 *
 	 * @param string $path
 	 * @param string $content
@@ -2035,7 +2035,7 @@ class FeatureContext extends BehatVariablesContext {
 		$jsonRespondedEncoded = \json_encode((string) $this->response->getBody());
 		Assert::assertEquals(
 			$jsonExpectedEncoded, $jsonRespondedEncoded,
-			"The json responded: {$jsonRespondedEncoded} doesnot match with json expected: {$jsonExpectedEncoded}"
+			"The json responded: {$jsonRespondedEncoded} does not match with json expected: {$jsonExpectedEncoded}"
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/LoggingContext.php
+++ b/tests/acceptance/features/bootstrap/LoggingContext.php
@@ -75,7 +75,7 @@ class LoggingContext implements Context {
 		foreach ($expectedLogEntries as $expectedLogEntry) {
 			$logEntry = \json_decode($logLines[$lineNo], true);
 			if ($logEntry === null) {
-				throw new \Exception("the logline :\n{$logLines[$lineNo]} is not valid JSON");
+				throw new \Exception("the log line :\n{$logLines[$lineNo]} is not valid JSON");
 			}
 
 			foreach (\array_keys($expectedLogEntry) as $attribute) {
@@ -256,7 +256,7 @@ class LoggingContext implements Context {
 		foreach ($logLines as $logLine) {
 			$logEntry = \json_decode($logLine, true);
 			if ($logEntry === null) {
-				throw new \Exception("the logline :\n{$logLine} is not valid JSON");
+				throw new \Exception("the log line :\n{$logLine} is not valid JSON");
 			}
 			//reindex the array, we might have deleted entries
 			$expectedLogEntries = \array_values($expectedLogEntries);
@@ -352,7 +352,7 @@ class LoggingContext implements Context {
 		foreach ($logLines as $logLine) {
 			$logEntry = \json_decode($logLine, true);
 			if ($logEntry === null) {
-				throw new \Exception("the logline :\n$logLine is not valid JSON");
+				throw new \Exception("the log line :\n$logLine is not valid JSON");
 			}
 			foreach ($logEntriesExpectedNotToExist as $logEntryExpectedNotToExist) {
 				$match = true; // start by assuming the worst, we match the unwanted log entry

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1331,7 +1331,7 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the adminstrator lists the :backend backend of type :backendType using the occ command
+	 * @When the administrator lists the :backend backend of type :backendType using the occ command
 	 *
 	 * @param String $backend
 	 * @param String $backendType

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -377,7 +377,7 @@ trait Provisioning {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theAdministratorHasSetTheSystemLanguagaeTo($defaultLanguage) {
+	public function theAdministratorHasSetTheSystemLanguageTo($defaultLanguage) {
 		$this->runOcc(
 			["config:system:set default_language --value $defaultLanguage"]
 		);

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -317,7 +317,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * This only works with the old API, autorename is not supported in the new API
+	 * This only works with the old API, auto-rename is not supported in the new API
 	 * auto renaming is handled on files drop folders implicitly
 	 *
 	 * @param string $filename target file name
@@ -330,7 +330,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :filename with content :body with autorename mode using the old public WebDAV API
+	 * @When the public uploads file :filename with content :body with auto-rename mode using the old public WebDAV API
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
@@ -342,7 +342,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Given the public has uploaded file :filename with content :body with autorename mode
+	 * @Given the public has uploaded file :filename with content :body with auto-rename mode
 	 *
 	 * @param string $filename target file name
 	 * @param string $body content to upload
@@ -886,7 +886,7 @@ class PublicWebDavContext implements Context {
 	 * @param string $filename
 	 * @param string $password
 	 * @param string $body
-	 * @param bool $autorename
+	 * @param bool $autoRename
 	 * @param array $additionalHeaders
 	 * @param string $publicWebDAVAPIVersion
 	 *
@@ -896,7 +896,7 @@ class PublicWebDavContext implements Context {
 		$filename,
 		$password = '',
 		$body = 'test',
-		$autorename = false,
+		$autoRename = false,
 		$additionalHeaders = [],
 		$publicWebDAVAPIVersion = "old"
 	) {
@@ -916,7 +916,7 @@ class PublicWebDavContext implements Context {
 		$url .= \ltrim($filename, '/');
 		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
 
-		if ($autorename) {
+		if ($autoRename) {
 			$headers['OC-Autorename'] = 1;
 		}
 		$headers = \array_merge($headers, $additionalHeaders);

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2147,7 +2147,7 @@ trait Sharing {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function userRemovesAllSharesFromTheFileNamedzz($user, $fileName) {
+	public function userRemovesAllSharesFromTheFileNamed($user, $fileName) {
 		$this->removeAllSharesFromResource($user, $fileName);
 	}
 

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -1339,7 +1339,7 @@ class TagsContext implements Context {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theHttpStatusWhenuserRequestsTagsForEntryOwnedByShouldBe(
+	public function theHttpStatusWhenUserRequestsTagsForEntryOwnedByShouldBe(
 		$user, $fileName, $sharingUser, $status
 	) {
 		$this->requestTagsForFile($user, $fileName, $sharingUser);
@@ -1378,7 +1378,7 @@ class TagsContext implements Context {
 	 *
 	 * @param string $fileName
 	 * @param string $sharingUser
-	 * @param TableNode $table  - Table containg tags. Should have two columns ('name' and 'type')
+	 * @param TableNode $table  - Table containing tags. Should have two columns ('name' and 'type')
 	 *                          e.g.
 	 *                          | name | type   |
 	 *                          | tag1 | normal |

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -144,16 +144,16 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
-	 * @When the user changes the full name to :newFullname using the webUI
-	 * @Given the user has changed the full name to :newFullname using the webUI
+	 * @When the user changes the full name to :newFullName using the webUI
+	 * @Given the user has changed the full name to :newFullName using the webUI
 	 *
-	 * @param string $newFullname
+	 * @param string $newFullName
 	 *
 	 * @return void
 	 */
-	public function theUserChangesTheFullnameToUsingTheWebUI($newFullname) {
+	public function theUserChangesTheFullNameToUsingTheWebUI($newFullName) {
 		$this->personalGeneralSettingsPage->changeFullname(
-			$newFullname, $this->getSession()
+			$newFullName, $this->getSession()
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -520,7 +520,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theAdministratorShouldNotbeAbleToSeePasswordColumnOfTheseUsers(TableNode $table) {
+	public function theAdministratorShouldNotBeAbleToSeePasswordColumnOfTheseUsers(TableNode $table) {
 		$this->featureContext->verifyTableNodeColumns($table, ['username']);
 		foreach ($table as $row) {
 			$visible = $this->usersPage->isPasswordColumnOfUserVisible($row['username']);

--- a/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
+++ b/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
@@ -43,7 +43,7 @@ Feature: show available backends using occ command
       | local                      |
 
   Scenario Outline: list specific backend of type storage for created local storage
-    When the adminstrator lists the "<backend>" backend of type "storage" using the occ command
+    When the administrator lists the "<backend>" backend of type "storage" using the occ command
     Then the following storage backend keys should be listed:
       | backend-keys                      |
       | name                              |
@@ -64,7 +64,7 @@ Feature: show available backends using occ command
       | local                      |
 
   Scenario Outline: list specific backend of type authentication for created local storage
-    When the adminstrator lists the "<backend>" backend of type "authentication" using the occ command
+    When the administrator lists the "<backend>" backend of type "authentication" using the occ command
     Then the following authentication backend keys should be listed:
       | backend-keys  |
       | name          |


### PR DESCRIPTION
## Description
Port of PR #37207 to `release-10.4.1` branch.

We really want the `skipOnOcis` tags so that the 10.4.1 release QA tarball has those in it, and so would work OK against an OCIS system-under-test (if someone does that some day - who knows)

The small typo fixes to test steps like `When the administrator lists the :backend backend...` will be useful to have so that the 10.4.1 QA tarball will have consistent up-to-date versions of those steps.

The other typo fixes can come along also - they do not break anything.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
