### PR TITLE
[Tests-Only] Use assertContainsEquals to compare status codes that could be in string or int form

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1221,7 +1221,7 @@ class FeatureContext extends BehatVariablesContext {
 				$message = "HTTP status code $actualStatusCode is not one of the expected values";
 			}
 
-			Assert::assertContains(
+			Assert::assertContainsEquals(
 				$actualStatusCode, $expectedStatusCode,
 				$message
 			);

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -571,7 +571,7 @@ class OCSContext implements Context {
 			$this->featureContext->getResponse()
 		);
 		if (\is_array($statusCode)) {
-			Assert::assertContains(
+			Assert::assertContainsEquals(
 				$responseStatusCode, $statusCode,
 				$message
 			);

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -3309,8 +3309,8 @@ trait Provisioning {
 		$users = $usersList->getRows();
 		$usersSimplified = $this->simplifyArray($users);
 		$respondedArray = $this->getArrayOfUsersResponded($this->response);
-		Assert::assertEquals(
-			$usersSimplified, $respondedArray, "", 0.0, 10, true
+		Assert::assertEqualsCanonicalizing(
+			$usersSimplified, $respondedArray
 		);
 	}
 
@@ -3326,8 +3326,8 @@ trait Provisioning {
 		$groups = $groupsList->getRows();
 		$groupsSimplified = $this->simplifyArray($groups);
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-		Assert::assertEquals(
-			$groupsSimplified, $respondedArray, "", 0.0, 10, true
+		Assert::assertEqualsCanonicalizing(
+			$groupsSimplified, $respondedArray
 		);
 	}
 
@@ -3377,8 +3377,8 @@ trait Provisioning {
 		$tableRows = $groupsOrUsersList->getRows();
 		$simplifiedTableRows = $this->simplifyArray($tableRows);
 		$respondedArray = $this->getArrayOfSubadminsResponded($this->response);
-		Assert::assertEquals(
-			$simplifiedTableRows, $respondedArray, "", 0.0, 10, true
+		Assert::assertEqualsCanonicalizing(
+			$simplifiedTableRows, $respondedArray
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2033,12 +2033,19 @@ trait Sharing {
 			);
 		}
 
-		// check if attributes received from table is subset of actualAttributes
-		Assert::assertArraySubset(
-			$attributes,
-			$actualAttributesArray,
-			"The additional sharing attributes did not include the expected attributes. See the differences below."
-		);
+		// check if the expected attributes received from table match actualAttributes
+		foreach (['scope', 'key', 'enabled'] as $key) {
+			Assert::assertArrayHasKey(
+				$key,
+				$actualAttributesArray,
+				"the additional sharing attributes in the last response did not have key '$key'"
+			);
+			Assert::assertEquals(
+				$attributes[$key],
+				$actualAttributesArray[$key],
+				"the additional sharing attribute '$key' had value " . $actualAttributesArray[$key] . " but was expected to have value " . $actualAttributesArray[$key]
+			);
+		}
 	}
 
 	/**
@@ -2418,13 +2425,8 @@ trait Sharing {
 			$row['path'] = "/" . \trim($row['path'], "/");
 			foreach ($usersShares as $share) {
 				try {
-					Assert::assertArraySubset(
-						$row,
-						$share,
-						"Expected '"
-						. \ implode(', ', $row)
-						. "' was not included in the share of the user. See the difference below"
-					);
+					Assert::assertArrayHasKey('path', $share);
+					Assert::assertEquals($row['path'], $share['path']);
 					$found = true;
 					break;
 				} catch (PHPUnit\Framework\ExpectationFailedException $e) {


### PR DESCRIPTION
## Description
In phpunit9 and the associated `Assert` class, `assertContains` is going to do a strict comparison, including types (e.g. int or string). When comparing HTTP or OCS status codes we do not care if the actual and expected codes arrive as int or string - we want a loose comparison so that we do not have to constantly be fussy about exactly what is being passed around.

Make these checks use `assertContainsEquals` which is a loose comparison.

In phpunit9 `assertEquals` on 2 arrays will start doing an exact comparison (the array order has to be the same as well as the key values and labels), and the extra parameters that used to be available are being removed. `assertEqualsCanonicalizing` is the new method to use for when we just care about the keys and values (and the order does not matter), which is normally the case. So those are fixed.

In phpunit9 `assertArraySubset` is removed. Replace the uses of it in acceptance test code with code to specifically check the expected array keys.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
