### PR TITLE
Adjust expire trash background job interval

### DIFF
--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -60,8 +60,8 @@ class ExpireTrash extends TimedJob {
 	public function __construct(IConfig $config = null,
 								IUserManager $userManager = null,
 								TrashExpiryManager $trashExpiryManager = null) {
-		// Run once per 30 minutes
-		$this->setInterval(60 * 30);
+		// Run once per 10 minutes
+		$this->setInterval(60 * 10);
 
 		if ($trashExpiryManager === null || $userManager === null) {
 			$this->fixDIForJobs();


### PR DESCRIPTION
Adjusting to the same interval as [ScanFiles](https://github.com/owncloud/core/blob/v10.4.1/apps/files/lib/BackgroundJob/ScanFiles.php). Due to https://github.com/owncloud/core/pull/36602 job runs in chunks, so interval needs adjustment too.