### PR TITLE
RepairUnmergedShares: sum up users across all backends

### DIFF
--- a/changelog/unreleased/37246
+++ b/changelog/unreleased/37246
@@ -1,0 +1,7 @@
+Bugfix: Send max number of steps as integer in RepairUnmergedShares
+
+RepairUnmergedShares repair step dispatched an array as a number of steps.
+It is fixed to be integer.
+
+https://github.com/owncloud/core/issues/37241
+https://github.com/owncloud/core/pull/37246

--- a/lib/private/Repair/RepairUnmergedShares.php
+++ b/lib/private/Repair/RepairUnmergedShares.php
@@ -335,6 +335,22 @@ class RepairUnmergedShares implements IRepairStep {
 		}
 	}
 
+	/**
+	 * Count all the users
+	 *
+	 * @return int
+	 */
+	private function countUsers() {
+		$allCount = $this->userManager->countUsers();
+
+		$totalCount = 0;
+		foreach ($allCount as $backend => $count) {
+			$totalCount += $count;
+		}
+
+		return $totalCount;
+	}
+
 	public function run(IOutput $output) {
 		$ocVersionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
 		// this situation was only possible between 9.0.0 and 9.0.3 included, and 9.1.0
@@ -349,7 +365,7 @@ class RepairUnmergedShares implements IRepairStep {
 
 			$this->buildPreparedQueries();
 
-			$output->startProgress($this->userManager->countUsers());
+			$output->startProgress($this->countUsers());
 
 			$this->userManager->callForAllUsers($function);
 


### PR DESCRIPTION
## Description
`$this->userManager->countUsers()` returns an array `backend` => `count` so wee need to sum it up to get all users count.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/37241

## Motivation and Context
Broken upgrade from 9.1

## How Has This Been Tested?



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
