### PR TITLE
Unskip issue-ocis-reva-62

### DIFF
--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -9,7 +9,7 @@ Feature: auth
     When a user requests "/remote.php/webdav" with "PROPFIND" and no authentication
     Then the HTTP status code should be "401"
 
-  @smokeTest @issue-ocis-reva-62
+  @smokeTest
   Scenario: using WebDAV with basic auth
     When user "user0" requests "/remote.php/webdav" with "PROPFIND" using basic auth
     Then the HTTP status code should be "207"


### PR DESCRIPTION
Doing a PROPFIND on the Webdav root now returns the correct value.

Fixes https://github.com/owncloud/ocis-reva/issues/62