### PR TITLE
Fix to allow sharing with UID that is an integer

### DIFF
--- a/changelog/unreleased/37324
+++ b/changelog/unreleased/37324
@@ -1,0 +1,7 @@
+Bugfix: Cannot share with user name that has only numbers in the UI
+
+A regression in 10.4.0 meant that new shares with user names that were numbers
+could not be created in the UI. This regression has been fixed.
+
+https://github.com/owncloud/core/issues/37324
+https://github.com/owncloud/core/pull/37327

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -242,6 +242,9 @@ class Share implements IShare {
 	 * @inheritdoc
 	 */
 	public function setSharedWith($sharedWith) {
+		if (\is_int($sharedWith)) {
+			$sharedWith = (string) $sharedWith;
+		}
 		if (!\is_string($sharedWith)) {
 			throw new \InvalidArgumentException();
 		}

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -151,7 +151,7 @@ interface IShare {
 	/**
 	 * Set the receiver of this share.
 	 *
-	 * @param string $sharedWith
+	 * @param string|int $sharedWith
 	 * @return \OCP\Share\IShare The modified object
 	 * @since 9.0.0
 	 */

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -56,16 +56,25 @@ Feature: Sharing files and folders with internal users
     And file "lorem.txt" should not be listed in shared-with-others page on the webUI
     And as "user2" file "lorem (2).txt" should not exist
 
-  Scenario: user shares a file with another user with uppercase username
+  Scenario Outline: user shares a file with another user with unusual usernames
     Given user "user1" has been created with default attributes and skeleton files
     And these users have been created without skeleton files:
-      | username |
-      | SomeUser |
+      | username   |
+      | <username> |
     And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "SomeUser" using the webUI
-    And the user re-logs in as "SomeUser" using the webUI
+    When the user shares file "lorem.txt" with user "<username>" using the webUI
+    And the user re-logs in as "<username>" using the webUI
     And the user browses to the shared-with-you page
     Then file "lorem.txt" should be listed on the webUI
+    Examples:
+      | username  |
+      | 123456    |
+      | -12       |
+      | +12       |
+      | 1.2       |
+      | 1.2E3     |
+      | 0x10      |
+      | Some-User |
 
   Scenario: multiple users share a file with the same name to a user
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/lib/Share20/ShareTest.php
+++ b/tests/lib/Share20/ShareTest.php
@@ -40,6 +40,39 @@ class ShareTest extends \Test\TestCase {
 		$this->share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
 	}
 
+	public function setSharedWithInvalidProvider() {
+		return [
+			[1.2],
+			[true],
+			[[]],
+		];
+	}
+
+	/**
+	 * @dataProvider setSharedWithInvalidProvider
+	 */
+	public function testSetSharedWithInvalid($sharedWith) {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->share->setSharedWith($sharedWith);
+	}
+
+	public function setSharedWithProvider() {
+		return [
+			[123, '123'],
+			[-12, '-12'],
+			['+12', '+12'],
+			['user.name@example.com', 'user.name@example.com'],
+		];
+	}
+
+	/**
+	 * @dataProvider setSharedWithProvider
+	 */
+	public function testSetSharedWith($sharedWith, $expectedValue) {
+		$this->share->setSharedWith($sharedWith);
+		$this->assertSame($expectedValue, $this->share->getSharedWith());
+	}
+
 	/**
 	 */
 	public function testSetIdInvalid() {


### PR DESCRIPTION
## Description
TBD - I will add some UI acceptance test cases also.

## Related Issue
- Fixes #37324 

## How Has This Been Tested?
- unit tests
- manually sharing in the UI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
