### PR TITLE
[Tests-Only] Explicitly specify empty glue in implode calls

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1326,7 +1326,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 
 		if (\is_array($relativePath)) {
 			// Store the single full concatenated file or folder name.
-			$breadCrumbs[] = \implode($relativePath);
+			$breadCrumbs[] = \implode('', $relativePath);
 			// The passed-in path is itself an array of pieces of a single file
 			// or folder name. That is done when the file or folder name contains
 			// both single and double quotes. The pieces of the file or folder
@@ -1522,7 +1522,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		}
 
 		if (\is_array($name)) {
-			$nameText = \implode($name);
+			$nameText = \implode('', $name);
 		} else {
 			$nameText = $name;
 		}
@@ -1554,7 +1554,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			);
 		} else {
 			if (\is_array($name)) {
-				$name = \implode($name);
+				$name = \implode('', $name);
 			}
 			if ($fileRow === null) {
 				Assert::assertStringContainsString(

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -110,7 +110,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 				$xpathString .= ")";
 			}
 
-			$name = \implode($name);
+			$name = \implode('', $name);
 		} else {
 			$xpathString = $this->quotedText($name);
 		}

--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -194,7 +194,7 @@ class FilesPageCRUD extends FilesPageBasic {
 		$maxRetries = STANDARD_RETRY_COUNT
 	) {
 		if (\is_array($toFileName)) {
-			$toFileName = \implode($toFileName);
+			$toFileName = \implode('', $toFileName);
 		}
 
 		for ($counter = 0; $counter < $maxRetries; $counter++) {
@@ -412,7 +412,7 @@ class FilesPageCRUD extends FilesPageBasic {
 		}
 		if ($expectToDeleteFile && ($counter > 0)) {
 			if (\is_array($name)) {
-				$name = \implode($name);
+				$name = \implode('', $name);
 			}
 			$message = "INFORMATION: retried to delete file '$name' $counter times";
 			echo $message;

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -103,7 +103,7 @@ class FileRow extends OwncloudPage {
 	 */
 	public function getNameAsString() {
 		if (\is_array($this->name)) {
-			return \implode($this->name);
+			return \implode('', $this->name);
 		}
 		return $this->name;
 	}

--- a/tests/acceptance/features/lib/SharedWithYouPage.php
+++ b/tests/acceptance/features/lib/SharedWithYouPage.php
@@ -127,7 +127,7 @@ class SharedWithYouPage extends FilesPageBasic {
 		}
 		if ($expectToDeleteFile && ($counter > 0)) {
 			if (\is_array($name)) {
-				$name = \implode($name);
+				$name = \implode('', $name);
 			}
 			$message = "INFORMATION: retried to decline file '$name' $counter times";
 			echo $message;


### PR DESCRIPTION
## Description
The `implode` function can take just 1 parameter (the array to implode) and the glue defaults to the empty string. But to be consistent and make the code clearer, always specify the empty string when it is the glue.

## Related Issue
Suggested in issue comment https://github.com/owncloud/core/issues/36509#issuecomment-597061791

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
