### PR TITLE
Catch setSharedWith InvalidArgumentException

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -408,7 +408,12 @@ class Share20OcsController extends OCSController {
 				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 				return new Result(null, 404, $this->l->t('Please specify a valid user'));
 			}
-			$share->setSharedWith($shareWith);
+			try {
+				$share->setSharedWith($shareWith);
+			} catch (\InvalidArgumentException $e) {
+				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
+				return new Result(null, 403, $e->getMessage());
+			}
 			$share->setPermissions($permissions);
 			if ($userAutoAccept) {
 				$share->setState(Share::STATE_ACCEPTED);
@@ -429,7 +434,12 @@ class Share20OcsController extends OCSController {
 			if ($this->sharingBlacklist->isGroupBlacklisted($this->groupManager->get($shareWith))) {
 				return new Result(null, 403, $this->l->t('The group is blacklisted for sharing'));
 			}
-			$share->setSharedWith($shareWith);
+			try {
+				$share->setSharedWith($shareWith);
+			} catch (\InvalidArgumentException $e) {
+				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
+				return new Result(null, 403, $e->getMessage());
+			}
 			$share->setPermissions($permissions);
 			if ($globalAutoAccept) {
 				$share->setState(Share::STATE_ACCEPTED);
@@ -495,7 +505,12 @@ class Share20OcsController extends OCSController {
 				return new Result(null, 403, $this->l->t('Sharing %s failed because the back end does not allow shares from type %s', [$path->getPath(), $shareType]));
 			}
 
-			$share->setSharedWith($shareWith);
+			try {
+				$share->setSharedWith($shareWith);
+			} catch (\InvalidArgumentException $e) {
+				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
+				return new Result(null, 403, $e->getMessage());
+			}
 			$share->setPermissions($permissions);
 		} else {
 			$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -195,7 +195,7 @@ class ShareesController extends OCSController {
 				'label' => $user->getDisplayName(),
 				'value' => [
 					'shareType' => Share::SHARE_TYPE_USER,
-					'shareWith' => $uid,
+					'shareWith' => $user->getUID(),
 				],
 			];
 			$additionalInfo = $this->getAdditionalUserInfo($user);

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -424,7 +424,7 @@ class ShareesTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test' => $this->getUserMock('test1', 'Test One'),
+						'test' => $this->getUserMock('test', 'Test One'),
 					]],
 					['xyz', 'test', 2, 0, [
 						'test2' => $this->getUserMock('test2', 'Test Two'),
@@ -446,7 +446,7 @@ class ShareesTest extends TestCase {
 				['abc', 'xyz'],
 				[
 					['abc', 'test', 2, 0, [
-						'test' => $this->getUserMock('test1', 'Test One'),
+						'test' => $this->getUserMock('test', 'Test One'),
 					]],
 					['xyz', 'test', 2, 0, [
 						'test2' => $this->getUserMock('test2', 'Test Two'),

--- a/changelog/unreleased/37324
+++ b/changelog/unreleased/37324
@@ -1,0 +1,7 @@
+Bugfix: Cannot share with user name that has only numbers in the UI
+
+A regression in 10.4.0 meant that new shares with user names that were numbers
+could not be created in the UI. This regression has been fixed.
+
+https://github.com/owncloud/core/issues/37324
+https://github.com/owncloud/core/pull/37336

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -243,7 +243,9 @@ class Share implements IShare {
 	 */
 	public function setSharedWith($sharedWith) {
 		if (!\is_string($sharedWith)) {
-			throw new \InvalidArgumentException();
+			throw new \InvalidArgumentException(
+				"sharedWith is " . \gettype($sharedWith) . " but must be a string"
+			);
 		}
 		$this->sharedWith = $sharedWith;
 		return $this;

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -56,16 +56,25 @@ Feature: Sharing files and folders with internal users
     And file "lorem.txt" should not be listed in shared-with-others page on the webUI
     And as "user2" file "lorem (2).txt" should not exist
 
-  Scenario: user shares a file with another user with uppercase username
+  Scenario Outline: user shares a file with another user with unusual usernames
     Given user "user1" has been created with default attributes and skeleton files
     And these users have been created without skeleton files:
-      | username |
-      | SomeUser |
+      | username   |
+      | <username> |
     And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "SomeUser" using the webUI
-    And the user re-logs in as "SomeUser" using the webUI
+    When the user shares file "lorem.txt" with user "<username>" using the webUI
+    And the user re-logs in as "<username>" using the webUI
     And the user browses to the shared-with-you page
     Then file "lorem.txt" should be listed on the webUI
+    Examples:
+      | username  |
+      | 123456    |
+      | -12       |
+      | +12       |
+      | 1.2       |
+      | 1.2E3     |
+      | 0x10      |
+      | Some-User |
 
   Scenario: multiple users share a file with the same name to a user
     Given these users have been created with default attributes and without skeleton files:


### PR DESCRIPTION
## Description
POC on top of PR #37336 

This PR demonstrates how we could catch an `InvalidArgumentException` thrown by `setSharedWith` if someone does an API call like:

```
curl --user jim:jim http://172.17.0.1:8080/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json -d '{"shareType": 0, "shareWith": 256, "permissions": 31, "path": "/faaa"}' -X POST -H "Content-Type: application/json"
{"ocs":{"meta":{"status":"failure","statuscode":403,"message":"sharedWith is integer but must be a string","totalitems":"","itemsperpage":""},"data":[]}}
```

So they get a 403 and error message instead of a 500 with no message.

## Related Issue
#37324 

## How Has This Been Tested?
Needs unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
