### PR TITLE
[tests-only] test creating folder with the name of an existing resource

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties/createFolder.feature
@@ -6,7 +6,7 @@ Feature: create folder
 
   Background:
     Given using OCS API version "1"
-    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has been created with default attributes and without skeleton files
 
   Scenario Outline: create a folder
     Given using <dav_version> DAV path
@@ -65,6 +65,62 @@ Feature: create folder
     And the DAV reason should be "Can`t upload files with extension .part because these extensions are reserved for internal use."
     And user "user0" should not see the following elements
       | /folder.with.ext.part |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis @issue-ocis-reva-168
+  Scenario Outline: try to create a folder that already exists
+    Given using <dav_version> DAV path
+    And user "user0" has created folder "my-data"
+    When user "user0" creates folder "my-data" using the WebDAV API
+    Then the HTTP status code should be "405"
+    And as "user0" folder "my-data" should exist
+    And the DAV exception should be "Sabre\DAV\Exception\MethodNotAllowed"
+    And the DAV message should be "The resource you tried to create already exists"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcV10 @issue-ocis-reva-168
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario Outline: try to create a folder that already exists
+    Given using <dav_version> DAV path
+    And user "user0" has created folder "my-data"
+    When user "user0" creates folder "my-data" using the WebDAV API
+    Then the HTTP status code should be "405"
+    And as "user0" folder "my-data" should exist
+    And the body of the response should be empty
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis @issue-ocis-reva-168
+  Scenario Outline: try to create a folder with a name of an existing file
+    Given using <dav_version> DAV path
+    And user "user0" has uploaded file with content "uploaded data" to "/my-data.txt"
+    When user "user0" creates folder "my-data.txt" using the WebDAV API
+    Then the HTTP status code should be "405"
+    And the DAV exception should be "Sabre\DAV\Exception\MethodNotAllowed"
+    And the DAV message should be "The resource you tried to create already exists"
+    And the content of file "/my-data.txt" for user "user0" should be "uploaded data"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcV10 @issue-ocis-reva-168
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario Outline: try to create a folder with a name of an existing file
+    Given using <dav_version> DAV path
+    And user "user0" has uploaded file with content "uploaded data" to "/my-data.txt"
+    When user "user0" creates folder "my-data.txt" using the WebDAV API
+    Then the HTTP status code should be "405"
+    And the body of the response should be empty
+    And the content of file "/my-data.txt" for user "user0" should be "uploaded data"
     Examples:
       | dav_version |
       | old         |


### PR DESCRIPTION
## Description
Test how the webdav API reacts when creating a folder with a name of an existing resource

test-run in ocis-reva https://github.com/owncloud/ocis-reva/pull/169

## Related Issue
see https://github.com/owncloud/ocis-reva/issues/165#issuecomment-623378937

## Motivation and Context
more tests === more better

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
