### PR TITLE
[Tests-Only] Refactor unit test calls

### DIFF
--- a/tests/lib/AppFramework/Db/EntityTest.php
+++ b/tests/lib/AppFramework/Db/EntityTest.php
@@ -104,7 +104,7 @@ class EntityTest extends \Test\TestCase {
 	public function testSetterMarksFieldUpdated() {
 		$this->entity->setId(3);
 
-		$this->assertContains('id', $this->entity->getUpdatedFields());
+		$this->assertArrayHasKey('id', $this->entity->getUpdatedFields());
 	}
 
 	public function testCallShouldOnlyWorkForGetterSetter() {

--- a/tests/lib/Files/External/Backend/BackendTest.php
+++ b/tests/lib/Files/External/Backend/BackendTest.php
@@ -40,8 +40,8 @@ class BackendTest extends \Test\TestCase {
 		$this->assertEquals($json['name'], $json['backend']);
 		$this->assertEquals(57, $json['priority']);
 
-		$this->assertContains('foopass', $json['authSchemes']);
-		$this->assertContains('barauth', $json['authSchemes']);
+		$this->assertArrayHasKey('foopass', $json['authSchemes']);
+		$this->assertArrayHasKey('barauth', $json['authSchemes']);
 	}
 
 	public function validateStorageProvider() {

--- a/tests/lib/Files/Storage/DavTest.php
+++ b/tests/lib/Files/Storage/DavTest.php
@@ -407,7 +407,7 @@ class DavTest extends TestCase {
 	public function testFileTypeDir() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir/file%25type', $this->contains('{DAV:}resourcetype'))
+			->with('some%25dir/file%25type', $this->containsIdentical('{DAV:}resourcetype'))
 			->willReturn([
 				'{DAV:}resourcetype' => $this->getResourceTypeResponse(true)
 			]);
@@ -418,7 +418,7 @@ class DavTest extends TestCase {
 	public function testFileTypeFile() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir/file%25type', $this->contains('{DAV:}resourcetype'))
+			->with('some%25dir/file%25type', $this->containsIdentical('{DAV:}resourcetype'))
 			->willReturn([]);
 
 		$this->assertEquals('file', $this->instance->filetype('/some%dir/file%type'));
@@ -427,7 +427,7 @@ class DavTest extends TestCase {
 	public function testFileTypeNotFound() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir/file%25type', $this->contains('{DAV:}resourcetype'))
+			->with('some%25dir/file%25type', $this->containsIdentical('{DAV:}resourcetype'))
 			->willThrowException($this->createClientHttpException(Http::STATUS_NOT_FOUND));
 
 		$this->assertFalse($this->instance->filetype('/some%dir/file%type'));
@@ -440,7 +440,7 @@ class DavTest extends TestCase {
 
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir/file%25type', $this->contains('{DAV:}resourcetype'))
+			->with('some%25dir/file%25type', $this->containsIdentical('{DAV:}resourcetype'))
 			->willThrowException($this->createClientHttpException(Http::STATUS_FORBIDDEN));
 
 		$this->instance->filetype('/some%dir/file%type');
@@ -637,7 +637,7 @@ class DavTest extends TestCase {
 		// isCreatable on parent / getPermissions
 		$this->davClient->expects($this->at(1))
 			->method('propfind')
-			->with('some%25dir', $this->contains('{http://owncloud.org/ns}permissions'))
+			->with('some%25dir', $this->containsIdentical('{http://owncloud.org/ns}permissions'))
 			->willReturn([
 				'{http://owncloud.org/ns}permissions' => 'RDWCK'
 			]);
@@ -670,7 +670,7 @@ class DavTest extends TestCase {
 		// isCreatable on parent / getPermissions
 		$this->davClient->expects($this->at(1))
 			->method('propfind')
-			->with('some%25dir', $this->contains('{http://owncloud.org/ns}permissions'))
+			->with('some%25dir', $this->containsIdentical('{http://owncloud.org/ns}permissions'))
 			->willReturn([
 				'{http://owncloud.org/ns}permissions' => 'R'
 			]);
@@ -779,7 +779,7 @@ class DavTest extends TestCase {
 	public function testFreeSpace($propFindResponse, $apiResponse) {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir', $this->contains('{DAV:}quota-available-bytes'), 0)
+			->with('some%25dir', $this->containsIdentical('{DAV:}quota-available-bytes'), 0)
 			->willReturn($propFindResponse);
 
 		$this->assertEquals($apiResponse, $this->instance->free_space('/some%dir'));
@@ -830,7 +830,7 @@ class DavTest extends TestCase {
 		// propfind after proppatch, to check if applied
 		$this->davClient->expects($this->at(2))
 			->method('propfind')
-			->with('some%25dir', $this->contains('{DAV:}getlastmodified'), 0)
+			->with('some%25dir', $this->containsIdentical('{DAV:}getlastmodified'), 0)
 			->willReturn([
 				'{DAV:}getlastmodified' => $readMtime
 			]);
@@ -848,7 +848,7 @@ class DavTest extends TestCase {
 		// isCreatable on parent / getPermissions
 		$this->davClient->expects($this->at(1))
 			->method('propfind')
-			->with('some%25dir', $this->contains('{http://owncloud.org/ns}permissions'))
+			->with('some%25dir', $this->containsIdentical('{http://owncloud.org/ns}permissions'))
 			->willReturn([
 				'{http://owncloud.org/ns}permissions' => 'RDWCK'
 			]);
@@ -900,7 +900,7 @@ class DavTest extends TestCase {
 		// maybe the file disappeared in-between ?
 		$this->davClient->expects($this->at(2))
 			->method('propfind')
-			->with('some%25dir', $this->contains('{DAV:}getlastmodified'), 0)
+			->with('some%25dir', $this->containsIdentical('{DAV:}getlastmodified'), 0)
 			->willReturn(false);
 
 		$this->assertFalse($this->instance->touch('/some%dir', 1508496363));
@@ -935,7 +935,7 @@ class DavTest extends TestCase {
 	public function testRename($httpMethod, $storageMethod, $isDir, $extra) {
 		$mock = $this->davClient->expects($this->once())
 			->method('propfind')
-			->with('new%25path/new%25file.txt', $this->contains('{DAV:}resourcetype'));
+			->with('new%25path/new%25file.txt', $this->containsIdentical('{DAV:}resourcetype'));
 		$mock->willReturn([
 				'{DAV:}resourcetype' => $this->getResourceTypeResponse($isDir)
 			]);
@@ -972,7 +972,7 @@ class DavTest extends TestCase {
 	public function testStat($davResponse, $apiResponse) {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir/file%25type', $this->logicalAnd($this->contains('{DAV:}getlastmodified'), $this->contains('{DAV:}getcontentlength')))
+			->with('some%25dir/file%25type', $this->logicalAnd($this->containsIdentical('{DAV:}getlastmodified'), $this->containsIdentical('{DAV:}getcontentlength')))
 			->willReturn($davResponse);
 
 		$this->assertEquals($apiResponse, $this->instance->stat('/some%dir/file%type'));
@@ -981,7 +981,7 @@ class DavTest extends TestCase {
 	public function testStatRoot() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('', $this->logicalAnd($this->contains('{DAV:}getlastmodified'), $this->contains('{DAV:}getcontentlength')))
+			->with('', $this->logicalAnd($this->containsIdentical('{DAV:}getlastmodified'), $this->containsIdentical('{DAV:}getcontentlength')))
 			->willReturn(['{DAV:}getlastmodified' => '2017-10-20T12:46:03+02:00']);
 
 		$this->assertEquals(['mtime' => 1508496363, 'size' => 0], $this->instance->stat(''));
@@ -1035,7 +1035,7 @@ class DavTest extends TestCase {
 	public function testMimeType($davResponse, $apiResponse) {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir/file%25type', $this->logicalAnd($this->contains('{DAV:}resourcetype'), $this->contains('{DAV:}getcontenttype')))
+			->with('some%25dir/file%25type', $this->logicalAnd($this->containsIdentical('{DAV:}resourcetype'), $this->containsIdentical('{DAV:}getcontenttype')))
 			->willReturn($davResponse);
 
 		$this->assertEquals($apiResponse, $this->instance->getMimeType('/some%dir/file%type'));
@@ -1069,7 +1069,7 @@ class DavTest extends TestCase {
 	public function testPermissions($perms, $creatable, $updatable, $deletable, $sharable) {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir', $this->contains('{http://owncloud.org/ns}permissions'))
+			->with('some%25dir', $this->containsIdentical('{http://owncloud.org/ns}permissions'))
 			->willReturn([
 				'{http://owncloud.org/ns}permissions' => $perms
 			]);
@@ -1084,7 +1084,7 @@ class DavTest extends TestCase {
 	public function testNoPermissionsDir() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir', $this->contains('{http://owncloud.org/ns}permissions'))
+			->with('some%25dir', $this->containsIdentical('{http://owncloud.org/ns}permissions'))
 			->willReturn(['{DAV:}resourcetype' => $this->getResourceTypeResponse(true)]);
 
 		// all perms given
@@ -1098,7 +1098,7 @@ class DavTest extends TestCase {
 	public function testNoPermissionsFile() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir', $this->contains('{http://owncloud.org/ns}permissions'))
+			->with('some%25dir', $this->containsIdentical('{http://owncloud.org/ns}permissions'))
 			->willReturn(['{DAV:}resourcetype' => $this->getResourceTypeResponse(false)]);
 
 		// all perms given except create
@@ -1112,7 +1112,7 @@ class DavTest extends TestCase {
 	public function testGetPermissionsUnexist() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir', $this->contains('{http://owncloud.org/ns}permissions'))
+			->with('some%25dir', $this->containsIdentical('{http://owncloud.org/ns}permissions'))
 			->willReturn(false);
 
 		// all perms given
@@ -1140,7 +1140,7 @@ class DavTest extends TestCase {
 	public function testGetEtag() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir', $this->contains('{DAV:}getetag'))
+			->with('some%25dir', $this->containsIdentical('{DAV:}getetag'))
 			->willReturn([
 				'{DAV:}getetag' => '"thisisanetagisntit"'
 			]);
@@ -1151,7 +1151,7 @@ class DavTest extends TestCase {
 	public function testGetEtagFallback() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir', $this->contains('{DAV:}getetag'))
+			->with('some%25dir', $this->containsIdentical('{DAV:}getetag'))
 			->willReturn([]);
 
 		// unique id
@@ -1161,7 +1161,7 @@ class DavTest extends TestCase {
 	public function testGetEtagUnexist() {
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir', $this->contains('{DAV:}getetag'))
+			->with('some%25dir', $this->containsIdentical('{DAV:}getetag'))
 			->willReturn(false);
 
 		$this->assertNull($this->instance->getETag('some%dir'));
@@ -1174,7 +1174,7 @@ class DavTest extends TestCase {
 
 		$this->davClient->expects($this->once())
 			->method('propfind')
-			->with('some%25dir', $this->contains('{DAV:}getetag'))
+			->with('some%25dir', $this->containsIdentical('{DAV:}getetag'))
 			->willThrowException($this->createClientHttpException(Http::STATUS_FORBIDDEN));
 
 		$this->instance->getETag('some%dir');
@@ -1285,10 +1285,10 @@ class DavTest extends TestCase {
 			->method('propfind')
 			->with('some%25dir',
 				$this->logicalAnd(
-					$this->contains('{DAV:}getetag'),
-					$this->contains('{DAV:}getlastmodified'),
-					$this->contains('{http://owncloud.org/ns}permissions'),
-					$this->contains('{http://open-collaboration-services.org/ns}share-permissions')
+					$this->containsIdentical('{DAV:}getetag'),
+					$this->containsIdentical('{DAV:}getlastmodified'),
+					$this->containsIdentical('{http://owncloud.org/ns}permissions'),
+					$this->containsIdentical('{http://open-collaboration-services.org/ns}share-permissions')
 				)
 			)
 			->willReturn($davResponse);

--- a/tests/lib/Repair/RemoveGetETagEntriesTest.php
+++ b/tests/lib/Repair/RemoveGetETagEntriesTest.php
@@ -61,7 +61,7 @@ class RemoveGetETagEntriesTest extends TestCase {
 
 		$this->assertCount(2, $entries, 'Asserts that two entries are returned as we have inserted two');
 		foreach ($entries as $entry) {
-			$this->assertContains($entry, $data, 'Asserts that the entries are the ones from the test data set');
+			$this->assertContainsEquals($entry, $data, 'Asserts that the entries are the ones from the test data set');
 		}
 
 		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */

--- a/tests/lib/Repair/RepairSubSharesTest.php
+++ b/tests/lib/Repair/RepairSubSharesTest.php
@@ -146,7 +146,7 @@ class RepairSubSharesTest extends TestCase {
 		$this->assertCount(3, $results);
 
 		foreach ($results as $id) {
-			$this->assertContains($id, $getAllIdsPerUser[$id['share_with']]);
+			$this->assertContainsEquals($id, $getAllIdsPerUser[$id['share_with']]);
 		}
 	}
 
@@ -228,7 +228,7 @@ class RepairSubSharesTest extends TestCase {
 		$this->assertCount(7, $results);
 
 		foreach ($results as $id) {
-			$this->assertContains($id, $getAllIdsPerUser['ids']);
+			$this->assertContainsEquals($id, $getAllIdsPerUser['ids']);
 		}
 
 		//Verify that these ids are not there
@@ -295,7 +295,7 @@ class RepairSubSharesTest extends TestCase {
 		$this->assertCount(6, $results);
 
 		foreach ($results as $id) {
-			$this->assertContains($id, $getAllIdsPerUser['ids']);
+			$this->assertContainsEquals($id, $getAllIdsPerUser['ids']);
 			if (\array_search($id, $results, true) === 5) {
 				for ($i = $id['id'] + 1; $i < $id['id'] + 486; $i++) {
 					$this->assertNotContains(['id' => $i], $results);

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -1521,7 +1521,7 @@ class DefaultShareProviderTest extends TestCase {
 				$shareNode = $share->getNode();
 				$this->assertSame($node1, $shareNode);
 			} else {
-				$this->assertContains($share->getId(), $idGroups);
+				$this->assertContains((int) $share->getId(), $idGroups);
 				$this->assertStringStartsWith('group', $share->getSharedWith());
 				$this->assertSame('user1', $share->getShareOwner());
 				$this->assertSame('user1', $share->getSharedBy());


### PR DESCRIPTION
## Description
In phpunit9 some things are changing. The new way of doing these things is already possible in phpunit8, so do it now:

- `assertContains` stops looking at keys, it just looks in values. Use `assertArrayHasKey` to look for a key existing.
- `contains` becomes `containsEquals` or `containsIdentical` - use the new ones.
- `assertContains` adds `assertContainsEquals` or `assertContainsIdentical`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
