### PR TITLE
Fix sharing with uids in numerical format

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -404,7 +404,7 @@ class Share20OcsController extends OCSController {
 				$userAutoAccept = $this->config->getUserValue($shareWith, 'files_sharing', 'auto_accept_share', 'yes') === 'yes';
 			}
 			// Valid user is required to share
-			if ($shareWith === null || !$this->userManager->userExists($shareWith)) {
+			if (!\is_string($shareWith) || !$this->userManager->userExists($shareWith)) {
 				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 				return new Result(null, 404, $this->l->t('Please specify a valid user'));
 			}
@@ -422,7 +422,7 @@ class Share20OcsController extends OCSController {
 			}
 
 			// Valid group is required to share
-			if ($shareWith === null || !$this->groupManager->groupExists($shareWith)) {
+			if (!\is_string($shareWith) || !$this->groupManager->groupExists($shareWith)) {
 				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 				return new Result(null, 404, $this->l->t('Please specify a valid group'));
 			}
@@ -494,7 +494,10 @@ class Share20OcsController extends OCSController {
 				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 				return new Result(null, 403, $this->l->t('Sharing %s failed because the back end does not allow shares from type %s', [$path->getPath(), $shareType]));
 			}
-
+			if (!\is_string($shareWith)) {
+				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
+				return new Result(null, 404, $this->l->t('shareWith parameter must be a string'));
+			}
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
 		} else {

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -189,7 +189,12 @@ class ShareesController extends OCSController {
 
 		$foundUserById = false;
 		$lowerSearch = \strtolower($search);
-		foreach ($users as $uid => $user) {
+		foreach ($users as $user) {
+			/**
+			 * Php parses numeric UID strings as integer in array key,
+			 * because of that, we need to learn uid from User object
+			 */
+			$uid = $user->getUID();
 			/* @var $user IUser */
 			$entry = [
 				'label' => $user->getDisplayName(),

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -424,7 +424,7 @@ class ShareesTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test' => $this->getUserMock('test1', 'Test One'),
+						'test' => $this->getUserMock('test', 'Test One'),
 					]],
 					['xyz', 'test', 2, 0, [
 						'test2' => $this->getUserMock('test2', 'Test Two'),
@@ -446,7 +446,7 @@ class ShareesTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test' => $this->getUserMock('test1', 'Test One'),
+						'test' => $this->getUserMock('test', 'Test One'),
 					]],
 					['xyz', 'test', 2, 0, [
 						'test2' => $this->getUserMock('test2', 'Test Two'),

--- a/changelog/unreleased/37324
+++ b/changelog/unreleased/37324
@@ -1,0 +1,7 @@
+Bugfix: Cannot share with user name that has only numbers in the UI
+
+A regression in 10.4.0 meant that new shares with user names that were numbers
+could not be created in the UI. This regression has been fixed.
+
+https://github.com/owncloud/core/issues/37324
+https://github.com/owncloud/core/pull/37336

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -56,16 +56,26 @@ Feature: Sharing files and folders with internal users
     And file "lorem.txt" should not be listed in shared-with-others page on the webUI
     And as "user2" file "lorem (2).txt" should not exist
 
-  Scenario: user shares a file with another user with uppercase username
+  @skipOnOcV10.3 @skipOnOcV10.4
+  Scenario Outline: user shares a file with another user with unusual usernames
     Given user "user1" has been created with default attributes and skeleton files
     And these users have been created without skeleton files:
-      | username |
-      | SomeUser |
+      | username   |
+      | <username> |
     And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "SomeUser" using the webUI
-    And the user re-logs in as "SomeUser" using the webUI
+    When the user shares file "lorem.txt" with user "<username>" using the webUI
+    And the user re-logs in as "<username>" using the webUI
     And the user browses to the shared-with-you page
     Then file "lorem.txt" should be listed on the webUI
+    Examples:
+      | username  |
+      | 123456    |
+      | -12       |
+      | +12       |
+      | 1.2       |
+      | 1.2E3     |
+      | 0x10      |
+      | Some-User |
 
   Scenario: multiple users share a file with the same name to a user
     Given these users have been created with default attributes and without skeleton files:


### PR DESCRIPTION
## Description
Php does not allow numeric string as array key and converts these strings to integer. Share autocompletion api returns numerical uids as integer because of the desribed behavior of php. 

When autcomplete share api response directly used in ownCloud clients without type checking, it leds to problem when sharing with numerical uids. This PR fixes api response.

## Related Issue
- Fixes #37324

## How Has This Been Tested?
- Acceptance tests added.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
