### PR TITLE
[Tests-Only] remove out-of-date user_ldap comments

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareReceivedInMultipleWays.feature
@@ -8,7 +8,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "welcome.txt" with group "grp1"
     When user "user0" shares file "/welcome.txt" with user "user1" using the sharing API
@@ -35,7 +34,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and skeleton files
     And group "grp4" has been created
-    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     When user "user0" shares folder "/PARENT" with user "user1" using the sharing API
     And user "user0" shares folder "/PARENT/CHILD" with group "grp4" using the sharing API
@@ -75,7 +73,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "user1" has been created with default attributes and without skeleton files
     And user "user3" has been created with default attributes and without skeleton files
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user1" has created folder "/test"
     And user "user1" has created folder "/test/sub"
@@ -165,7 +162,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     And these groups have been created:
       | groupname |
       | grp1      |
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has uploaded file with content "user0 content" to "lorem.txt"
     And user "user2" has uploaded file with content "user2 content" to "lorem.txt"

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -11,9 +11,7 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "user3" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
-    # Note: in the user_ldap test environment user3 is in grp2
     And user "user3" has been added to group "grp2"
     When user "user1" shares folder "/PARENT" with group "grp2" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -30,7 +28,6 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "user1" has been created with default attributes and skeleton files
     And user "user3" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1, and user3 is not in grp1
     And user "user1" has been added to group "grp1"
     When user "user1" shares folder "/PARENT" with user "user3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -47,7 +44,6 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "user1" has been created with default attributes and skeleton files
     And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     When user "user1" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -66,9 +62,7 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "user3" has been created with default attributes and skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
-    # Note: in the user_ldap test environment user3 is in grp2
     And user "user3" has been added to group "grp2"
     When user "user1" shares file "/textfile0.txt" with group "grp2" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -85,7 +79,6 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "user1" has been created with default attributes and skeleton files
     And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     When user "user1" shares folder "/textfile0.txt" with group "grp1" using the sharing API
@@ -103,7 +96,6 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "user1" has been created with default attributes and skeleton files
     And user "user3" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1, and user3 is not in grp1
     And user "user1" has been added to group "grp1"
     When user "user1" shares folder "/textfile0.txt" with user "user3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -13,7 +13,6 @@ Feature: accept/decline shares coming from internal users
       | user1    |
       | user2    |
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
 

--- a/tests/acceptance/features/apiShareManagement/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagement/disableSharing.feature
@@ -36,7 +36,6 @@ Feature: sharing
   Scenario Outline: user tries to share a file with group when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
     Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
@@ -50,7 +49,6 @@ Feature: sharing
   Scenario Outline: user tries to share a folder with group when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
     Then user "user0" should not be able to share folder "/FOLDER" with group "grp1" using the sharing API
@@ -88,7 +86,6 @@ Feature: sharing
   Scenario Outline: user tries to share a file with user who is not in their group when sharing outside the group has been restricted
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     Then user "user1" should not be able to share file "welcome.txt" with user "user0" using the sharing API
@@ -103,7 +100,6 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user2" has been created with default attributes and skeleton files
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -120,9 +116,7 @@ Feature: sharing
     And group "grp2" has been created
     And group "grp1" has been created
     And user "user3" has been created with default attributes and skeleton files
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
-    # Note: in the user_ldap test environment user3 is in grp2
     And user "user3" has been added to group "grp2"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     Then user "user3" should be able to share file "welcome.txt" with group "grp1" using the sharing API
@@ -137,7 +131,6 @@ Feature: sharing
   Scenario Outline: user who is not a member of a group tries to share a file in the group when group sharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     Then user "user0" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
@@ -152,7 +145,6 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user2" has been created with default attributes and skeleton files
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -8,7 +8,6 @@ Feature: sharing
       | user0    |
       | user1    |
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
 
   @smokeTest
@@ -28,7 +27,6 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from outside with two groups
     Given group "grp4" has been created
-    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user0" has created folder "/merge-test-outside-twogroups"
     When user "user0" shares folder "/merge-test-outside-twogroups" with group "grp1" using the sharing API
@@ -38,7 +36,6 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from outside with two groups with different permissions
     Given group "grp4" has been created
-    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user0" has created folder "/merge-test-outside-twogroups-perms"
     When user "user0" shares folder "/merge-test-outside-twogroups-perms" with group "grp1" with permissions "read" using the sharing API
@@ -48,7 +45,6 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from outside with two groups and member
     Given group "grp4" has been created
-    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user0" has created folder "/merge-test-outside-twogroups-member-perms"
     When user "user0" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp1" with permissions "read" using the sharing API
@@ -65,7 +61,6 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from inside with two groups
     Given group "grp4" has been created
