### PR TITLE
[Tests-Only] escape plus in uid when creating ldap user

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -585,11 +585,15 @@ trait Provisioning {
 	 */
 	public function createLdapUser($setting) {
 		$ou = "TestUsers";
-		$newDN = 'uid=' . $setting["userid"] . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
+		// Some special characters need to be escaped in LDAP DN and attributes
+		// The special characters allowed in a username (UID) are +_.@-
+		// Of these, only + has to be escaped.
+		$userId = \str_replace('+', '\+', $setting["userid"]);
+		$newDN = 'uid=' . $userId . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
 		$uidNumber = \count($this->ldapCreatedUsers) + 1;
 		$entry = [];
-		$entry['cn'] = $setting["userid"];
-		$entry['sn'] = $setting["userid"];
+		$entry['cn'] = $userId;
+		$entry['sn'] = $userId;
 		$entry['homeDirectory'] = '/home/openldap/' . $setting["userid"];
 		$entry['objectclass'][] = 'posixAccount';
 		$entry['objectclass'][] = 'inetOrgPerson';


### PR DESCRIPTION
## Description
When creating a user in LDAP during test setup, escape any `+` sign in the user name.
Otherwise you get test fails like: https://drone.owncloud.com/owncloud/user_ldap/2412/28/11
```
       Provisioning::createUser cannot create a LDAP user with provided data. Error: Laminas\Ldap\Exception\LdapException: DN is malformed in /var/www/owncloud/testrunner/apps/user_ldap/vendor/laminas/laminas-ldap/src/Dn.php:555
        Stack trace:
        #0 /var/www/owncloud/testrunner/apps/user_ldap/vendor/laminas/laminas-ldap/src/Dn.php(75): Laminas\Ldap\Dn::explodeDn('uid=jack+jill,o...')
        #1 /var/www/owncloud/testrunner/apps/user_ldap/vendor/laminas/laminas-ldap/src/Dn.php(56): Laminas\Ldap\Dn::fromString('uid=jack+jill,o...', NULL)
        #2 /var/www/owncloud/testrunner/apps/user_ldap/vendor/laminas/laminas-ldap/src/Ldap.php(1354): Laminas\Ldap\Dn::factory('uid=jack+jill,o...', NULL)
        #3 /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/Provisioning.php(611): Laminas\Ldap\Ldap->add('uid=jack+jill,o...', Array)
        #4 /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/Provisioning.php(754): FeatureContext->createLdapUser(Array)
        #5 /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/Provisioning.php(2153): FeatureContext->usersHaveBeenCreated(true, Array)
        #6 /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/Provisioning.php(309): FeatureContext->createUser('jack+jill')
        #7 /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/Provisioning.php(325): FeatureContext->userHasBeenCreatedWithDefaultAttributes('jack+jill')
        #8 [internal function]: FeatureContext->userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles('jack+jill')
```

## How Has This Been Tested?
CI - user_ldap PR https://github.com/owncloud/user_ldap/pull/540 passes against this branch. It is able to create an LDAP user like `Jack+Jill`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
