### PR TITLE
[Tests-Only] Skip meta username test on 10.4

### DIFF
--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -39,6 +39,11 @@ Feature: add users
       | a)~  | "%alt2%"    | Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "+_.@-'" |
       | a(=  | "%alt3%"    | Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "+_.@-'" |
       | a`*^ | "%alt4%"    | Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "+_.@-'" |
+
+  @skipOnOcV10.3 @skipOnOcV10.4
+  Scenario: use the webUI to create a user with special invalid username
+    When the administrator attempts to create these users then the notifications should be as listed
+      | user | password    | notification                                                                                                    |
       | meta | "%alt4%"    | Error creating user: The special username meta is not allowed                                                   |
 
   Scenario: use the webUI to create a user with empty password


### PR DESCRIPTION
## Description
PR #37268 added code that prohibits certain special usernames. The acceptance test that was added will only work in 10.5 onwards. Skip it on older ownCloud versions.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
