### PR TITLE
[Tests-Only] Fixup federation test steps that specify the user

### DIFF
--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -160,7 +160,8 @@ class FederationContext implements Context {
 		$share_id = SharingHelper::getLastShareIdFromResponse(
 			$this->featureContext->getResponseXml()
 		);
-		$this->ocsContext->theUserSendsToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user,
 			'POST',
 			"/apps/files_sharing/api/v1/remote_shares/pending/{$share_id}",
 			null
@@ -251,7 +252,8 @@ class FederationContext implements Context {
 	public function userGetsTheListOfPendingFederatedCloudShares($user) {
 		$url = "/apps/files_sharing/api/v1/remote_shares/pending";
 		$this->featureContext->asUser($user);
-		$this->ocsContext->theUserSendsToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user,
 			'GET',
 			$url,
 			null
@@ -313,8 +315,8 @@ class FederationContext implements Context {
 	 */
 	public function userRequestsSharedSecretUsingTheFederationApi($user) {
 		$url = '/apps/federation/api/v1/request-shared-secret';
-		$this->featureContext->asUser($user);
-		$this->ocsContext->theUserSendsToOcsApiEndpointWithBody(
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user,
 			'POST',
 			$url,
 			null


### PR DESCRIPTION
## Description
Some steps in `FederationContext` specify the user in the step text, but do not pass it through to the HTTP request. The request ends up being sent as "current user". So these steps depend on a previous step like `Given as user "user0"` having a username that matches.

Fix it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
