### PR TITLE
[Tests-Only] Skip local-storage read-only test UI test on ceph and scality object storage

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -165,6 +165,7 @@ Feature: admin storage settings
     And folder "local_storage1" should be listed on the webUI
 
   @issue-36803
+  @issue-files_primary_s3-351 @skipOnStorage:ceph @skipOnStorage:scality
   Scenario: applicable user is not able to share top-level of read-only storage
     Given these users have been created with default attributes and without skeleton files:
       | username |


### PR DESCRIPTION
## Description
In core, when local storage is set `read_only` there is a known problem when trying to share the top-level of the storage - issue #36803 A core test scenario demonstrating that was added in PR #37262 

The test scenario behaves differently with `files_primary_s3` object storage (e.g. ceph or scality)
https://drone.owncloud.com/owncloud/files_primary_s3/1680/15/19
```
  @issue-36803
  Scenario: applicable user is not able to share top-level of read-only storage                                                               # /var/www/owncloud/testrunner/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature:168
    Given these users have been created with default attributes and without skeleton files:                                                   # FeatureContext::theseUsersHaveBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles()
      | username |
      | user0    |
      | user1    |
    And the administrator has enabled the external storage                                                                                    # OccContext::enableExternalStorageUsingOccAsAdmin()
    And the administrator has browsed to the admin storage settings page                                                                      # WebUIAdminStorageSettingsContext::theAdministratorHasBrowsedToTheAdminStorageSettingsPage()
    And the administrator has created the local storage mount "local_storage1" from the admin storage settings page                           # WebUIAdminStorageSettingsContext::theAdministratorHasCreatedTheLocalStorageMountUsingTheWebui()
    And the administrator has added user "user0" as the applicable user for the last local storage mount from the admin storage settings page # WebUIAdminStorageSettingsContext::theAdministratorAddsUserAsTheApplicableUserForTheLastLocalStorageMountUsingTheUsingTheWebui()
    And the administrator has enabled read-only for the last created local storage mount using the webUI                                      # WebUIAdminStorageSettingsContext::theAdministratorEnablesReadonlyForTheLastCreatedLocalStorageMountUsingTheWebui()
    And the administrator has enabled sharing for the last created local storage mount using the webUI                                        # WebUIAdminStorageSettingsContext::theAdministratorHasEnabledSharingForTheLastCreatedLocalStorageMountUsingTheWebui()
    And the user has re-logged in as "user0" using the webUI                                                                                  # WebUILoginContext::theUserHasReloggedInUsingTheWebUI()
    When the user shares folder "local_storage1" with user "User One" using the webUI                                                         # WebUISharingContext::theUserSharesFileFolderWithUserUsingTheWebUI()
    Then notifications should be displayed on the webUI with the text                                                                         # WebUIGeneralContext::notificationsShouldBeDisplayedOnTheWebUIWithTheText()
      | Cannot set the requested share permissions for local_storage1 |
      expected at least 1 notifications but only found 0
      Failed asserting that 0 is equal to 1 or is greater than 1.
    And as "user1" folder "local_storage1" should not exist                                                                                   # FeatureContext::asFileOrFolderShouldNotExist()
SCENARIO RESULT: (fail)

--- Failed scenarios:

    /var/www/owncloud/testrunner/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature:168

1 scenario (1 failed)
11 steps (9 passed, 1 failed, 1 skipped)
0m59.96s (24.35Mb)
webUI test rerun failed with exit status: 1
```
There is no error in the webUI. So perhaps the sharing works in this case. But I suspect that there is more to it - perhaps it shares with full permissions rather than `read_only`??? I raised https://github.com/owncloud/files_primary_s3/issues/351 to investigate that in `files_primary_s3`

Skip the scenario when testing with ceph or scality. We can write specific test scenarios in `files_primary_s3` when we understand how the problem is different there.

## Related Issue
#36803 
https://github.com/owncloud/files_primary_s3/issues/351

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
