### PR TITLE
[Tests-Only] Run apiVersions test on Oracle db

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -113,6 +113,13 @@ config = {
 				'apiWebdavUpload2',
 			],
 		},
+		'apiOnOracle': {
+		    'suites': [
+		        'apiVersions',
+		    ],
+		    'filterTags': '@skip&&@issue-37026',
+		    'databases': ['oracle'],
+		},
 		'apiNotifications': {
 			'suites': [
 				'apiSharingNotifications',

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -129,7 +129,7 @@ Feature: dav-versions
     Then the content of file "/textfile0.txt" for user "user0" should be "Dav-Test"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-156
-  @skipOnOcis @issue-ocis-reva-57
+  @skipOnOcis @issue-ocis-reva-57 @skipOnOracle
   Scenario: Restore a file and check, if the content and correct checksum is now in the current file
     Given user "user0" has uploaded file with content "AAAAABBBBBCCCCC" and checksum "MD5:45a72715acdd5019c5be30bdbb75233e" to "/davtest.txt"
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/davtest.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
@@ -137,6 +137,16 @@ Feature: dav-versions
     When user "user0" restores version index "1" of file "/davtest.txt" using the WebDAV API
     Then the content of file "/davtest.txt" for user "user0" should be "AAAAABBBBBCCCCC"
     And as user "user0" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
+
+  @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-156
+  @skipOnOcis @issue-ocis-reva-57 @skip @issue-37026
+  Scenario: Restore a file and check, if the content and correct checksum is now in the current file
+    Given user "user0" has uploaded file with content "AAAAABBBBBCCCCC" and checksum "MD5:45a72715acdd5019c5be30bdbb75233e" to "/davtest.txt"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/davtest.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    And the version folder of file "/davtest.txt" for user "user0" should contain "1" element
+    When user "user0" restores version index "1" of file "/davtest.txt" using the WebDAV API
+    Then the content of file "/davtest.txt" for user "user0" should be "AAAAABBBBBCCCCC"
+    And as user "user0" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
   Scenario: User cannot access meta folder of a file which is owned by somebody else
     Given user "user1" has been created with default attributes and without skeleton files

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -898,7 +898,12 @@ fi
 # If the caller did not mention specific tags, skip the skipped tests by default
 if [ "${BEHAT_TAGS_OPTION_FOUND}" = false ]
 then
-	BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&~@skip"
+  #  If the caller has already specified specifically to run "@skip" scenarios
+  #  then do not append "not @skip"
+  if [[ ! ${BEHAT_FILTER_TAGS} =~ "&&@skip&&" ]]
+  then
+	  BEHAT_FILTER_TAGS="${BEHAT_FILTER_TAGS}&&~@skip"
+  fi
 fi
 
 if [ -n "${BROWSER_VERSION}" ]


### PR DESCRIPTION
## Description
Run apiVersions test on oracle DB

## Related Issue
- #37026 

## Motivation and Context
A single test scenario of apiVersions feature file fails on oracle db. This PR makes a separate scenario demonstrating the behavior of the failing one and then makes a pipeline for running the test scenario separately in oracle database.

## How Has This Been Tested?
CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
