### PR TITLE
[tests-only] test the OCIS implementation of the previews

### DIFF
--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -1,10 +1,10 @@
 @api @TestAlsoOnExternalUserBackend
-@skipOnOcis
 Feature: previews of files downloaded through the webdav API
 
   Background:
     Given user "user0" has been created with default attributes and without skeleton files
 
+  @skipOnOcis @issue-ocis-200
   Scenario Outline: download previews of different sizes
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "user0" downloads the preview of "/parent.txt" with width <width> and height <height> using the WebDAV API
@@ -18,7 +18,7 @@ Feature: previews of files downloaded through the webdav API
       | 1     | 1024   |
       | 1024  | 1      |
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcis @issue-ocis-188
   Scenario Outline: download previews with invalid width
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "user0" downloads the preview of "/parent.txt" with width "<width>" and height "32" using the WebDAV API
@@ -35,7 +35,23 @@ Feature: previews of files downloaded through the webdav API
       | A     |
       | %2F   |
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-188
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario Outline: download previews with invalid width
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    When user "user0" downloads the preview of "/parent.txt" with width "<width>" and height "32" using the WebDAV API
+    Then the HTTP status code should be "200"
+    Examples:
+      | width |
+      | 0     |
+      | 0.5   |
+      | -1    |
+      | false |
+      | true  |
+      | A     |
+      | %2F   |
+
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcis @issue-ocis-188
   Scenario Outline: download previews with invalid height
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "user0" downloads the preview of "/parent.txt" with width "32" and height "<height>" using the WebDAV API
@@ -52,6 +68,23 @@ Feature: previews of files downloaded through the webdav API
       | A      |
       | %2F    |
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-188
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario Outline: download previews with invalid height
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    When user "user0" downloads the preview of "/parent.txt" with width "32" and height "<height>" using the WebDAV API
+    Then the HTTP status code should be "200"
+    Examples:
+      | height |
+      | 0      |
+      | 0.5    |
+      | -1     |
+      | false  |
+      | true   |
+      | A      |
+      | %2F    |
+
+  @skipOnOcis @issue-ocis-200
   Scenario: download previews of files inside sub-folders
     Given user "user0" has created folder "subfolder"
     And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/subfolder/parent.txt"
@@ -59,6 +92,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
+  @skipOnOcis @issue-ocis-189
   Scenario Outline: download previews of file types that don't support preview
     Given user "user0" has uploaded file "filesForUpload/<filename>" to "/<newfilename>"
     When user "user0" downloads the preview of "/<newfilename>" with width "32" and height "32" using the WebDAV API
@@ -70,7 +104,19 @@ Feature: previews of files downloaded through the webdav API
       | simple.odt   | test.odt    |
       | new-data.zip | test.zip    |
 
-  @issue-ocis-webdav-187
+  @skipOnOcV10 @issue-ocis-189
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario Outline: download previews of file types that don't support preview
+    Given user "user0" has uploaded file "filesForUpload/<filename>" to "/<newfilename>"
+    When user "user0" downloads the preview of "/<newfilename>" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "200"
+    Examples:
+      | filename     | newfilename |
+      | simple.pdf   | test.pdf    |
+      | simple.odt   | test.odt    |
+      | new-data.zip | test.zip    |
+
+  @skipOnOcis @issue-ocis-187
   Scenario Outline: download previews of different image file types
     Given user "user0" has uploaded file "filesForUpload/<imageName>" to "/<newImageName>"
     When user "user0" downloads the preview of "/<newImageName>" with width "32" and height "32" using the WebDAV API
@@ -81,7 +127,19 @@ Feature: previews of files downloaded through the webdav API
       | testavatar.jpg | testimage.jpg |
       | testavatar.png | testimage.png |
 
-  @issue-ocis-webdav-187
+  @skipOnOcV10 @issue-ocis-187
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario Outline: download previews of different image file types
+    Given user "user0" has uploaded file "filesForUpload/<imageName>" to "/<newImageName>"
+    When user "user0" downloads the preview of "/<newImageName>" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded image should be "1240" pixels wide and "648" pixels high
+    Examples:
+      | imageName      | newImageName  |
+      | testavatar.jpg | testimage.jpg |
+      | testavatar.png | testimage.png |
+
+  @skipOnOcis @issue-ocis-187
   Scenario: download previews of image after renaming it
     Given user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
     When user "user0" moves file "/testimage.jpg" to "/testimage.txt" using the WebDAV API
