### PR TITLE
this->l holds wrong app and translations cannot be found

### DIFF
--- a/changelog/unreleased/37321
+++ b/changelog/unreleased/37321
@@ -1,0 +1,4 @@
+Bugfix: Translate public link sharing email subject
+
+https://github.com/owncloud/core/issues/37321
+https://github.com/owncloud/core/pull/37322

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -244,11 +244,7 @@ class MailNotifications {
 		} catch (ShareNotFound $e) {
 			return $recipients;
 		}
-		if ($notificationLang !== null) {
-			$l10n = \OC::$server->getL10N('lib', $notificationLang);
-		} else {
-			$l10n = $this->l;
-		}
+		$l10n = \OC::$server->getL10N('lib', $notificationLang);
 		$expirationDate = null;
 		if ($share->getExpirationDate()) {
 			$expirationDate = $share->getExpirationDate()->getTimestamp();


### PR DESCRIPTION
## Description
Sharing notification email subject is not translated...
... because the l10n object from the share app notifications controller is injected and no translations are found.

Other usage locations of $this->l need to be verified .... follow up PR ...

## Related Issue
- Fixes #37321 

## How Has This Been Tested?
- :hand: 
- follow steps in #37321 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
