### PR TITLE
[Tests-Only] skip test that was adjusted in PR 37216 on old oC10

### DIFF
--- a/tests/acceptance/features/apiFederation/federated.feature
+++ b/tests/acceptance/features/apiFederation/federated.feature
@@ -106,6 +106,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
   Scenario Outline: Remote sharee requests information of only one share before accepting it
     Given user "user0" from server "REMOTE" has shared "/textfile0.txt" with user "user1" from server "LOCAL"
     And using OCS API version "<ocs-api-version>"


### PR DESCRIPTION
## Description
This scenario was adjusted in PR #37216 
That PR corrected the behavior.
The adjusted test will not pass on old versions of ownCloud10, e.g. 10.3.* 10.4.0 or 10.4.1 so skip it on those.

Note: core `master` currently says it is 10.4.1. That is not actually true, the version in master should be bumped to 10.4.2prealpha (and the actual next release version might be 10.4.2 or 10.5.0 depending on what ends up in it and semver) But we can wait a day or 2 to do that, maybe `release-10.4.1` branch will get merged back first, and we avoid a merge conflict of `version.php`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
