### PR TITLE
PHP-7.4 Fix litmus

### DIFF
--- a/apps/dav/lib/DAV/FileCustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/FileCustomPropertiesBackend.php
@@ -30,6 +30,7 @@ use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\Node;
 use OC\Cache\CappedMemoryCache;
 use Sabre\DAV\INode;
+use Sabre\DAV\Xml\Property\Complex;
 
 /**
  * Class FileCustomPropertiesBackend
@@ -186,6 +187,12 @@ class FileCustomPropertiesBackend extends AbstractCustomPropertiesBackend {
 					);
 				}
 			} else {
+				// FIXME: PHP 7.4 handles object serialization differently so we store 'Object' here
+				// to keep old (wrong) behavior and fix Oracle failure
+				// see https://github.com/owncloud/core/issues/32670
+				if ($propertyValue instanceof Complex) {
+					$propertyValue = 'Object';
+				}
 				if (!$propertyExists) {
 					$this->connection->executeUpdate($insertStatement,
 						[


### PR DESCRIPTION
## Description
Right now complex PROPPATCH causes a hard failure for Oracle, see https://github.com/owncloud/core/issues/32670 for details
It also fails in the same manner under PHP 7.4

This PR make the behavior consistent  across all DB engines and PHP versions. 
In the terms of non-Orcacle/PHP7.4 environment it changes **nothing**.

## Related Issue
https://github.com/owncloud/enterprise/issues/3967
https://github.com/owncloud/core/issues/32670

## Motivation and Context
Failing litmus test

## How Has This Been Tested?
By CI


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
