### PR TITLE
[Tests-Only] Test against federated server running core 10.3.2

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -133,7 +133,7 @@ config = {
 				'apiFederation',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['daily-master-qa', 'latest', '10.2.1']
+			'federatedServerVersions': ['daily-master-qa', 'latest', '10.3.2']
 		},
 		'cli': {
 			'suites': [
@@ -156,7 +156,7 @@ config = {
 				'cliExternalStorage',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['daily-master-qa', 'latest', '10.2.1']
+			'federatedServerVersions': ['daily-master-qa', 'latest', '10.3.2']
 		},
 		'webUI': {
 			'suites': {
@@ -209,7 +209,7 @@ config = {
 				'webUISharingExternal2': 'webUISharingExt2',
 			},
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['daily-master-qa', 'latest', '10.2.1']
+			'federatedServerVersions': ['daily-master-qa', 'latest', '10.3.2']
 		},
 		'webUIFirefox': {
 			'suites': {


### PR DESCRIPTION
## Description
We run federated acceptance tests against a federated server that is running the `daily-master-qa` tarball, the `latest` tarball (which is currently 10.4.1) and against one older version, to ensure that code changes in newer ownCloud versions will communicate OK with a somewhat-older federated server.

This PR adjusts the "older" version from 10.2.1 to 10.3.2.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
