### PR TITLE
[Tests-Only] Fix checkingAttributesInLastShareResponse acceptance test method

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2034,16 +2034,19 @@ trait Sharing {
 		}
 
 		// check if the expected attributes received from table match actualAttributes
-		foreach (['scope', 'key', 'enabled'] as $key) {
-			Assert::assertArrayHasKey(
-				$key,
-				$actualAttributesArray,
-				"the additional sharing attributes in the last response did not have key '$key'"
-			);
-			Assert::assertEquals(
-				$attributes[$key],
-				$actualAttributesArray[$key],
-				"the additional sharing attribute '$key' had value " . $actualAttributesArray[$key] . " but was expected to have value " . $actualAttributesArray[$key]
+		foreach ($attributes as $row) {
+			$foundRow = false;
+			foreach ($actualAttributesArray as $item) {
+				if (($item['scope'] === $row['scope'])
+					&& ($item['key'] === $row['key'])
+					&& ($item['enabled'] === $row['enabled'])
+				) {
+					$foundRow = true;
+				}
+			}
+			Assert::assertTrue(
+				$foundRow,
+				"Could not find expected attribute with scope '" . $row['scope'] . "' and key '" . $row['key'] . "'"
 			);
 		}
 	}


### PR DESCRIPTION
## Description
In #37310 I refactored `checkingAttributesInLastShareResponse` to get rid of `assertArraySubset` which is being removed in a future `phpunit` Assert release. But the test step is not used in core, only in `richdocuments`. I messed it up. `richdocuments` CI failed last night.

This PR fixes it so that it owrks.

## How Has This Been Tested?
CI and locally running richdocuments scenarios that use this acceptance test step.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
