### PR TITLE
Update PHPdoc of Group get methods

### DIFF
--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -159,7 +159,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 
 	/**
 	 * @param string $gid
-	 * @return \OC\Group\Group
+	 * @return \OC\Group\Group|null
 	 */
 	public function get($gid) {
 		if (isset($this->cachedGroups[$gid])) {
@@ -171,7 +171,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	/**
 	 * @param string $gid
 	 * @param string $displayName
-	 * @return \OCP\IGroup
+	 * @return \OC\Group\Group|null
 	 */
 	protected function getGroupObject($gid, $displayName = null) {
 		$backends = [];

--- a/lib/public/IGroupManager.php
+++ b/lib/public/IGroupManager.php
@@ -66,7 +66,7 @@ interface IGroupManager {
 
 	/**
 	 * @param string $gid
-	 * @return \OCP\IGroup
+	 * @return \OCP\IGroup|null
 	 * @since 8.0.0
 	 */
 	public function get($gid);


### PR DESCRIPTION
## Description
This PR updates PHP doc only. There is no change to any run-time code, so I have not made a changelog. (It is a "tools-only" change)

When running `phpstan` from apps that use ` lib/private/Group/Manager.php` `get` method, and the app code checks the return value for being not `null` then `phpstan` will claim that the check is useless because the PHP doc of this in core says that the method always returns a group object. 

But the code in `getGroupObject` clearly has a `return null` in it.

Update the PHP doc to tell the truth.

(and then it will be easier to get `phpstan` passing in other repos)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
