### PR TITLE
Keep the same mtime as in the ownCloud's FS for files inside

### DIFF
--- a/changelog/unreleased/37222
+++ b/changelog/unreleased/37222
@@ -1,0 +1,11 @@
+Change: Keep the mtime of files and folders inside the tarball
+
+Previously, when a folder or several files were downloaded, a tarball (.tar for
+mac, .zip for windows and linux) was created. Such tarball had the mtime of the
+files and folders inside with the time they were added into the tarball, not the
+one shown in ownCloud.
+
+This change makes the mtime of the files and folders inside the tarball to be
+maintained as they're shown in the ownCloud's FS.
+
+https://github.com/owncloud/core/pull/37222

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -155,8 +155,11 @@ class OC_Files {
 					$file = $dir . '/' . $file;
 					if (\OC\Files\Filesystem::is_file($file)) {
 						$fileSize = \OC\Files\Filesystem::filesize($file);
+						$fileOpts = [
+							'timestamp' => \OC\Files\Filesystem::filemtime($file),
+						];
 						$fh = \OC\Files\Filesystem::fopen($file, 'r');
-						$streamer->addFileFromStream($fh, \basename($file), $fileSize);
+						$streamer->addFileFromStream($fh, \basename($file), $fileSize, $fileOpts);
 						\fclose($fh);
 					} elseif (\OC\Files\Filesystem::is_dir($file)) {
 						$streamer->addDirRecursive($file);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Keep the mtime of the files and folders inside the downloaded tarball

## Related Issue
https://github.com/owncloud/enterprise/issues/3939

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested both in mac and linux. Both the tar and zip files keeps the mtime of the files.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