-    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user1" has created folder "/merge-test-inside-twogroups"
     When user "user1" shares folder "/merge-test-inside-twogroups" with group "grp1" using the sharing API
@@ -76,7 +71,6 @@ Feature: sharing
 
   Scenario: Merging shares for recipient when shared from inside with group with less permissions
     Given group "grp4" has been created
-    # Note: in the user_ldap test environment user1 is in grp4
     And user "user1" has been added to group "grp4"
     And user "user1" has created folder "/merge-test-inside-twogroups-perms"
     When user "user1" shares folder "/merge-test-inside-twogroups-perms" with group "grp1" using the sharing API

--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -11,7 +11,6 @@ Feature: sharing
 
   Scenario: Keep usergroup shares (#22143)
     Given group "grp1" has been created
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And user "user0" has created folder "/TMP"

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -296,7 +296,6 @@ Feature: sharing
       | user1    |
       | user2    |
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And user "user0" has created folder "/PARENT"
@@ -322,7 +321,6 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user1" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "user1" has shared file "textfile0.txt" with group "grp1"
@@ -385,7 +383,6 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user1" has been created with default attributes and without skeleton files
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "user0" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with group "grp1" using the sharing API
@@ -417,7 +414,6 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "user1" has been created with default attributes and without skeleton files
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "user0" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/textfile0.txt"
@@ -458,7 +454,6 @@ Feature: sharing
       | username |
       | user1    |
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "USER1" has been added to group "grp1"
     And user "user0" has uploaded file with content "user0 file" to "/randomfile.txt"
     And user "user0" has shared file "randomfile.txt" with group "grp1"
@@ -476,7 +471,6 @@ Feature: sharing
       | user1    |
       | user2    |
     And group "😀 😁" has been created
-    # Note: in the user_ldap test environment user1 and user2 are already in this group
     And user "user1" has been added to group "😀 😁"
     And user "user2" has been added to group "😀 😁"
     And user "user0" has created folder "/PARENT"
@@ -507,7 +501,6 @@ Feature: sharing
     And these groups have been created:
       | groupname |
       | grp1      |
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has uploaded file with content "some content" to "lorem.txt"
     When user "user0" shares file "lorem.txt" with group "grp1" using the sharing API

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -8,7 +8,6 @@ Feature: sharing
       | user1    |
     And using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "textfile0.txt" with group "grp1"
     And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
@@ -124,7 +123,6 @@ Feature: sharing
       | user0    |
       | user1    |
     And user "user2" has been created with default attributes and skeleton files
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And user "user2" has shared file "/PARENT/parent.txt" with group "grp1"
@@ -178,7 +176,6 @@ Feature: sharing
       | username |
       | user1    |
       | user2    |
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And user "user0" has shared entry "<entry_to_share>" with group "grp1"

--- a/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -10,7 +10,6 @@ Feature: resharing a resource with an expiration date
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     And user "user3" has been created with default attributes and skeleton files
     And group "grp2" has been created
-    # Note: in the user_ldap test environment user3 is in grp2
     And user "user3" has been added to group "grp2"
     And user "user0" has shared folder "/PARENT" with user "user1"
     When user "user1" shares folder "/PARENT" with group "grp2" using the sharing API
@@ -27,7 +26,6 @@ Feature: resharing a resource with an expiration date
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     And user "user3" has been created with default attributes and skeleton files
     And group "grp2" has been created
-    # Note: in the user_ldap test environment user3 is in grp2
     And user "user3" has been added to group "grp2"
     And user "user0" has shared file "/textfile0.txt" with user "user1"
     When user "user1" shares folder "/textfile0.txt" with group "grp2" using the sharing API

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -29,7 +29,6 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user1" has been added to group "grp1"
     And user "user0" has shared file "textfile0.txt" with group "grp1"
     And user "user1" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
@@ -177,7 +176,6 @@ Feature: sharing
     And user "user1" has been created with default attributes and without skeleton files
     And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 and user2 are in grp1
     And user "user1" has been added to group "grp1"
     And user "user2" has been added to group "grp1"
     And as user "user2"
@@ -209,7 +207,6 @@ Feature: sharing
   Scenario Outline: Editing share permission of existing share is forbidden when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user0" has shared file "textfile0.txt" with group "grp1"
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When user "user0" updates the last share using the sharing API with
@@ -235,7 +232,6 @@ Feature: sharing
   Scenario Outline: Deleting group share is allowed when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    # Note: in the user_ldap test environment user1 is in grp1
     And user "user0" has shared file "textfile0.txt" with group "grp1"
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When user "user0" deletes the last share using the sharing API


### PR DESCRIPTION
## Description
Users and groups are properly created on-the-fly nowadays when running tests with user_ldap. These comments are no longer relevant.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
