### PR TITLE
[Tests-Only] Bump phan 2.7

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -31,6 +31,17 @@ return [
 		'settings'
 	],
 
+	'exclude_file_list' => [
+		'apps/federation/appinfo/routes.php',
+		'apps/files/appinfo/routes.php',
+		'apps/files_external/appinfo/routes.php',
+		'apps/files_sharing/appinfo/routes.php',
+		'apps/files_trashbin/appinfo/routes.php',
+		'apps/updatenotification/appinfo/routes.php',
+		'core/routes.php',
+		'settings/routes.php'
+	],
+
 	// A directory list that defines files that will be excluded
 	// from static analysis, but whose class and method
 	// information should be included.

--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -302,7 +302,7 @@ class Comment implements IComment {
 	/**
 	 * sets the date of the most recent child
 	 *
-	 * @param \DateTime $dateTime
+	 * @param \DateTime|null $dateTime
 	 * @return IComment
 	 * @since 9.0.0
 	 */

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -113,7 +113,7 @@ class Manager implements ICommentsManager {
 		if ($comment->getId() === '') {
 			$comment->setChildrenCount(0);
 			$comment->setLatestChildDateTime(new \DateTime('0000-00-00 00:00:00', new \DateTimeZone('UTC')));
-			$comment->setLatestChildDateTime(null);
+			$comment->setLatestChildDateTime();
 		}
 
 		if ($comment->getCreationDateTime() === null) {

--- a/lib/public/Comments/IComment.php
+++ b/lib/public/Comments/IComment.php
@@ -203,11 +203,11 @@ interface IComment {
 	/**
 	 * sets the date of the most recent child
 	 *
-	 * @param \DateTime $dateTime
+	 * @param \DateTime|null $dateTime
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setLatestChildDateTime(\DateTime $dateTime);
+	public function setLatestChildDateTime(\DateTime $dateTime = null);
 
 	/**
 	 * returns the object type the comment is attached to

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -432,6 +432,7 @@ class UsersController extends Controller {
 			}
 		}
 
+		'@phan-var \OC\User\Manager $this->userManager';
 		if ($this->userManager->userExists($username)) {
 			return new DataResponse(
 				[
@@ -483,6 +484,7 @@ class UsersController extends Controller {
 				$user->setEMailAddress($email);
 
 				try {
+					'@phan-var \OC\Settings\Controller\UsersController $this';
 					$this->generateTokenAndSendMail($username, $email);
 				} catch (\Exception $e) {
 					$this->log->error("Can't send new user mail to $email: " . $e->getMessage(), ['app' => 'settings']);

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^1.3"
+        "phan/phan": "^2.7"
     }
 }


### PR DESCRIPTION
## Description
- bump `phan` to 2.7 and exclude various `routes.php` files that do not analyze nicely
- Remove extra setLatestChildDateTime in prepareCommentForDatabaseWrite
- Teach phan about the objects in settings/Controller/UsersController.php (there were already various hints to phan about `groupManager` and it also then gets confused about `userManager`)

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/644

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
