### PR TITLE
[Tests-Only] Fix scanLocalStorage scenario

### DIFF
--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
@@ -45,7 +45,7 @@ Feature: Scanning files on local storage
       | /local_storage/folder1/hello1.txt |
     When user "user0" requests "/remote.php/dav/files/user0/local_storage/folder2" with "PROPFIND" using basic auth
     Then the propfind result of user "user0" should not contain these entries:
-      | /local_storage/folder1/hello2.txt |
+      | /local_storage/folder2/hello2.txt |
 
   @files_sharing-app-required @skipOnLDAP
   Scenario Outline: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group


### PR DESCRIPTION
## Description
The scenario creates `folder2/hello2.txt` but at the end it was checking for the existence of `folder1/hello2.txt`, which never existed anyway.

It should be checking that `folder2/hello2.txt` does not exist.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
