### PR TITLE
Allow reading params of PUT with empty body more than once

### DIFF
--- a/changelog/unreleased/37394
+++ b/changelog/unreleased/37394
@@ -1,0 +1,7 @@
+Bugfix: Allow unlimited access to PUT body if content length is 0
+
+It was not possible to read more than one URL param of the PUT request with the empty body.
+This change checks Content-Length and do not throw the exception on empty request body if 
+Content-Length states that the empty body had been sent. 
+
+https://github.com/owncloud/core/pull/37394

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -388,6 +388,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	protected function getContent() {
 		// If the content can't be parsed into an array then return a stream resource.
 		if ($this->method === 'PUT'
+			&& $this->getHeader('Content-Length') !== 0
+			&& $this->getHeader('Content-Length') !== null
 			&& \strpos($this->getHeader('Content-Type'), 'application/x-www-form-urlencoded') === false
 			&& \strpos($this->getHeader('Content-Type'), 'application/json') === false
 		) {

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -308,7 +308,10 @@ class RequestTest extends TestCase {
 		$vars = [
 			'put' => $data,
 			'method' => 'PUT',
-			'server' => ['CONTENT_TYPE' => 'image/png'],
+			'server' => [
+				'CONTENT_TYPE' => 'image/png',
+				'CONTENT_LENGTH' => \strlen($data),
+			],
 		];
 
 		$request = new Request(
@@ -330,6 +333,37 @@ class RequestTest extends TestCase {
 			return;
 		}
 		$this->fail('Expected LogicException.');
+	}
+
+	public function testDoubleGetParamOnPut() {
+		$vars = [
+			'method' => 'PUT',
+			'server' => [],
+		];
+
+		$request = new Request(
+			$vars,
+			$this->secureRandom,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		// trigger decoding of the request
+		$request->getParam('foo');
+
+		$request->setUrlParameters([
+			'var1' => 'value1',
+			'var2' => 'value2'
+		]);
+
+		// it should be possible to get unlimited number of URL parameters
+		// without reading the request body
+		$var1 = $request->getParam('var1');
+		$var2 = $request->getParam('var2');
+
+		$this->assertEquals('value1', $var1);
+		$this->assertEquals('value2', $var2);
 	}
 
 	public function testSetUrlParameters() {


### PR DESCRIPTION
## Description
Allows read URL params of PUT request with an empty body more than once.
Missing or 0  Content-Length means that the request has an empty body and we should NOT throw  LogicException while reading it.

## How Has This Been Tested?
1. Create an OCS route with urlParam like this:
```
[
	'root' => '/cloud',
	'name' => 'Users#enableUser',
	'url' => '/users/{userId}/enable',
	'verb' => 'PUT'
],
```
2. Create a controller
```
use OCP\AppFramework\OCSController;

class UsersController extends OCSController {
/**
	 * @NoCSRFRequired
	 *
	 * @param string $userId
	 * @return Result
	 */
	public function enableUser($userId) {
		return $this->setEnabled($userId, true);
	}
```

2. Use it
```
curl -X PUT http://admin:admin@localhost/OC/ocs/v1.php/cloud/users/fatima/enable
```

### Expected
`$userId` is 'fatima' in the controller

### Actual
`$userId` is `null`

The log file contains
```
{"reqId":"08vb9aIDIHfQVAQp5ZB1","level":3,"time":"2020-05-15T09:19:24+00:00","remoteAddr":"127.0.0.1","user":"admin","app":"PHP","method":"PUT","url":"\/OC\/ocs\/v1.php\/cloud\/users\/user1\/disable","message":"LogicException: \"put\" can only be accessed once if not application\/x-www-form-urlencoded or application\/json. at 
 \/lib\/private\/AppFramework\/Http\/Request.php#395"}
```

OCS routes always get `format` param from URL and adding one more URL param  causes a logic exception  

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
