### PR TITLE
[Tests-only] cast LDAP port to int

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -52,7 +52,7 @@ class OcisHelper {
 	 */
 	public static function getLdapPort() {
 		$port = \getenv("REVA_LDAP_PORT");
-		return $port ? $port : 636;
+		return $port ? (int)$port : 636;
 	}
 
 	/**


### PR DESCRIPTION
## Description
if the env variable for the LDAP port is set it might end up being a string, but in line 62 we compare to int, so better cast here to int

## Motivation and Context
more robust test-code

## How Has This Been Tested?
:robot:  https://github.com/owncloud/ocis-reva/pull/130

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
