### PR TITLE
 Try to detect the connection status after flush() - this might lead to earlier detection of a broken connection

### DIFF
--- a/changelog/unreleased/37291
+++ b/changelog/unreleased/37291
@@ -1,0 +1,6 @@
+Bugfix: Earlier detection of connection status
+
+On public video streaming the connection is detected to reduce server load #37219
+To optimize this the connection status is queried after flush()
+
+https://github.com/owncloud/core/pull/37291

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -475,8 +475,8 @@ class View {
 			$size = $this->filesize($path);
 			while (!\feof($handle)) {
 				echo \fread($handle, $chunkSize);
-				$this->checkConnectionStatus();
 				\flush();
+				$this->checkConnectionStatus();
 			}
 			return $size;
 		}
@@ -505,8 +505,8 @@ class View {
 						$len = $chunkSize;
 					}
 					echo \fread($handle, $len);
-					$this->checkConnectionStatus();
 					\flush();
+					$this->checkConnectionStatus();
 				}
 				return \ftell($handle) - $from;
 			}


### PR DESCRIPTION

## Description

Bugfix: Earlier detection of connection status

On public video streaming the connection is detected to reduce server load #37219
To optimize this the connection status is queried after flush()


## Related Issue
https://github.com/owncloud/core/pull/37291

## How Has This Been Tested?
Live at customer ;-)
same test steps as in https://github.com/owncloud/core/pull/37291

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
