### PR TITLE
[Tests-Only] Bump phpstan to 0.12

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -47,7 +47,6 @@ use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
 use OC\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
-use OCP\Files\Cache\ICache;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Util;
 
@@ -68,7 +67,7 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 	protected $root;
 
 	/**
-	 * @var ICache
+	 * @var CappedMemoryCache
 	 */
 	protected $statCache;
 

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -358,6 +358,9 @@ class ShareesController extends OCSController {
 	protected function getRemote($search) {
 		$this->result['remotes'] = [];
 		// Fetch remote search properties from app config
+		/**
+		 * @var array $searchProperties
+		 */
 		$searchProperties = \explode(',', $this->config->getAppValue('dav', 'remote_search_properties', 'CLOUD,FN'));
 		// Search in contacts
 		$matchMode = $this->config->getSystemValue('accounts.enable_medial_search', true) === true

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -28,7 +28,6 @@ use OCP\Files\Config\ICachedMountInfo;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
-use OCP\ICache;
 use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\IUser;
@@ -53,7 +52,7 @@ class UserMountCache implements IUserMountCache {
 	 * Cached mount info.
 	 * Map of $userId to ICachedMountInfo.
 	 *
-	 * @var ICache
+	 * @var CappedMemoryCache
 	 **/
 	private $mountsForUsers;
 
@@ -63,7 +62,7 @@ class UserMountCache implements IUserMountCache {
 	private $logger;
 
 	/**
-	 * @var ICache
+	 * @var CappedMemoryCache
 	 */
 	private $cacheInfoCache;
 

--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -21,7 +21,6 @@
 
 namespace OC\Files\Storage\Wrapper;
 
-use OCP\ICache;
 use OC\Cache\CappedMemoryCache;
 
 /**
@@ -33,7 +32,7 @@ use OC\Cache\CappedMemoryCache;
 class Encoding extends Wrapper {
 
 	/**
-	 * @var ICache
+	 * @var CappedMemoryCache
 	 */
 	private $namesCache;
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,10 +35,8 @@ parameters:
     - '#Undefined variable: \$baseuri#'
     - '#Instantiated class OC_Theme not found.#'
     # errors below are to be addressed by own pull requests - non trivial changes required
-    - '#OCA\\DAV\\Connector\\Sabre\\ObjectTree::__construct\(\) does not call parent constructor from Sabre\\DAV\\Tree.#'
-    - '#OC\\Files\\ObjectStore\\NoopScanner::__construct\(\) does not call parent constructor from OC\\Files\\Cache\\Scanner.#'
-    - '#OC\\Files\\Cache\\Wrapper\\CacheWrapper::__construct\(\) does not call parent constructor from OC\\Files\\Cache\\Cache.#'
-    - '#Anonymous function has an unused use \$folder.#'
+    - '#Unsafe usage of new static().#'
+    - '#Cannot instantiate interface OCP\\Files\\ObjectStore\\IObjectStore.#'
     - '#Result of function rewinddir \(void\) is used.#'
     - '#Instantiated class OCA\\Encryption\\Crypto\\Crypt not found.#'
     - '#Instantiated class OCA\\Encryption\\Util not found.#'

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^0.11"
+        "phpstan/phpstan": "^0.12"
     }
 }


### PR DESCRIPTION
## Description
Note: I marked this as Tests-Only because it only changes PHP doc and `phpstan` `ignoreErrors` so as to get the latest `phpstan` passing in core. There is no change to actual run-time code.

- bump phpstan to 0.12 (the current release series is 0.12.*)

The following is reported:
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=2G --configuration=./phpstan.neon --level=0 apps core settings lib/private lib/public ocs ocs-provider
 1367/1367 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------- 
  Line   apps/files_external/lib/Lib/Storage/SMB.php            
 ------ ------------------------------------------------------- 
  395    Cannot unset offset string on OCP\Files\Cache\ICache.  
  444    Cannot unset offset string on OCP\Files\Cache\ICache.  
  477    Cannot unset offset string on OCP\Files\Cache\ICache.  
 ------ ------------------------------------------------------- 

 ------ --------------------------------------------------------- 
  Line   apps/files_sharing/lib/Controller/ShareesController.php  
 ------ --------------------------------------------------------- 
  409    Cannot unset offset 'CLOUD' on array<int, string>.       
 ------ --------------------------------------------------------- 

 ------ --------------------------------------------- 
  Line   lib/private/Files/Config/UserMountCache.php  
 ------ --------------------------------------------- 
  123    Cannot unset offset string on OCP\ICache.    
 ------ --------------------------------------------- 

 ------ ------------------------------------------------------------------ 
  Line   lib/private/Files/External/ConfigAdapter.php                      
 ------ ------------------------------------------------------------------ 
  94     Cannot instantiate interface OCP\Files\ObjectStore\IObjectStore.  
 ------ ------------------------------------------------------------------ 

 ------ ------------------------------------------------ 
  Line   lib/private/Files/Storage/Wrapper/Encoding.php  
 ------ ------------------------------------------------ 
  145    Cannot unset offset string on OCP\ICache.       
  323    Cannot unset offset string on OCP\ICache.       
  361    Cannot unset offset string on OCP\ICache.       
  498    Cannot unset offset string on OCP\ICache.       
  513    Cannot unset offset string on OCP\ICache.       
  513    Cannot unset offset string on OCP\ICache.       
  520    Cannot unset offset string on OCP\ICache.       
  520    Cannot unset offset string on OCP\ICache.       
 ------ ------------------------------------------------ 

 ------ ------------------------------------------------------- 
  Line   lib/public/AppFramework/Db/Entity.php                  
 ------ ------------------------------------------------------- 
  45     Unsafe usage of new static().                          
         💡 Consider making the class or the constructor final.  
  61     Unsafe usage of new static().                          
         💡 Consider making the class or the constructor final.  
 ------ ------------------------------------------------------- 

 -- --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
     Error                                                                                                                                                                
 -- --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
     Ignored error pattern #OCA\\DAV\\Connector\\Sabre\\ObjectTree::__construct\(\) does not call parent constructor from Sabre\\DAV\\Tree.# was not matched in reported  
     errors.                                                                                                                                                              
     Ignored error pattern #OC\\Files\\ObjectStore\\NoopScanner::__construct\(\) does not call parent constructor from OC\\Files\\Cache\\Scanner.# was not matched in     
     reported errors.                                                                                                                                                     
     Ignored error pattern #OC\\Files\\Cache\\Wrapper\\CacheWrapper::__construct\(\) does not call parent constructor from OC\\Files\\Cache\\Cache.# was not matched in   
     reported errors.                                                                                                                                                     
     Ignored error pattern #Anonymous function has an unused use \$folder.# was not matched in reported errors.                                                           
 -- --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 20 errors                                                                                                
```

- adjust PHP  doc for various vars that were documented as being just `ICache` when in fact they are more than that, they are `CappedMemoryCache` (that makes phpstan happy about a lot of things done with those vars)

- in ` apps/files_sharing/lib/Controller/ShareesController.php` document the `$searchProperties` var so phpstan really believes it is always an array

- remove "errors"  that are no longer reported from `phpstan.neon`

- add a couple of new "errors" to `phpstan.neon` (rather than adjusting actual code for now)

My objective with this PR is to get running the latest `phpstan`. There are already various things listed in `ignoreErrors of `phpstan.neon` - I am not attempting to dig into those, that is for some future effort to be prioritized/scheduled to look into those.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
