### PR TITLE
[Tests-Only] [10.4.1] Add another skipOnBruteForceProtection test tag due to issue 112

### DIFF
--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -122,6 +122,7 @@ Feature: auth
   @issue-ocis-reva-29
   @issue-ocis-reva-30
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as normal user with wrong password
     When user "user0" requests these endpoints with "GET" using password "invalid" then the status codes should be as listed
       | endpoint                                                    | ocs-code | http-code |

--- a/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
@@ -7,6 +7,7 @@ Feature: auth
   @skipOnOcis
   @issue-ocis-reva-30
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to OCS endpoints as normal user with wrong password
     When user "user0" requests these endpoints with "POST" including body using password "invalid" then the status codes should be as listed
       | endpoint                                                        | ocs-code | http-code | body          |

--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
@@ -11,6 +11,7 @@ Feature: delete file/folder
     And user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to webDav endpoints as normal user with wrong password
     When user "user0" requests these endpoints with "DELETE" including body using password "invalid" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -57,6 +58,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to webDav endpoints without any authentication
     When a user requests these endpoints with "DELETE" and no authentication then the status codes should be as listed
       | endpoint                                      | http-code | body          |

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -11,6 +11,7 @@ Feature: LOCK file/folder
     And user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints as normal user with wrong password
     When user "user0" requests these endpoints with "LOCK" including body using password "invalid" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -21,6 +22,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints as normal user with no password
     When user "user0" requests these endpoints with "LOCK" including body using password "" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -66,6 +68,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints without any authentication
     When a user requests these endpoints with "LOCK" and no authentication then the status codes should be as listed
       | endpoint                                      | http-code | body          |

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -10,6 +10,7 @@ Feature: get file info using MKCOL
     And user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints as normal user with wrong password
     When user "user0" requests these endpoints with "MKCOL" including body using password "invalid" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -20,6 +21,7 @@ Feature: get file info using MKCOL
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints as normal user with no password
     When user "user0" requests these endpoints with "MKCOL" including body using password "" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -65,6 +67,7 @@ Feature: get file info using MKCOL
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints without any authentication
     When a user requests these endpoints with "MKCOL" and no authentication then the status codes should be as listed
       | endpoint                                      | http-code | body          |

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -10,6 +10,7 @@ Feature: MOVE file/folder
     And user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MOVE requests to webDav endpoints as normal user with wrong password
     When user "user0" requests these endpoints with "MOVE" including body using password "invalid" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -20,6 +21,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MOVE requests to webDav endpoints as normal user with no password
     When user "user0" requests these endpoints with "MOVE" including body using password "" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -65,6 +67,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MOVE requests to webDav endpoints without any authentication
     When a user requests these endpoints with "MOVE" and no authentication then the status codes should be as listed
       | endpoint                                      | http-code | body          |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -11,6 +11,7 @@ Feature: get file info using POST
     And user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to webDav endpoints as normal user with wrong password
     When user "user0" requests these endpoints with "POST" including body using password "invalid" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -21,6 +22,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to webDav endpoints as normal user with no password
     When user "user0" requests these endpoints with "POST" including body using password "" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -56,6 +58,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to webDav endpoints without any authentication
     When a user requests these endpoints with "POST" and no authentication then the status codes should be as listed
       | endpoint                                      | http-code | body          |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -10,6 +10,7 @@ Feature: get file info using PROPFIND
     And user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPFIND requests to webDav endpoints as normal user with wrong password
     When user "user0" requests these endpoints with "PROPFIND" including body using password "invalid" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -20,6 +21,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPFIND requests to webDav endpoints as normal user with no password
     When user "user0" requests these endpoints with "PROPFIND" including body using password "" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -65,6 +67,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPFIND requests to webDav endpoints without any authentication
     When a user requests these endpoints with "PROPFIND" and no authentication then the status codes should be as listed
       | endpoint                                      | http-code | body          |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -11,6 +11,7 @@ Feature: PROPPATCH file/folder
     And user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPPATCH requests to webDav endpoints as normal user with wrong password
     When user "user0" requests these endpoints with "PROPPATCH" including body using password "invalid" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -21,6 +22,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPPATCH requests to webDav endpoints as normal user with no password
     When user "user0" requests these endpoints with "PROPPATCH" including body using password "" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -66,6 +68,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPPATCH requests to webDav endpoints without any authentication
     When a user requests these endpoints with "PROPPATCH" and no authentication then the status codes should be as listed
       | endpoint                                      | http-code | body          |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -11,6 +11,7 @@ Feature: get file info using PUT
     And user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT requests to webDav endpoints as normal user with wrong password
     When user "user0" requests these endpoints with "PUT" including body using password "invalid" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -21,6 +22,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT requests to webDav endpoints as normal user with no password
     When user "user0" requests these endpoints with "PUT" including body using password "" then the status codes should be as listed
       | endpoint                                      | http-code | body          |
@@ -66,6 +68,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/user0/PARENT/parent.txt | 401       | doesnotmatter |
 
   @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT requests to webDav endpoints without any authentication
     When a user requests these endpoints with "PUT" and no authentication then the status codes should be as listed
       | endpoint                                      | http-code | body          |

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -585,11 +585,15 @@ trait Provisioning {
 	 */
 	public function createLdapUser($setting) {
 		$ou = "TestUsers";
-		$newDN = 'uid=' . $setting["userid"] . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
+		// Some special characters need to be escaped in LDAP DN and attributes
+		// The special characters allowed in a username (UID) are +_.@-
+		// Of these, only + has to be escaped.
+		$userId = \str_replace('+', '\+', $setting["userid"]);
+		$newDN = 'uid=' . $userId . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
 		$uidNumber = \count($this->ldapCreatedUsers) + 1;
 		$entry = [];
-		$entry['cn'] = $setting["userid"];
-		$entry['sn'] = $setting["userid"];
+		$entry['cn'] = $userId;
+		$entry['sn'] = $userId;
 		$entry['homeDirectory'] = '/home/openldap/' . $setting["userid"];
 		$entry['objectclass'][] = 'posixAccount';
 		$entry['objectclass'][] = 'inetOrgPerson';


### PR DESCRIPTION
## Description
1) I missed some scenarios when I added this tag in PR #37204 (master) and #37205 (release-10.4.1)

The scenario about "using OCS as normal user with wrong password". When brute_force_protection` is triggered then status 996 starts getting returned instead of 997. https://github.com/owncloud/brute_force_protection/issues/112#issuecomment-607678816

2) And similar for the other scenarios that send requests with wrong password.

3) Commit from PR #37229 has been added here. That enables testing of user_ldap scenarios with `+` in the user name - e.g. user name `Jack+Jill`. That will help with the new release of user_ldap that will support `+` in the user name.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
