### PR TITLE
[Tests-Only] Remove unneeded phpstan ignoreErrors entry

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,7 +36,6 @@ parameters:
     # errors below are to be addressed by own pull requests - non trivial changes required
     - '#Unsafe usage of new static().#'
     - '#Cannot instantiate interface OCP\\Files\\ObjectStore\\IObjectStore.#'
-    - '#Result of function rewinddir \(void\) is used.#'
     - '#Instantiated class OCA\\Encryption\\Crypto\\Crypt not found.#'
     - '#Instantiated class OCA\\Encryption\\Util not found.#'
     - '#Instantiated class OCA\\Encryption\\KeyManager not found.#'


### PR DESCRIPTION
## Description
```
make test-php-phpstan
composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead.
Package guzzlehttp/ringphp is abandoned, you should avoid using it. No replacement was suggested.
Package guzzlehttp/streams is abandoned, you should avoid using it. No replacement was suggested.
Package jakub-onderka/php-console-color is abandoned, you should avoid using it. Use php-parallel-lint/php-console-color instead.
Package jakub-onderka/php-console-highlighter is abandoned, you should avoid using it. Use php-parallel-lint/php-console-highlighter instead.
Generating optimized autoload files
Composer cleaner: Removed 5 files or directories.
composer bin phpstan install --no-progress
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=2G --configuration=./phpstan.neon --level=0 apps core settings lib/private lib/public ocs ocs-provider
 1367/1367 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 -- ------------------------------------------------------------------------------------------------------------ 
     Error                                                                                                       
 -- ------------------------------------------------------------------------------------------------------------ 
     Ignored error pattern #Result of function rewinddir \(void\) is used.# was not matched in reported errors.  
 -- ------------------------------------------------------------------------------------------------------------ 

                                                                                                                        
 [ERROR] Found 1 error                                                                                                  
                                                                                                                        

Makefile:231: recipe for target 'test-php-phpstan' failed
make: *** [test-php-phpstan] Error 1
```

This started happening today because that error pattern was actually a bug in `phpstan`. The bug was fixed in https://github.com/phpstan/phpstan-src/pull/192 and released in https://github.com/phpstan/phpstan/releases/tag/0.12.22 

So now our CI fails because it was expected this "error" to be reported. But it is no longer reported.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
