### PR TITLE
[Tests-Only] Correct mount option read_only in manageOptionsForLocalStorage.feature

### DIFF
--- a/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
@@ -12,17 +12,17 @@ Feature: manage options for a mount using occ command
 
   Scenario: add options for a local storage mount
     When the administrator adds an option with key "enable_sharing" and value "true" for the local storage mount "local_storage2"
-    And the administrator adds an option with key "read-only" and value "1" for the local storage mount "local_storage2"
+    And the administrator adds an option with key "read_only" and value "1" for the local storage mount "local_storage2"
     And the administrator adds an option with key "enable_sharing" and value "false" for the local storage mount "local_storage3"
-    And the administrator adds an option with key "read-only" and value "1" for the local storage mount "local_storage3"
+    And the administrator adds an option with key "read_only" and value "1" for the local storage mount "local_storage3"
     And the administrator lists the local storage using the occ command
     Then the following should be included in the options of local storage "/local_storage2":
        | options              |
        | enable_sharing: true |
-       | read-only: 1         |
+       | read_only: 1         |
     And the following should be included in the options of local storage "/local_storage3":
        | options               |
-       | read-only: 1          |
+       | read_only: 1          |
     But the following should not be included in the options of local storage "/local_storage3":
       | options               |
       | enable_sharing: false |


### PR DESCRIPTION
## Description
https://drone.owncloud.com/owncloud/core/24446/89/13
```
{"reqId":"XcLOlwnH64k1hz6WKBMI","level":3,"time":"2020-04-24T06:29:04+00:00","remoteAddr":"172.23.0.6","user":"--","app":"PHP","method":"POST","url":"\/ocs\/v2.php\/apps\/testing\/api\/v1\/occ","message":"Undefined index: read-only at \/drone\/src\/apps\/files_external\/lib\/Command\/ListCommand.php#222"}
{"reqId":"XcLOlwnH64k1hz6WKBMI","level":3,"time":"2020-04-24T06:29:04+00:00","remoteAddr":"172.23.0.6","user":"--","app":"PHP","method":"POST","url":"\/ocs\/v2.php\/apps\/testing\/api\/v1\/occ","message":"Undefined index: read-only at \/drone\/src\/apps\/files_external\/lib\/Command\/ListCommand.php#222"}
```

The test is using mount option`read-only` but the correct name of the mount option is `read_only`.

Fix it.

Note: there is a problem with the code in `ListCommand.php#222` if someone uses an "unknown" mount option that does not have a default value. That is a different problem that this test scenario was not intended to be testing. I raised a separate issue #37305 for that.

## How Has This Been Tested?
CI and local test run confirming that nothing is logged in owncloud.log

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
