### PR TITLE
adjust method signatures in Encryption.php

### DIFF
--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -192,7 +192,7 @@ class Encryption extends Wrapper {
 	 * @return resource
 	 * @throws \BadMethodCallException
 	 */
-	protected static function wrapSource($source, $context, $protocol, $class, $mode = 'r+') {
+	protected static function wrapSource($source, $context = [], $protocol = null, $class = null, $mode = 'r+') {
 		try {
 			\stream_wrapper_register($protocol, $class);
 			if (@\rewinddir($source) === false) {
@@ -215,7 +215,7 @@ class Encryption extends Wrapper {
 	 * @return array
 	 * @throws \BadMethodCallException
 	 */
-	protected function loadContext($name) {
+	protected function loadContext($name = null) {
 		$context = parent::loadContext($name);
 
 		foreach ($this->expectedContextProperties as $property) {


### PR DESCRIPTION
## Description
Update the `wrapSource` and `loadContext` methods so that the default parameters match the parent class in `icewind/streams`

This makes the encryption unit tests pass. See demonstration PR https://github.com/owncloud/encryption/pull/199 and drone result https://drone.owncloud.com/owncloud/encryption/1264/4/4
```
phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "../../lib/composer/bin/phpunit" --configuration ./phpunit.xml --testsuite unit
PHPUnit 8.5.4 by Sebastian Bergmann and contributors.

Runtime:       PHPDBG 7.2.27-6+ubuntu18.04.1+deb.sury.org+1
Configuration: /var/www/owncloud/server/apps/encryption/phpunit.xml

a test string for helloWelcome to your ownCloud account!

This is just an example file for developers and git users. 
The packaged and released versions will come with better examples.

a test string for world.a foo testLets modify again3Welcome to your ownCloud account!

This is just an example file for developers and git users. 
The packaged and released versions will come with better examples.

a test string for world.a foo testLets modify again3Welcome to your ownCloud account!

This is just an example file for developers and git users. 
The packaged and released versions will come with better examples.

a test string for world.............................................................  63 / 251 ( 25%)
............................................................... 126 / 251 ( 50%)
............................................................... 189 / 251 ( 75%)
..............................................................  251 / 251 (100%)

Time: 11.08 seconds, Memory: 504.00 MB

OK (251 tests, 725 assertions)
```

Note: these adjustments are part of implementing #37249 which already has a changelog entry.

## Related Issue
- part of https://github.com/owncloud/encryption/issues/198

## How Has This Been Tested?
Local run of encryption unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
