### PR TITLE
Stop writing data to the output buffer in case the connection is no l…

### DIFF
--- a/changelog/unreleased/37219
+++ b/changelog/unreleased/37219
@@ -1,0 +1,11 @@
+Bugfix: Stop writing data to the output buffer when the connection is not alive
+
+Publicly shared video playback is sending a range http request to get the video
+content. In cases where the user is seeking to different positions of the video
+will result in a pretty high server load because all the video content is sent
+to the browser. Without detecting the connection state on server side all data
+is put to the output buffer.
+With this change the server processes will stop sending data as soon as the
+connection is detected as non-active.
+
+https://github.com/owncloud/core/pull/37219

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -475,6 +475,7 @@ class View {
 			$size = $this->filesize($path);
 			while (!\feof($handle)) {
 				echo \fread($handle, $chunkSize);
+				$this->checkConnectionStatus();
 				\flush();
 			}
 			return $size;
@@ -504,10 +505,10 @@ class View {
 						$len = $chunkSize;
 					}
 					echo \fread($handle, $len);
+					$this->checkConnectionStatus();
 					\flush();
 				}
-				$size = \ftell($handle) - $from;
-				return $size;
+				return \ftell($handle) - $from;
 			}
 
 			throw new \OCP\Files\UnseekableException('fseek error');
@@ -2267,5 +2268,12 @@ class View {
 	 */
 	public static function setIgnorePartFile($isIgnored) {
 		self::$ignorePartFile = $isIgnored;
+	}
+
+	private function checkConnectionStatus(): void {
+		$connectionStatus = \connection_status();
+		if ($connectionStatus !== 0) {
+			throw new \RuntimeException("Connection lost. Status: $connectionStatus");
+		}
 	}
 }

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -192,9 +192,6 @@ class OC_Files {
 			$l = \OC::$server->getL10N('lib');
 			/* @phan-suppress-next-line PhanUndeclaredMethod */
 			$hint = \method_exists($ex, 'getHint') ? $ex->getHint() : '';
-			if ($event->hasArgument('message')) {
-				$hint .= ' ' . $event->getArgument('message');
-			}
 			\OC_Template::printErrorPage($l->t('File cannot be downloaded'), $hint);
 		}
 	}


### PR DESCRIPTION

## Description
Bugfix: Stop writing data to the output buffer when the connection is not alive

Publicly shared video playback is sending a range http request to get the video
content. In cases where the user is seeking to different positions of the video
will result in a pretty high server load because all the video content is sent
to the browser. Without detecting the connection state on server side all data
is put to the output buffer.
With this change the server processes will stop sending data as soon as the
connection is detected as non-active.

https://github.com/owncloud/core/pull/37219

## How Has This Been Tested?
- :hand: 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
