### PR TITLE
[Tests-Only] skip new preview test scenarios on old ownCloud versions

### DIFF
--- a/changelog/unreleased/37237
+++ b/changelog/unreleased/37237
@@ -1,0 +1,3 @@
+Change: Update nikic/php-parser (4.3.0 => 4.4.0)
+
+https://github.com/owncloud/core/pull/37237

--- a/composer.lock
+++ b/composer.lock
@@ -927,7 +927,7 @@
             "time": "2015-08-01T16:27:37+00:00"
         },
         {
-            "name": "jeremeamia/SuperClosure",
+            "name": "jeremeamia/superclosure",
             "version": "2.4.0",
             "source": {
                 "type": "git",
@@ -1454,16 +1454,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.3.0",
+            "version": "v4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
+                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
+                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
                 "shasum": ""
             },
             "require": {
@@ -1502,7 +1502,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-11-08T13:50:10+00:00"
+            "time": "2020-04-10T16:34:50+00:00"
         },
         {
             "name": "patchwork/jsqueeze",

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -18,6 +18,7 @@ Feature: previews of files downloaded through the webdav API
       | 1     | 1024   |
       | 1024  | 1      |
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0
   Scenario Outline: download previews with invalid width
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "user0" downloads the preview of "/parent.txt" with width "<width>" and height "32" using the WebDAV API
@@ -34,6 +35,7 @@ Feature: previews of files downloaded through the webdav API
       | A     |
       | %2F   |
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0
   Scenario Outline: download previews with invalid height
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "user0" downloads the preview of "/parent.txt" with width "32" and height "<height>" using the WebDAV API
@@ -103,6 +105,7 @@ Feature: previews of files downloaded through the webdav API
     And the value of the item "/d:error/s:message" in the response should be "File not found: parent.txt in 'user0'"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotFound"
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0
   Scenario: download previews of folders
     Given user "user0" has created folder "subfolder"
     When user "user0" downloads the preview of "/subfolder/" with width "32" and height "32" using the WebDAV API
@@ -131,6 +134,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotFound"
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0
   Scenario: set maximum size of previews
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When the administrator updates system config key "preview_max_x" with value "null" using the occ command


### PR DESCRIPTION
## Description
PR #37166 added and enhanced tests of previews. Some of the functionality has been fixed in core master since 10.4.0 was released. So some of these fail on old ownCloud versions.
e.g. https://drone.owncloud.com/owncloud/encryption/1195/73/16
```
--- Failed scenarios:

    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:29
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:30
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:31
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:32
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:33
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:34
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:35
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:45
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:46
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:47
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:48
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:49
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:50
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:51
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:106
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavPreviews/previews.feature:134

33 scenarios (17 passed, 16 failed)
192 steps (145 passed, 16 failed, 31 skipped)
```

Skip the scenarios when test against old ownCloud versions.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
