### PR TITLE
[10.4.1] [Security] Bump minimist from 1.2.2 to 1.2.3 in /build

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -32,7 +32,7 @@
     "@bower_components/strengthify": "MorrisJobke/strengthify#0.5.6",
     "@bower_components/underscore": "jashkenas/underscore#1.9.1",
     "@bower_components/zxcvbn": "dropbox/zxcvbn#4.4.2",
-    "minimist": "1.2.2",
+    "minimist": "1.2.3",
     "modclean": "^3.0.0-beta.1",
     "modclean-patterns-owncloud": "./modclean-patterns-owncloud/"
   },

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -1598,10 +1598,10 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@1.2.2, minimist@^1.1.3:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.2.tgz#b00a00230a1108c48c169e69a291aafda3aacd63"
-  integrity sha512-rIqbOrKb8GJmx/5bc2M0QchhUouMXSpd1RTclXsB41JdL+VtnojfaJR+h7F9k18/4kHUsBFgk80Uk+q569vjPA==
+minimist@1.2.3, minimist@^1.1.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
+  integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
 
 minimist@~0.0.1:
   version "0.0.10"


### PR DESCRIPTION
## Description
This is a port of #37211 to the `release-10.4.1` branch.

The original core master PR that the bot created to bump this was #37138 
There was difficulty getting drone to run on that branch/PR. So the change in master actually happened in PR #37154 
Then core master PR #37157 got merged and accidentally moved the version of `minimist` back from 1.2.3 to 1.2.2.
Then last night the bot has noticed that and raised PR #37211 to core master to again bump `minimist` from 1.2.2 to 1.2.3

There is already a changelog for this that is in both master and release-10.4.1 branches. So IMO  this is just a "repair" PR to put things back the way they should be. No need for another changelog entry.

Bumps [minimist](https://github.com/substack/minimist) from 1.2.2 to 1.2.3. **This update includes a security fix.**
- [Release notes](https://github.com/substack/minimist/releases)
- [Commits](https://github.com/substack/minimist/compare/1.2.2...1.2.3)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
