### PR TITLE
Adjust IConfig PHP doc for value parameter

### DIFF
--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -145,7 +145,7 @@ interface IConfig {
 	 * @param string $userId the userId of the user that we want to store the value under
 	 * @param string $appName the appName that we want to store the value under
 	 * @param string $key the key under which the value is being stored
-	 * @param string $value the value that you want to store
+	 * @param string|float|int $value the value that you want to store
 	 * @param string $preCondition only update if the config value was previously the value passed as $preCondition
 	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
 	 * @throws \UnexpectedValueException when trying to store an unexpected value


### PR DESCRIPTION
## Description
`lib/private/AllConfig.php` has this PHP doc:
```
	/**
	 * Set a user defined value
	 *
	 * @param string $userId the userId of the user that we want to store the value under
	 * @param string $appName the appName that we want to store the value under
	 * @param string $key the key under which the value is being stored
	 * @param string|float|int $value the value that you want to store
	 * @param string $preCondition only update if the config value was previously the value passed as $preCondition
	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
	 * @throws \UnexpectedValueException when trying to store an unexpected value
	 * @return bool
	 */
	public function setUserValue($userId, $appName, $key, $value, $preCondition = null) {
```
`$value` can be any of `string|float|int`

But `lib/public/IConfig.php` has:
```
	/**
	 * Set a user defined value
	 *
	 * @param string $userId the userId of the user that we want to store the value under
	 * @param string $appName the appName that we want to store the value under
	 * @param string $key the key under which the value is being stored
	 * @param string $value the value that you want to store
	 * @param string $preCondition only update if the config value was previously the value passed as $preCondition
	 * @throws \OCP\PreConditionNotMetException if a precondition is specified and is not met
	 * @throws \UnexpectedValueException when trying to store an unexpected value
	 * @since 6.0.0 - parameter $precondition was added in 8.0.0
	 */
	public function setUserValue($userId, $appName, $key, $value, $preCondition = null);
```

`$value` can be only `string`

I noticed this when doing `phpstan` for an app. I get messages like:
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 ------ -------------------------------------------------------------------------------------- 
  Line   lib/Blocker.php                                                                       
 ------ -------------------------------------------------------------------------------------- 
  101    Parameter #4 $value of method OCP\IConfig::setUserValue() expects string, int given.  
 ------ -------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 1 error                                                                                                  
```

The app code stores an `int` in the config. And the app unit tests actually check that the value stored really is an `int`.

## How Has This Been Tested?
CI and running `phpstan` in app repos.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
