### PR TITLE
Fix access array offset on bool for FederatedShareProvider tests

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -146,7 +146,7 @@ class FederatedShareProvider implements IShareProvider {
 		$itemType = $share->getNodeType();
 		$permissions = $share->getPermissions();
 		$sharedBy = $share->getSharedBy();
-		
+
 		/*
 		 * Check if file is not already shared with the remote user
 		 */
@@ -253,7 +253,7 @@ class FederatedShareProvider implements IShareProvider {
 			 * if there is one coming from the remote server, otherwise use a generic one.
 			 */
 			if (!$status || $status['ocs']['meta']['status'] === 'failure') {
-				$msg = $status['ocs']['meta']['message'];
+				$msg = $status['ocs']['meta']['message'] ?? false;
 				if (!$msg) {
 					$message_t = $this->l->t('Sharing %s failed, could not find %s, maybe the server is currently unreachable.',
 						[$share->getNode()->getName(), $share->getSharedWith()]);
@@ -631,10 +631,10 @@ class FederatedShareProvider implements IShareProvider {
 			}
 			$cursor->closeCursor();
 		}
-		
+
 		return $shares;
 	}
-	
+
 	/**
 	 * @inheritdoc
 	 */
@@ -701,7 +701,7 @@ class FederatedShareProvider implements IShareProvider {
 			->from($this->shareTable)
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
 			->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(self::SHARE_TYPE_REMOTE)));
-		
+
 		$cursor = $qb->execute();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -52,6 +52,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @group DB
  */
 class FederatedShareProviderTest extends \Test\TestCase {
+	protected const OCS_GENERIC_SUCCESS = ['ocs' => ['meta' => [ 'status' => 'success']]];
 
 	/** @var IDBConnection */
 	protected $connection;
@@ -160,7 +161,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$this->equalTo('token'),
 				$this->equalTo('myFile'),
 				$this->anything()
-			)->willReturn(true);
+			)->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
@@ -235,7 +236,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$this->equalTo('token'),
 				$this->equalTo('myFile'),
 				$this->anything()
-			)->willReturn(true);
+			)->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		$folderOwner = $this->createMock(IUser::class);
 		$folderOwner->method('getUID')->willReturn('folderOwner');
@@ -462,7 +463,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$this->equalTo('token'),
 				$this->equalTo('myFile'),
 				$this->anything()
-			)->willReturn(true);
+			)->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
@@ -528,7 +529,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$this->equalTo('token'),
 				$this->equalTo('myFile'),
 				$this->anything()
-			)->willReturn(true);
+			)->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		if ($owner === $sharedBy) {
 			$this->provider->expects($this->never())->method('sendPermissionUpdate');
@@ -568,7 +569,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
 			->method('sendRemoteShare')
-			->willReturn(true);
+			->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
@@ -608,7 +609,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
 			->method('sendRemoteShare')
-			->willReturn(true);
+			->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
@@ -660,7 +661,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
 			->method('sendRemoteShare')
-			->willReturn(true);
+			->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
@@ -697,7 +698,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
 			->method('sendRemoteShare')
-			->willReturn(true);
+			->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
@@ -737,7 +738,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
 			->method('sendRemoteShare')
-			->willReturn(true);
+			->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
@@ -780,7 +781,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->tokenHandler->method('generateToken')->willReturn('token');
 		$this->notifications
 			->method('sendRemoteShare')
-			->willReturn(true);
+			->willReturn(self::OCS_GENERIC_SUCCESS);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
 


### PR DESCRIPTION
## Description
- Use null coalesce operator in case $status is not defined.
- `true` is not valid response - we expect an array there

## Related Issue
https://github.com/owncloud/enterprise/issues/3967

## Motivation and Context
PHP 7.4  support

## How Has This Been Tested?
phpunit 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
