### PR TITLE
Support PHP 7.4

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -31,6 +31,7 @@ config = {
 		'reducedDatabases' : {
 			'phpVersions': [
 				'7.3',
+				'7.4',
 			],
 			'databases': [
 				'sqlite',
@@ -41,6 +42,7 @@ config = {
 		'external-samba-windows' : {
 			'phpVersions': [
 				'7.2',
+				'7.4',
 			],
 			'databases': [
 				'sqlite',
@@ -60,6 +62,7 @@ config = {
 		'external-other' : {
 			'phpVersions': [
 				'7.2',
+				'7.4',
 			],
 			'databases': [
 				'sqlite',
@@ -422,7 +425,7 @@ def codestyle():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.3'],
+		'phpVersions': ['7.4'],
 	}
 
 	if 'defaults' in config:
@@ -597,7 +600,7 @@ def phpstan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.2'],
+		'phpVersions': ['7.4'],
 		'logLevel': '2',
 	}
 
@@ -674,7 +677,7 @@ def phan():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.2', '7.3'],
+		'phpVersions': ['7.2', '7.3', '7.4'],
 		'logLevel': '2',
 	}
 
@@ -751,7 +754,7 @@ def litmus():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.2'],
+		'phpVersions': ['7.2', '7.3', '7.4'],
 		'logLevel': '2'
 	}
 
@@ -916,7 +919,7 @@ def dav():
 		return pipelines
 
 	default = {
-		'phpVersions': ['7.2'],
+		'phpVersions': ['7.2', '7.3', '7.4'],
 		'logLevel': '2'
 	}
 
@@ -1110,7 +1113,7 @@ def phptests(testType):
 	errorFound = False
 
 	default = {
-		'phpVersions': ['7.2', '7.3'],
+		'phpVersions': ['7.2', '7.3', '7.4'],
 		'databases': [
 			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mariadb:10.4', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'postgres:10.3', 'oracle'
 		],
@@ -1294,8 +1297,9 @@ def acceptance():
 	default = {
 		'federatedServerVersions': [''],
 		'browsers': ['chrome'],
-		'phpVersions': ['7.2'],
+		'phpVersions': ['7.4'],
 		'databases': ['mariadb:10.2'],
+		'federatedPhpVersion': '7.2',
 		'federatedServerNeeded': False,
 		'filterTags': '',
 		'logLevel': '2',
@@ -1454,7 +1458,7 @@ def acceptance():
 										yarnInstall(phpVersion) +
 										installServer(phpVersion, db, params['logLevel'], params['federatedServerNeeded'], params['proxyNeeded']) +
 										(
-											installFederated(federatedServerVersion, phpVersion, params['logLevel'], protocol, db, federationDbSuffix) +
+											installFederated(federatedServerVersion, params['federatedPhpVersion'], params['logLevel'], protocol, db, federationDbSuffix) +
 											owncloudLog('federated', 'federated') if params['federatedServerNeeded'] else []
 										) +
 										installExtraApps(phpVersion, extraAppsDict) +
@@ -1488,7 +1492,7 @@ def acceptance():
 										params['extraServices'] +
 										owncloudService(phpVersion, 'server', '/drone/src', params['useHttps']) +
 										((
-											owncloudService(phpVersion, 'federated', '/drone/federated', params['useHttps']) +
+											owncloudService(params['federatedPhpVersion'], 'federated', '/drone/federated', params['useHttps']) +
 											databaseServiceForFederation(db, federationDbSuffix)
 										) if params['federatedServerNeeded'] else []),
 									'depends_on': [],

--- a/changelog/unreleased/36509
+++ b/changelog/unreleased/36509
@@ -1,0 +1,7 @@
+Change: Support PHP 7.4
+
+PHP 7.4 was released in Dec 2019. ownCloud server now supports PHP 7.4.
+
+https://github.com/owncloud/core/issues/36509
+https://github.com/owncloud/core/pull/37302
+https://www.php.net/supported-versions.php

--- a/console.php
+++ b/console.php
@@ -41,9 +41,9 @@ if (\version_compare(PHP_VERSION, '7.2.0') === -1) {
 	exit(1);
 }
 
-// Show warning if PHP 7.4 or later is used as ownCloud is not compatible with PHP 7.4
-if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
-	echo 'This version of ownCloud is not compatible with PHP 7.4' . PHP_EOL;
+// Show warning if PHP 7.5 or later is used as ownCloud is not compatible with PHP 7.5
+if (\version_compare(PHP_VERSION, '7.5.0alpha1') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 7.5' . PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '.' . PHP_EOL;
 	exit(1);
 }

--- a/index.php
+++ b/index.php
@@ -35,9 +35,9 @@ if (\version_compare(PHP_VERSION, '7.2.0') === -1) {
 	return;
 }
 
-// Show warning if PHP 7.4 or later is used as ownCloud is not compatible with PHP 7.4
-if (\version_compare(PHP_VERSION, '7.4.0alpha1') !== -1) {
-	echo 'This version of ownCloud is not compatible with PHP 7.4<br/>';
+// Show warning if PHP 7.5 or later is used as ownCloud is not compatible with PHP 7.5
+if (\version_compare(PHP_VERSION, '7.5.0alpha1') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 7.5<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '.';
 	return;
 }


### PR DESCRIPTION
## Description
- allow PHP 7.4 in `console.php` and `index.php`
- add extra unit test pipelines in CI for PHP 7.4
- switch acceptance test pipelines in CI  from PHP  7.2 to 7.4

Note: for pipelines that use a federated server as part of the test environment, those will keep running the federated server on PHP  7.2, because the federated server will be some older release of ownCloud (e.g. 10.3.2 or 10.4.1) that we know does not support PHP 7.4.

## Related Issue
#36509 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
