### PR TITLE
[Tests-Only] Adjust test step wording

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareWhenExcludedFromSharing.feature
@@ -8,7 +8,6 @@ Feature: cannot share resources when in a group that is excluded from sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    # Note: in user_ldap, user1 is already in grp1
     And user "user1" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
@@ -28,7 +27,6 @@ Feature: cannot share resources when in a group that is excluded from sharing
     And user "user3" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
-    # Note: in user_ldap, user1 is already in grp1, user3 is already in grp2
     And user "user1" has been added to group "grp1"
     And user "user3" has been added to group "grp2"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -47,7 +45,6 @@ Feature: cannot share resources when in a group that is excluded from sharing
     Given using OCS API version "<ocs_api_version>"
     And user "user1" has been created with default attributes and without skeleton files
     And group "grp1" has been created
-    # Note: in user_ldap, user1 is already in grp1
     And user "user1" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
@@ -67,7 +64,6 @@ Feature: cannot share resources when in a group that is excluded from sharing
     And user "user3" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
-    # Note: in user_ldap, user1 is already in grp1, user3 is already in grp2
     And user "user1" has been added to group "grp1"
     And user "user3" has been added to group "grp2"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -49,39 +49,6 @@ Feature: sharing
     Then the HTTP status code should be "204"
     And as "user1" folder "/sub" should not exist
 
-  Scenario Outline: sharing subfolder of already shared folder, GET result is correct
-    Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and without skeleton files:
-      | username |
-      | user0    |
-      | user1    |
-      | user2    |
-      | user3    |
-      | user4    |
-    And user "user0" has created folder "/folder1"
-    And user "user0" has shared folder "/folder1" with user "user1"
-    And user "user0" has shared folder "/folder1" with user "user2"
-    And user "user0" has created folder "/folder1/folder2"
-    And user "user0" has shared folder "/folder1/folder2" with user "user3"
-    And user "user0" has shared folder "/folder1/folder2" with user "user4"
-    And as user "user0"
-    When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the response should contain 4 entries
-    And folder "/folder1" should be included as path in the response
-    And folder "/folder1/folder2" should be included as path in the response
-    When the user sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares?path=/folder1/folder2"
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the response should contain 2 entries
-    And folder "/folder1" should not be included as path in the response
-    And folder "/folder1/folder2" should be included as path in the response
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
-
   @smokeTest @files_trashbin-app-required
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"

--- a/tests/acceptance/features/apiShareManagementBasic/excludeGroupFromReceivingShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/excludeGroupFromReceivingShares.feature
@@ -18,7 +18,7 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: user cannot share with a group that is excluded from receiving shares but can share with other groups
     Given using OCS API version "<ocs_api_version>"
-    When the administrator adds group "grp1" to the exclude group from sharing list using the occ command
+    When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
     And user "user0" shares file "welcome.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
@@ -42,9 +42,9 @@ Feature: Exclude groups from receiving shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp4" has been created
     And user "user1" has been added to group "grp4"
-    When the administrator adds group "grp1" to the exclude group from sharing list using the occ command
-    And the administrator adds group "grp2" to the exclude group from sharing list using the occ command
-    And the administrator adds group "grp4" to the exclude group from sharing list using the occ command
+    When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
+    And the administrator adds group "grp2" to the exclude groups from receiving shares list using the occ command
+    And the administrator adds group "grp4" to the exclude groups from receiving shares list using the occ command
     And user "user0" shares file "welcome.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
@@ -69,7 +69,7 @@ Feature: Exclude groups from receiving shares
     Given using OCS API version "<ocs_api_version>"
     And user "user2" has shared file "textfile0.txt" with user "user0"
     And user "user2" has shared folder "PARENT" with user "user0"
-    When the administrator adds group "grp1" to the exclude group from sharing list using the occ command
+    When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
     And user "user0" shares file "textfile0 (2).txt" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
@@ -91,7 +91,7 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: sharing with a user that is part of a group that is excluded from receiving shares still works
     Given using OCS API version "<ocs_api_version>"
-    When the administrator adds group "grp1" to the exclude group from sharing list using the occ command
+    When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
     And user "user0" shares file "welcome.txt" with user "user1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -109,7 +109,7 @@ Feature: Exclude groups from receiving shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp4" has been created
     And user "user1" has been added to group "grp4"
-    When the administrator adds group "grp1" to the exclude group from sharing list using the occ command
+    When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
     And user "user0" shares file "welcome.txt" with group "grp4" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -125,7 +125,7 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: a user that is part of a group that is excluded from receiving shares still can initiate shares
     Given using OCS API version "<ocs_api_version>"
-    When the administrator adds group "grp1" to the exclude group from sharing list using the occ command
+    When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
     And user "user1" shares file "welcome.txt" with user "user2" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2461,14 +2461,14 @@ trait Sharing {
 	}
 
 	/**
-	 * @When the administrator adds group :group to the exclude group from sharing list using the occ command
+	 * @When the administrator adds group :group to the exclude groups from receiving shares list using the occ command
 	 *
 	 * @param string $group
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function administratorAddsGroupToExcludeFromSharingList($group) {
+	public function administratorAddsGroupToExcludeFromReceivingSharesList($group) {
 		//get current groups
 		$occExitCode = $this->runOcc(
 			['config:app:get files_sharing blacklisted_receiver_groups']


### PR DESCRIPTION
## Description
1) delete scenario from deleteShare that is already in createShare
2) reword test step about exclude groups from receiving shares so that the words match how it is described on the webUI admin sharing settings page. This should make the test scenarios easier to understand.
3) remove more out-of-date comments about user_ldap

Note: the test step that is changed in this PR is used in scenarios that are `@skipOnOcis` so this should not break any OCIS CI.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
