### PR TITLE
Fix hasUpdated for webdav storage

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -807,16 +807,18 @@ class DAV extends Common {
 				return false;
 			}
 			if (isset($response['{DAV:}getetag'])) {
-				$cachedData = $this->getCache()->get($path);
 				$etag = \trim($response['{DAV:}getetag'], '"');
-				if (!empty($etag) && $cachedData['etag'] !== $etag) {
+				$cachedData = $this->getCache()->get($path);
+				$cachedEtag = $cachedData['etag'] ?? null;
+				if (!empty($etag) && $cachedEtag !== $etag) {
 					return true;
 				} elseif (isset($response['{http://open-collaboration-services.org/ns}share-permissions'])) {
 					$sharePermissions = (int)$response['{http://open-collaboration-services.org/ns}share-permissions'];
 					return $sharePermissions !== $cachedData['permissions'];
 				} elseif (isset($response['{http://owncloud.org/ns}permissions'])) {
 					$permissions = $this->parsePermissions($response['{http://owncloud.org/ns}permissions']);
-					return $permissions !== $cachedData['permissions'];
+					$cachedPermissions = $cachedData['permissions'] ?? null;
+					return $permissions !== $cachedPermissions;
 				} else {
 					return false;
 				}


### PR DESCRIPTION
## Description
Unit tests get this fail on PHP 7.4
```
There was 1 failure:

1) Test\Files\Storage\DavTest::testHasUpdated with data set #4 (array('"oldetag"', 1), array('oldetag', 31), true)
Failed asserting that false matches expected true.

/drone/src/tests/lib/Files/Storage/DavTest.php:1306
```

Adjust the code so that it checks more carefully for non-existent array indexes etc.

The commit has been cherry-picked from PR #37280 where the demostration of PHP 7.4 tests is happening.

Note: there are no individual changelog entries being done for these PHP 7.4 code refactorings. An overall changelog entry for PHP 7.4 support will happen at the end.

## Related Issue


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
