### PR TITLE
[Tests-Only] Skip fixed complex dav property test on old ownCloud 10.3 and 10.4

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
@@ -20,6 +20,7 @@ Feature: set file properties
       | old         |
       | new         |
 
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario Outline: Setting custom complex DAV property and reading it
     Given using <dav_version> DAV path
     And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/testcustomprop.txt"


### PR DESCRIPTION
## Description
This acceptance test scenario was adjusted and the associated bug fixed by PR #37314 and will be in 10.5.0. Skip the test when run against a 10.3 or 10.4 system - it will not pass against those.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
