### PR TITLE
Do not extend share info from FS for pending federated shares

### DIFF
--- a/apps/files_sharing/lib/Controller/RemoteOcsController.php
+++ b/apps/files_sharing/lib/Controller/RemoteOcsController.php
@@ -210,11 +210,13 @@ class RemoteOcsController extends OCSController {
 	 */
 	private function extendShareInfo($share) {
 		$info = $this->getFileInfo($share['mountpoint']);
-		$share['mimetype'] = $info->getMimetype();
-		$share['mtime'] = $info->getMtime();
-		$share['permissions'] = $info->getPermissions();
-		$share['type'] = $info->getType();
-		$share['file_id'] = $info->getId();
+		if ($info !== false) {
+			$share['mimetype'] = $info->getMimetype();
+			$share['mtime'] = $info->getMtime();
+			$share['permissions'] = $info->getPermissions();
+			$share['type'] = $info->getType();
+			$share['file_id'] = $info->getId();
+		}
 		return $share;
 	}
 

--- a/changelog/unreleased/37216
+++ b/changelog/unreleased/37216
@@ -1,0 +1,6 @@
+Bugfix: List data for pending federated share via OCS API correctly
+
+Share info requested by id via OCS was empty for pending federated shares.
+
+https://github.com/owncloud/core/issues/34636
+https://github.com/owncloud/core/pull/37216

--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -106,25 +106,22 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @issue-34636
   Scenario Outline: Remote sharee requests information of only one share before accepting it
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "user1" retrieves the information of the last pending federated cloud share using the sharing API
-    Then the HTTP status code should be "200" or "500"
-    And the body of the response should be empty
-    #Then the HTTP status code should be "200"
-    #And the OCS status code should be "100"
-    #And the fields of the last response should include
-    #  | id          | A_NUMBER                                   |
-    #  | remote      | REMOTE                                     |
-    #  | remote_id   | A_NUMBER                                   |
-    #  | share_token | A_TOKEN                                    |
-    #  | name        | /textfile0.txt                             |
-    #  | owner       | user0                                      |
-    #  | user        | user1                                      |
-    #  | mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
-    #  | accepted    | 0                                          |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs-status>"
+    And the fields of the last response should include
+      | id          | A_NUMBER                                   |
+      | remote      | REMOTE                                     |
+      | remote_id   | A_NUMBER                                   |
+      | share_token | A_TOKEN                                    |
+      | name        | /textfile0.txt                             |
+      | owner       | user0                                      |
+      | user        | user1                                      |
+      | mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
+      | accepted    | 0                                          |
     Examples:
       | ocs-api-version | ocs-status |
       | 1               | 100        |


### PR DESCRIPTION
## Description
Pending federated shares have no related filesystem item so extending them via  `View::getFileInfo` leads to errors in the log file

## Related Issue
- Fixes #34636

## Motivation and Context
Share info requested by id via OCS was empty for pending federated shares.

## How Has This Been Tested?
1. from server1 share a folder to server2
2. on server2 do **not** accept the share
3. on server2 find the share-id `curl -u admin:admin http://localhost/owncloud-core/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending`
4. try to get information about that share `curl -u admin:admin http://localhost/owncloud-core/ocs/v1.php/apps/files_sharing/api/v1/remote_shares/22 -v`

### Expected behaviour
information of the share shown

### Actual behaviour
HTTP code 200 but empty content
```
{"reqId":"jeeKxCEMNmITSnccyKE4",
"level":3,
"time":"2020-04-06T10:12:08+00:00",
"remoteAddr":"127.0.0.1",
"user":"admin",
"app":"PHP",
"method":"GET",
"url":"\/ocs\/v1.php\/apps\/files_sharing\/api\/v1\/remote_shares\/32",
"message":"Error: Call to a member function getMimetype() on boolean at \/apps\/files_sharing\/lib\/Controller\/RemoteOcsController.php#213"}
```
in the log file

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
