### PR TITLE
Check get result against false when removing file from cache

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -463,10 +463,12 @@ class Cache implements ICache {
 	 */
 	public function remove($file) {
 		$entry = $this->get($file);
-		$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `fileid` = ?';
-		$this->connection->executeQuery($sql, [$entry['fileid']]);
-		if ($entry['mimetype'] === 'httpd/unix-directory') {
-			$this->removeChildren($entry);
+		if ($entry !== false) {
+			$sql = 'DELETE FROM `*PREFIX*filecache` WHERE `fileid` = ?';
+			$this->connection->executeQuery($sql, [$entry['fileid']]);
+			if ($entry['mimetype'] === 'httpd/unix-directory') {
+				$this->removeChildren($entry);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
This is critical for unit tests to pass with PHP 7.4

## Related Issue
https://github.com/owncloud/enterprise/issues/3967

## Motivation and Context
Many unit tests are failing for PHP 7.4 
Before https://drone.owncloud.com/owncloud/core/24348/24/9:
```
Tests: 9984, Assertions: 57374, Errors: 153, Failures: 1, Skipped: 79.
```

After https://drone.owncloud.com/owncloud/core/24349/24/9
```
 Tests: 9984, Assertions: 57729, Errors: 44, Failures: 1, Skipped: 79.
```


## How Has This Been Tested?
By CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
