### PR TITLE
[Tests-Only] skip 'add to your owncloud button' test on old oC versions

### DIFF
--- a/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
@@ -341,6 +341,7 @@ Feature: Share by public link
      And the public accesses the last created public link using the webUI
      Then add to your owncloud button should be displayed on the webUI
 
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
   Scenario: add to your owncloud button is not present
     Given user "user1" has created folder "/simple-folder"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"


### PR DESCRIPTION
## Description
PR #37232 fixed a problem with the "add to your ownCloud" button on public link pages. That fix is in master, and not older versions of ownCloud like 10.3 or 10.4.0/10.4.1

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
