### PR TITLE
Use return void phpdoc when a function is not supposed to have any return

### DIFF
--- a/lib/private/Activity/Manager.php
+++ b/lib/private/Activity/Manager.php
@@ -158,7 +158,7 @@ class Manager implements IManager {
 	 *  - setSubject()
 	 *
 	 * @param IEvent $event
-	 * @return null
+	 * @return void
 	 * @throws \BadMethodCallException if required values have not been set
 	 */
 	public function publish(IEvent $event) {
@@ -201,7 +201,7 @@ class Manager implements IManager {
 	 * @param string $affectedUser  Recipient of the activity
 	 * @param string $type          Type of the notification
 	 * @param int    $priority      Priority of the notification
-	 * @return null
+	 * @return void
 	 */
 	public function publishActivity($app, $subject, $subjectParams, $message, $messageParams, $file, $link, $affectedUser, $type, $priority) {
 		$event = $this->generateEvent();

--- a/lib/private/DB/PgSqlTools.php
+++ b/lib/private/DB/PgSqlTools.php
@@ -44,7 +44,7 @@ class PgSqlTools {
 	* @brief Resynchronizes all sequences of a database after using INSERTs
 	*        without leaving out the auto-incremented column.
 	* @param \OC\DB\Connection $conn
-	* @return null
+	* @return void
 	*/
 	public function resynchronizeDatabaseSequences(Connection $conn) {
 		$filterExpression = '/^' . \preg_quote($this->config->getSystemValue('dbtableprefix', 'oc_')) . '/';

--- a/lib/private/Log/CommandLogger.php
+++ b/lib/private/Log/CommandLogger.php
@@ -44,7 +44,7 @@ class CommandLogger implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function emergency($message, array $context = []) {
@@ -56,7 +56,7 @@ class CommandLogger implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function alert($message, array $context = []) {
@@ -68,7 +68,7 @@ class CommandLogger implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function critical($message, array $context = []) {
@@ -81,7 +81,7 @@ class CommandLogger implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function error($message, array $context = []) {
@@ -93,7 +93,7 @@ class CommandLogger implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function warning($message, array $context = []) {
@@ -105,7 +105,7 @@ class CommandLogger implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function notice($message, array $context = []) {
@@ -117,7 +117,7 @@ class CommandLogger implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function info($message, array $context = []) {
@@ -129,7 +129,7 @@ class CommandLogger implements ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function debug($message, array $context = []) {

--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -77,7 +77,7 @@ class Manager implements IManager {
 	/**
 	 * @param \Closure $service The service must implement IApp, otherwise a
 	 *                          \InvalidArgumentException is thrown later
-	 * @return null
+	 * @return void
 	 * @since 8.2.0
 	 */
 	public function registerApp(\Closure $service) {
@@ -90,7 +90,7 @@ class Manager implements IManager {
 	 *                          \InvalidArgumentException is thrown later
 	 * @param \Closure $info    An array with the keys 'id' and 'name' containing
 	 *                          the app id and the app name
-	 * @return null
+	 * @return void
 	 * @since 8.2.0 - Parameter $info was added in 9.0.0
 	 */
 	public function registerNotifier(\Closure $service, \Closure $info) {
@@ -225,7 +225,7 @@ class Manager implements IManager {
 
 	/**
 	 * @param INotification $notification
-	 * @return null
+	 * @return void
 	 * @throws \InvalidArgumentException When the notification is not valid
 	 * @since 8.2.0
 	 */
@@ -275,7 +275,7 @@ class Manager implements IManager {
 
 	/**
 	 * @param INotification $notification
-	 * @return null
+	 * @return void
 	 */
 	public function markProcessed(INotification $notification) {
 		$apps = $this->getApps();

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -1496,7 +1496,7 @@ class Share extends Constants {
 	 * Unshares a share given a share data array
 	 * @param array $item Share data (usually database row)
 	 * @param int $newParent parent ID
-	 * @return null
+	 * @return void
 	 */
 	protected static function unshareItem(array $item, $newParent = null) {
 		$shareType = (int)$item['share_type'];

--- a/lib/public/Activity/IConsumer.php
+++ b/lib/public/Activity/IConsumer.php
@@ -39,7 +39,7 @@ namespace OCP\Activity;
 interface IConsumer {
 	/**
 	 * @param IEvent $event
-	 * @return null
+	 * @return void
 	 * @since 6.0.0
 	 * @since 8.2.0 Replaced the parameters with an IEvent object
 	 */

--- a/lib/public/Activity/IManager.php
+++ b/lib/public/Activity/IManager.php
@@ -63,7 +63,7 @@ interface IManager {
 	 *  - setSubject()
 	 *
 	 * @param IEvent $event
-	 * @return null
+	 * @return void
 	 * @since 8.2.0
 	 */
 	public function publish(IEvent $event);
@@ -79,7 +79,7 @@ interface IManager {
 	 * @param string $affectedUser  Recipient of the activity
 	 * @param string $type          Type of the notification
 	 * @param int    $priority      Priority of the notification
-	 * @return null
+	 * @return void
 	 * @since 6.0.0
 	 * @deprecated 8.2.0 Grab an IEvent from generateEvent() instead and use the publish() method
 	 */

--- a/lib/public/ILogger.php
+++ b/lib/public/ILogger.php
@@ -37,7 +37,7 @@ interface ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function emergency($message, array $context = []);
@@ -47,7 +47,7 @@ interface ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function alert($message, array $context = []);
@@ -57,7 +57,7 @@ interface ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function critical($message, array $context = []);
@@ -68,7 +68,7 @@ interface ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function error($message, array $context = []);
@@ -78,7 +78,7 @@ interface ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function warning($message, array $context = []);
@@ -88,7 +88,7 @@ interface ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function notice($message, array $context = []);
@@ -98,7 +98,7 @@ interface ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function info($message, array $context = []);
@@ -108,7 +108,7 @@ interface ILogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return null
+	 * @return void
 	 * @since 7.0.0
 	 */
 	public function debug($message, array $context = []);

--- a/lib/public/Notification/IApp.php
+++ b/lib/public/Notification/IApp.php
@@ -30,7 +30,7 @@ namespace OCP\Notification;
 interface IApp {
 	/**
 	 * @param INotification $notification
-	 * @return null
+	 * @return void
 	 * @throws \InvalidArgumentException When the notification is not valid
 	 * @since 9.0.0
 	 */
@@ -38,7 +38,7 @@ interface IApp {
 
 	/**
 	 * @param INotification $notification
-	 * @return null
+	 * @return void
 	 * @since 9.0.0
 	 */
 	public function markProcessed(INotification $notification);

--- a/lib/public/Notification/IManager.php
+++ b/lib/public/Notification/IManager.php
@@ -31,7 +31,7 @@ interface IManager extends IApp, INotifier {
 	/**
 	 * @param \Closure $service The service must implement IApp, otherwise a
 	 *                          \InvalidArgumentException is thrown later
-	 * @return null
+	 * @return void
 	 * @since 9.0.0
 	 */
 	public function registerApp(\Closure $service);
@@ -41,7 +41,7 @@ interface IManager extends IApp, INotifier {
 	 *                          \InvalidArgumentException is thrown later
 	 * @param \Closure $info    An array with the keys 'id' and 'name' containing
 	 *                          the app id and the app name
-	 * @return null
+	 * @return void
 	 * @since 9.0.0
 	 */
 	public function registerNotifier(\Closure $service, \Closure $info);

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -389,7 +389,7 @@ interface IShare {
 
 	/**
 	 * @param $status
-	 * @return null
+	 * @return void
 	 * @since 10.0.10
 	 */
 	public function setShouldHashPassword($status);

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -551,7 +551,7 @@ class UsersController extends Controller {
 	/**
 	 * @param string $token
 	 * @param string $userId
-	 * @return null
+	 * @return void
 	 * @throws InvalidUserTokenException
 	 * @throws UserTokenExpiredException
 	 * @throws UserTokenMismatchException


### PR DESCRIPTION
## Description
`phpstan` started failing in some apps that implement interfaces defined in core.
Those interfaces  have phpdoc specifying:
```
@return null
```
and phpstan looks for a `return null;` statement in the method implementation.

Change those to:
```
@return void
````

So that it is clear that a return statement is not expected at all.

The 1st commit makes just the changes needed to fix the failing app phpstan.

The 2nd commit changes other places that have `return null` in the phpdoc.

## Related Issue
- Fixes https://github.com/owncloud/notifications/issues/312
- Fixes https://github.com/owncloud/openidconnect/issues/81

## How Has This Been Tested?
Local runs of phpstan

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