@@ -89,6 +147,16 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
+  @skipOnOcV10 @issue-ocis-187
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario: download previews of image after renaming it
+    Given user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
+    When user "user0" moves file "/testimage.jpg" to "/testimage.txt" using the WebDAV API
+    And user "user0" downloads the preview of "/testimage.txt" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded image should be "1240" pixels wide and "648" pixels high
+
+  @skipOnOcis @issue-ocis-68
   Scenario: download previews of shared files
     Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -97,6 +165,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
+  @skipOnOcis @issue-ocis-thumbnails-191
   Scenario: download previews of other users files
     Given user "user1" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -105,7 +174,15 @@ Feature: previews of files downloaded through the webdav API
     And the value of the item "/d:error/s:message" in the response should be "File not found: parent.txt in 'user0'"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotFound"
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0
+  @skipOnOcV10 @issue-ocis-thumbnails-191
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario: download previews of other users files
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    When user "user1" downloads the preview of "/parent.txt" of "user0" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "200"
+
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcis @issue-ocis-190
   Scenario: download previews of folders
     Given user "user0" has created folder "subfolder"
     When user "user0" downloads the preview of "/subfolder/" with width "32" and height "32" using the WebDAV API
@@ -113,12 +190,21 @@ Feature: previews of files downloaded through the webdav API
     And the value of the item "/d:error/s:message" in the response should be "Unsupported file type"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\BadRequest"
 
+  @skipOnOcV10 @issue-ocis-190
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario: download previews of folders
+    Given user "user0" has created folder "subfolder"
+    When user "user0" downloads the preview of "/subfolder/" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "501"
+
+  @skipOnOcis
   Scenario: download previews of not-existing files
     When user "user0" downloads the preview of "/parent.txt" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:message" in the response should be "File with name parent.txt could not be located"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotFound"
 
+  @skipOnOcis @issue-ocis-192
   Scenario: Download file previews when it is disabled by the administrator
     Given the administrator has updated system config key "enable_previews" with value "false" and type "boolean"
     And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -126,6 +212,15 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotFound"
 
+  @skipOnOcV10 @issue-ocis-192
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario: Download file previews when it is disabled by the administrator
+    Given the administrator has updated system config key "enable_previews" with value "false" and type "boolean"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    When user "user0" downloads the preview of "/parent.txt" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "200"
+
+  @skipOnOcis @issue-ocis-193
   Scenario: unset maximum size of previews
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And the administrator has updated system config key "preview_max_x" with value "null"
@@ -134,7 +229,16 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\NotFound"
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0
+  @skipOnOcV10 @issue-ocis-193
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario: unset maximum size of previews
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    And the administrator has updated system config key "preview_max_x" with value "null"
+    And the administrator has updated system config key "preview_max_y" with value "null"
+    When user "user0" downloads the preview of "/parent.txt" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "200"
+
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcis @issue-ocis-193
   Scenario: set maximum size of previews
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When the administrator updates system config key "preview_max_x" with value "null" using the occ command
@@ -144,6 +248,17 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "400"
     And the value of the item "/d:error/s:exception" in the response should be "Sabre\DAV\Exception\BadRequest"
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-193
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario: set maximum size of previews
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    When the administrator updates system config key "preview_max_x" with value "null" using the occ command
+    And the administrator updates system config key "preview_max_y" with value "null" using the occ command
+    Then the HTTP status code should be "201"
+    When user "user0" downloads the preview of "/parent.txt" with width "null" and height "null" using the WebDAV API
+    Then the HTTP status code should be "200"
+
+  @skipOnOcis @issue-ocis-200
   Scenario Outline: download previews of different size smaller than the maximum size set
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And the administrator has updated system config key "preview_max_x" with value "32"
@@ -158,6 +273,7 @@ Feature: previews of files downloaded through the webdav API
       | 32    | 12     | 200       |
       | 12    | 32     | 200       |
 
+  @skipOnOcis @issue-ocis-200
   Scenario Outline: download previews of different size larger than the maximum size set
     Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And the administrator has updated system config key "preview_max_x" with value "32"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Test the OCIS implementation of the WebDAV API previews test for testing the previews of different types of files like text, images, pdf, etc. with valid as well as invalid preview size.

## Related Issue
- #37156 

## Motivation and Context
- To test the OCIS implementation of the previews

## How Has This Been Tested?
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
