### PR TITLE
[Tests-Only] Remove OC_Theme not found from ignored errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,7 +33,6 @@ parameters:
     - '#Undefined variable: \$OC_[a-zA-Z0-9\\_]+#'
     - '#Undefined variable: \$vendor#'
     - '#Undefined variable: \$baseuri#'
-    - '#Instantiated class OC_Theme not found.#'
     # errors below are to be addressed by own pull requests - non trivial changes required
     - '#Unsafe usage of new static().#'
     - '#Cannot instantiate interface OCP\\Files\\ObjectStore\\IObjectStore.#'


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Fixes phpstan inspection on master:
```
Ignored error pattern #Instantiated class OC_Theme not found.# was not matched in reported errors.
```
Like this https://drone.owncloud.com/owncloud/core/24335/4/7

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
