### PR TITLE
[Tests-Only] Remove out-of-date comments about ldap-users.ldif

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1711,9 +1711,6 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	public function getDisplayNameForUser($userName) {
 		$userName = $this->getActualUsername($userName);
-		// The hard-coded user names and display names are also in ldap-users.ldif
-		// for testing in an LDAP environment. The mapping must be kept the
-		// same in both places.
 		$userName = $this->normalizeUsername($userName);
 		if (\array_key_exists($userName, $this->createdUsers)) {
 			return (string) $this->createdUsers[$userName]['displayname'];
@@ -1754,9 +1751,6 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	public function getEmailAddressForUser($userName) {
 		$userName = $this->getActualUsername($userName);
-		// The hard-coded user names and email addresses are also in ldap-users.ldif
-		// for testing in an LDAP environment. The mapping must be kept the
-		// same in both places.
 		$userName = $this->normalizeUsername($userName);
 		if (\array_key_exists($userName, $this->createdUsers)) {
 			return (string) $this->createdUsers[$userName]['email'];


### PR DESCRIPTION
## Description
The LDAP test environment was refactored a while ago so that it creates users and groups on-the-fly. Remove the out-of-date comments about `ldap-users.ldif`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
