### PR TITLE
Include option to allow scanner to reuse etags only for files

### DIFF
--- a/changelog/unreleased/37218
+++ b/changelog/unreleased/37218
@@ -1,0 +1,17 @@
+Bugfix: Ensure ETag changes if a change is detected in a folder
+
+Previously, if a change was detected in a folder, the ETag of the folder only
+changed if the folder's mtime changed. The ETag propagation to the root folder
+was working fine.
+If the folder's mtime didn't change, the ETag of the folder didn't change neither.
+This behaviour was causing problems in the desktop client because it was looking for
+a change, but it lost track once the client reached the modified folder because the
+ETag was the same.
+This was detected in the GDrive storage integration. Other storage works without problems.
+Basically, the desktop client wasn't able to download newly-added files in GDrive
+because it was unable to find where those files were.
+
+The changes fix the problem mentioned above, so the GDrive storage integration keeps
+the same behaviour as other external storages
+
+https://github.com/owncloud/core/pull/37218

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -188,13 +188,17 @@ class Scanner extends BasicEmitter implements IScanner {
 						$fileId = $cacheData['fileid'];
 						$data['fileid'] = $fileId;
 						// only reuse data if the file hasn't explicitly changed
-						if (isset($data['storage_mtime'], $cacheData['storage_mtime'])   && $data['storage_mtime'] === $cacheData['storage_mtime']) {
+						if (isset($data['storage_mtime'], $cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime']) {
 							$data['mtime'] = $cacheData['mtime'];
 							if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
-								$data['size'] = $cacheData['size'];
+								if (($data['mimetype'] !== 'httpd/unix-directory') || !($reuseExisting & self::REUSE_ONLY_FOR_FILES)) {
+									$data['size'] = $cacheData['size'];
+								}
 							}
 							if ($reuseExisting & self::REUSE_ETAG) {
-								$data['etag'] = $etag;
+								if (($data['mimetype'] !== 'httpd/unix-directory') || !($reuseExisting & self::REUSE_ONLY_FOR_FILES)) {
+									$data['etag'] = $etag;
+								}
 							}
 						}
 						// Only update metadata that has changed

--- a/lib/private/Files/Cache/Watcher.php
+++ b/lib/private/Files/Cache/Watcher.php
@@ -100,7 +100,7 @@ class Watcher implements IWatcher {
 	 */
 	public function update($path, $cachedData) {
 		if ($this->storage->is_dir($path)) {
-			$this->scanner->scan($path, Scanner::SCAN_SHALLOW);
+			$this->scanner->scan($path, Scanner::SCAN_SHALLOW, Scanner::REUSE_ETAG | Scanner::REUSE_ONLY_FOR_FILES);
 		} else {
 			$this->scanner->scanFile($path);
 		}

--- a/lib/public/Files/Cache/IScanner.php
+++ b/lib/public/Files/Cache/IScanner.php
@@ -33,6 +33,7 @@ interface IScanner {
 
 	const REUSE_ETAG = 1;
 	const REUSE_SIZE = 2;
+	const REUSE_ONLY_FOR_FILES = 4;  // apply the reuse (either tag or size) only to files, not folders
 
 	/**
 	 * scan a single file and store it in the cache


### PR DESCRIPTION
This option will be used by the watcher, in case it detects a change in
a folder, so the etag of the folder will always change (not just
depending on mtime) but the contents might retain its current etag.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Changes in gdrive weren't being propagated properly because the mtime of the folder doesn't change when a file is added / removed / modified there.
The etag of the folder didn't change, so the desktop client loses track of where to look for changes once it reaches the modified folder. This means that the new files inside the folder don't appear in the desktop (files aren't removed neither)

Note that the mtime of the folder in ownCloud still be the same as the one reported by gdrive

## Related Issue
https://github.com/owncloud/client/issues/7837#issuecomment-609791541

## Motivation and Context
gdrive integration don't behave like other external storages from a desktop client's perspective otherwise.

## How Has This Been Tested?
Manually checked:
1. Connect ownCloud with a gdrive account
2. Let desktop client sync normally the first time
3. Add a new file directly in a folder inside the gdrive account
4. Make a propfind to the target folder (you can navigate the ownCloud's web UI to the target folder instead) to detect the change
5. Sync client should pick up the change

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
