### PR TITLE
[Tests-Only] Fix apiProvisioning-v2 createSubAdmin test scenario

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -44,5 +44,4 @@ Feature: create a subadmin
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"
-    And user "not-user" should not be a subadmin of group "new-group"
-	
+    And user "brand-new-user" should not be a subadmin of group "new-group"


### PR DESCRIPTION
## Description
The test scenario creates ordinary user `brand-new-user` that should not be s sub-admin. But at the end it checks that `not-user` is not a sub-admin. Fix that.

Note: it is correct in `apiProvisioning-v1/createSubAdmin.feature` (but somehow it is wrong in `v2`)

## Motivation and Context
Reduce :snake: :oil_drum: 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
