### PR TITLE
[Tests-Only] Add acceptance tests to share top-level of read-only storage

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -481,6 +481,7 @@ default:
         - WebUIHelpAndTipsContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
+        - WebUISharingContext:
         - OccContext:
 
     webUIComments:

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -191,6 +191,31 @@ class OccContext implements Context {
 
 	/**
 	 * @param string $mountPoint
+	 * @param boolean $setting
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function setExtStorageSharingUsingTheOccCommand($mountPoint, $setting = true) {
+		$command = "files_external:option";
+
+		$mountId = $this->featureContext->getStorageId($mountPoint);
+
+		$key = "enable_sharing";
+
+		if ($setting) {
+			$value = "true";
+		} else {
+			$value = "false";
+		}
+
+		$this->invokingTheCommand(
+			"$command $mountId $key $value"
+		);
+	}
+
+	/**
+	 * @param string $mountPoint
 	 * @param string $setting "never" (switch it off) otherwise "Once every direct access"
 	 *
 	 * @return void
@@ -932,6 +957,19 @@ class OccContext implements Context {
 	 */
 	public function theAdminHasSetTheExtStorageToReadOnly($mountPoint) {
 		$this->setExtStorageReadOnlyUsingTheOccCommand($mountPoint);
+		$this->theCommandShouldHaveBeenSuccessful();
+	}
+
+	/**
+	 * @Given the administrator has set the external storage :mountPoint to sharing
+	 *
+	 * @param string $mountPoint
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminHasSetTheExtStorageToSharing($mountPoint) {
+		$this->setExtStorageSharingUsingTheOccCommand($mountPoint);
 		$this->theCommandShouldHaveBeenSuccessful();
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
@@ -185,6 +185,7 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @Given the administrator has enabled read-only for the last created local storage mount using the webUI
 	 * @When the administrator enables read-only for the last created local storage mount using the webUI
 	 *
 	 * @return void
@@ -192,6 +193,18 @@ class WebUIAdminStorageSettingsContext extends RawMinkContext implements Context
 	public function theAdministratorEnablesReadonlyForTheLastCreatedLocalStorageMountUsingTheWebui() {
 		$this->adminStorageSettingsPage->openMountOptions($this->getSession());
 		$this->adminStorageSettingsPage->enableReadonlyMountOption($this->getSession());
+		$this->adminStorageSettingsPage->openMountOptions($this->getSession());
+	}
+
+	/**
+	 * @Given the administrator has enabled sharing for the last created local storage mount using the webUI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasEnabledSharingForTheLastCreatedLocalStorageMountUsingTheWebui() {
+		$this->adminStorageSettingsPage->openMountOptions($this->getSession());
+		$this->adminStorageSettingsPage->enableSharingMountOption($this->getSession());
+		$this->adminStorageSettingsPage->openMountOptions($this->getSession());
 	}
 
 	/**

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnlyAndShare.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnlyAndShare.feature
@@ -1,0 +1,40 @@
+@cli @skipOnLDAP @local_storage
+Feature: create local storage and enable read-only and sharing from the command line
+  As an admin
+  I want to create read-only local storage and enable sharing from the command line
+  So that local folders on my server can be made visible but read-only to users of ownCloud
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And the administrator has created the local storage mount "local_storage1"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage1/file-in-local-storage.txt"
+    And the administrator has added user "user0" as the applicable user for the last local storage mount
+    And the administrator has set the external storage "local_storage1" to read-only
+    And the administrator has set the external storage "local_storage1" to sharing
+
+  Scenario: applicable user is not able to share with all permissions the top-level of read-only storage
+    When user "user0" shares folder "local_storage1" with user "user1" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "404"
+    And the OCS status message should be "Cannot set the requested share permissions for local_storage1"
+
+  Scenario: applicable user is able to share with read permissions the top-level of read-only storage
+    When user "user0" shares folder "local_storage1" with user "user1" with permissions "read" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And as "user1" folder "local_storage1" should exist
+
+  Scenario: applicable user is able to share with read permissions the file inside the top-level of read-only storage
+    When user "user0" shares file "/local_storage1/file-in-local-storage.txt" with user "user1" with permissions "read" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And as "user1" file "file-in-local-storage.txt" should exist
+
+  Scenario: applicable user is able to share with default permissions the file inside the top-level of read-only storage
+    When user "user0" shares file "/local_storage1/file-in-local-storage.txt" with user "user1" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And as "user1" file "file-in-local-storage.txt" should exist

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadWriteAndShare.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadWriteAndShare.feature
@@ -1,0 +1,27 @@
+@cli @skipOnLDAP @local_storage
+Feature: create local storage and enable sharing from the command line
+  As an admin
+  I want to create read-write local storage and enable sharing from the command line
+  So that local folders on my server can be made visible and read-write to users of ownCloud
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And the administrator has created the local storage mount "local_storage1"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage1/file-in-local-storage.txt"
+    And the administrator has added user "user0" as the applicable user for the last local storage mount
+    And the administrator has set the external storage "local_storage1" to sharing
+
+  Scenario: applicable user is able to share with all permissions the top-level of read-write storage
+    When user "user0" shares folder "local_storage1" with user "user1" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And as "user1" folder "local_storage1" should exist
+
+  Scenario: applicable user is able to share the file inside the top-level of read-write storage
+    When user "user0" shares file "/local_storage1/file-in-local-storage.txt" with user "user1" with permissions "read" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And as "user1" file "file-in-local-storage.txt" should exist

--- a/tests/acceptance/features/lib/AdminStorageSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminStorageSettingsPage.php
@@ -58,6 +58,7 @@ class AdminStorageSettingsPage extends OwncloudPage {
 	protected $lastCreatedMountDeleteButtonXpath = "//tr[@id='addMountPoint']/preceding-sibling::tr[1]/td[@class='remove']";
 	protected $lastCreatedMountOptionsButtonXpath = "//tr[@id='addMountPoint']/preceding-sibling::tr[1]/td[@class='mountOptionsToggle']";
 	protected $setReadonlyId = "mountOptionsReadonly";
+	protected $setSharingId = "mountOptionsSharing";
 	protected $mountPointNameXpath = "//tr[@class='local'][%s]//input[@placeholder='Folder name']";
 
 	/**
@@ -318,6 +319,26 @@ class AdminStorageSettingsPage extends OwncloudPage {
 			__METHOD__ .
 			" id " . $this->setReadonlyId .
 			" could not find checkbox for read-only mount option"
+		);
+		if ((!($checkCheckbox->isChecked()))) {
+			$checkCheckbox->click();
+		}
+	}
+
+	/**
+	 * enable sharing mount option
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function enableSharingMountOption(Session $session) {
+		$checkCheckbox = $this->findById($this->setSharingId);
+		$this->assertElementNotNull(
+			$checkCheckbox,
+			__METHOD__ .
+			" id " . $this->setSharingId .
+			" could not find checkbox for sharing mount option"
 		);
 		if ((!($checkCheckbox->isChecked()))) {
 			$checkCheckbox->click();

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -163,3 +163,22 @@ Feature: admin storage settings
     Then the last created local storage mount should be listed on the webUI
     And the user re-logs in as "user1" using the webUI
     And folder "local_storage1" should be listed on the webUI
+
+  @issue-36803
+  Scenario: applicable user is not able to share top-level of read-only storage
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
+    And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
+    And the administrator has added user "user0" as the applicable user for the last local storage mount from the admin storage settings page
+    And the administrator has enabled read-only for the last created local storage mount using the webUI
+    And the administrator has enabled sharing for the last created local storage mount using the webUI
+    And the user has re-logged in as "user0" using the webUI
+    When the user shares folder "local_storage1" with user "User One" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | Cannot set the requested share permissions for local_storage1 |
+   # And as "user1" folder "local_storage1" should exist
+    And as "user1" folder "local_storage1" should not exist


### PR DESCRIPTION
## Description
Add acceptance tests to share top-level of read-only storage

## Related Issue
#36803 

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
