### PR TITLE
Do not allow various special usernames (UIDs)

### DIFF
--- a/changelog/unreleased/32547
+++ b/changelog/unreleased/32547
@@ -1,0 +1,8 @@
+Change: Disallow various special usernames
+
+Special names "avatars", "files_encryption", "files_external" and "meta" are
+used for other purposes in ownCloud and are not valid usernames (UIDs).
+Creating a user with any of these names is now disallowed.
+
+https://github.com/owncloud/core/issues/32547
+https://github.com/owncloud/core/pull/37268

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -366,6 +366,17 @@ class Manager extends PublicEmitter implements IUserManager {
 				throw new \Exception($l->t('The username can not be longer than 64 characters'));
 			}
 
+			$invalidUids = [
+				'avatars',
+				'meta',
+				'files_external',
+				'files_encryption'
+			];
+
+			if (\in_array(\strtolower($uid), $invalidUids)) {
+				throw new \Exception($l->t("The special username $uid is not allowed"));
+			}
+
 			// No empty password
 			if (\trim($password) == '') {
 				throw new \Exception($l->t('A valid password must be provided'));

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -39,6 +39,7 @@ Feature: add users
       | a)~  | "%alt2%"    | Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "+_.@-'" |
       | a(=  | "%alt3%"    | Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "+_.@-'" |
       | a`*^ | "%alt4%"    | Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "+_.@-'" |
+      | meta | "%alt4%"    | Error creating user: The special username meta is not allowed                                                   |
 
   Scenario: use the webUI to create a user with empty password
     When the administrator attempts to create a user with the name "bijay" and the password "" using the webUI

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -381,6 +381,26 @@ class ManagerTest extends TestCase {
 		$this->manager->createUser($uid, 'testuser');
 	}
 
+	public function usernameIsSpecialInvalidValueDataProvider() {
+		return [
+			['avatars'],
+			['meta'],
+			['files_external'],
+			['files_encryption'],
+		];
+	}
+
+	/**
+	 * @dataProvider usernameIsSpecialInvalidValueDataProvider
+	 * @param $uid string
+	 */
+	public function testUsernameIsSpecialInvalidValue($uid) {
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage("The special username $uid is not allowed");
+		$this->manager = \OC::$server->getUserManager();
+		$this->manager->createUser($uid, 'testuser');
+	}
+
 	public function testPasswordIsNotJustWhiteSpace() {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('A valid password must be provided');


### PR DESCRIPTION
## Description
If UIDs are created with these "special" values then "bad things happen" because there are folders in the `data` directory, or end-points that become ambiguous or...
```
avatars
files_external
files_encryption
meta
```

Prevent them from being created as local users.

(will also need some action for user_ldap to sort out what to do if a UID like this exists in LDAP)

## Related Issue
#30438 and #32547 and #37267 

## How Has This Been Tested?
CI and manually try to create these users in the webUI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
