### PR TITLE
[PHP7.4] Fix array access in FederatedShareProvider and Storage/DAV

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -240,7 +240,7 @@ class FederatedShareProvider implements IShareProvider {
 			$ownerAddress = $this->addressHandler->getLocalUserFederatedAddress($owner);
 			$sharedWith = $share->getSharedWith();
 			$shareWithAddress = new Address($sharedWith);
-			$status = $this->notifications->sendRemoteShare(
+			$result = $this->notifications->sendRemoteShare(
 				$shareWithAddress,
 				$ownerAddress,
 				$sharedByAddress,
@@ -252,8 +252,16 @@ class FederatedShareProvider implements IShareProvider {
 			/* Check for failure or null return from sending and pick up an error message
 			 * if there is one coming from the remote server, otherwise use a generic one.
 			 */
-			if (!$status || $status['ocs']['meta']['status'] === 'failure') {
-				$msg = $status['ocs']['meta']['message'] ?? false;
+			if (\is_bool($result)) {
+				$status = $result;
+			} elseif (isset($result['ocs']['meta']['status'])) {
+				$status = $result['ocs']['meta']['status'];
+			} else {
+				$status = false;
+			}
+
+			if ($status === false) {
+				$msg = $result['ocs']['meta']['message'] ?? false;
 				if (!$msg) {
 					$message_t = $this->l->t('Sharing %s failed, could not find %s, maybe the server is currently unreachable.',
 						[$share->getNode()->getName(), $share->getSharedWith()]);

--- a/changelog/unreleased/37311
+++ b/changelog/unreleased/37311
@@ -1,0 +1,8 @@
+Bugfix: Rewrite code to fix some notices under PHP 7.4
+
+Fixed "Trying to access array offset on value of type" notices in
+OC\Files\Storage\DAV and OCA\FederatedFileSharing\FederatedShareProvider
+under PHP 7.4.
+
+https://github.com/owncloud/core/pull/37311
+https://github.com/owncloud/core/issues/37303

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -684,7 +684,7 @@ class DAV extends Common {
 			// client request is in \OC\HTTP\Client
 			/* @phan-suppress-next-line PhanUndeclaredMethod */
 			$response = $this->client->request($method, $this->encodePath($path), $body);
-			return $response['statusCode'] == $expected;
+			return isset($response['statusCode']) && $response['statusCode'] == $expected;
 		} catch (ClientHttpException $e) {
 			if ($e->getHttpStatus() === Http::STATUS_NOT_FOUND && $method === 'DELETE') {
 				$this->statCache->clear($path . '/');


### PR DESCRIPTION
## Description
check array key existence before accessing it

## Related Issue
- Fixes #37303 

## Motivation and Context
Clean log file

## How Has This Been Tested?
CI
search for  `Trying to access array offset on value of type` in
 https://drone.owncloud.com/owncloud/core/24446/36/8
and 
https://drone.owncloud.com/owncloud/core/24446/127/18

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
