### PR TITLE
[Tests-Only] Run phpunit from the tests dir

### DIFF
--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -42,7 +42,7 @@ set_up_external_storage() {
       exit 1
       ;;
   esac
-  FILES_EXTERNAL_TEST_TO_RUN="apps/files_external/tests/Storage/${FILES_EXTERNAL_TEST_TO_RUN}"
+  FILES_EXTERNAL_TEST_TO_RUN="../apps/files_external/tests/Storage/${FILES_EXTERNAL_TEST_TO_RUN}"
 }
 
 if [[ "${DB_TYPE}" == "sqlite" || -z "${DB_TYPE}" || "${COVERAGE}" == "true" ]]; then
@@ -54,15 +54,17 @@ fi
 # show a little debug information
 php occ app:list
 
-phpunit_cmd="php ./lib/composer/bin/phpunit"
+phpunit_cmd="php ../lib/composer/bin/phpunit"
 if [[ "${COVERAGE}" == "true" ]]; then
-    phpunit_cmd="phpdbg -d memory_limit=4096M -rr ./lib/composer/bin/phpunit"
+    phpunit_cmd="phpdbg -d memory_limit=4096M -rr ../lib/composer/bin/phpunit"
 fi
 
 if [[ -n "${FILES_EXTERNAL_TYPE}" ]]; then
     set_up_external_storage
-    $phpunit_cmd --configuration tests/phpunit-autotest-external.xml ${GROUP} --coverage-clover tests/output/coverage/autotest-external-clover-"${DB_TYPE}".xml
-    $phpunit_cmd --configuration tests/phpunit-autotest-external.xml ${GROUP} --coverage-clover tests/output/coverage/autotest-external-clover-"${DB_TYPE}"-"${FILES_EXTERNAL_TYPE}".xml "${FILES_EXTERNAL_TEST_TO_RUN}"
+    cd tests
+    $phpunit_cmd --configuration phpunit-autotest-external.xml ${GROUP} --coverage-clover output/coverage/autotest-external-clover-"${DB_TYPE}".xml
+    $phpunit_cmd --configuration phpunit-autotest-external.xml ${GROUP} --coverage-clover output/coverage/autotest-external-clover-"${DB_TYPE}"-"${FILES_EXTERNAL_TYPE}".xml "${FILES_EXTERNAL_TEST_TO_RUN}"
 else
-    $phpunit_cmd --configuration tests/phpunit-autotest.xml ${GROUP} --coverage-clover tests/output/coverage/autotest-clover-"${DB_TYPE}".xml
+    cd tests
+    $phpunit_cmd --configuration phpunit-autotest.xml ${GROUP} --coverage-clover output/coverage/autotest-clover-"${DB_TYPE}".xml
 fi


### PR DESCRIPTION
## Description
`make test-php-unit` runs `build/autotest.sh` which does all the stuff to setup and run PHP unit tests. That script changes the working directory to the `tests` directory and runs from there.

Drone CI runs `tests/drone/test-phpunit.sh` - that script does not `cd tests` It runs unit tests with the working directory not in `tests`. When I try to use `phpunit` 9 it complains:
```
php ./lib/composer/bin/phpunit --configuration tests/phpunit-autotest.xml --coverage-clover tests/output/coverage/autotest-clover-sqlite.xml
PHP Fatal error:  Uncaught PHPUnit\Framework\Exception: Cannot open file "tests/apps.php".


  thrown in /drone/src/lib/composer/phpunit/phpunit/src/Util/FileLoader.php on line 39
```
It does not cope with trying to find `apps.php` inside `tests` (which is referenced from `tests/phpunit-autotest.xml` )

It will be nicer if `tests/drone/test-phpunit.sh` works more like `build/autotest.sh` by doing `cd tests` before running `phpunit`. That keeps `phpunit` 9 happy for the future, and makes our scripts a little  bit more consistent.

Note: there is the whole issue of "why do we have these 2 different shell scripts for running phpunit" - that is another issue that I did not want to get into right now.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
