### PR TITLE
[Tests-Only] Fix testCreateShareGroupNoValidShareWith issue 37350

### DIFF
--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -888,8 +888,8 @@ class Share20OcsControllerTest extends TestCase {
 				->will($this->returnValueMap([
 						['path', null, 'valid-path'],
 						['permissions', null, \OCP\Constants::PERMISSION_ALL],
-						['shareType', $this->any(), Share::SHARE_TYPE_GROUP],
-						['shareWith', $this->any(), $shareWith],
+						['shareType', '-1', Share::SHARE_TYPE_GROUP],
+						['shareWith', null, $shareWith],
 				]));
 
 		$userFolder = $this->createMock('\OCP\Files\Folder');
@@ -909,7 +909,11 @@ class Share20OcsControllerTest extends TestCase {
 				->with('valid-path')
 				->willReturn($path);
 
-		$expected = new Result(null, 404, 'Please specify a valid user');
+		$this->shareManager->expects($this->once())
+			->method('allowGroupSharing')
+			->willReturn(true);
+
+		$expected = new Result(null, 404, 'Please specify a valid group');
 
 		$path->expects($this->once())
 			->method('lock')


### PR DESCRIPTION
## Description
Adjust the unit test so that it actually tests the group sharing case.

## Related Issue
- Fixes #37350 

## How Has This Been Tested?
Unit test run

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
