### PR TITLE
[Tests-Only] Adjust usernames in UI tests

### DIFF
--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -227,11 +227,11 @@ Feature: add users
     Then user "<username>" should exist
     And the user should be redirected to a webUI page with the title "Files - %productname%"
     Examples:
-      | creation-username | login-username | username       |
-      | Brand-New-User    | brand-new-user | BRAND-NEW-USER |
-      | brand-new-user    | Brand-New-User | Brand-New-User |
-      | Brand-New-User    | BRAND-NEW-USER | brand-new-user |
-      | brand-new-user    | Brand-New-User | BRAND-NEW-USER |
+      | creation-username  | login-username  | username        |
+      | Mixed-Case-user    | mixed-case-user | MIXED-CASE-USER |
+      | mixed-case-user    | Mixed-Case-user | Mixed-Case-user |
+      | Mixed-Case-user    | MIXED-CASE-USER | mixed-case-user |
+      | mixed-case-user    | Mixed-Case-user | MIXED-CASE-USER |
 
   Scenario Outline: user names are not case-sensitive, multiple users can't exist with different upper and lower case names
     When the administrator creates a user with the name "<user_id1>" and the password "password" using the webUI
@@ -242,7 +242,7 @@ Feature: add users
     Then notifications should be displayed on the webUI with the text
       | Error creating user: A user with that name already exists. |
     Examples:
-      | user_id1       | user_id2       | user_id3       |
-      | Brand-New-User | brand-new-user | BRAND-NEW-USER |
-      | brand-new-user | BRAND-NEW-USER | Brand-New-User |
-      | BRAND-NEW-USER | Brand-New-User | brand-new-user |
+      | user_id1        | user_id2        | user_id3        |
+      | Mixed-Case-user | mixed-case-user | MIXED-CASE-USER |
+      | mixed-case-user | MIXED-CASE-USER | Mixed-Case-user |
+      | MIXED-CASE-USER | Mixed-Case-user | mixed-case-user |

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -87,12 +87,12 @@ Feature: admin storage settings
       | username |
       | user0    |
       | user1    |
-    And group "newgroup" has been created
-    And user "user0" has been added to group "newgroup"
+    And group "brand-new-group" has been created
+    And user "user0" has been added to group "brand-new-group"
     And the administrator has enabled the external storage
     And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
-    When the administrator adds group "newgroup" as the applicable group for the last local storage mount using the webUI
+    When the administrator adds group "brand-new-group" as the applicable group for the last local storage mount using the webUI
     And the user re-logs in as "user0" using the webUI
     Then folder "local_storage1" should be listed on the webUI
     And the user re-logs in as "user1" using the webUI
@@ -103,13 +103,13 @@ Feature: admin storage settings
       | username |
       | user0    |
       | user1    |
-    And group "newgroup" has been created
-    And user "user0" has been added to group "newgroup"
+    And group "brand-new-group" has been created
+    And user "user0" has been added to group "brand-new-group"
     And the administrator has enabled the external storage
     And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
-    And the administrator has added group "newgroup" as the applicable group for the last local storage mount from the admin storage settings page
-    When the administrator removes group "newgroup" from the applicable group for the last local storage mount using the webUI
+    And the administrator has added group "brand-new-group" as the applicable group for the last local storage mount from the admin storage settings page
+    When the administrator removes group "brand-new-group" from the applicable group for the last local storage mount using the webUI
     And the user re-logs in as "user0" using the webUI
     Then folder "local_storage1" should be listed on the webUI
     And the user re-logs in as "user1" using the webUI
@@ -136,13 +136,13 @@ Feature: admin storage settings
 
   Scenario: local storage mount is not deleted when the last group applicable to it is deleted but the member of the deleted group should not have access to it
     Given user "user0" has been created with default attributes and skeleton files
-    And group "newgroup" has been created
-    And user "user0" has been added to group "newgroup"
+    And group "brand-new-group" has been created
+    And user "user0" has been added to group "brand-new-group"
     And the administrator has enabled the external storage
     And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
-    And the administrator has added group "newgroup" as the applicable group for the last local storage mount from the admin storage settings page
-    And group "newgroup" has been deleted
+    And the administrator has added group "brand-new-group" as the applicable group for the last local storage mount from the admin storage settings page
+    And group "brand-new-group" has been deleted
     When the administrator reloads the current page of the webUI
     Then the last created local storage mount should be listed on the webUI
     And the user re-logs in as "user0" using the webUI

--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -8,10 +8,10 @@ Feature: Add, delete and edit comments in files and folders
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user1" has uploaded file with content "does-not-matter" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has uploaded file with content "does-not-matter" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario Outline: user adds and deletes comment for a file/folder
@@ -31,8 +31,8 @@ Feature: Add, delete and edit comments in files and folders
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"
     And the user comments with content "<comment>" using the webUI
-    And the user shares file "new-lorem.txt" with user "User Two" using the webUI
-    And the user re-logs in as "user2" using the webUI
+    And the user shares file "new-lorem.txt" with user "User One" using the webUI
+    And the user re-logs in as "user1" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"
     Then the comment "<comment>" should be listed in the comments tab in details dialog
     Examples:

--- a/tests/acceptance/features/webUICreateDelete/createFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFolders.feature
@@ -5,8 +5,8 @@ Feature: create folders
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario Outline: Create a folder
@@ -30,15 +30,15 @@ Feature: create folders
     Then folder "sub-folder" should be listed on the webUI
 
   Scenario: Create a folder with existing name
-    Given user "user1" has created folder "/simple-folder"
+    Given user "user0" has created folder "/simple-folder"
     And the user has reloaded the current page of the webUI
     When the user creates a folder with the invalid name "simple-folder" using the webUI
     Then near the folder input field a tooltip with the text 'simple-folder already exists' should be displayed on the webUI
 
   @files_sharing-app-required
   Scenario: Create a folder in a public share
-    Given user "user1" has created folder "/simple-empty-folder"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-empty-folder"
+    And user "user0" has created a public link share with settings
       | path        | /simple-empty-folder |
       | permissions | read,create          |
     And the public accesses the last created public link using the webUI

--- a/tests/acceptance/features/webUICreateDelete/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFoldersEdgeCases.feature
@@ -5,8 +5,8 @@ Feature: create folder
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario Outline: Create a folder using special characters
@@ -39,7 +39,7 @@ Feature: create folder
 
   @smokeTest
   Scenario Outline: Create a sub-folder inside an existing folder with problematic name
-    Given user "user1" has created folder <folder>
+    Given user "user0" has created folder <folder>
     And the user has reloaded the current page of the webUI
     When the user opens folder <folder> using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -7,8 +7,8 @@ Feature: deleting files and folders
   Background:
     Given these users have been created with default attributes and skeleton files:
       | username |
-      | user1    |
-    And user "user1" has logged in using the webUI
+      | user0    |
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest
@@ -19,10 +19,10 @@ Feature: deleting files and folders
       | lorem.txt                             |
       | strängé नेपाली folder                 |
       | strängé filename (duplicate #2 &).txt |
-    Then as "user1" folder "simple-folder" should not exist
-    And as "user1" file "lorem.txt" should not exist
-    And as "user1" folder "strängé नेपाली folder" should not exist
-    And as "user1" file "strängé filename (duplicate #2 &).txt" should not exist
+    Then as "user0" folder "simple-folder" should not exist
+    And as "user0" file "lorem.txt" should not exist
+    And as "user0" folder "strängé नेपाली folder" should not exist
+    And as "user0" file "strängé filename (duplicate #2 &).txt" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
@@ -69,9 +69,9 @@ Feature: deleting files and folders
       | data.zip      |
       | lorem.txt     |
       | simple-folder |
-    Then as "user1" file "data.zip" should not exist
-    And as "user1" file "lorem.txt" should not exist
-    And as "user1" folder "simple-folder" should not exist
+    Then as "user0" file "data.zip" should not exist
+    And as "user0" file "lorem.txt" should not exist
+    And as "user0" folder "simple-folder" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
@@ -80,9 +80,9 @@ Feature: deleting files and folders
     When the user marks all files for batch action using the webUI
     And the user batch deletes the marked files using the webUI
     # Check just some example files/folders that should not exist any more
-    Then as "user1" file "data.zip" should not exist
-    And as "user1" file "lorem.txt" should not exist
-    And as "user1" folder "simple-folder" should not exist
+    Then as "user0" file "data.zip" should not exist
+    And as "user0" file "lorem.txt" should not exist
+    And as "user0" folder "simple-folder" should not exist
     And the folder should be empty on the webUI
     And the folder should be empty on the webUI after a page reload
 
@@ -94,38 +94,38 @@ Feature: deleting files and folders
       | lorem.txt     |
       | simple-folder |
     And the user batch deletes the marked files using the webUI
-    Then as "user1" file "lorem.txt" should exist
-    And as "user1" folder "simple-folder" should exist
+    Then as "user0" file "lorem.txt" should exist
+    And as "user0" folder "simple-folder" should exist
     And folder "simple-folder" should be listed on the webUI
     And file "lorem.txt" should be listed on the webUI
     # Check just an example of a file that should not exist any more
-    But as "user1" file "data.zip" should not exist
+    But as "user0" file "data.zip" should not exist
     And file "data.zip" should not be listed on the webUI
 
   Scenario: Delete an empty folder
     When the user creates a folder with the name "my-empty-folder" using the webUI
     And the user creates a folder with the name "my-other-empty-folder" using the webUI
     And the user deletes folder "my-empty-folder" using the webUI
-    Then as "user1" folder "my-other-empty-folder" should exist
+    Then as "user0" folder "my-other-empty-folder" should exist
     And folder "my-other-empty-folder" should be listed on the webUI
-    But as "user1" folder "my-empty-folder" should not exist
+    But as "user0" folder "my-empty-folder" should not exist
     And folder "my-empty-folder" should not be listed on the webUI
 
   Scenario: Delete the last file in a folder
     When the user deletes file "zzzz-must-be-last-file-in-folder.txt" using the webUI
-    Then as "user1" file "zzzz-must-be-last-file-in-folder.txt" should not exist
+    Then as "user0" file "zzzz-must-be-last-file-in-folder.txt" should not exist
     And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
 
   @files_sharing-app-required
   Scenario: delete files from shared with others page
-    Given user "user2" has been created with default attributes and without skeleton files
-    And the user has shared file "lorem.txt" with user "user2"
-    And the user has shared folder "simple-folder" with user "user2"
+    Given user "user1" has been created with default attributes and without skeleton files
+    And the user has shared file "lorem.txt" with user "user1"
+    And the user has shared folder "simple-folder" with user "user1"
     And the user has browsed to the shared-with-others page
     When the user deletes file "lorem.txt" using the webUI
     And the user deletes folder "simple-folder" using the webUI
-    Then as "user1" file "lorem.txt" should not exist
-    And as "user1" folder "simple-folder" should not exist
+    Then as "user0" file "lorem.txt" should not exist
+    And as "user0" folder "simple-folder" should not exist
     And file "lorem.txt" should not be listed on the webUI
     And folder "simple-folder" should not be listed on the webUI
     When the user browses to the files page
@@ -138,27 +138,27 @@ Feature: deleting files and folders
     And the user has browsed to the shared-by-link page
     Then file "lorem.txt" should be listed on the webUI
     When the user deletes file "lorem.txt" using the webUI
-    Then as "user1" file "lorem.txt" should not exist
+    Then as "user0" file "lorem.txt" should not exist
     And file "lorem.txt" should not be listed on the webUI
     When the user browses to the files page
     Then file "lorem.txt" should not be listed on the webUI
 
   @systemtags-app-required
   Scenario: delete files from tags page
-    Given user "user1" has created a "normal" tag with name "lorem"
-    And user "user1" has added tag "lorem" to file "/lorem.txt"
+    Given user "user0" has created a "normal" tag with name "lorem"
+    And user "user0" has added tag "lorem" to file "/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI
     When the user deletes file "lorem.txt" using the webUI
-    Then as "user1" file "lorem.txt" should not exist
+    Then as "user0" file "lorem.txt" should not exist
     And file "lorem.txt" should not be listed on the webUI
     When the user browses to the files page
     Then file "lorem.txt" should not be listed on the webUI
 
   @files_sharing-app-required
   Scenario: delete a file on a public share
-    Given user "user1" has created a public link share with settings
+    Given user "user0" has created a public link share with settings
       | path        | /simple-folder            |
       | permissions | read,update,create,delete |
     And the public accesses the last created public link using the webUI
@@ -167,15 +167,15 @@ Feature: deleting files and folders
       | simple-empty-folder                   |
       | lorem.txt                             |
       | strängé filename (duplicate #2 &).txt |
-    Then as "user1" file "simple-folder/lorem.txt" should not exist
-    And as "user1" folder "simple-folder/simple-empty-folder" should not exist
-    And as "user1" file "simple-folder/strängé filename (duplicate #2 &).txt" should not exist
+    Then as "user0" file "simple-folder/lorem.txt" should not exist
+    And as "user0" folder "simple-folder/simple-empty-folder" should not exist
+    And as "user0" file "simple-folder/strängé filename (duplicate #2 &).txt" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
   @skipOnFIREFOX @files_sharing-app-required
   Scenario: delete a file on a public share with problematic characters
-    Given user "user1" has created a public link share with settings
+    Given user "user0" has created a public link share with settings
       | path        | /simple-folder |
       | permissions | read,change    |
     And the public accesses the last created public link using the webUI
@@ -207,7 +207,7 @@ Feature: deleting files and folders
 
   @skipOnEncryption @encryption-issue-74 @files_sharing-app-required
   Scenario: Delete multiple files at once on a public share
-    Given user "user1" has created a public link share with settings
+    Given user "user0" has created a public link share with settings
       | path        | /simple-folder            |
       | permissions | read,update,create,delete |
     And the public accesses the last created public link using the webUI
@@ -216,32 +216,32 @@ Feature: deleting files and folders
       | data.zip            |
       | lorem.txt           |
       | simple-empty-folder |
-    Then as "user1" file "simple-folder/data.zip" should not exist
-    And as "user1" file "simple-folder/lorem.txt" should not exist
-    And as "user1" folder "simple-folder/simple-empty-folder" should not exist
+    Then as "user0" file "simple-folder/data.zip" should not exist
+    And as "user0" file "simple-folder/lorem.txt" should not exist
+    And as "user0" folder "simple-folder/simple-empty-folder" should not exist
     And the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
   @files_sharing-app-required
   Scenario Outline: delete a folder when there is a default folder for received shares
     Given the administrator has set the default folder for received shares to "<share_folder>"
-    And user "user0" has been created with default attributes and without skeleton files
-    And user "user0" has created folder "/ShareThis"
-    And user "user1" has created folder "<other_folder1>"
-    And user "user1" has created folder "<top_folder2>"
-    And user "user1" has created folder "<top_folder2>/<other_folder2>"
-    And user "user0" has shared folder "/ShareThis" with user "user1"
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "/ShareThis"
+    And user "user0" has created folder "<other_folder1>"
+    And user "user0" has created folder "<top_folder2>"
+    And user "user0" has created folder "<top_folder2>/<other_folder2>"
+    And user "user1" has shared folder "/ShareThis" with user "user0"
     And the user reloads the current page of the webUI
     When the user deletes folder "<other_folder1>" using the webUI
-    Then as "user1" folder "<other_folder1>" should not exist
+    Then as "user0" folder "<other_folder1>" should not exist
     When the user opens folder "<top_folder2>" using the webUI
     And the user deletes folder "<other_folder2>" using the webUI
-    Then as "user1" folder "<top_folder2>/<other_folder2>" should not exist
+    Then as "user0" folder "<top_folder2>/<other_folder2>" should not exist
     When the user browses to the files page
     And the user deletes folder "<top_folder2>" using the webUI
-    Then as "user1" folder "<top_folder2>" should not exist
+    Then as "user0" folder "<top_folder2>" should not exist
     And it should not be possible to delete folder "<top_share_folder_on_ui>" using the webUI
-    And as "user1" folder "<share_folder>/ShareThis" should exist
+    And as "user0" folder "<share_folder>/ShareThis" should exist
     Examples:
       | share_folder        | top_share_folder_on_ui | other_folder1 | top_folder2 | other_folder2  |
       | /ReceivedShares     | ReceivedShares         | Received      | Top         | ReceivedShares |

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -7,10 +7,10 @@ Feature: Mark file as favorite
 
   @smokeTest
   Scenario: mark a file as favorite and list it in favorites page
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has uploaded file "filesForUpload/data.zip" to "/data.zip"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file "filesForUpload/data.zip" to "/data.zip"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
     When the user marks file "data.zip" as favorite using the webUI
     Then file "data.zip" should be marked as favorite on the webUI
@@ -20,10 +20,10 @@ Feature: Mark file as favorite
     And file "lorem.txt" should not be listed in the favorites page on the webUI
 
   Scenario: mark a folder as favorite and list it in favorites page
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/simple-empty-folder"
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
     When the user marks folder "simple-folder" as favorite using the webUI
     Then folder "simple-folder" should be marked as favorite on the webUI
@@ -33,8 +33,8 @@ Feature: Mark file as favorite
     And folder "simple-empty-folder" should not be listed in the favorites page on the webUI
 
   Scenario: mark files with same name and different path as favorites and list them in favourites page
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
     When the user marks file "lorem.txt" as favorite using the webUI
     And the user marks folder "simple-empty-folder" as favorite using the webUI

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -6,10 +6,10 @@ Feature: Unmark file/folder as favorite
   So that I can remove my favorite file/folder from favorite page
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has uploaded file "filesForUpload/data.zip" to "/data.zip"
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file "filesForUpload/data.zip" to "/data.zip"
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -5,8 +5,8 @@ Feature: browse directly to details tab
   So that I can see the details immediately without needing to click in the UI
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has logged in using the webUI
 
   @smokeTest @TestAlsoOnExternalUserBackend
   Scenario Outline: Browse directly to the sharing details of a file

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -7,12 +7,12 @@ Feature: User can open the details panel for any file or folder
   Background:
     Given these users have been created with default attributes and skeleton files:
       | username |
-      | user1    |
+      | user0    |
 
   @comments-app-required @files_versions-app-required @files_sharing-app-required
   Scenario: View different areas of the details panel in files page
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has logged in using the webUI
     When the user opens the file action menu of file "randomfile.txt" on the webUI
     And the user clicks the details file action on the webUI
     Then the details dialog should be visible on the webUI
@@ -26,8 +26,8 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @files_versions-app-required @files_sharing-app-required
   Scenario: View different areas of the details panel in favorites page
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has logged in using the webUI
     When the user marks file "randomfile.txt" as favorite using the webUI
     And the user browses to the favorites page
     And the user opens the file action menu of file "randomfile.txt" on the webUI
@@ -43,9 +43,9 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @public_link_share-feature-required @files_sharing-app-required
   Scenario: user shares a file through public link and then the details dialog should work in a Shared by link page
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has created a public link share of folder "a-folder" with read permissions
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has created a public link share of folder "a-folder" with read permissions
+    And user "user0" has logged in using the webUI
     When the user browses to the shared-by-link page
     Then folder "a-folder" should be listed on the webUI
     When the user opens the file action menu of folder "a-folder" on the webUI
@@ -59,10 +59,10 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @files_sharing-app-required
   Scenario: user shares a file and then the details dialog should work in a Shared with others page
-    Given user "user2" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "a-folder"
-    And user "user1" has shared folder "a-folder" with user "user2"
-    And user "user1" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "a-folder"
+    And user "user0" has shared folder "a-folder" with user "user1"
+    And user "user0" has logged in using the webUI
     When the user browses to the shared-with-others page
     Then folder "a-folder" should be listed on the webUI
     When the user opens the file action menu of folder "a-folder" on the webUI
@@ -76,10 +76,10 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @files_sharing-app-required
   Scenario: the recipient user should be able to view different areas of details panel in Shared with you page
-    Given user "user2" has been created with default attributes and skeleton files
-    And user "user1" has created folder "a-folder"
-    And user "user1" has shared folder "a-folder" with user "user2"
-    And user "user2" has logged in using the webUI
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user0" has created folder "a-folder"
+    And user "user0" has shared folder "a-folder" with user "user1"
+    And user "user1" has logged in using the webUI
     When the user browses to the shared-with-you page
     Then folder "a-folder" should be listed on the webUI
     When the user opens the file action menu of folder "a-folder" on the webUI
@@ -93,10 +93,10 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @files_sharing-app-required
   Scenario: View different areas of details panel for the folder with given tag in Tags page
-    Given user "user1" has created a "normal" tag with name "simple"
-    And user "user1" has created folder "a-folder"
-    And user "user1" has added tag "simple" to folder "a-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created a "normal" tag with name "simple"
+    And user "user0" has created folder "a-folder"
+    And user "user0" has added tag "simple" to folder "a-folder"
+    And user "user0" has logged in using the webUI
     When the user browses to the tags page
     And the user searches for tag "simple" using the webUI
     Then folder "a-folder" should be listed on the webUI
@@ -110,8 +110,7 @@ Feature: User can open the details panel for any file or folder
     Then the "comments" details panel should be visible
 
   Scenario Outline: Breadcrumb through folders
-    Given user "user0" has been created with default attributes and without skeleton files
-    And user "user0" has created folder "<grand-parent>"
+    Given user "user0" has created folder "<grand-parent>"
     And user "user0" has created folder "<grand-parent>/<parent>"
     And user "user0" has created folder "<grand-parent>/<parent>/<child>"
     And user "user0" has created folder "<grand-parent>/<parent>/<child>/<grand-child>"
@@ -131,6 +130,6 @@ Feature: User can open the details panel for any file or folder
     Examples:
       | grand-parent | parent      | child       | grand-child |
       | grand-parent | parent      | child       | grand-child |
-      | PARENT       | PARENT      | PARENT      | PARENT      |
+      | SAMENAME     | SAMENAME    | SAMENAME    | SAMENAME    |
       | Grand parent | grand child | grand child | grand child |
       | Folder12     | #fol3der    | FOL DER     | FoLdEr      |

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -6,8 +6,8 @@ Feature: Hide file/folders
   So that I can choose to see the files that I want.
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest @TestAlsoOnExternalUserBackend
@@ -18,14 +18,14 @@ Feature: Hide file/folders
     Then folder ".xyz" should be listed on the webUI
 
   Scenario: create a hidden file
-    Given user "user1" has uploaded file with content "some content" to "/.lorem.txt"
+    Given user "user0" has uploaded file with content "some content" to "/.lorem.txt"
     When the user browses to the files page
     Then file ".lorem.txt" should not be listed on the webUI
     When the user enables the setting to view hidden files on the webUI
     Then folder ".lorem.txt" should be listed on the webUI
 
   Scenario: Delete and restore a hidden file from trashbin
-    Given user "user1" has uploaded file with content "some content" to "/.lorem.txt"
+    Given user "user0" has uploaded file with content "some content" to "/.lorem.txt"
     When the user browses to the files page
     And the user enables the setting to view hidden files on the webUI
     And the user deletes file ".lorem.txt" using the webUI

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -5,8 +5,8 @@ Feature: scroll menu of actions that can be done on a file into view
   So that I can manage and work with my files
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   @skipOnINTERNETEXPLORER

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -6,8 +6,8 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest @TestAlsoOnExternalUserBackend
@@ -46,19 +46,19 @@ Feature: Search
 
   @systemtags-app-required
   Scenario: search for a file using a tag
-    Given user "user1" has created a "normal" tag with name "ipsum"
-    And user "user1" has added tag "ipsum" to file "/lorem.txt"
+    Given user "user0" has created a "normal" tag with name "ipsum"
+    And user "user0" has added tag "ipsum" to file "/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "ipsum" using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   @systemtags-app-required
   Scenario: search for a file with multiple tags
-    Given user "user1" has created a "normal" tag with name "lorem"
-    And user "user1" has created a "normal" tag with name "ipsum"
-    And user "user1" has added tag "lorem" to file "/lorem.txt"
-    And user "user1" has added tag "lorem" to file "/testimage.jpg"
-    And user "user1" has added tag "ipsum" to file "/lorem.txt"
+    Given user "user0" has created a "normal" tag with name "lorem"
+    And user "user0" has created a "normal" tag with name "ipsum"
+    And user "user0" has added tag "lorem" to file "/lorem.txt"
+    And user "user0" has added tag "lorem" to file "/testimage.jpg"
+    And user "user0" has added tag "ipsum" to file "/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
     And the user searches for tag "ipsum" using the webUI
@@ -67,9 +67,9 @@ Feature: Search
 
   @systemtags-app-required
   Scenario: search for a file with tags
-    Given user "user1" has created a "normal" tag with name "lorem"
-    And user "user1" has added tag "lorem" to file "/lorem.txt"
-    And user "user1" has added tag "lorem" to file "/simple-folder/lorem.txt"
+    Given user "user0" has created a "normal" tag with name "lorem"
+    And user "user0" has added tag "lorem" to file "/lorem.txt"
+    And user "user0" has added tag "lorem" to file "/simple-folder/lorem.txt"
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -78,26 +78,26 @@ Feature: Search
 
   @files_sharing-app-required
   Scenario: Search for a shared file
-    Given user "user0" has been created with default attributes and skeleton files
-    When user "user0" shares file "/lorem.txt" with user "user1" using the sharing API
+    Given user "user2" has been created with default attributes and skeleton files
+    When user "user2" shares file "/lorem.txt" with user "user0" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "lorem" using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
 
   @files_sharing-app-required
   Scenario: Search for a re-shared file
-    Given user "user2" has been created with default attributes and skeleton files
-    And user "user0" has been created with default attributes and skeleton files
-    When user "user2" shares file "/lorem.txt" with user "user0" using the sharing API
-    And user "user0" shares file "/lorem (2).txt" with user "user1" using the sharing API
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
+    When user "user1" shares file "/lorem.txt" with user "user2" using the sharing API
+    And user "user2" shares file "/lorem (2).txt" with user "user0" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "lorem" using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
 
   @files_sharing-app-required
   Scenario: Search for a shared folder
-    Given user "user0" has been created with default attributes and skeleton files
-    When user "user0" shares folder "simple-folder" with user "user1" using the sharing API
+    Given user "user2" has been created with default attributes and skeleton files
+    When user "user2" shares folder "simple-folder" with user "user0" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "simple" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
@@ -110,22 +110,22 @@ Feature: Search
     And file "torem.txt" should be listed on the webUI
 
   Scenario: Search for a newly uploaded file
-    Given user "user1" has uploaded file with content "does-not-matter" to "torem.txt"
-    And user "user1" has uploaded file with content "does-not-matter" to "simple-folder/another-torem.txt"
+    Given user "user0" has uploaded file with content "does-not-matter" to "torem.txt"
+    And user "user0" has uploaded file with content "does-not-matter" to "simple-folder/another-torem.txt"
     When the user searches for "torem" using the webUI
     Then file "torem.txt" with path "/" should be listed in the search results in the other folders section on the webUI
     And file "another-torem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI
 
   Scenario: Search for files with difficult names
-    Given user "user1" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
-    And user "user1" has uploaded file with content "does-not-matter" to "/strängé नेपाली folder/strängéनेपालीloremfile.txt"
+    Given user "user0" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
+    And user "user0" has uploaded file with content "does-not-matter" to "/strängé नेपाली folder/strängéनेपालीloremfile.txt"
     When the user searches for "lorem" using the webUI
     Then file "strängéनेपालीloremfile.txt" with path "/" should be listed in the search results in the other folders section on the webUI
     And file "strängéनेपालीloremfile.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
 
   Scenario: Search for files with difficult names and difficult search phrase
-    Given user "user1" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
-    And user "user1" has uploaded file with content "does-not-matter" to "/strängé नेपाली folder/strängéनेपालीloremfile.txt"
+    Given user "user0" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
+    And user "user0" has uploaded file with content "does-not-matter" to "/strängé नेपाली folder/strängéनेपालीloremfile.txt"
     When the user searches for "strängéनेपाली" using the webUI
     Then file "strängéनेपालीloremfile.txt" with path "/" should be listed in the search results in the other folders section on the webUI
     And file "strängéनेपालीloremfile.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -12,8 +12,8 @@ Feature: login users
   Scenario: simple user login
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    When user "user1" logs in using the webUI
+      | user0    |
+    When user "user0" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   @smokeTest @TestAlsoOnExternalUserBackend

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -7,9 +7,9 @@ Feature: reset the password
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
+      | user0    |
     And the user has browsed to the login page
-    And the user has logged in with username "user1" and invalid password "%alt2%" using the webUI
+    And the user has logged in with username "user0" and invalid password "%alt2%" using the webUI
 
   @smokeTest
   Scenario: send password reset email
@@ -18,7 +18,7 @@ Feature: reset the password
       """
       The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
       """
-    And the email address "user1@example.org" should have received an email with the body containing
+    And the email address "user0@example.org" should have received an email with the body containing
       """
       Use the following link to reset your password: <a href=
       """
@@ -27,34 +27,34 @@ Feature: reset the password
   @smokeTest
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
-    And the user follows the password reset link from email address "user1@example.org"
+    And the user follows the password reset link from email address "user0@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user resets the password to "%alt3%" and confirms with the same password using the webUI
     Then the user should be redirected to the login page
-    And the email address "user1@example.org" should have received an email with the body containing
+    And the email address "user0@example.org" should have received an email with the body containing
       """
       Password changed successfully
       """
-    When the user logs in with username "user1" and password "%alt3%" using the webUI
+    When the user logs in with username "user0" and password "%alt3%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   @skipOnEncryption
   Scenario: check if the sender email address is valid
     When the user requests the password reset link using the webUI
-    And the user follows the password reset link from email address "user1@example.org"
+    And the user follows the password reset link from email address "user0@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user resets the password to "%alt3%" and confirms with the same password using the webUI
     Then the user should be redirected to the login page
-    And the email address "user1@example.org" should have received an email with the body containing
+    And the email address "user0@example.org" should have received an email with the body containing
       """
       Password changed successfully
       """
-    And the reset email to "user1@example.org" should be from "owncloud@foobar.com"
+    And the reset email to "user0@example.org" should be from "owncloud@foobar.com"
 
   @skipOnEncryption
   Scenario: using the password reset token plus invalid username does not work
     When the user requests the password reset link using the webUI
-    And the user follows the password reset link from email address "user1@example.org" but supplying invalid user name "qwerty"
+    And the user follows the password reset link from email address "user0@example.org" but supplying invalid user name "qwerty"
     Then the user should be redirected to a webUI page with the title "%productname%"
     And a lost password reset error message with this text should be displayed on the webUI:
       """
@@ -64,7 +64,7 @@ Feature: reset the password
   @skipOnEncryption
   Scenario: using an invalid password reset token with valid username does not work
     When the user requests the password reset link using the webUI
-    And the user follows the password reset link from email address "user1@example.org" but supplying an invalid token
+    And the user follows the password reset link from email address "user0@example.org" but supplying an invalid token
     Then the user should be redirected to a webUI page with the title "%productname%"
     And a lost password reset error message with this text should be displayed on the webUI:
       """
@@ -74,7 +74,7 @@ Feature: reset the password
   @skipOnEncryption
   Scenario: When new password and confirmation password are different does not reset user password
     When the user requests the password reset link using the webUI
-    And the user follows the password reset link from email address "user1@example.org"
+    And the user follows the password reset link from email address "user0@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user resets the password to "%alt3%" and confirms with "foo" using the webUI
     Then the user should see a password mismatch message displayed on the webUI

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -7,9 +7,9 @@ Feature: reset the password using an email address
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
+      | user0    |
     And the user has browsed to the login page
-    And the user logs in with email "user1@example.org" and invalid password "%alt2%" using the webUI
+    And the user logs in with email "user0@example.org" and invalid password "%alt2%" using the webUI
 
   @smokeTest
   Scenario: send password reset email
@@ -18,7 +18,7 @@ Feature: reset the password using an email address
       """
       The link to reset your password has been sent to your email. If you do not receive it within a reasonable amount of time, check your spam/junk folders. If it is not there ask your local administrator.
       """
-    And the email address "user1@example.org" should have received an email with the body containing
+    And the email address "user0@example.org" should have received an email with the body containing
       """
       Use the following link to reset your password: <a href=
       """
@@ -26,13 +26,13 @@ Feature: reset the password using an email address
   @skipOnEncryption @smokeTest
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
-    And the user follows the password reset link from email address "user1@example.org"
+    And the user follows the password reset link from email address "user0@example.org"
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user resets the password to "%alt3%" and confirms with the same password using the webUI
     Then the user should be redirected to the login page
-    And the email address "user1@example.org" should have received an email with the body containing
+    And the email address "user0@example.org" should have received an email with the body containing
       """
       Password changed successfully
       """
-    When the user logs in with username "user1" and password "%alt3%" using the webUI
+    When the user logs in with username "user0" and password "%alt3%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -7,15 +7,15 @@ Feature: manage user quota
   Background:
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
-      | user1    |
+      | user0    |
     And the administrator has logged in using the webUI
     And the administrator has browsed to the users page
 
   Scenario Outline: change quota to a valid value
-    Given the administrator has set the quota of user "user1" to "<start_quota>"
-    When the administrator changes the quota of user "user1" to "<wished_quota>" using the webUI
+    Given the administrator has set the quota of user "user0" to "<start_quota>"
+    When the administrator changes the quota of user "user0" to "<wished_quota>" using the webUI
     And the administrator reloads the users page
-    Then the quota of user "user1" should be set to "<expected_quota>" on the webUI
+    Then the quota of user "user0" should be set to "<expected_quota>" on the webUI
     Examples:
       | start_quota | wished_quota | expected_quota |
       | Unlimited   | 5 GB         | 5 GB           |
@@ -29,15 +29,15 @@ Feature: manage user quota
 
   @skipOnOcV10.0.3
   Scenario: change quota to a valid value that do not work on 10.0.3
-    Given the administrator has set the quota of user "user1" to "Unlimited"
-    When the administrator changes the quota of user "user1" to "0 Kb" using the webUI
+    Given the administrator has set the quota of user "user0" to "Unlimited"
+    When the administrator changes the quota of user "user0" to "0 Kb" using the webUI
     And the administrator reloads the users page
-    Then the quota of user "user1" should be set to "0 B" on the webUI
+    Then the quota of user "user0" should be set to "0 B" on the webUI
 
   Scenario Outline: change quota to an invalid value
-    When the administrator changes the quota of user "user1" to the invalid string "<wished_quota>" using the webUI
+    When the administrator changes the quota of user "user0" to the invalid string "<wished_quota>" using the webUI
     Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
-    And the quota of user "user1" should be set to "Default" on the webUI
+    And the quota of user "user0" should be set to "Default" on the webUI
     Examples:
       | wished_quota |
       | stupidtext   |

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -7,22 +7,22 @@ Feature: delete users
   Background:
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
     And the administrator has logged in using the webUI
     And the administrator has browsed to the users page
 
   Scenario: use the webUI to delete a simple user
-    When the administrator deletes user "user1" using the webUI and confirms the deletion using the webUI
-    And the deleted user "user1" tries to login using the password "%alt1%" using the webUI
+    When the administrator deletes user "user0" using the webUI and confirms the deletion using the webUI
+    And the deleted user "user0" tries to login using the password "%alt1%" using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user has browsed to the login page
-    And user "user2" logs in using the webUI
+    And user "user1" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   Scenario: use the webUI to cancel deletion of user
-    When the administrator deletes user "user1" using the webUI and cancels the deletion using the webUI
-    Then user "user1" should exist
+    When the administrator deletes user "user0" using the webUI and cancels the deletion using the webUI
+    Then user "user0" should exist
 
   Scenario Outline:  user names are not case-sensitive, deleting users with different upper and lower case names
     When the administrator creates a user with the name "<user_id1>" and the password "password" using the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
@@ -7,32 +7,32 @@ Feature: disable users
   Background:
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
 
   Scenario: disable a user
     Given the administrator has logged in using the webUI
     And the administrator has browsed to the users page
-    When the administrator disables user "user1" using the webUI
-    Then user "user1" should be disabled
-    When the disabled user "user1" tries to login using the password "%alt1%" from the webUI
+    When the administrator disables user "user0" using the webUI
+    Then user "user0" should be disabled
+    When the disabled user "user0" tries to login using the password "%regular%" from the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user has browsed to the login page
-    And user "user2" logs in using the webUI
+    And user "user1" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   Scenario: subadmin disables a user
     Given group "grp1" has been created
     And user "subadmin" has been created with default attributes and skeleton files
+    And user "user0" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
-    And user "user2" has been added to group "grp1"
     And user "subadmin" has been made a subadmin of group "grp1"
     And user "subadmin" has logged in using the webUI
     And the user has browsed to the users page
-    When the user disables user "user1" using the webUI
-    Then user "user1" should be disabled
-    When the disabled user "user1" tries to login using the password "%alt1%" from the webUI
+    When the user disables user "user0" using the webUI
+    Then user "user0" should be disabled
+    When the disabled user "user0" tries to login using the password "%regular%" from the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the user has browsed to the login page
-    And user "user2" logs in using the webUI
+    And user "user1" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -5,8 +5,8 @@ Feature: move files
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario: An attempt to move a file into a sub-folder using rename is not allowed
@@ -82,7 +82,7 @@ Feature: move files
 
   @files_sharing-app-required
   Scenario: move files on a public share
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path        | /simple-folder     |
       | permissions | read,create,change |
     And the public has accessed the last created public link using the webUI
@@ -90,5 +90,5 @@ Feature: move files
     Then file "data.zip" should not be listed on the webUI
     When the user reloads the current page of the webUI
     Then file "data.zip" should not be listed on the webUI
-    And as "user1" file "simple-folder/simple-empty-folder/data.zip" should exist
-    But as "user1" file "simple-folder/data.zip" should not exist
+    And as "user0" file "simple-folder/simple-empty-folder/data.zip" should exist
+    But as "user0" file "simple-folder/data.zip" should not exist

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -5,8 +5,8 @@ Feature: move folders
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   Scenario: An attempt to move a folder into a sub-folder using rename is not allowed

--- a/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
@@ -5,8 +5,8 @@ Feature: Control access to edit fullname of user through config file
   So that users can edit their fullname after getting permission from administrator
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
 
   Scenario: Admin gives access to users to change their full name
     When the administrator updates system config key "allow_user_to_change_display_name" with value "true" and type "boolean" using the occ command
@@ -14,7 +14,7 @@ Feature: Control access to edit fullname of user through config file
     And the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
     And the user reloads the current page of the webUI
     Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the WebUI
-    And the attributes of user "user1" returned by the API should include
+    And the attributes of user "user0" returned by the API should include
       | displayname | my#very&weird?नेपालि%name |
 
   Scenario: Admin does not give access to users to change their full name

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -5,8 +5,8 @@ Feature: Change own email address on the personal settings page
   So that I can be reached by the owncloud server
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest
@@ -14,5 +14,5 @@ Feature: Change own email address on the personal settings page
   Scenario: Change email address
     When the user changes the email address to "new-address@owncloud.com" using the webUI
     And the user follows the email change confirmation link received by "new-address@owncloud.com" using the webUI
-    Then the attributes of user "user1" returned by the API should include
+    Then the attributes of user "user0" returned by the API should include
       | email | new-address@owncloud.com |

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -5,8 +5,8 @@ Feature: Change own full name on the personal settings page
   So that other users can recognize me by it
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest
@@ -14,5 +14,5 @@ Feature: Change own full name on the personal settings page
     When the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
     And the user reloads the current page of the webUI
     Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the WebUI
-    And the attributes of user "user1" returned by the API should include
+    And the attributes of user "user0" returned by the API should include
       | displayname | my#very&weird?नेपालि%name |

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -5,19 +5,19 @@ Feature: Change Login Password
   So that I can login with my new password
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest
   Scenario: Change password
     When the user changes the password to "%alt3%" using the webUI
-    And the user re-logs in with username "user1" and password "%alt3%" using the webUI
+    And the user re-logs in with username "user0" and password "%alt3%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   Scenario Outline: Change password to some unusual values
     When the user changes the password to "<new_password>" using the webUI
-    And the user re-logs in with username "user1" and password "<new_password>" using the webUI
+    And the user re-logs in with username "user0" and password "<new_password>" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
     Examples:
       | new_password                 | comment                               |
@@ -30,7 +30,7 @@ Feature: Change Login Password
     Then a password error message should be displayed on the webUI with the text "Wrong current password"
 
   Scenario: New password is same as current password
-    When the user changes the password to "%alt1%" using the webUI
+    When the user changes the password to "%regular%" using the webUI
     Then a password error message should be displayed on the webUI with the text "The new password cannot be the same as the previous one"
 
   Scenario Outline: Password change with invalid or no new password

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -5,8 +5,8 @@ Feature: personal general settings
   So that I can personalise the User Interface
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
   @smokeTest
@@ -24,7 +24,7 @@ Feature: personal general settings
 
   Scenario: change language using the occ command and check that file actions menu have been translated
     Given the user has created folder "simple-folder"
-    When the administrator changes the language of user "user1" to "fr" using the occ command
+    When the administrator changes the language of user "user0" to "fr" using the occ command
     And the user browses to the files page
     And the user opens the file action menu of folder "simple-folder" on the webUI
     Then the user should see "Details" file action translated to "Détails" on the webUI
@@ -32,7 +32,7 @@ Feature: personal general settings
 
   Scenario: change language to invalid language using the occ command and check that the language defaults back to english
     Given the user has created folder "simple-folder"
-    When the administrator changes the language of user "user1" to "not-valid-lan" using the occ command
+    When the administrator changes the language of user "user0" to "not-valid-lan" using the occ command
     And the user browses to the files page
     And the user opens the file action menu of folder "simple-folder" on the webUI
     Then the user should see "Details" file action translated to "Details" on the webUI
@@ -41,28 +41,28 @@ Feature: personal general settings
   Scenario: user sees displayed version number, groupnames and federated cloud ID on the personal general settings page
     Given group "new-group" has been created
     And group "another-group" has been created
-    And user "user1" has been added to group "new-group"
-    And user "user1" has been added to group "another-group"
+    And user "user0" has been added to group "new-group"
+    And user "user0" has been added to group "another-group"
     And the user has reloaded the current page of the webUI
     Then the owncloud version should be displayed on the personal general settings page on the webUI
-    And the federated cloud id for user "user1" should be displayed on the personal general settings page on the webUI
+    And the federated cloud id for user "user0" should be displayed on the personal general settings page on the webUI
     And group "new-group" should be displayed on the personal general settings page on the webUI
     And group "another-group" should be displayed on the personal general settings page on the webUI
 
   Scenario: User sets profile picture from their existing cloud file
-    Given user "user1" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
+    Given user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
     And the user has deleted any existing profile picture
     When the user sets profile picture to "testimage.jpg" from their cloud files using the webUI
     Then the preview of the profile picture should be shown on the webUI
 
   Scenario: User deletes the existing profile picture
-    Given user "user1" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
+    Given user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
     And the user has set profile picture to "testimage.jpg" from their cloud files
     When the user deletes the existing profile picture
     Then the preview of the profile picture should not be shown on the webUI
 
   Scenario: User uploads new profile picture
-    Given user "user1" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
+    Given user "user0" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
     And the user has deleted any existing profile picture
     When the user uploads "testavatar.png" as a new profile picture using the webUI
     Then the preview of the profile picture should be shown on the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -5,19 +5,19 @@ Feature: personal security settings
   So that I can enable, allow and deny access to and from other storage systems or resources
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the personal security settings page
 
   @smokeTest
   Scenario: login with new app password
     When the user creates a new App password using the webUI
-    And the user re-logs in with username "user1" and generated app password using the webUI
+    And the user re-logs in with username "user0" and generated app password using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
   @smokeTest
   Scenario: delete the app password
     When the user creates a new App password using the webUI
     And the user deletes the app password
-    And the user re-logs in with username "user1" and deleted app password using the webUI
+    And the user re-logs in with username "user0" and deleted app password using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"

--- a/tests/acceptance/features/webUIRenameFiles/renameFile.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFile.feature
@@ -5,12 +5,12 @@ Feature: rename files
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Rename a file using special characters
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to <to_file_name> using the webUI
     Then file <to_file_name> should be listed on the webUI
     When the user reloads the current page of the webUI
@@ -40,13 +40,13 @@ Feature: rename files
       | 0.0      |
 
   Scenario Outline: Rename a file that has special characters in its name
-    Given user "user1" has uploaded file with content "some content" to <from_name>
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to <from_name>
+    And user "user0" has logged in using the webUI
     When the user renames file <from_name> to <to_name> using the webUI
     Then file <to_name> should be listed on the webUI
     When the user reloads the current page of the webUI
     Then file <to_name> should be listed on the webUI
-    And the content of file <to_name> for user "user1" should be "some content"
+    And the content of file <to_name> for user "user0" should be "some content"
     Examples:
       | from_name                               | to_name                               |
       | "strängé filename (duplicate #2 &).txt" | "strängé filename (duplicate #3).txt" |
@@ -55,9 +55,9 @@ Feature: rename files
 
   @smokeTest
   Scenario: Rename a file using special characters and check its existence after page reload
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has uploaded file with content "more content" to "/zzzz-must-be-last-file-in-folder.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has uploaded file with content "more content" to "/zzzz-must-be-last-file-in-folder.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to "लोरेम।तयक्स्त $%&" using the webUI
     And the user reloads the current page of the webUI
     Then file "लोरेम।तयक्स्त $%&" should be listed on the webUI
@@ -75,8 +75,8 @@ Feature: rename files
     Then file "aaaaaa.txt" should be listed on the webUI
 
   Scenario: Rename a file using spaces at front and/or back of file name and type
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to " space at start" using the webUI
     And the user reloads the current page of the webUI
     Then file " space at start" should be listed on the webUI
@@ -97,8 +97,8 @@ Feature: rename files
     Then file "  multiple   space    all     over   .  dat  " should be listed on the webUI
 
   Scenario: Rename a file using both double and single quotes
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has logged in using the webUI
     When the user renames the following file using the webUI
       | from-name-parts | to-name-parts         |
       | randomfile.txt  | First 'single' quotes |
@@ -116,9 +116,9 @@ Feature: rename files
     Then file "loremz.dat" should be listed on the webUI
 
   Scenario: Rename a file using forbidden characters
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the administrator has updated system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | lorem\txt            |
       | \\.txt               |
@@ -133,11 +133,11 @@ Feature: rename files
 
   @skipOnOcV10.3
   Scenario: Rename a file to a filename that matches (or not) blacklisted_files_regex
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
     And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | filename.ext                  |
       | bannedfilename.txt            |
@@ -149,9 +149,9 @@ Feature: rename files
     And file "randomfile.txt" should be listed on the webUI
 
   Scenario: Rename a file to an excluded folder name
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | .github |
     Then notifications should be displayed on the webUI with the text
@@ -159,10 +159,10 @@ Feature: rename files
     And file "randomfile.txt" should be listed on the webUI
 
   Scenario: Rename a file to an excluded folder name inside a parent folder
-    Given user "user1" has created folder "top-folder"
-    And user "user1" has uploaded file with content "some content" to "/top-folder/randomfile.txt"
+    Given user "user0" has created folder "top-folder"
+    And user "user0" has uploaded file with content "some content" to "/top-folder/randomfile.txt"
     And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has opened folder "top-folder" using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | .github |
@@ -172,11 +172,11 @@ Feature: rename files
 
   @skipOnOcV10.3
   Scenario: Rename a file to a filename that matches (or not) excluded_directories_regex
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
     And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | thisendswith.bad                |
       | .github                         |
@@ -188,51 +188,51 @@ Feature: rename files
     And file "randomfile.txt" should be listed on the webUI
 
   Scenario: Rename the last file in a folder
-    Given user "user1" has uploaded file with content "some content" to "/firstfile.txt"
-    And user "user1" has uploaded file with content "more content" to "/zzzz-must-be-last-file-in-folder.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/firstfile.txt"
+    And user "user0" has uploaded file with content "more content" to "/zzzz-must-be-last-file-in-folder.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "zzzz-must-be-last-file-in-folder.txt" to "a-file.txt" using the webUI
     And the user reloads the current page of the webUI
     Then file "a-file.txt" should be listed on the webUI
 
   Scenario: Rename a file to become the last file in a folder
-    Given user "user1" has uploaded file with content "some content" to "/firstfile.txt"
-    And user "user1" has uploaded file with content "more content" to "/lastfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/firstfile.txt"
+    And user "user0" has uploaded file with content "more content" to "/lastfile.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "firstfile.txt" to "zzzz-z-this-is-now-the-last-file.txt" using the webUI
     And the user reloads the current page of the webUI
     Then file "zzzz-z-this-is-now-the-last-file.txt" should be listed on the webUI
 
   Scenario: Rename a file putting a name of a file which already exists
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has uploaded file with content "another content" to "/anotherfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has uploaded file with content "another content" to "/anotherfile.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "anotherfile.txt" to "randomfile.txt" using the webUI
     Then near file "anotherfile.txt" a tooltip with the text 'randomfile.txt already exists' should be displayed on the webUI
 
   Scenario: Rename a file to ..
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to ".." using the webUI
     Then near file "randomfile.txt" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
   Scenario: Rename a file to .
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to "." using the webUI
     Then near file "randomfile.txt" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
   Scenario: Rename a file to .part
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to "randomfile.part" using the webUI
     Then near file "randomfile.txt" a tooltip with the text '"randomfile.part" has a forbidden file type/extension.' should be displayed on the webUI
 
   @files_sharing-app-required
   Scenario: rename a file on a public share
-    Given user "user1" has created folder "/FOLDER_TO_SHARE"
-    And user "user1" has uploaded file with content "some content" to "/FOLDER_TO_SHARE/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/FOLDER_TO_SHARE"
+    And user "user0" has uploaded file with content "some content" to "/FOLDER_TO_SHARE/randomfile.txt"
+    And user "user0" has logged in using the webUI
     And the user has created a new public link for folder "FOLDER_TO_SHARE" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
@@ -242,5 +242,5 @@ Feature: rename files
     When the user reloads the current page of the webUI
     Then file "a-renamed-file.txt" should be listed on the webUI
     But file "randomfile.txt" should not be listed on the webUI
-    And as "user1" file "FOLDER_TO_SHARE/a-renamed-file.txt" should exist
-    And as "user1" file "FOLDER_TO_SHARE/randomfile.txt" should not exist
+    And as "user0" file "FOLDER_TO_SHARE/a-renamed-file.txt" should exist
+    And as "user0" file "FOLDER_TO_SHARE/randomfile.txt" should not exist

--- a/tests/acceptance/features/webUIRenameFiles/renameFileToBlacklistedName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFileToBlacklistedName.feature
@@ -5,15 +5,15 @@ Feature: users cannot rename a file to a blacklisted name
   So that I can prevent unwanted file names existing in the cloud storage
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.3
   Scenario: Rename a file to a filename that matches (or not) blacklisted_files_regex
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
     And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | filename.ext                  |
       | bannedfilename.txt            |

--- a/tests/acceptance/features/webUIRenameFiles/renameFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFileToExcludedDirectory.feature
@@ -5,12 +5,12 @@ Feature: users cannot rename a file to or into an excluded directory
   So that I can have directories on my cloud server storage that are not available for syncing.
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   Scenario: Rename a file to an excluded folder name
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | .github |
     Then notifications should be displayed on the webUI with the text
@@ -18,10 +18,10 @@ Feature: users cannot rename a file to or into an excluded directory
     And file "randomfile.txt" should be listed on the webUI
 
   Scenario: Rename a file to an excluded folder name inside a parent folder
-    Given user "user1" has created folder "top-folder"
-    And user "user1" has uploaded file with content "some content" to "/top-folder/randomfile.txt"
+    Given user "user0" has created folder "top-folder"
+    And user "user0" has uploaded file with content "some content" to "/top-folder/randomfile.txt"
     And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has opened folder "top-folder" using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | .github |
@@ -31,11 +31,11 @@ Feature: users cannot rename a file to or into an excluded directory
 
   @skipOnOcV10.3
   Scenario: Rename a file to a filename that matches (or not) excluded_directories_regex
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
     And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames file "randomfile.txt" to one of these names using the webUI
       | thisendswith.bad                |
       | .github                         |

--- a/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFilesInsideProblematicFolderName.feature
@@ -5,13 +5,13 @@ Feature: Renaming files inside a folder with problematic name
   So that I can recognize my file easily
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
 
   Scenario Outline: Rename the existing file inside a problematic folder
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has created folder "<folder>"
-    And user "user1" has moved file "/randomfile.txt" to "/<folder>/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has created folder "<folder>"
+    And user "user0" has moved file "/randomfile.txt" to "/<folder>/randomfile.txt"
     And the user reloads the current page of the webUI
     When the user opens folder "<folder>" using the webUI
     And the user renames file "randomfile.txt" to "???.txt" using the webUI

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -5,11 +5,11 @@ Feature: rename folders
   So that I can organise my data structure
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   Scenario Outline: Rename a folder using special characters
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to <to_folder_name> using the webUI
     Then folder <to_folder_name> should be listed on the webUI
     When the user reloads the current page of the webUI
@@ -21,8 +21,8 @@ Feature: rename folders
       | "'quotes2'"             |
 
   Scenario Outline: Rename a folder that has special characters in its name
-    Given user "user1" has created folder <from_name>
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder <from_name>
+    And user "user0" has logged in using the webUI
     When the user renames folder <from_name> to <to_name> using the webUI
     Then folder <to_name> should be listed on the webUI
     When the user reloads the current page of the webUI
@@ -33,8 +33,8 @@ Feature: rename folders
       | "'single'quotes"        | "single-quotes"             |
 
   Scenario: Rename a folder using special characters and check its existence after page reload
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to "लोरेम।तयक्स्त $%&" using the webUI
     And the user reloads the current page of the webUI
     Then folder "लोरेम।तयक्स्त $%&" should be listed on the webUI
@@ -49,8 +49,8 @@ Feature: rename folders
     Then folder "hash#And&QuestionMark?At@FolderName" should be listed on the webUI
 
   Scenario: Rename a folder using spaces at front and/or back of the name
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to " space at start" using the webUI
     And the user reloads the current page of the webUI
     Then folder " space at start" should be listed on the webUI
@@ -62,8 +62,8 @@ Feature: rename folders
     Then folder "  multiple   spaces    all     over   " should be listed on the webUI
 
   Scenario: Rename a folder using both double and single quotes
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has logged in using the webUI
     When the user renames the following folder using the webUI
       | from-name-parts | to-name-parts         |
       | a-folder        | First 'single' quotes |
@@ -81,9 +81,9 @@ Feature: rename folders
     Then folder "a normal folder" should be listed on the webUI
 
   Scenario: Rename a folder using forbidden characters
-    Given user "user1" has created folder "a-folder"
+    Given user "user0" has created folder "a-folder"
     And the administrator has updated system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to one of these names using the webUI
       | simple\folder        |
       | \\simple-folder      |
@@ -97,37 +97,37 @@ Feature: rename folders
     And folder "a-folder" should be listed on the webUI
 
   Scenario: Rename a folder putting a name of a file which already exists
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to "randomfile.txt" using the webUI
     Then near folder "a-folder" a tooltip with the text 'randomfile.txt already exists' should be displayed on the webUI
 
   Scenario: Rename a folder to ..
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to ".." using the webUI
     Then near folder "a-folder" a tooltip with the text '".." is an invalid file name.' should be displayed on the webUI
 
   Scenario: Rename a folder to .
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to "." using the webUI
     Then near folder "a-folder" a tooltip with the text '"." is an invalid file name.' should be displayed on the webUI
 
   Scenario: Rename a folder to .part
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to "a.part" using the webUI
     Then near folder "a-folder" a tooltip with the text '"a.part" has a forbidden file type/extension.' should be displayed on the webUI
 
   @issue-30325
   Scenario: Rename a folder which is received as a share (without change permission)
-    Given user "user2" has been created with default attributes and without skeleton files
-    And user "user2" has created folder "RandomFolder"
-    And user "user2" has uploaded file with content "thisIsFileInsideFolder" to "/RandomFolder/newFile"
-    And user "user2" has shared folder "RandomFolder" with user "user1" with permissions "read, share"
-    And user "user1" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "RandomFolder"
+    And user "user1" has uploaded file with content "thisIsFileInsideFolder" to "/RandomFolder/newFile"
+    And user "user1" has shared folder "RandomFolder" with user "user0" with permissions "read, share"
+    And user "user0" has logged in using the webUI
     When the user renames folder "RandomFolder" to "renamedFolder" using the webUI
 #   Then folder "renamedFolder" should be listed on the webUI
     Then a notification should be displayed on the webUI with the text 'Could not rename "RandomFolder"'
@@ -136,11 +136,11 @@ Feature: rename folders
     Then the option to rename file "newFile" should not be available on the webUI
 
   Scenario: Rename a folder which is received as a share (with change permission)
-    Given user "user2" has been created with default attributes and without skeleton files
-    And user "user2" has created folder "RandomFolder"
-    And user "user2" has uploaded file with content "thisIsFileInsideFolder" to "/RandomFolder/newFile"
-    And user "user2" has shared folder "RandomFolder" with user "user1" with permissions "read, share, change"
-    And user "user1" has logged in using the webUI
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "RandomFolder"
+    And user "user1" has uploaded file with content "thisIsFileInsideFolder" to "/RandomFolder/newFile"
+    And user "user1" has shared folder "RandomFolder" with user "user0" with permissions "read, share, change"
+    And user "user0" has logged in using the webUI
     When the user renames folder "RandomFolder" to "renamedFolder" using the webUI
     Then folder "renamedFolder" should be listed on the webUI
     But folder "RandomFolder" should not be listed on the webUI

--- a/tests/acceptance/features/webUIRenameFolders/renameFoldersToBlacklistedName.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFoldersToBlacklistedName.feature
@@ -5,15 +5,15 @@ Feature: users cannot rename a folder to a blacklisted name
   So that I can prevent unwanted file names existing in the cloud storage
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.3
   Scenario: Rename a folder to a foldername that matches (or not) blacklisted_files_regex
-    Given user "user1" has created folder "a-folder"
+    Given user "user0" has created folder "a-folder"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
     And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to one of these names using the webUI
       | filename.ext                  |
       | bannedfilename.txt            |

--- a/tests/acceptance/features/webUIRenameFolders/renameFoldersToExcludedDirectory.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFoldersToExcludedDirectory.feature
@@ -5,12 +5,12 @@ Feature: users cannot rename a folder to or into an excluded directory
   So that I can have directories on my cloud server storage that are not available for syncing.
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   Scenario: Rename a folder to an excluded folder name
-    Given user "user1" has created folder "a-folder"
+    Given user "user0" has created folder "a-folder"
     And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to one of these names using the webUI
       | .github |
     Then notifications should be displayed on the webUI with the text
@@ -18,10 +18,10 @@ Feature: users cannot rename a folder to or into an excluded directory
     And folder "a-folder" should be listed on the webUI
 
   Scenario: Rename a folder to an excluded folder name inside a parent folder
-    Given user "user1" has created folder "top-folder"
-    And user "user1" has created folder "top-folder/a-folder"
+    Given user "user0" has created folder "top-folder"
+    And user "user0" has created folder "top-folder/a-folder"
     And the administrator has updated system config key "excluded_directories" with value '[".github"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has opened folder "top-folder" using the webUI
     When the user renames folder "a-folder" to one of these names using the webUI
       | .github            |
@@ -31,11 +31,11 @@ Feature: users cannot rename a folder to or into an excluded directory
 
   @skipOnOcV10.3
   Scenario: Rename a folder to a foldername that matches (or not) excluded_directories_regex
-    Given user "user1" has created folder "a-folder"
+    Given user "user0" has created folder "a-folder"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
     And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user renames folder "a-folder" to one of these names using the webUI
       | thisendswith.bad                |
       | .github                         |

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -5,12 +5,12 @@ Feature: disable sharing
   So that users cannot share files
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Users tries to share via WebUI when Sharing is disabled
-    Given user "user1" has created folder "simple-folder"
+    Given user "user0" has created folder "simple-folder"
     And the setting "Allow apps to use the Share API" in the section "Sharing" has been disabled
-    When user "user1" logs in using the webUI
+    When user "user0" logs in using the webUI
     Then it should not be possible to share folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -8,26 +8,26 @@ Feature: restrict resharing
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
     And these groups have been created:
       | groupname |
       | grp1      |
+    And user "user0" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
-    And user "user2" has been added to group "grp1"
+    And user "user0" has created folder "simple-folder"
     And user "user1" has created folder "simple-folder"
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
 
   @skipOnMICROSOFTEDGE @skipOnFIREFOX @TestAlsoOnExternalUserBackend @files_sharing-app-required
   @smokeTest @skipOnOcV10.3
   Scenario: share a folder with another internal user and prohibit resharing
     Given the setting "Allow resharing" in the section "Sharing" has been enabled
     And the user has browsed to the files page
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
       | share | no |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then it should not be possible to share folder "simple-folder (2)" using the webUI
 
   @TestAlsoOnExternalUserBackend @files_sharing-app-required
@@ -35,6 +35,6 @@ Feature: restrict resharing
   Scenario: forbid resharing globally
     Given the setting "Allow resharing" in the section "Sharing" has been disabled
     And the user has browsed to the files page
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then it should not be possible to share folder "simple-folder (2)" using the webUI

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -7,26 +7,28 @@ Feature: restrict Sharing
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
     And these groups have been created:
       | groupname |
       | grp1      |
       | grp2      |
+    And user "user0" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
-    And user "user2" has been added to group "grp1"
+    And user "user2" has been added to group "grp2"
+    And user "user0" has created folder "simple-folder"
     And user "user1" has created folder "simple-folder"
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Restrict users to only share with users in their groups
     Given the setting "Restrict users to only share with users in their groups" in the section "Sharing" has been enabled
     When the user browses to the files page
-    Then it should not be possible to share folder "simple-folder" with user "User Three" using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    Then it should not be possible to share folder "simple-folder" with user "User Two" using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -36,7 +38,7 @@ Feature: restrict Sharing
     When the user browses to the files page
     Then it should not be possible to share folder "simple-folder" with group "grp2" using the webUI
     When the user shares folder "simple-folder" with group "grp1" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
   @TestAlsoOnExternalUserBackend
@@ -57,8 +59,8 @@ Feature: restrict Sharing
     When the user browses to the files page
     Then it should not be possible to share folder "simple-folder" with group "grp1" using the webUI
     And it should not be possible to share folder "simple-folder" with group "grp2" using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
   @skipOnOcV10.3

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -7,8 +7,8 @@ Feature: add users
   Background:
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
     And the administrator has logged in using the webUI
     And the administrator has browsed to the users page
 
@@ -16,68 +16,68 @@ Feature: add users
     When the administrator enables the setting "Show email address" in the User Management page using the webUI
     Then the administrator should be able to see the email of these users in the User Management page:
       | username | email             |
+      | user0    | user0@example.org |
       | user1    | user1@example.org |
-      | user2    | user2@example.org |
 
   Scenario: administrator should be able to see storage location of a user
     When the administrator enables the setting "Show storage location" in the User Management page using the webUI
     Then the administrator should be able to see the storage location of these users in the User Management page:
       | username | storage location |
+      | user0    | /data/user0      |
       | user1    | /data/user1      |
-      | user2    | /data/user2      |
 
   Scenario: administrator should be able to see last login of a user when the user is not initialized
     When the administrator enables the setting "Show last log in" in the User Management page using the webUI
     Then the administrator should be able to see the last login of these users in the User Management page:
       | username | last login |
+      | user0    | never      |
       | user1    | never      |
-      | user2    | never      |
 
   Scenario: administrator should be able to see last login of a user when the user is initialized
     When the administrator enables the setting "Show last log in" in the User Management page using the webUI
     And the administrator logs out of the webUI
-    And user "user1" logs in using the webUI
+    And user "user0" logs in using the webUI
     And the user logs out of the webUI
     And the administrator logs in using the webUI
     And the administrator browses to the users page
     Then the administrator should be able to see the last login of these users in the User Management page:
       | username | last login  |
-      | user1    | seconds ago |
-      | user2    | never       |
+      | user0    | seconds ago |
+      | user1    | never       |
 
   Scenario: administrator should be able to see password column of user
     When the administrator enables the setting "Show password field" in the User Management page using the webUI
     Then the administrator should be able to see the password of these users in the User Management page:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
 
   Scenario: administrator should not be able to see password column of user
     When the administrator disables the setting "Show password field" in the User Management page using the webUI
     Then the administrator should not be able to see the password of these users in the User Management page:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
 
   Scenario: administrator should be able to see quota of user
     When the administrator enables the setting "Show quota field" in the User Management page using the webUI
     Then the administrator should be able to see the quota of these users in the User Management page:
       | username | quota   |
+      | user0    | Default |
       | user1    | Default |
-      | user2    | Default |
 
   Scenario: administrator should be able to see updated quota of user when enabled show quota field
-    Given the administrator has changed the quota of user "user1" to "Unlimited"
-    And the administrator has changed the quota of user "user2" to "5 GB"
+    Given the administrator has changed the quota of user "user0" to "Unlimited"
+    And the administrator has changed the quota of user "user1" to "5 GB"
     When the administrator enables the setting "Show quota field" in the User Management page using the webUI
     Then the administrator should be able to see the quota of these users in the User Management page:
       | username | quota     |
-      | user1    | Unlimited |
-      | user2    | 5 GB      |
+      | user0    | Unlimited |
+      | user1    | 5 GB      |
 
   Scenario: administrator should not be able to see quota of user
     When the administrator disables the setting "Show quota field" in the User Management page using the webUI
     Then the administrator should not be able to see the quota of these users in the User Management page:
       | username |
+      | user0    |
       | user1    |
-      | user2    |

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -5,20 +5,20 @@ Feature: accept/decline shares coming from internal users
   So that I can keep my file system clean
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    Given user "user2" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    Given user "user1" has been created with default attributes and skeleton files
     And these groups have been created:
       | groupname |
       | grp1      |
+    And user "user0" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
-    And user "user2" has been added to group "grp1"
 
   @smokeTest
   Scenario: Auto-accept disabled results in "Pending" shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And user "user2" has shared file "/testimage.jpg" with user "user1"
-    When user "user1" logs in using the webUI
+    And user "user1" has shared folder "/simple-folder" with group "grp1"
+    And user "user1" has shared file "/testimage.jpg" with user "user0"
+    When user "user0" logs in using the webUI
     Then folder "simple-folder" should not be listed on the webUI
     And file "testimage.jpg" should not be listed on the webUI
     But folder "simple-folder" should be listed in the shared-with-you page on the webUI
@@ -28,37 +28,37 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive shares with same name from different users, accept one by one
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user3" has been created with default attributes and without skeleton files
-    And user "user2" has created folder "/simple-folder/from_user2"
-    And user "user2" has shared folder "/simple-folder" with user "user3"
-    And user "user1" has created folder "/simple-folder"
+    And user "user2" has been created with default attributes and without skeleton files
     And user "user1" has created folder "/simple-folder/from_user1"
-    And user "user1" has shared folder "/simple-folder" with user "user3"
-    And user "user3" has logged in using the webUI
-    When the user accepts share "simple-folder" offered by user "User One" using the webUI
-    And the user accepts share "simple-folder" offered by user "User Two" using the webUI
-    Then folder "simple-folder" shared by "User One" should be in state "" in the shared-with-you page on the webUI
-    And folder "simple-folder (2)" shared by "User Two" should be in state "" in the shared-with-you page on the webUI
-    And user "user3" should see the following elements
-      | /simple-folder/from_user1/       |
-      | /simple-folder%20(2)/from_user2/ |
+    And user "user1" has shared folder "/simple-folder" with user "user2"
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/from_user0"
+    And user "user0" has shared folder "/simple-folder" with user "user2"
+    And user "user2" has logged in using the webUI
+    When the user accepts share "simple-folder" offered by user "User Zero" using the webUI
+    And the user accepts share "simple-folder" offered by user "User One" using the webUI
+    Then folder "simple-folder" shared by "User Zero" should be in state "" in the shared-with-you page on the webUI
+    And folder "simple-folder (2)" shared by "User One" should be in state "" in the shared-with-you page on the webUI
+    And user "user2" should see the following elements
+      | /simple-folder/from_user0/       |
+      | /simple-folder%20(2)/from_user1/ |
 
   Scenario: receive shares with same name from different users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user3" has been created with default attributes and skeleton files
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user3" has shared folder "/simple-folder" with user "user1"
-    When user "user1" logs in using the webUI
-    Then folder "simple-folder" shared by "User Three" should be in state "Pending" in the shared-with-you page on the webUI
-    And folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
+    And user "user2" has been created with default attributes and skeleton files
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user2" has shared folder "/simple-folder" with user "user0"
+    When user "user0" logs in using the webUI
+    Then folder "simple-folder" shared by "User Two" should be in state "Pending" in the shared-with-you page on the webUI
+    And folder "simple-folder" shared by "User One" should be in state "Pending" in the shared-with-you page on the webUI
 
   @smokeTest
   Scenario: accept an offered share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared file "/testimage.jpg" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user accepts share "simple-folder" offered by user "User One" using the webUI
     Then folder "simple-folder" should be in state "" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder" should be in state "" in the shared-with-you page on the webUI after a page reload
@@ -69,11 +69,11 @@ Feature: accept/decline shares coming from internal users
   Scenario Outline: accept an offered share when there is a default folder for received shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And the administrator has set the default folder for received shares to "<share_folder>"
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
-    And the user accepts share "testimage.jpg" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared file "/testimage.jpg" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user accepts share "simple-folder" offered by user "User One" using the webUI
+    And the user accepts share "testimage.jpg" offered by user "User One" using the webUI
     Then folder "simple-folder" should be listed in the files page folder "<share_folder>" on the webUI
     And file "testimage.jpg" should be listed in the files page folder "<share_folder>" on the webUI
     Examples:
@@ -84,10 +84,10 @@ Feature: accept/decline shares coming from internal users
   @smokeTest
   Scenario: decline an offered (pending) share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user declines share "simple-folder" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared file "/testimage.jpg" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user declines share "simple-folder" offered by user "User One" using the webUI
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder" should not be listed in the files page on the webUI
@@ -96,12 +96,12 @@ Feature: accept/decline shares coming from internal users
   @smokeTest
   Scenario: decline an accepted share (with page-reload in between)
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared file "/testimage.jpg" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user accepts share "simple-folder" offered by user "User One" using the webUI
     And the user reloads the current page of the webUI
-    And the user declines share "simple-folder" offered by user "User Two" using the webUI
+    And the user declines share "simple-folder" offered by user "User One" using the webUI
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder" should not be listed in the files page on the webUI
@@ -109,11 +109,11 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: decline an accepted share (without any page-reload in between)
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
-    And the user declines share "simple-folder" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared file "/testimage.jpg" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user accepts share "simple-folder" offered by user "User One" using the webUI
+    And the user declines share "simple-folder" offered by user "User One" using the webUI
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder" should not be listed in the files page on the webUI
@@ -121,11 +121,11 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: accept a previously declined share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared file "/testimage.jpg" with user "user1"
-    And user "user1" has logged in using the webUI
-    And the user declines share "simple-folder" offered by user "User Two" using the webUI
-    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared file "/testimage.jpg" with user "user0"
+    And user "user0" has logged in using the webUI
+    And the user declines share "simple-folder" offered by user "User One" using the webUI
+    When the user accepts share "simple-folder" offered by user "User One" using the webUI
     Then folder "simple-folder" should be in state "" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder" should be listed in the files page on the webUI
@@ -133,32 +133,32 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: accept a share that you received as user and as group member
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And user "user1" has logged in using the webUI
-    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared folder "/simple-folder" with group "grp1"
+    And user "user0" has logged in using the webUI
+    When the user accepts share "simple-folder" offered by user "User One" using the webUI
     And the user reloads the current page of the webUI
     Then folder "simple-folder" should be in state "" in the shared-with-you page on the webUI
     And folder "simple-folder" should be listed in the files page on the webUI
 
   Scenario: reject a share that you received as user and as group member
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And user "user1" has logged in using the webUI
-    When the user declines share "simple-folder" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared folder "/simple-folder" with group "grp1"
+    And user "user0" has logged in using the webUI
+    When the user declines share "simple-folder" offered by user "User One" using the webUI
     And the user reloads the current page of the webUI
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And folder "simple-folder" should not be listed in the files page on the webUI
 
   Scenario: reshare a share that you received to a group that you are member of
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user accepts share "simple-folder" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user accepts share "simple-folder" offered by user "User One" using the webUI
     And the user has browsed to the files page
     And the user shares folder "simple-folder" with group "grp1" using the webUI
-    And the user declines share "simple-folder" offered by user "User Two" using the webUI
+    And the user declines share "simple-folder" offered by user "User One" using the webUI
     And the user reloads the current page of the webUI
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And folder "simple-folder" should not be listed in the files page on the webUI
@@ -166,11 +166,11 @@ Feature: accept/decline shares coming from internal users
   @smokeTest
   Scenario: unshare an accepted share on the "All files" page
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared folder "/testimage.jpg" with group "grp1"
-    And user "user1" has accepted the share "/simple-folder" offered by user "user2"
-    And user "user1" has accepted the share "/testimage.jpg" offered by user "user2"
-    And user "user1" has logged in using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared folder "/testimage.jpg" with group "grp1"
+    And user "user0" has accepted the share "/simple-folder" offered by user "user1"
+    And user "user0" has accepted the share "/testimage.jpg" offered by user "user1"
+    And user "user0" has logged in using the webUI
     When the user unshares folder "simple-folder" using the webUI
     And the user unshares file "testimage.jpg" using the webUI
     Then folder "simple-folder" should not be listed in the files page on the webUI
@@ -181,9 +181,9 @@ Feature: accept/decline shares coming from internal users
   @smokeTest
   Scenario: Auto-accept shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And user "user2" has shared folder "/testimage.jpg" with user "user1"
-    When user "user1" logs in using the webUI
+    And user "user1" has shared folder "/simple-folder" with group "grp1"
+    And user "user1" has shared folder "/testimage.jpg" with user "user0"
+    When user "user0" logs in using the webUI
     Then folder "simple-folder" should be listed on the webUI
     And file "testimage.jpg" should be listed on the webUI
     And folder "simple-folder" should be listed in the shared-with-you page on the webUI
@@ -194,9 +194,9 @@ Feature: accept/decline shares coming from internal users
   Scenario Outline: auto-accept a share when there is a default folder for received shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And the administrator has set the default folder for received shares to "<share_folder>"
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user2" has shared file "/testimage.jpg" with user "user1"
-    When user "user1" logs in using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user1" has shared file "/testimage.jpg" with user "user0"
+    When user "user0" logs in using the webUI
     Then folder "simple-folder" should be listed in the files page folder "<share_folder>" on the webUI
     And file "testimage.jpg" should be listed in the files page folder "<share_folder>" on the webUI
     Examples:
@@ -206,11 +206,11 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: decline auto-accepted shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And user "user2" has shared folder "/testimage.jpg" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user declines share "simple-folder" offered by user "User Two" using the webUI
-    And the user declines share "testimage.jpg" offered by user "User Two" using the webUI
+    And user "user1" has shared folder "/simple-folder" with group "grp1"
+    And user "user1" has shared folder "/testimage.jpg" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user declines share "simple-folder" offered by user "User One" using the webUI
+    And the user declines share "testimage.jpg" offered by user "User One" using the webUI
     And the user has browsed to the files page
     Then folder "simple-folder" should not be listed on the webUI
     And file "testimage.jpg" should not be listed on the webUI
@@ -219,9 +219,9 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: unshare auto-accepted shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And user "user2" has shared folder "/simple-folder" with group "grp1"
-    And user "user2" has shared folder "/testimage.jpg" with user "user1"
-    And user "user1" has logged in using the webUI
+    And user "user1" has shared folder "/simple-folder" with group "grp1"
+    And user "user1" has shared folder "/testimage.jpg" with user "user0"
+    And user "user0" has logged in using the webUI
     When the user unshares folder "simple-folder" using the webUI
     And the user unshares file "testimage.jpg" using the webUI
     Then folder "simple-folder" should not be listed on the webUI
@@ -231,19 +231,19 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: unshare renamed shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user1" has moved folder "/simple-folder" to "/simple-folder-renamed"
-    And user "user1" has logged in using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user0" has moved folder "/simple-folder" to "/simple-folder-renamed"
+    And user "user0" has logged in using the webUI
     When the user unshares folder "simple-folder-renamed" using the webUI
     Then folder "simple-folder-renamed" should not be listed on the webUI
     And folder "simple-folder-renamed" should be in state "Declined" in the shared-with-you page on the webUI
 
   Scenario: unshare moved shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user1" has created folder "/new-folder"
-    And user "user1" has moved folder "/simple-folder" to "/new-folder/shared"
-    And user "user1" has logged in using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user0" has created folder "/new-folder"
+    And user "user0" has moved folder "/simple-folder" to "/new-folder/shared"
+    And user "user0" has logged in using the webUI
     When the user opens folder "new-folder" using the webUI
     And the user unshares folder "shared" using the webUI
     Then folder "shared" should not be listed on the webUI
@@ -251,21 +251,21 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: unshare renamed shares, accept it again
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And user "user2" has shared folder "/simple-folder" with user "user1"
-    And user "user1" has moved folder "/simple-folder" to "/simple-folder-renamed"
-    And user "user1" has logged in using the webUI
+    And user "user1" has shared folder "/simple-folder" with user "user0"
+    And user "user0" has moved folder "/simple-folder" to "/simple-folder-renamed"
+    And user "user0" has logged in using the webUI
     When the user unshares folder "simple-folder-renamed" using the webUI
-    And the user accepts share "simple-folder-renamed" offered by user "User Two" using the webUI
+    And the user accepts share "simple-folder-renamed" offered by user "User One" using the webUI
     Then folder "simple-folder-renamed" should be in state "" in the shared-with-you page on the webUI
     And folder "simple-folder-renamed" should be listed in the files page on the webUI
 
   Scenario: User-based accepting is disabled while global is enabled
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
     When the user disables automatically accepting new incoming local shares
-    And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
-    And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
+    And user "user1" shares folder "/simple-folder" with group "grp1" using the sharing API
+    And user "user1" shares file "/testimage.jpg" with user "user0" using the sharing API
     And the user browses to the files page
     Then folder "simple-folder" should not be listed on the webUI
     And file "testimage.jpg" should not be listed on the webUI
@@ -276,11 +276,11 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: User-based accepting is enabled while global is enabled
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
     When the user enables automatically accepting new incoming local shares
-    And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
-    And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
+    And user "user1" shares folder "/simple-folder" with group "grp1" using the sharing API
+    And user "user1" shares file "/testimage.jpg" with user "user0" using the sharing API
     And the user browses to the files page
     Then folder "simple-folder" should be listed on the webUI
     And file "testimage.jpg" should be listed on the webUI
@@ -291,19 +291,19 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: User-based accepting checkbox is not visible while global is disabled
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
     Then User-based auto accepting checkbox should not be displayed on the personal sharing settings page on the webUI
 
   Scenario: Admin disables auto-accept setting again after user enabled personal auto-accept setting
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
     When the user disables automatically accepting new incoming local shares
     And the user enables automatically accepting new incoming local shares
     And the administrator disables the setting "Automatically accept new incoming local user shares" in the section "Sharing"
-    And user "user2" shares folder "/simple-folder" with group "grp1" using the sharing API
-    And user "user2" shares file "/testimage.jpg" with user "user1" using the sharing API
+    And user "user1" shares folder "/simple-folder" with group "grp1" using the sharing API
+    And user "user1" shares file "/testimage.jpg" with user "user0" using the sharing API
     And the user browses to the files page
     Then folder "simple-folder" should not be listed on the webUI
     And file "testimage.jpg" should not be listed on the webUI

--- a/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
@@ -6,27 +6,27 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Background:
     Given using server "REMOTE"
-    And user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "simple-folder"
-    And user "user1" has created folder "simple-empty-folder"
-    And user "user1" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "simple-folder"
+    And user "user0" has created folder "simple-empty-folder"
+    And user "user0" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And using server "LOCAL"
-    And user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "simple-folder"
-    And user "user1" has created folder "simple-empty-folder"
-    And user "user1" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "simple-folder"
+    And user "user0" has created folder "simple-empty-folder"
+    And user "user0" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
   @skipOnMICROSOFTEDGE @skipOnOcV10.3
   Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
     Given using server "REMOTE"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    And user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
     When the user updates the last share using the sharing API with
       | permissions | read |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
@@ -34,93 +34,93 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   @skipOnMICROSOFTEDGE
   Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
     # permissions read+update+create = 7 (no delete, no (re)share permission)
-    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL" with permissions "create,read,update"
+    Given user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL" with permissions "create,read,update"
     When the user browses to the files page
     And the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: overwrite a file in a received share - local server shares - remote server receives
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
+    Given user "user0" from server "LOCAL" has shared "simple-folder" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    When user "user0" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/lorem.txt" using the WebDAV API
     And the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
 
   Scenario: overwrite a file in a received share - remote server shares - local server receives
-    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    Given user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     And using server "REMOTE"
-    Then as "user1" file "simple-folder/lorem.txt" should exist
-    And the content of "simple-folder/lorem.txt" on the remote server for user "user1" should be the same as the local "lorem.txt"
+    Then as "user0" file "simple-folder/lorem.txt" should exist
+    And the content of "simple-folder/lorem.txt" on the remote server for user "user0" should be the same as the local "lorem.txt"
 
   Scenario: upload a new file in a received share - local server shares - remote server receives
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
+    Given user "user0" from server "LOCAL" has shared "simple-folder" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    When user "user0" on "REMOTE" uploads file "filesForUpload/new-lorem.txt" to "simple-folder (2)/new-lorem.txt" using the WebDAV API
     And the user opens folder "simple-folder" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
 
   Scenario: upload a new file in a received share - remote server shares - local server receives
-    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    Given user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     And using server "REMOTE"
-    Then as "user1" file "simple-folder/new-lorem.txt" should exist
-    And the content of "simple-folder/new-lorem.txt" on the remote server for user "user1" should be the same as the local "new-lorem.txt"
+    Then as "user0" file "simple-folder/new-lorem.txt" should exist
+    And the content of "simple-folder/new-lorem.txt" on the remote server for user "user0" should be the same as the local "new-lorem.txt"
 
   Scenario: rename a file in a received share - local server shares - remote server receives
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" on "REMOTE" moves file "/simple-folder (2)/lorem.txt" to "/simple-folder (2)/renamed file.txt" using the WebDAV API
+    Given user "user0" from server "LOCAL" has shared "simple-folder" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    When user "user0" on "REMOTE" moves file "/simple-folder (2)/lorem.txt" to "/simple-folder (2)/renamed file.txt" using the WebDAV API
     And the user opens folder "simple-folder" using the webUI
     Then file "renamed file.txt" should be listed on the webUI
     But file "lorem.txt" should not be listed on the webUI
-    And the content of file "simple-folder/renamed file.txt" for user "user1" on server "LOCAL" should be "I am lorem.txt inside simple-folder"
+    And the content of file "simple-folder/renamed file.txt" for user "user0" on server "LOCAL" should be "I am lorem.txt inside simple-folder"
 
   @skipOnFIREFOX
   Scenario: rename a file in a received share - remote server shares - local server receives
-    Given user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    Given user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user renames file "lorem.txt" to "renamed file.txt" using the webUI
     And using server "REMOTE"
-    Then as "user1" file "simple-folder/renamed file.txt" should exist
-    And the content of file "simple-folder/renamed file.txt" for user "user1" on server "REMOTE" should be "I am lorem.txt inside simple-folder"
-    But as "user1" file "simple-folder/lorem.txt" should not exist
+    Then as "user0" file "simple-folder/renamed file.txt" should exist
+    And the content of file "simple-folder/renamed file.txt" for user "user0" on server "REMOTE" should be "I am lorem.txt inside simple-folder"
+    But as "user0" file "simple-folder/lorem.txt" should not exist
 
   Scenario: delete a file in a received share - local server shares - remote server receives
-    Given user "user1" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
-    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    When user "user1" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
+    Given user "user0" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
+    And user "user0" from server "LOCAL" has shared "simple-folder" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    When user "user0" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
     And the user opens folder "simple-folder" using the webUI
     Then file "data.zip" should not be listed on the webUI
 
   Scenario: delete a file in a received share - remote server shares - local server receives
-    Given user "user1" on "REMOTE" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
+    Given user "user0" on "REMOTE" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
+    And user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user deletes file "data.zip" using the webUI
     And using server "REMOTE"
-    Then as "user1" file "simple-folder/data.zip" should not exist
+    Then as "user0" file "simple-folder/data.zip" should not exist
 
   Scenario: receive same name federation share from two users
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes and without skeleton files
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-    And user "user2" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" from server "REMOTE" has shared "/lorem.txt" with user "user0" from server "LOCAL"
+    And user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user0" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user accepts the offered remote shares using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
@@ -129,8 +129,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And file "lorem (3).txt" should be listed in the shared-with-you page on the webUI
 
   Scenario: unshare a federation share
-    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
+    Given user "user0" from server "REMOTE" has shared "/lorem.txt" with user "user0" from server "LOCAL"
+    And user "user0" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
     When the user unshares file "lorem (2).txt" using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
@@ -139,8 +139,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
   Scenario: unshare a federation share from "share-with-you" page
-    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
+    Given user "user0" from server "REMOTE" has shared "/lorem.txt" with user "user0" from server "LOCAL"
+    And user "user0" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
     When the user unshares file "lorem (2).txt" using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
@@ -148,116 +148,116 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test sharing folder to a remote server and resharing it back to the local
     Given using server "LOCAL"
-    And user "user2" has been created with default attributes and without skeleton files
-    And user "user2" has created folder "simple-folder"
-    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
-    And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
-    And the user re-logs in as "user2" using the webUI
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "simple-folder"
+    When the user shares folder "simple-folder" with remote user "user0@%remote_server_without_scheme%" using the webUI
+    And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
+    And user "user0" from server "REMOTE" shares "/simple-folder (2)" with user "user1" from server "LOCAL" using the sharing API
+    And the user re-logs in as "user1" using the webUI
     And the user accepts the offered remote shares using the webUI
-    Then as "user2" folder "/simple-folder (2)" should exist
-    And as "user2" file "/simple-folder (2)/lorem.txt" should exist
+    Then as "user1" folder "/simple-folder (2)" should exist
+    And as "user1" file "/simple-folder (2)/lorem.txt" should exist
 
   Scenario: test resharing folder as readonly and set it as readonly by resharer
     Given using server "LOCAL"
-    And user "user2" has been created with default attributes and without skeleton files
-    And user "user2" has created folder "simple-folder"
-    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
-    And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "simple-folder"
+    When the user shares folder "simple-folder" with remote user "user0@%remote_server_without_scheme%" using the webUI
+    And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
+    And user "user0" from server "REMOTE" shares "/simple-folder (2)" with user "user1" from server "LOCAL" using the sharing API
     And the user updates the last share using the sharing API with
       | permissions | read |
-    And the user re-logs in as "user2" using the webUI
+    And the user re-logs in as "user1" using the webUI
     And the user accepts the offered remote shares using the webUI
-    Then as "user2" folder "/simple-folder (2)" should exist
-    And as "user2" file "/simple-folder (2)/lorem.txt" should exist
+    Then as "user1" folder "/simple-folder (2)" should exist
+    And as "user1" file "/simple-folder (2)/lorem.txt" should exist
     When the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   @skipOnOcV10.3
   Scenario: test resharing folder and set it as readonly by owner
     Given using server "LOCAL"
-    And user "user2" has been created with default attributes and without skeleton files
-    And user "user2" has created folder "simple-folder"
-    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
-    And user "user1" from server "REMOTE" shares "/simple-folder (2)" with user "user2" from server "LOCAL" using the sharing API
-    And the user re-logs in as "user1" using the webUI
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has created folder "simple-folder"
+    When the user shares folder "simple-folder" with remote user "user0@%remote_server_without_scheme%" using the webUI
+    And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
+    And user "user0" from server "REMOTE" shares "/simple-folder (2)" with user "user1" from server "LOCAL" using the sharing API
+    And the user re-logs in as "user0" using the webUI
     And the user opens the share dialog for folder "simple-folder"
-    And the user sets the sharing permissions of user "user2@%local_server% (federated)" for "simple-folder" using the webUI to
+    And the user sets the sharing permissions of user "user1@%local_server% (federated)" for "simple-folder" using the webUI to
       | edit | no |
-    And the user re-logs in as "user2" using the webUI
+    And the user re-logs in as "user1" using the webUI
     And the user accepts the offered remote shares using the webUI
-    Then as "user2" folder "/simple-folder (2)" should exist
-    And as "user2" file "/simple-folder (2)/lorem.txt" should exist
+    Then as "user1" folder "/simple-folder (2)" should exist
+    And as "user1" file "/simple-folder (2)/lorem.txt" should exist
     When the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   @issue-36730
   Scenario: test sharing long file names with federation share
-    When user "user1" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
+    When user "user0" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
     And the user has reloaded the current page of the webUI
-    And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    #  And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
+    And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "user0@%remote_server_without_scheme%" using the webUI
+    #  And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
     And using server "REMOTE"
-    Then user "user1" should not have any received shares
-    # Then as "user1" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
-    Then as "user1" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should not exist
+    Then user "user0" should not have any received shares
+    # Then as "user0" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
+    Then as "user0" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should not exist
 
   Scenario: sharee should be able to access the files/folders inside other folder
-    Given user "user1" has created folder "simple-folder/simple-empty-folder"
-    And user "user1" has created folder "simple-folder/simple-empty-folder/finalfolder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
+    Given user "user0" has created folder "simple-folder/simple-empty-folder"
+    And user "user0" has created folder "simple-folder/simple-empty-folder/finalfolder"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
+    And user "user0" from server "LOCAL" has shared "simple-folder" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
-    Then as "user1" file "simple-folder (2)/lorem.txt" should exist
-    And as "user1" file "simple-folder (2)/simple-empty-folder/textfile.txt" should exist
-    And as "user1" folder "simple-folder (2)/simple-empty-folder/finalfolder" should exist
+    Then as "user0" file "simple-folder (2)/lorem.txt" should exist
+    And as "user0" file "simple-folder (2)/simple-empty-folder/textfile.txt" should exist
+    And as "user0" folder "simple-folder (2)/simple-empty-folder/finalfolder" should exist
 
   Scenario: sharee uploads a file inside a folder of a folder
-    Given user "user1" has created folder "simple-folder/simple-empty-folder"
-    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
+    Given user "user0" has created folder "simple-folder/simple-empty-folder"
+    And user "user0" from server "LOCAL" has shared "simple-folder" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
-    When user "user1" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/simple-empty-folder/lorem.txt" using the WebDAV API
-    Then as "user1" file "simple-folder (2)/simple-empty-folder/lorem.txt" should exist
+    When user "user0" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "simple-folder (2)/simple-empty-folder/lorem.txt" using the WebDAV API
+    Then as "user0" file "simple-folder (2)/simple-empty-folder/lorem.txt" should exist
     When using server "LOCAL"
-    Then as "user1" file "simple-folder/simple-empty-folder/lorem.txt" should exist
+    Then as "user0" file "simple-folder/simple-empty-folder/lorem.txt" should exist
 
   @skipOnFIREFOX
   Scenario: rename a file in a folder inside a shared folder
     Given using server "REMOTE"
-    And user "user1" has created folder "simple-folder/simple-empty-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    When the user re-logs in as "user1" using the webUI
+    And user "user0" has created folder "simple-folder/simple-empty-folder"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
+    And user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
+    When the user re-logs in as "user0" using the webUI
     And the user accepts the offered remote shares using the webUI
     And the user opens folder "simple-folder (2)/simple-empty-folder" using the webUI
     And the user renames file "textfile.txt" to "new-lorem.txt" using the webUI
     And using server "REMOTE"
-    Then as "user1" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
-    But as "user1" file "simple-folder/simple-empty-folder/textfile.txt" should not exist
+    Then as "user0" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
+    But as "user0" file "simple-folder/simple-empty-folder/textfile.txt" should not exist
 
   Scenario: delete a file in a folder inside a shared folder
     Given using server "REMOTE"
-    And user "user1" has created folder "simple-folder/simple-empty-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    When the user re-logs in as "user1" using the webUI
+    And user "user0" has created folder "simple-folder/simple-empty-folder"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
+    And user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
+    When the user re-logs in as "user0" using the webUI
     And the user accepts the offered remote shares using the webUI
     And the user opens folder "/simple-folder (2)/simple-empty-folder" using the webUI
     And the user deletes file "textfile.txt" using the webUI
     And using server "REMOTE"
-    Then as "user1" file "/simple-folder/simple-empty-folder/textfile.txt" should not exist
+    Then as "user0" file "/simple-folder/simple-empty-folder/textfile.txt" should not exist
 
   Scenario: delete shared folder and create a folder for federation sharing with same name
-    Given user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
-    And user "user1" has deleted folder "simple-folder"
-    And user "user1" has created folder "simple-folder"
-    And user "user1" from server "LOCAL" has shared "simple-folder" with user "user1" from server "REMOTE"
-    When user "user1" from server "REMOTE" accepts the last pending share using the sharing API
+    Given user "user0" from server "LOCAL" has shared "simple-folder" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
+    And user "user0" has deleted folder "simple-folder"
+    And user "user0" has created folder "simple-folder"
+    And user "user0" from server "LOCAL" has shared "simple-folder" with user "user0" from server "REMOTE"
+    When user "user0" from server "REMOTE" accepts the last pending share using the sharing API
     And using server "REMOTE"
-    Then as "user1" folder "simple-folder" should exist
-    And as "user1" folder "simple-folder (3)" should exist
+    Then as "user0" folder "simple-folder" should exist
+    And as "user0" folder "simple-folder (3)" should exist

--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
@@ -6,23 +6,23 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Background:
     Given using server "REMOTE"
-    And user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "simple-folder"
-    And user "user1" has created folder "simple-empty-folder"
-    And user "user1" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "simple-folder"
+    And user "user0" has created folder "simple-empty-folder"
+    And user "user0" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And using server "LOCAL"
-    And user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "simple-folder"
-    And user "user1" has created folder "simple-empty-folder"
-    And user "user1" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "simple-folder"
+    And user "user0" has created folder "simple-empty-folder"
+    And user "user0" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
 
   Scenario: declining a federation share on the webUI
-    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    Given user "user0" from server "REMOTE" has shared "/lorem.txt" with user "user0" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     When the user declines the offered remote shares using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
@@ -30,47 +30,47 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: automatically accept a federation share when it is allowed by the config
     Given parameter "autoAddServers" of app "federation" has been set to "1"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
+    And user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
+    And user "user0" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     And parameter "autoAddServers" of app "federation" has been set to "0"
-    When user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
+    When user "user0" from server "REMOTE" shares "/lorem.txt" with user "user0" from server "LOCAL" using the sharing API
     And the user has reloaded the current page of the webUI
     Then file "lorem (2).txt" should be listed on the webUI
 
   Scenario: User-based auto accepting is disabled while global is enabled
     Given parameter "autoAddServers" of app "federation" has been set to "1"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
+    And user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
+    And user "user0" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     And parameter "autoAddServers" of app "federation" has been set to "0"
     And the user has browsed to the personal sharing settings page
     When the user disables automatically accepting remote shares from trusted servers
-    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
-    Then user "user1" should not see the following elements
+    And user "user0" from server "REMOTE" shares "/lorem.txt" with user "user0" from server "LOCAL" using the sharing API
+    Then user "user0" should not see the following elements
       | /lorem%20(2).txt |
 
   Scenario: one user disabling user-based auto accepting while global is enabled has no effect on other users
-    Given user "user2" has been created with default attributes and without skeleton files
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "autoAddServers" of app "federation" has been set to "1"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
+    And user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
+    And user "user0" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     And parameter "autoAddServers" of app "federation" has been set to "0"
     And the user has browsed to the personal sharing settings page
     When the user disables automatically accepting remote shares from trusted servers
-    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user2" from server "LOCAL" using the sharing API
-    Then user "user2" should see the following elements
+    And user "user0" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
+    Then user "user1" should see the following elements
       | /lorem%20(2).txt |
 
   Scenario: User-based accepting from trusted server checkbox is not visible while global is disabled
     Given parameter "autoAddServers" of app "federation" has been set to "1"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user1" from server "LOCAL" has accepted the last pending share
+    And user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
+    And user "user0" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
     And parameter "autoAddServers" of app "federation" has been set to "0"
@@ -84,21 +84,21 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user has browsed to the personal sharing settings page
     When the user disables automatically accepting remote shares from trusted servers
     And the user enables automatically accepting remote shares from trusted servers
-    And user "user1" from server "REMOTE" shares "/lorem.txt" with user "user1" from server "LOCAL" using the sharing API
-    Then user "user1" should not see the following elements
+    And user "user0" from server "REMOTE" shares "/lorem.txt" with user "user0" from server "LOCAL" using the sharing API
+    Then user "user0" should not see the following elements
       | /lorem%20(2).txt |
 
   @skipOnOcV10.3 @skipOnOcV10.4.0
   Scenario: Local user accepts a pending federated share on the webUI
-    Given user "user1" from server "REMOTE" has shared "/lorem.txt" with user "user1" from server "LOCAL"
+    Given user "user0" from server "REMOTE" has shared "/lorem.txt" with user "user0" from server "LOCAL"
     When the user browses to the shared-with-you page
     And the user closes the federation sharing dialog
     And the user accepts the pending remote share using the webUI
     Then file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
 
   Scenario: Federated share from Local user to remote user
-    Given user "user1" from server "LOCAL" has shared "/lorem.txt" with user "user1" from server "REMOTE"
-    And user "user1" from server "REMOTE" has accepted the last pending share
+    Given user "user0" from server "LOCAL" has shared "/lorem.txt" with user "user0" from server "REMOTE"
+    And user "user0" from server "REMOTE" has accepted the last pending share
     When the user browses to the shared-with-others page
-    Then user "user1" should see the following elements
+    Then user "user0" should see the following elements
       | lorem.txt |

--- a/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
@@ -6,61 +6,61 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Background:
     Given using server "REMOTE"
-    And user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "simple-folder"
-    And user "user1" has created folder "simple-empty-folder"
-    And user "user1" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "simple-folder"
+    And user "user0" has created folder "simple-empty-folder"
+    And user "user0" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And using server "LOCAL"
-    And user "user1" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "simple-folder"
-    And user "user1" has created folder "simple-empty-folder"
-    And user "user1" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "simple-folder"
+    And user "user0" has created folder "simple-empty-folder"
+    And user "user0" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
   Scenario: test the single steps of sharing a folder to a remote server
-    When the user shares folder "simple-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
-    And the user shares folder "simple-empty-folder" with remote user "user1@%remote_server_without_scheme%" using the webUI
-    And user "user1" from server "REMOTE" accepts the last pending share using the sharing API
+    When the user shares folder "simple-folder" with remote user "user0@%remote_server_without_scheme%" using the webUI
+    And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
+    And the user shares folder "simple-empty-folder" with remote user "user0@%remote_server_without_scheme%" using the webUI
+    And user "user0" from server "REMOTE" accepts the last pending share using the sharing API
     And using server "REMOTE"
-    Then as "user1" folder "/simple-folder (2)" should exist
-    And as "user1" file "/simple-folder (2)/lorem.txt" should exist
-    And as "user1" folder "/simple-empty-folder (2)" should exist
+    Then as "user0" folder "/simple-folder (2)" should exist
+    And as "user0" file "/simple-folder (2)/lorem.txt" should exist
+    And as "user0" folder "/simple-empty-folder (2)" should exist
 
   Scenario: test the single steps of receiving a federation share
     Given using server "REMOTE"
     And these users have been created with default attributes and without skeleton files:
       | username |
+      | user1    |
       | user2    |
-      | user3    |
-    And user "user2" has created folder "simple-empty-folder"
-    And user "user3" has uploaded file with content "I am lorem.txt" to "/lorem.txt"
-    And user "user1" from server "REMOTE" has shared "simple-folder" with user "user1" from server "LOCAL"
-    And user "user2" from server "REMOTE" has shared "simple-empty-folder" with user "user1" from server "LOCAL"
-    And user "user3" from server "REMOTE" has shared "lorem.txt" with user "user1" from server "LOCAL"
+    And user "user1" has created folder "simple-empty-folder"
+    And user "user2" has uploaded file with content "I am lorem.txt" to "/lorem.txt"
+    And user "user0" from server "REMOTE" has shared "simple-folder" with user "user0" from server "LOCAL"
+    And user "user1" from server "REMOTE" has shared "simple-empty-folder" with user "user0" from server "LOCAL"
+    And user "user2" from server "REMOTE" has shared "lorem.txt" with user "user0" from server "LOCAL"
     And the user has reloaded the current page of the webUI
     Then dialogs should be displayed on the webUI
       | title        | content                                                                                             |
-      | Remote share | Do you want to add the remote share /simple-folder from user1@%remote_server_without_scheme%?       |
-      | Remote share | Do you want to add the remote share /simple-empty-folder from user2@%remote_server_without_scheme%? |
-      | Remote share | Do you want to add the remote share /lorem.txt from user3@%remote_server_without_scheme%?           |
+      | Remote share | Do you want to add the remote share /simple-folder from user0@%remote_server_without_scheme%?       |
+      | Remote share | Do you want to add the remote share /simple-empty-folder from user1@%remote_server_without_scheme%? |
+      | Remote share | Do you want to add the remote share /lorem.txt from user2@%remote_server_without_scheme%?           |
     When the user accepts the offered remote shares using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
-    And the content of file "lorem (2).txt" for user "user1" on server "LOCAL" should be "I am lorem.txt"
+    And the content of file "lorem (2).txt" for user "user0" on server "LOCAL" should be "I am lorem.txt"
     And folder "simple-folder (2)" should be listed on the webUI
     And file "lorem.txt" should be listed in folder "simple-folder (2)" on the webUI
-    And the content of file "simple-folder (2)/lorem.txt" for user "user1" on server "LOCAL" should be "I am lorem.txt inside simple-folder"
+    And the content of file "simple-folder (2)/lorem.txt" for user "user0" on server "LOCAL" should be "I am lorem.txt inside simple-folder"
     And file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
     And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
     And folder "simple-empty-folder (2)" should be listed in the shared-with-you page on the webUI
 
   @skipOnOcV10.3
   Scenario: sharing indicator inside folder shared using federated sharing
-    Given user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    Given user "user0" has created folder "/simple-folder/sub-folder"
+    And user "user0" from server "LOCAL" has shared "/simple-folder" with user "user0" from server "REMOTE"
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | lorem.txt  |
@@ -68,7 +68,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @skipOnOcV10.3
   Scenario: sharing indicator for file uploaded inside folder shared using federated sharing
-    Given user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    Given user "user0" from server "LOCAL" has shared "/simple-folder" with user "user0" from server "REMOTE"
     When the user opens folder "simple-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -76,7 +76,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @skipOnOcV10.3
   Scenario: sharing indicator for folder created inside folder shared using federated sharing
-    Given user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    Given user "user0" from server "LOCAL" has shared "/simple-folder" with user "user0" from server "REMOTE"
     When the user opens folder "simple-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -84,23 +84,23 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   @skipOnOcV10.3
   Scenario: sharing details inside folder shared using federated sharing
-    Given user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
+    Given user "user0" has created folder "/simple-folder/sub-folder"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user0" from server "LOCAL" has shared "/simple-folder" with user "user0" from server "REMOTE"
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder"
-    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    Then federated user "user0@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
     When the user opens the share dialog for file "textfile.txt"
-    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    Then federated user "user0@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
 
   @skipOnOcV10.3
   Scenario: sharing details of items inside a shared folder shared with local user and federated user
-    Given user "user2" has been created with default attributes and without skeleton files
-    And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
-    And user "user1" from server "LOCAL" has shared "/simple-folder" with user "user1" from server "REMOTE"
-    And user "user1" has shared folder "simple-folder/sub-folder" with user "user2"
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has created folder "/simple-folder/sub-folder"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
+    And user "user0" from server "LOCAL" has shared "/simple-folder" with user "user0" from server "REMOTE"
+    And user "user0" has shared folder "simple-folder/sub-folder" with user "user1"
     When the user opens folder "simple-folder/sub-folder" using the webUI
     And the user opens the share dialog for file "textfile.txt"
-    Then federated user "user1@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
-    And user "User Two" should be listed as share receiver via "sub-folder" on the webUI
+    Then federated user "user0@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    And user "User One" should be listed as share receiver via "sub-folder" on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups1/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups1/shareWithGroups.feature
@@ -7,38 +7,38 @@ Feature: Sharing files and folders with internal groups
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user3" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And these groups have been created:
       | groupname |
       | grp1      |
+    And user "user0" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
-    And user "user2" has been added to group "grp1"
 
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a folder with an internal group
-    Given user "user3" has logged in using the webUI
+    Given user "user2" has logged in using the webUI
     When the user shares folder "simple-folder" with group "grp1" using the webUI
     And the user shares file "testimage.jpg" with group "grp1" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then folder "simple-folder" should be listed on the webUI
-    And folder "simple-folder" should be marked as shared with "grp1" by "User Three" on the webUI
+    And folder "simple-folder" should be marked as shared with "grp1" by "User Two" on the webUI
     And file "testimage.jpg" should be listed on the webUI
-    And file "testimage.jpg" should be marked as shared with "grp1" by "User Three" on the webUI
-    When the user re-logs in as "user2" using the webUI
+    And file "testimage.jpg" should be marked as shared with "grp1" by "User Two" on the webUI
+    When the user re-logs in as "user1" using the webUI
     Then folder "simple-folder" should be listed on the webUI
-    And folder "simple-folder" should be marked as shared with "grp1" by "User Three" on the webUI
+    And folder "simple-folder" should be marked as shared with "grp1" by "User Two" on the webUI
     And file "testimage.jpg" should be listed on the webUI
-    And file "testimage.jpg" should be marked as shared with "grp1" by "User Three" on the webUI
+    And file "testimage.jpg" should be marked as shared with "grp1" by "User Two" on the webUI
 
   @TestAlsoOnExternalUserBackend @skipOnFIREFOX
   Scenario: share a file with an internal group a member overwrites and unshares the file
-    Given user "user3" has logged in using the webUI
+    Given user "user2" has logged in using the webUI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user shares file "new-lorem.txt" with group "grp1" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
     When the user uploads overwriting file "new-lorem.txt" using the webUI and retries if the file is locked
@@ -48,18 +48,18 @@ Feature: Sharing files and folders with internal groups
     When the user unshares file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should not be listed on the webUI
 		# check that another group member can still see the file
-    When the user re-logs in as "user2" using the webUI
+    When the user re-logs in as "user1" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 		# check that the original file owner can still see the file
-    When the user re-logs in as "user3" using the webUI
+    When the user re-logs in as "user2" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
-    Given user "user3" has logged in using the webUI
+    Given user "user2" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with group "grp1" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
@@ -73,13 +73,13 @@ Feature: Sharing files and folders with internal groups
     When the user deletes file "data.zip" using the webUI
     Then file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible to another group member
-    When the user re-logs in as "user2" using the webUI
+    When the user re-logs in as "user1" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should be the same as the local "lorem.txt"
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
     And file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-    When the user re-logs in as "user3" using the webUI
+    When the user re-logs in as "user2" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should be the same as the local "lorem.txt"
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
@@ -88,21 +88,21 @@ Feature: Sharing files and folders with internal groups
   @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a folder with an internal group and a member unshares the folder
-    Given user "user3" has logged in using the webUI
+    Given user "user2" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with group "grp1" using the webUI
 		# unshare the received shared folder and check it is gone
-    When the user re-logs in as "user1" using the webUI
+    When the user re-logs in as "user0" using the webUI
     And the user unshares folder "new-simple-folder" using the webUI
     Then folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible to another group member
-    When the user re-logs in as "user2" using the webUI
+    When the user re-logs in as "user1" using the webUI
     Then folder "new-simple-folder" should be listed on the webUI
     When the user opens folder "new-simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 		# check that the folder is still visible for the share owner
-    When the user re-logs in as "user3" using the webUI
+    When the user re-logs in as "user2" using the webUI
     Then folder "new-simple-folder" should be listed on the webUI
     When the user opens folder "new-simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -112,19 +112,19 @@ Feature: Sharing files and folders with internal groups
     Given group "system-group" has been created
     And the administrator has browsed to the admin sharing settings page
     When the administrator excludes group "system-group" from receiving shares using the webUI
-    Then user "user3" should not be able to share file "lorem.txt" with group "system-group" using the sharing API
+    Then user "user2" should not be able to share file "lorem.txt" with group "system-group" using the sharing API
 
   Scenario: user tries to share a folder in a group which is excluded from receiving share
     Given group "system-group" has been created
     And the administrator has browsed to the admin sharing settings page
     When the administrator excludes group "system-group" from receiving shares using the webUI
-    Then user "user3" should not be able to share folder "simple-folder" with group "system-group" using the sharing API
+    Then user "user2" should not be able to share folder "simple-folder" with group "system-group" using the sharing API
 
   Scenario: autocompletion for a group that is excluded from receiving shares
     Given group "system-group" has been created
     And the administrator has browsed to the admin sharing settings page
     When the administrator excludes group "system-group" from receiving shares using the webUI
-    And the user re-logs in as "user3" using the webUI
+    And the user re-logs in as "user2" using the webUI
     And the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
     And the user types "system-group" in the share-with-field
@@ -135,25 +135,25 @@ Feature: Sharing files and folders with internal groups
   @mailhog
   Scenario: user should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user3" has logged in using the webUI
-    And user "user3" has shared file "lorem.txt" with group "grp1"
+    And user "user2" has logged in using the webUI
+    And user "user2" has shared file "lorem.txt" with group "grp1"
     And the user has opened the share dialog for file "lorem.txt"
     When the user sends the share notification by email for group "grp1" using the webUI
     Then a notification should be displayed on the webUI with the text "Email notification was sent!"
+    And the email address "user0@example.org" should have received an email with the body containing
+      """
+      just letting you know that User Two shared lorem.txt with you.
+      """
     And the email address "user1@example.org" should have received an email with the body containing
       """
-      just letting you know that User Three shared lorem.txt with you.
-      """
-    And the email address "user2@example.org" should have received an email with the body containing
-      """
-      just letting you know that User Three shared lorem.txt with you.
+      just letting you know that User Two shared lorem.txt with you.
       """
 
   @mailhog @skipOnOcV10.3
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user3" has logged in using the webUI
-    And user "user3" has shared file "lorem.txt" with group "grp1"
+    And user "user2" has logged in using the webUI
+    And user "user2" has shared file "lorem.txt" with group "grp1"
     And the user has opened the share dialog for file "lorem.txt"
     When the user sends the share notification by email for group "grp1" using the webUI
     Then the user should not be able to send the share notification by email for group "grp1" using the webUI
@@ -164,22 +164,22 @@ Feature: Sharing files and folders with internal groups
   @skipOnOcV10.3
   Scenario: user should not be able to send notification by email when allow share mail notification has been disabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "no"
-    And user "user3" has logged in using the webUI
-    And user "user3" has shared file "lorem.txt" with group "grp1"
+    And user "user2" has logged in using the webUI
+    And user "user2" has shared file "lorem.txt" with group "grp1"
     When the user opens the share dialog for file "lorem.txt"
     Then the user should not be able to send the share notification by email for group "grp1" using the webUI
 
   @mailhog @skipOnLDAP @skipOnOcV10.3
   Scenario: user should not get an email notification if the user is added to the group after the mail notification was sent
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user0" has been created with default attributes and skeleton files
-    And user "user3" has logged in using the webUI
-    And user "user3" has shared file "lorem.txt" with group "grp1"
+    And user "user3" has been created with default attributes and skeleton files
+    And user "user2" has logged in using the webUI
+    And user "user2" has shared file "lorem.txt" with group "grp1"
     And the user has opened the share dialog for file "lorem.txt"
     When the user sends the share notification by email for group "grp1" using the webUI
     Then a notification should be displayed on the webUI with the text "Email notification was sent!"
-    When the administrator adds user "user0" to group "grp1" using the provisioning API
-    Then the email address "user0@example.org" should not have received an email
+    When the administrator adds user "user3" to group "grp1" using the provisioning API
+    Then the email address "user3@example.org" should not have received an email
 
   @skipOnOcV10.3 @skipOnEncryptionType:user-keys @issue-encryption-126
   @mailhog
@@ -191,50 +191,50 @@ Feature: Sharing files and folders with internal groups
       | off-brand-new-user |
     And user "brand-new-user" has been added to group "grp1"
     And user "off-brand-new-user" has been added to group "grp1"
-    And user "user3" has logged in using the webUI
-    And user "user3" has shared file "lorem.txt" with group "grp1"
+    And user "user2" has logged in using the webUI
+    And user "user2" has shared file "lorem.txt" with group "grp1"
     And the user has opened the share dialog for file "lorem.txt"
     When the user sends the share notification by email for group "grp1" using the webUI
     Then dialog should be displayed on the webUI
       | title                       | content                                                                          |
       | Email notification not sent | Couldn't send mail to following recipient(s): brand-new-user, off-brand-new-user |
+    And the email address "user0@example.org" should have received an email with the body containing
+      """
+      just letting you know that User Two shared lorem.txt with you.
+      """
     And the email address "user1@example.org" should have received an email with the body containing
       """
-      just letting you know that User Three shared lorem.txt with you.
-      """
-    And the email address "user2@example.org" should have received an email with the body containing
-      """
-      just letting you know that User Three shared lorem.txt with you.
+      just letting you know that User Two shared lorem.txt with you.
       """
 
   Scenario: user added to a group has a share that matches the skeleton of added user
-    Given user "user1" has uploaded file with content "some content" to "lorem.txt"
-    And user "user3" has been added to group "grp1"
-    And user "user1" has shared file "lorem.txt" with group "grp1"
-    When user "user3" logs in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "lorem.txt"
+    And user "user2" has been added to group "grp1"
+    And user "user0" has shared file "lorem.txt" with group "grp1"
+    When user "user2" logs in using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And file "lorem (2).txt" should be listed on the webUI
-    And file "lorem (2).txt" should be marked as shared with "grp1" by "User One" on the webUI
-    And the content of file "lorem (2).txt" for user "user3" should be "some content"
+    And file "lorem (2).txt" should be marked as shared with "grp1" by "User Zero" on the webUI
+    And the content of file "lorem (2).txt" for user "user2" should be "some content"
 
   Scenario Outline: group names are case-sensitive, sharing with groups with different upper and lower case names
     Given user "some-user" has been created with default attributes and without skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
-    And user "user1" has been added to group "<group_id1>"
-    And user "user2" has been added to group "<group_id2>"
-    And user "user3" has been added to group "<group_id3>"
+    And user "user0" has been added to group "<group_id1>"
+    And user "user1" has been added to group "<group_id2>"
+    And user "user2" has been added to group "<group_id3>"
     And user "some-user" has created folder "/simple-folder"
     And user "some-user" has logged in using the webUI
     When the user shares folder "simple-folder" with group "<group_id1>" using the webUI
     And the user shares folder "simple-folder" with group "<group_id2>" using the webUI
     And the user shares folder "simple-folder" with group "<group_id3>" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then folder "simple-folder" should be marked as shared with "<group_id1>" by "Regular User" on the webUI
-    When the user re-logs in as "user2" using the webUI
+    When the user re-logs in as "user1" using the webUI
     Then folder "simple-folder" should be marked as shared with "<group_id2>" by "Regular User" on the webUI
-    When the user re-logs in as "user3" using the webUI
+    When the user re-logs in as "user2" using the webUI
     Then folder "simple-folder (2)" should be marked as shared with "<group_id3>" by "Regular User" on the webUI
     Examples:
       | group_id1            | group_id2            | group_id3            |
@@ -244,8 +244,8 @@ Feature: Sharing files and folders with internal groups
 
   Scenario Outline: group names are case-sensitive, sharing with groups in different case group name fail, if they don't exist
     Given group "<group_id1>" has been created
-    And user "user2" has created folder "/simple-folder"
-    And user "user2" has logged in using the webUI
+    And user "user1" has created folder "/simple-folder"
+    And user "user1" has logged in using the webUI
     When the user shares folder "simple-folder" with group "<group_id1>" using the webUI
     And the user has opened the share dialog for folder "simple-folder"
     And the user types "<group_id2>" in the share-with-field
@@ -260,71 +260,71 @@ Feature: Sharing files and folders with internal groups
 
   Scenario: sharer should not be able to share a folder to a group which he/she is not member of when share with groups they are member of is enabled
     Given group "grp2" has been created
-    And user "user1" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables restrict users to only share with groups they are member of using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens the share dialog for folder "simple-folder"
     And the user types "grp2" in the share-with-field
     Then a tooltip with the text "No users or groups found for grp2" should be shown near the share-with-field on the webUI
 
   Scenario: sharer should not be able to share a file to a group which he/she is not member of when share with groups they are member of is enabled
     Given group "grp2" has been created
-    And user "user1" has uploaded file with content "some content" to "lorem.txt"
+    And user "user0" has uploaded file with content "some content" to "lorem.txt"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables restrict users to only share with groups they are member of using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens the share dialog for file "lorem.txt"
     And the user types "grp2" in the share-with-field
     Then a tooltip with the text "No users or groups found for grp2" should be shown near the share-with-field on the webUI
 
   Scenario: sharer should be able to share a folder to his/her own group when only share with groups they are member of is enabled
-    Given user "user1" has created folder "/simple-folder"
+    Given user "user0" has created folder "/simple-folder"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables restrict users to only share with groups they are member of using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user shares folder "simple-folder" with group "grp1" using the webUI
-    Then as "user2" folder "/simple-folder" should exist
+    Then as "user1" folder "/simple-folder" should exist
 
   Scenario: sharer should be able to share a file to his/her own group when only share with groups they are member of is enabled
-    Given user "user1" has uploaded file with content "some content" to "lorem.txt"
+    Given user "user0" has uploaded file with content "some content" to "lorem.txt"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables restrict users to only share with groups they are member of using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user shares file "lorem.txt" with group "grp1" using the webUI
-    Then as "user2" file "/lorem.txt" should exist
+    Then as "user1" file "/lorem.txt" should exist
 
   Scenario: share folder with a group when group has matching folder
-    Given user "user1" has created folder "test"
-    And user "user3" has created folder "test"
-    And user "user3" has shared folder "test" with group "grp1"
-    When user "user1" logs in using the webUI
+    Given user "user0" has created folder "test"
+    And user "user2" has created folder "test"
+    And user "user2" has shared folder "test" with group "grp1"
+    When user "user0" logs in using the webUI
     Then folder "test" should be listed on the webUI
     And folder "test (2)" should be listed on the webUI
 
   Scenario: shares shared to deleted group should not be available
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     And the user has shared file "/lorem.txt" with group "grp1"
-    And the user re-logs in as "user2" using the webUI
-    Then file "lorem.txt" should be marked as shared with "grp1" by "User One" on the webUI
+    And the user re-logs in as "user1" using the webUI
+    Then file "lorem.txt" should be marked as shared with "grp1" by "User Zero" on the webUI
     When the administrator deletes group "grp1" using the provisioning API
     And the user reloads the current page of the webUI
     Then file "lorem.txt" should not be listed on the webUI
     When the user browses to the shared-with-you page
     Then file "lorem.txt" should not be listed on the webUI
-    And as "user2" file "/lorem.txt" should not exist
-    When the user re-logs in as "user1" using the webUI
+    And as "user1" file "/lorem.txt" should not exist
+    When the user re-logs in as "user0" using the webUI
     And the user opens the share dialog for file "lorem.txt"
     Then the group "grp1" should not be in share with group list
 
   @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has shared folder "simple-folder" with group "grp1"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/simple-empty-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has shared folder "simple-folder" with group "grp1"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | simple-empty-folder |
@@ -332,12 +332,12 @@ Feature: Sharing files and folders with internal groups
 
   @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder two levels down
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder/"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder/new-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/simple-empty-folder/lorem.txt"
-    And user "user1" has shared folder "simple-folder" with group "grp1"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/simple-empty-folder/"
+    And user "user0" has created folder "/simple-folder/simple-empty-folder/new-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/simple-empty-folder/lorem.txt"
+    And user "user0" has shared folder "simple-folder" with group "grp1"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens folder "simple-empty-folder" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -346,12 +346,12 @@ Feature: Sharing files and folders with internal groups
 
   @skipOnOcV10.3
   Scenario: sharing indicator of items inside a re-shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has shared folder "simple-folder" with group "grp1"
-    And user "user2" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/simple-empty-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user1" has shared folder "simple-folder" with group "grp1"
+    And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | simple-empty-folder |
@@ -359,10 +359,10 @@ Feature: Sharing files and folders with internal groups
 
   @skipOnOcV10.3
   Scenario: no sharing indicator of items inside a not shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-sub-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/simple-sub-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should not have share indicators on the webUI
       | simple-sub-folder |
@@ -370,8 +370,8 @@ Feature: Sharing files and folders with internal groups
 
   @skipOnOcV10.3
   Scenario: sharing indicator for file uploaded inside a shared folder
-    Given user "user3" has shared folder "/simple-empty-folder" with group "grp1"
-    And user "user3" has logged in using the webUI
+    Given user "user2" has shared folder "/simple-empty-folder" with group "grp1"
+    And user "user2" has logged in using the webUI
     When the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -379,8 +379,8 @@ Feature: Sharing files and folders with internal groups
 
   @skipOnOcV10.3
   Scenario: sharing indicator for folder created inside a shared folder
-    Given user "user3" has shared folder "/simple-empty-folder" with group "grp1"
-    And user "user3" has logged in using the webUI
+    Given user "user2" has shared folder "/simple-empty-folder" with group "grp1"
+    And user "user2" has logged in using the webUI
     When the user opens folder "simple-empty-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -388,12 +388,12 @@ Feature: Sharing files and folders with internal groups
 
   @skipOnOcV10.3
   Scenario: sharing details of items inside a shared folder shared with user and group
-    Given user "user3" has created folder "/simple-folder/sub-folder"
-    And user "user3" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
-    And user "user3" has shared folder "simple-folder" with user "user2"
-    And user "user3" has shared folder "/simple-folder/sub-folder" with group "grp1"
-    And user "user3" has logged in using the webUI
+    Given user "user2" has created folder "/simple-folder/sub-folder"
+    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user2" has shared folder "simple-folder" with user "user1"
+    And user "user2" has shared folder "/simple-folder/sub-folder" with group "grp1"
+    And user "user2" has logged in using the webUI
     When the user opens folder "simple-folder/sub-folder" using the webUI
     And the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
-    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
+    Then user "User One" should be listed as share receiver via "simple-folder" on the webUI
     And group "grp1" should be listed as share receiver via "sub-folder" on the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
@@ -11,241 +11,241 @@ Feature: Sharing files and folders with internal groups with expiration date set
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user3" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
     And these groups have been created:
       | groupname |
       | grp1      |
+    And user "user0" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
-    And user "user2" has been added to group "grp1"
 
   Scenario: expiration date is disabled for sharing with groups, user shares with a group
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "no"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be visible for the group "grp1" in the share dialog
     And the expiration date input field should be empty for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  |            |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario: expiration date is disabled for sharing with groups but enabled for sharing with users, user shares with a group
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "no"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be visible for the group "grp1" in the share dialog
     And the expiration date input field should be empty for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  |            |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario: expiration date is enabled for sharing with groups, user shares a file with a group
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be visible for the group "grp1" in the share dialog
     And the expiration date input field should be "+7 days" for the group "grp1" in the share dialog
     When the user changes expiration date for share of group "grp1" to "+3 days" in the share dialog
     Then the expiration date input field should be "+3 days" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario Outline: expiration date is enforced for group, user shares a file
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "<num_days>"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be visible for the group "grp1" in the share dialog
     And the expiration date input field should be "<days>" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | <days>     |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
     Examples:
       | num_days | days     |
       | 3        | +3 days  |
       | 0        | today    |
 
   Scenario: expiration date is enforced for group, user shares and tries to change expiration date more than allowed
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "3"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     And the user changes expiration date for share of group "grp1" to "+4 days" in the share dialog
     Then the expiration date input field should be "+3 days" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario: expiration date is enforced for group, user reshares received file with the group
-    Given user "user3" has shared file "lorem.txt" with user "user1"
+    Given user "user2" has shared file "lorem.txt" with user "user0"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "3"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be visible for the group "grp1" in the share dialog
     And the expiration date input field should be "+3 days" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario: expiration date is enabled but not enforced for group, user reshares received file with group
-    Given user "user3" has shared file "lorem.txt" with user "user1"
+    Given user "user2" has shared file "lorem.txt" with user "user0"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be visible for the group "grp1" in the share dialog
     And the expiration date input field should be "+7 days" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | +7 days    |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario: expiration date is enabled but not enforced for group, user reshares received file with group, but removes default expiration date
-    Given user "user3" has shared file "lorem.txt" with user "user1"
+    Given user "user2" has shared file "lorem.txt" with user "user0"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     And the user clears the expiration date input field for share of group "grp1" in the share dialog
     Then the expiration date input field should be empty for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  |            |
 
   Scenario: expiration date is enabled but not enforced for group, user reshares received file with user, but changes expiration date
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
-    And user "user3" has shared file "lorem.txt" with user "user1"
-    And user "user1" has logged in using the webUI
+    And user "user2" has shared file "lorem.txt" with user "user0"
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     And the user changes expiration date for share of group "grp1" to "+15 days" in the share dialog
     Then the expiration date input field should be "+15 days" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +15 days   |
 
   Scenario: expiration date is enabled but not enforced for group, user shares to group through api and checks the expiration date on webUI
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | group      |
       | shareWith   | grp1       |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user3" has logged in using the webUI
+    And user "user2" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt"
     Then the expiration date input field should be "+15 days" for the group "grp1" in the share dialog
 
   Scenario: expiration date is enabled but not enforced for group, user receives a share with expiration date and reshares with expiration date less than the original
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | user       |
-      | shareWith   | user1      |
+      | shareWith   | user0      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be "+7 days" for the group "grp1" in the share dialog
     When the user changes expiration date for share of group "grp1" to "+10 days" in the share dialog
     Then the expiration date input field should be "+10 days" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +10 days   |
 
   Scenario: expiration date is enabled but not enforced for group, user receives a share with expiration date and reshares with expiration date in future than the original
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | user       |
-      | shareWith   | user1      |
+      | shareWith   | user0      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be "+7 days" for the group "grp1" in the share dialog
     When the user changes expiration date for share of group "grp1" to "+20 days" in the share dialog
     Then the expiration date input field should be "+20 days" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +20 days   |
 
   Scenario: expiration date is enabled and enforced for group, user receives a share with expiration date and tries to reshare with expiration date less than the original
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | user       |
-      | shareWith   | user1      |
+      | shareWith   | user0      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be "+30 days" for the group "grp1" in the share dialog
     When the user changes expiration date for share of group "grp1" to "+20 days" in the share dialog
     Then the expiration date input field should be "+20 days" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +20 days   |
 
   Scenario: expiration date is enabled and enforced for group, user receives a share with expiration date and tries to reshare with expiration date further in future than the original
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | user       |
-      | shareWith   | user1      |
+      | shareWith   | user0      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be "+30 days" for the group "grp1" in the share dialog
     When the user changes expiration date for share of group "grp1" to "+40 days" in the share dialog
     Then the expiration date input field should be "+30 days" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +30 days   |
 
   Scenario: expiration date is enabled and enforced for group, user receives a folder from a group share with expiration date and shares sub-folder with group
@@ -253,39 +253,39 @@ Feature: Sharing files and folders with internal groups with expiration date set
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
     And group "grp2" has been created
-    And user "user1" has been added to group "grp2"
-    And user "user3" has created a share with settings
+    And user "user0" has been added to group "grp2"
+    And user "user2" has created a share with settings
       | path        | /simple-folder |
       | shareType   | group          |
       | shareWith   | grp2           |
       | permissions | read,share     |
       | expireDate  | +15 days       |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user shares file "simple-empty-folder" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be "+30 days" for the group "grp1" in the share dialog
     When the user changes expiration date for share of group "grp1" to "+20 days" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group                |
       | file_target | /simple-empty-folder |
-      | uid_owner   | user1                |
+      | uid_owner   | user0                |
       | expiration  | +20 days             |
       | share_with  | grp1                 |
 
   Scenario Outline: expiration date is disabled for sharing with group, user shares file with group and sets expiration date
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "no"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "no"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with group "grp1" using the webUI without closing the share dialog
     And the user changes expiration date for share of group "grp1" to "<days>" in the share dialog
     Then the expiration date input field should be visible for the group "grp1" in the share dialog
     And the expiration date input field should be "<days>" for the group "grp1" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the information of the last share of user "user0" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | <days>     |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | share_with  | grp1       |
     Examples:
       | days     |

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -7,29 +7,29 @@ Feature: Sharing files and folders with internal groups
   Background:
 	Given these users have been created with default attributes and without skeleton files:
 	  | username |
+	  | user0    |
 	  | user1    |
-	  | user2    |
-	And user "user3" has been created with default attributes and skeleton files
+	And user "user2" has been created with default attributes and skeleton files
 
   Scenario Outline: sharing  files and folder with an internal problematic group name
     Given these groups have been created:
       | groupname |
       | <group>   |
+    And user "user0" has been added to group "<group>"
     And user "user1" has been added to group "<group>"
-    And user "user2" has been added to group "<group>"
-    And user "user3" has logged in using the webUI
+    And user "user2" has logged in using the webUI
     When the user shares folder "simple-folder" with group "<group>" using the webUI
     And the user shares file "testimage.jpg" with group "<group>" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then folder "simple-folder" should be listed on the webUI
-    And folder "simple-folder" should be marked as shared with "<group>" by "User Three" on the webUI
+    And folder "simple-folder" should be marked as shared with "<group>" by "User Two" on the webUI
     And file "testimage.jpg" should be listed on the webUI
-    And file "testimage.jpg" should be marked as shared with "<group>" by "User Three" on the webUI
-    When the user re-logs in as "user2" using the webUI
+    And file "testimage.jpg" should be marked as shared with "<group>" by "User Two" on the webUI
+    When the user re-logs in as "user1" using the webUI
     Then folder "simple-folder" should be listed on the webUI
-    And folder "simple-folder" should be marked as shared with "<group>" by "User Three" on the webUI
+    And folder "simple-folder" should be marked as shared with "<group>" by "User Two" on the webUI
     And file "testimage.jpg" should be listed on the webUI
-    And file "testimage.jpg" should be marked as shared with "<group>" by "User Three" on the webUI
+    And file "testimage.jpg" should be marked as shared with "<group>" by "User Two" on the webUI
     Examples:
       | group     |
       | ?\?@#%@,; |
@@ -39,180 +39,180 @@ Feature: Sharing files and folders with internal groups
   Scenario: Share file with a user and a group with same name
     Given these groups have been created:
       | groupname |
-      | user1     |
-    And user "user1" has been added to group "user1"
-    And user "user2" has been added to group "user1"
-    And user "user3" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user shares folder "simple-folder" with group "user1" using the webUI
+      | user0     |
+    And user "user0" has been added to group "user0"
+    And user "user1" has been added to group "user0"
+    And user "user2" has logged in using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user shares folder "simple-folder" with group "user0" using the webUI
+    When the user re-logs in as "user0" using the webUI
+    Then folder "simple-folder" should be marked as shared by "User Two" on the webUI
     When the user re-logs in as "user1" using the webUI
-    Then folder "simple-folder" should be marked as shared by "User Three" on the webUI
-    When the user re-logs in as "user2" using the webUI
-    Then folder "simple-folder" should be marked as shared with "user1" by "User Three" on the webUI
+    Then folder "simple-folder" should be marked as shared with "user0" by "User Two" on the webUI
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: Share file with a group and a user with same name
     Given these groups have been created:
       | groupname |
-      | user1     |
-    And user "user1" has been added to group "user1"
-    And user "user2" has been added to group "user1"
-    And user "user3" has logged in using the webUI
-    When the user shares folder "simple-folder" with group "user1" using the webUI
-    And the user shares folder "simple-folder" with user "User One" using the webUI
+      | user0     |
+    And user "user0" has been added to group "user0"
+    And user "user1" has been added to group "user0"
+    And user "user2" has logged in using the webUI
+    When the user shares folder "simple-folder" with group "user0" using the webUI
+    And the user shares folder "simple-folder" with user "User Zero" using the webUI
+    When the user re-logs in as "user0" using the webUI
+    Then folder "simple-folder" should be marked as shared by "User Two" on the webUI
     When the user re-logs in as "user1" using the webUI
-    Then folder "simple-folder" should be marked as shared by "User Three" on the webUI
-    When the user re-logs in as "user2" using the webUI
-    Then folder "simple-folder" should be marked as shared with "user1" by "User Three" on the webUI
+    Then folder "simple-folder" should be marked as shared with "user0" by "User Two" on the webUI
 
   Scenario: Share file with a user and again with a group with same name but different case
     Given these groups have been created:
       | groupname |
-      | User1     |
-    And user "user2" has been added to group "User1"
-    And user "user3" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user shares folder "simple-folder" with group "User1" using the webUI
+      | User0     |
+    And user "user1" has been added to group "User0"
+    And user "user2" has logged in using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user shares folder "simple-folder" with group "User0" using the webUI
+    When the user re-logs in as "user0" using the webUI
+    Then folder "simple-folder" should be marked as shared by "User Two" on the webUI
     When the user re-logs in as "user1" using the webUI
-    Then folder "simple-folder" should be marked as shared by "User Three" on the webUI
-    When the user re-logs in as "user2" using the webUI
-    Then folder "simple-folder" should be marked as shared with "User1" by "User Three" on the webUI
+    Then folder "simple-folder" should be marked as shared with "User0" by "User Two" on the webUI
 
   Scenario: Share file with a group and again with a user with same name but different case
     Given these groups have been created:
       | groupname |
-      | User1     |
-    And user "user2" has been added to group "User1"
-    And user "user3" has logged in using the webUI
-    When the user shares folder "simple-folder" with group "User1" using the webUI
-    And the user shares folder "simple-folder" with user "User One" using the webUI
+      | User0     |
+    And user "user1" has been added to group "User0"
+    And user "user2" has logged in using the webUI
+    When the user shares folder "simple-folder" with group "User0" using the webUI
+    And the user shares folder "simple-folder" with user "User Zero" using the webUI
+    When the user re-logs in as "user0" using the webUI
+    Then folder "simple-folder" should be marked as shared by "User Two" on the webUI
     When the user re-logs in as "user1" using the webUI
-    Then folder "simple-folder" should be marked as shared by "User Three" on the webUI
-    When the user re-logs in as "user2" using the webUI
-    Then folder "simple-folder" should be marked as shared with "User1" by "User Three" on the webUI
+    Then folder "simple-folder" should be marked as shared with "User0" by "User Two" on the webUI
 
   @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions of the group
 	Given these groups have been created:
 	  | groupname |
-	  | user1     |
-	And user "user2" has been added to group "user1"
-	And user "user3" has shared folder "/simple-folder" with user "user1"
-	And user "user3" has shared folder "/simple-folder" with group "user1"
-	And user "user3" has logged in using the webUI
-	When the user sets the sharing permissions of group "user1" for "simple-folder" using the webUI to
+	  | user0     |
+	And user "user1" has been added to group "user0"
+	And user "user2" has shared folder "/simple-folder" with user "user0"
+	And user "user2" has shared folder "/simple-folder" with group "user0"
+	And user "user2" has logged in using the webUI
+	When the user sets the sharing permissions of group "user0" for "simple-folder" using the webUI to
 	  | delete | no |
 	  | share  | no |
-	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User Zero"
 	  | delete | yes |
 	  | share  | yes |
-	And the information for user "user1" about the received share of folder "simple-folder" should include
+	And the information for user "user0" about the received share of folder "simple-folder" should include
 	  | share_type  | user           |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 31             |
-	And the following permissions are seen for "simple-folder" in the sharing dialog for group "user1"
+	And the following permissions are seen for "simple-folder" in the sharing dialog for group "user0"
 	  | delete | no |
 	  | share  | no |
-	And the information for user "user2" about the received share of folder "simple-folder" should include
+	And the information for user "user1" about the received share of folder "simple-folder" should include
 	  | share_type  | group          |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 7              |
 
   @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions of the user
 	Given these groups have been created:
 	  | groupname |
-	  | user1     |
-	And user "user2" has been added to group "user1"
-	And user "user3" has shared folder "/simple-folder" with user "user1"
-	And user "user3" has shared folder "/simple-folder" with group "user1"
-	And user "user3" has logged in using the webUI
-	When the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+	  | user0     |
+	And user "user1" has been added to group "user0"
+	And user "user2" has shared folder "/simple-folder" with user "user0"
+	And user "user2" has shared folder "/simple-folder" with group "user0"
+	And user "user2" has logged in using the webUI
+	When the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
 	  | delete | no |
 	  | share  | no |
-	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User Zero"
 	  | delete | no |
 	  | share  | no |
-	And the information for user "user1" about the received share of folder "simple-folder" should include
+	And the information for user "user0" about the received share of folder "simple-folder" should include
 	  | share_type  | user           |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 7              |
-	And the following permissions are seen for "simple-folder" in the sharing dialog for group "user1"
+	And the following permissions are seen for "simple-folder" in the sharing dialog for group "user0"
 	  | delete | yes |
 	  | share  | yes |
-	And the information for user "user2" about the received share of folder "simple-folder" should include
+	And the information for user "user1" about the received share of folder "simple-folder" should include
 	  | share_type  | group          |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 31             |
 
   @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions of both user and group
 	Given these groups have been created:
 	  | groupname |
-	  | user1     |
-	And user "user2" has been added to group "user1"
-	And user "user3" has shared folder "/simple-folder" with user "user1"
-	And user "user3" has shared folder "/simple-folder" with group "user1"
-	And user "user3" has logged in using the webUI
-	When the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+	  | user0     |
+	And user "user1" has been added to group "user0"
+	And user "user2" has shared folder "/simple-folder" with user "user0"
+	And user "user2" has shared folder "/simple-folder" with group "user0"
+	And user "user2" has logged in using the webUI
+	When the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
 	  | edit    | no |
 	  | create  | no |
-	And the user sets the sharing permissions of group "user1" for "simple-folder" using the webUI to
+	And the user sets the sharing permissions of group "user0" for "simple-folder" using the webUI to
 	  | delete | no |
-	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User Zero"
 	  | edit    | no |
 	  | create  | no |
-	And the following permissions are seen for "simple-folder" in the sharing dialog for group "user1"
+	And the following permissions are seen for "simple-folder" in the sharing dialog for group "user0"
 	  | delete | no |
-	And the information for user "user1" about the received share of folder "simple-folder" should include
+	And the information for user "user0" about the received share of folder "simple-folder" should include
 	  | share_type  | user           |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 17             |
-	And the information for user "user2" about the received share of folder "simple-folder" should include
+	And the information for user "user1" about the received share of folder "simple-folder" should include
 	  | share_type  | group          |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 23             |
 
   @skipOnOcV10.3
   Scenario: Share file with a user and a group with same name and change sharing permissions and expiration date of the group
 	Given these groups have been created:
 	  | groupname |
-	  | user1     |
-	And user "user2" has been added to group "user1"
-	And user "user3" has shared folder "/simple-folder" with user "user1"
-	And user "user3" has shared folder "/simple-folder" with group "user1"
-	And user "user3" has logged in using the webUI
-	When the user sets the sharing permissions of group "user1" for "simple-folder" using the webUI to
+	  | user0     |
+	And user "user1" has been added to group "user0"
+	And user "user2" has shared folder "/simple-folder" with user "user0"
+	And user "user2" has shared folder "/simple-folder" with group "user0"
+	And user "user2" has logged in using the webUI
+	When the user sets the sharing permissions of group "user0" for "simple-folder" using the webUI to
 	  | share | no |
-	And the user changes expiration date for share of group "user1" to "+230 days" in the share dialog
-	Then the following permissions are seen for "simple-folder" in the sharing dialog for group "user1"
+	And the user changes expiration date for share of group "user0" to "+230 days" in the share dialog
+	Then the following permissions are seen for "simple-folder" in the sharing dialog for group "user0"
 	  | share | no |
-	And the expiration date input field should be "+230 days" for the group "user1" in the share dialog
-	And the information for user "user2" about the received share of folder "simple-folder" should include
+	And the expiration date input field should be "+230 days" for the group "user0" in the share dialog
+	And the information for user "user1" about the received share of folder "simple-folder" should include
 	  | share_type  | group          |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 15             |
 	  | expiration  | +230 days      |
-	And the expiration date input field should be empty for the user "User One" in the share dialog
-	And the information for user "user1" about the received share of folder "simple-folder" should include
+	And the expiration date input field should be empty for the user "User Zero" in the share dialog
+	And the information for user "user0" about the received share of folder "simple-folder" should include
 	  | share_type  | user           |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 31             |
 	  | expiration  |                |
 
@@ -220,30 +220,30 @@ Feature: Sharing files and folders with internal groups
   Scenario: Share file with a user and a group with same name and change sharing permissions and expiration date of the user
 	Given these groups have been created:
 	  | groupname |
-	  | user1     |
-	And user "user2" has been added to group "user1"
-	And user "user3" has shared folder "/simple-folder" with user "user1"
-	And user "user3" has shared folder "/simple-folder" with group "user1"
-	And user "user3" has logged in using the webUI
-	When the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+	  | user0     |
+	And user "user1" has been added to group "user0"
+	And user "user2" has shared folder "/simple-folder" with user "user0"
+	And user "user2" has shared folder "/simple-folder" with group "user0"
+	And user "user2" has logged in using the webUI
+	When the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
 	  | share | no |
-	And the user changes expiration date for share of user "User One" to "+5 days" in the share dialog
-	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+	And the user changes expiration date for share of user "User Zero" to "+5 days" in the share dialog
+	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User Zero"
 	  | share | no |
-	And the information for user "user1" about the received share of folder "simple-folder" should include
+	And the information for user "user0" about the received share of folder "simple-folder" should include
 	  | share_type  | user           |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 15             |
 	  | expiration  | +5 days        |
-	And the expiration date input field should be "+5 days" for the user "User One" in the share dialog
-	And the expiration date input field should be empty for the group "user1" in the share dialog
-	And the information for user "user2" about the received share of folder "simple-folder" should include
+	And the expiration date input field should be "+5 days" for the user "User Zero" in the share dialog
+	And the expiration date input field should be empty for the group "user0" in the share dialog
+	And the information for user "user1" about the received share of folder "simple-folder" should include
 	  | share_type  | group          |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 31             |
 	  | expiration  |                |
 
@@ -251,38 +251,38 @@ Feature: Sharing files and folders with internal groups
   Scenario: Share file with a user and a group with same name and change sharing permissions and expiration date of both user and group
 	Given these groups have been created:
 	  | groupname |
-	  | user1     |
-	And user "user2" has been added to group "user1"
-	And user "user3" has shared folder "/simple-folder" with user "user1"
-	And user "user3" has shared folder "/simple-folder" with group "user1"
-	And user "user3" has logged in using the webUI
-	When the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+	  | user0     |
+	And user "user1" has been added to group "user0"
+	And user "user2" has shared folder "/simple-folder" with user "user0"
+	And user "user2" has shared folder "/simple-folder" with group "user0"
+	And user "user2" has logged in using the webUI
+	When the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
 	  | edit    | no |
 	  | create  | no |
-	And the user changes expiration date for share of user "User One" to "+5 days" in the share dialog
-	And the user sets the sharing permissions of group "user1" for "simple-folder" using the webUI to
+	And the user changes expiration date for share of user "User Zero" to "+5 days" in the share dialog
+	And the user sets the sharing permissions of group "user0" for "simple-folder" using the webUI to
 	  | delete | no |
-	And the user changes expiration date for share of group "user1" to "+7 days" in the share dialog
-	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+	And the user changes expiration date for share of group "user0" to "+7 days" in the share dialog
+	Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User Zero"
 	  | edit    | no |
 	  | create  | no |
-	And the expiration date input field should be "+5 days" for the user "User One" in the share dialog
-	And the information for user "user1" about the received share of folder "simple-folder" should include
+	And the expiration date input field should be "+5 days" for the user "User Zero" in the share dialog
+	And the information for user "user0" about the received share of folder "simple-folder" should include
 	  | share_type  | user           |
 	  | file_target | /simple-folder |
 	  | expiration  | +5 days        |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 17             |
-	And the following permissions are seen for "simple-folder" in the sharing dialog for group "user1"
+	And the following permissions are seen for "simple-folder" in the sharing dialog for group "user0"
 	  | delete | no |
-	And the expiration date input field should be "+7 days" for the group "user1" in the share dialog
-	And the information for user "user2" about the received share of folder "simple-folder" should include
+	And the expiration date input field should be "+7 days" for the group "user0" in the share dialog
+	And the information for user "user1" about the received share of folder "simple-folder" should include
 	  | share_type  | group          |
 	  | file_target | /simple-folder |
 	  | expiration  | +7 days        |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | permissions | 23             |
 
   @skipOnOcV10.3
@@ -290,27 +290,27 @@ Feature: Sharing files and folders with internal groups
 	Given these groups have been created:
 	  | groupname |
 	  | grp1      |
+	And user "user0" has been added to group "grp1"
 	And user "user1" has been added to group "grp1"
-	And user "user2" has been added to group "grp1"
-	And user "user3" has shared folder "/simple-folder" with user "user1"
-	And user "user3" has shared folder "/simple-folder" with group "grp1"
-	And user "user3" has logged in using the webUI
+	And user "user2" has shared folder "/simple-folder" with user "user0"
+	And user "user2" has shared folder "/simple-folder" with group "grp1"
+	And user "user2" has logged in using the webUI
 	When the user sets the sharing permissions of group "grp1" for "simple-folder" using the webUI to
 	  | edit    | no |
 	  | create  | no |
 	And the user changes expiration date for share of group "grp1" to "+5 days" in the share dialog
-	Then the information for user "user2" about the received share of folder "simple-folder" should include
+	Then the information for user "user1" about the received share of folder "simple-folder" should include
 	  | share_type  | group          |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
+	  | uid_owner   | user2          |
 	  | share_with  | grp1           |
 	  | expiration  | +5 days        |
 	  | permissions | 17             |
-	And the information for user "user1" about the received share of folder "simple-folder" should include
+	And the information for user "user0" about the received share of folder "simple-folder" should include
 	  | share_type  | user           |
 	  | file_target | /simple-folder |
-	  | uid_owner   | user3          |
-	  | share_with  | user1          |
+	  | uid_owner   | user2          |
+	  | share_with  | user0          |
 	  | expiration  |                |
 	  | permissions | 31             |
 
@@ -320,11 +320,11 @@ Feature: Sharing files and folders with internal groups
 	  | groupname |
 	  | grp1      |
 	  | grp2      |
-	And user "user1" has been added to group "grp1"
-	And user "user2" has been added to group "grp2"
-	And user "user3" has shared folder "/simple-folder" with group "grp1"
-	And user "user3" has shared folder "/simple-folder" with group "grp2"
-	And user "user3" has logged in using the webUI
+	And user "user0" has been added to group "grp1"
+	And user "user1" has been added to group "grp2"
+	And user "user2" has shared folder "/simple-folder" with group "grp1"
+	And user "user2" has shared folder "/simple-folder" with group "grp2"
+	And user "user2" has logged in using the webUI
 	When the user sets the sharing permissions of group "grp1" for "simple-folder" using the webUI to
 	  | edit    | no |
 	  | create  | no |
@@ -333,17 +333,17 @@ Feature: Sharing files and folders with internal groups
 	  | share    | no |
 	  | delete   | no |
 	And the user changes expiration date for share of group "grp2" to "+7 days" in the share dialog
-	Then the information for user "user1" about the received share of folder "simple-folder" should include
+	Then the information for user "user0" about the received share of folder "simple-folder" should include
 	  | share_type  | group          |
 	  | file_target | /simple-folder |
 	  | expiration  | +5 days        |
-	  | uid_owner   | user3          |
+	  | uid_owner   | user2          |
 	  | share_with  | grp1           |
 	  | permissions | 17             |
-	And the information for user "user2" about the received share of folder "simple-folder" should include
+	And the information for user "user1" about the received share of folder "simple-folder" should include
 	  | share_type  | group          |
 	  | file_target | /simple-folder |
 	  | expiration  | +7 days        |
-	  | uid_owner   | user3          |
+	  | uid_owner   | user2          |
 	  | share_with  | grp2           |
 	  | permissions | 7              |

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -9,36 +9,36 @@ Feature: Sharing files and folders with internal users
   Scenario: share a file & folder with another internal user
     Given these users have been created with default attributes and skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has shared folder "simple-folder" with user "user1"
-    And user "user2" has shared file "testimage.jpg" with user "user1"
-    When user "user1" logs in using the webUI
+    And user "user1" has shared folder "simple-folder" with user "user0"
+    And user "user1" has shared file "testimage.jpg" with user "user0"
+    When user "user0" logs in using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
-    And folder "simple-folder (2)" should be marked as shared by "User Two" on the webUI
+    And folder "simple-folder (2)" should be marked as shared by "User One" on the webUI
     And file "testimage (2).jpg" should be listed on the webUI
-    And file "testimage (2).jpg" should be marked as shared by "User Two" on the webUI
+    And file "testimage (2).jpg" should be marked as shared by "User One" on the webUI
     When the user opens folder "simple-folder (2)" using the webUI
     Then file "lorem.txt" should be listed on the webUI
     But folder "simple-folder (2)" should not be listed on the webUI
 
   Scenario: share a folder with other user and then it should be listed on Shared with Others page
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has shared file "lorem.txt" with user "user1"
-    And user "user2" has shared file "simple-folder" with user "user1"
-    And user "user2" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has shared file "lorem.txt" with user "user0"
+    And user "user1" has shared file "simple-folder" with user "user0"
+    And user "user1" has logged in using the webUI
     When the user browses to the shared-with-others page
     Then file "lorem.txt" should be listed on the webUI
     And folder "simple-folder" should be listed on the webUI
 
   Scenario: share two file with same name but different paths
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has shared file "lorem.txt" with user "user1"
-    And user "user2" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has shared file "lorem.txt" with user "user0"
+    And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
-    And the user shares file "lorem.txt" with user "User One" using the webUI
+    And the user shares file "lorem.txt" with user "User Zero" using the webUI
     And the user browses to the shared-with-others page
     Then file "lorem.txt" with path "" should be listed in the shared with others page on the webUI
     And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
@@ -46,23 +46,23 @@ Feature: Sharing files and folders with internal users
   Scenario: user shares the file/folder with another internal user and delete the share with user
     Given these users have been created with default attributes and skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user1" has logged in using the webUI
-    And user "user1" has shared file "lorem.txt" with user "user2"
+    And user "user0" has logged in using the webUI
+    And user "user0" has shared file "lorem.txt" with user "user1"
     When the user opens the share dialog for file "lorem.txt"
-    And the user deletes share with user "User Two" for the current file
-    Then the user "User Two" should not be in share with user list
+    And the user deletes share with user "User One" for the current file
+    Then the user "User One" should not be in share with user list
     And file "lorem.txt" should not be listed in shared-with-others page on the webUI
-    And as "user2" file "lorem (2).txt" should not exist
+    And as "user1" file "lorem (2).txt" should not exist
 
   @skipOnOcV10.3 @skipOnOcV10.4
   Scenario Outline: user shares a file with another user with unusual usernames
-    Given user "user1" has been created with default attributes and skeleton files
+    Given user "user0" has been created with default attributes and skeleton files
     And these users have been created without skeleton files:
       | username   |
       | <username> |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user shares file "lorem.txt" with user "<username>" using the webUI
     And the user re-logs in as "<username>" using the webUI
     And the user browses to the shared-with-you page
@@ -80,43 +80,43 @@ Feature: Sharing files and folders with internal users
   Scenario: multiple users share a file with the same name to a user
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
-      | user3    |
+    And user "user1" has uploaded file with content "user1 file" to "/randomfile.txt"
     And user "user2" has uploaded file with content "user2 file" to "/randomfile.txt"
-    And user "user3" has uploaded file with content "user3 file" to "/randomfile.txt"
-    And user "user2" has shared file "randomfile.txt" with user "user1"
-    And user "user3" has shared file "randomfile.txt" with user "user1"
-    When user "user1" logs in using the webUI
+    And user "user1" has shared file "randomfile.txt" with user "user0"
+    And user "user2" has shared file "randomfile.txt" with user "user0"
+    When user "user0" logs in using the webUI
     Then file "randomfile.txt" should be listed on the webUI
-    And the content of file "randomfile.txt" for user "user1" should be "user2 file"
+    And the content of file "randomfile.txt" for user "user0" should be "user1 file"
     And file "randomfile (2).txt" should be listed on the webUI
-    And the content of file "randomfile (2).txt" for user "user1" should be "user3 file"
+    And the content of file "randomfile (2).txt" for user "user0" should be "user2 file"
 
   Scenario: multiple users share a folder with the same name to a user
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
-      | user3    |
+    And user "user1" has created folder "/zzzfolder"
     And user "user2" has created folder "/zzzfolder"
-    And user "user3" has created folder "/zzzfolder"
-    And user "user2" has shared folder "zzzfolder" with user "user1"
-    And user "user3" has shared folder "zzzfolder" with user "user1"
-    When user "user1" logs in using the webUI
+    And user "user1" has shared folder "zzzfolder" with user "user0"
+    And user "user2" has shared folder "zzzfolder" with user "user0"
+    When user "user0" logs in using the webUI
     Then folder "zzzfolder" should be listed on the webUI
-    And folder "zzzfolder" should be marked as shared by "User Two" on the webUI
+    And folder "zzzfolder" should be marked as shared by "User One" on the webUI
     And folder "zzzfolder (2)" should be listed on the webUI
-    And folder "zzzfolder (2)" should be marked as shared by "User Three" on the webUI
+    And folder "zzzfolder (2)" should be marked as shared by "User Two" on the webUI
 
   Scenario Outline:  user names are not case-sensitive, sharing same file to user specifying different upper and lower case names
     Given these users have been created with default attributes and without skeleton files:
       | username       |
-      | user1          |
+      | user0          |
       | brand-new-user |
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has shared folder "simple-folder" with user "brand-new-user"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has shared folder "simple-folder" with user "brand-new-user"
+    And user "user0" has logged in using the webUI
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "<user_id1>" in the share-with-field
     Then a tooltip with the text "No users or groups found for <user_id1>" should be shown near the share-with-field on the webUI
@@ -133,45 +133,45 @@ Feature: Sharing files and folders with internal users
   Scenario: sharer should be able to share a folder to a user when only share with groups they are member of is enabled
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
     And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user1" has created folder "/simple-folder"
+    And user "user0" has been added to group "grp1"
+    And user "user0" has created folder "/simple-folder"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables restrict users to only share with groups they are member of using the webUI
-    And the user re-logs in as "user1" using the webUI
-    And the user shares folder "simple-folder" with user "User Two" using the webUI
-    Then as "user2" folder "/simple-folder" should exist
+    And the user re-logs in as "user0" using the webUI
+    And the user shares folder "simple-folder" with user "User One" using the webUI
+    Then as "user1" folder "/simple-folder" should exist
 
   Scenario: sharer should be able to share a file to a user when only share with groups they are member of is enabled
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
     And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user1" has uploaded file with content "some content" to "lorem.txt"
+    And user "user0" has been added to group "grp1"
+    And user "user0" has uploaded file with content "some content" to "lorem.txt"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables restrict users to only share with groups they are member of using the webUI
-    And the user re-logs in as "user1" using the webUI
-    And the user shares file "lorem.txt" with user "User Two" using the webUI
-    Then as "user2" file "/lorem.txt" should exist
+    And the user re-logs in as "user0" using the webUI
+    And the user shares file "lorem.txt" with user "User One" using the webUI
+    Then as "user1" file "/lorem.txt" should exist
 
   @skipOnOcV10.3
   Scenario: Create share with share permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
-      | user3    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
-    And user "user2" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
       | edit | no |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should not be available on the webUI
     And the option to delete file "lorem.txt" should not be available on the webUI
@@ -179,94 +179,94 @@ Feature: Sharing files and folders with internal users
     # Even though the upload option is not shown in the ui, the file input is still present.
     # So we can attach a file to that input and try to upload.
     When the user uploads file "textfile.txt" using the webUI
-    Then as "user1" file "simple-folder/textfile.txt" should not exist
+    Then as "user0" file "simple-folder/textfile.txt" should not exist
     And file "textfile.txt" should not be listed on the webUI
-    When the user shares file "lorem.txt" with user "User Three" using the webUI
-    Then as "user3" file "lorem.txt" should exist
+    When the user shares file "lorem.txt" with user "User Two" using the webUI
+    Then as "user2" file "lorem.txt" should exist
 
   @skipOnOcV10.3
   Scenario: Create share with share and create permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
-    And user "user2" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
       | change | no |
       | delete | no |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should not be available on the webUI
     And the option to delete file "lorem.txt" should not be available on the webUI
     When the user uploads file "textfile.txt" using the webUI
-    Then as "user1" file "simple-folder/textfile.txt" should exist
+    Then as "user0" file "simple-folder/textfile.txt" should exist
     And the content of "textfile.txt" should be the same as the local "textfile.txt"
 
   @skipOnOcV10.3
   Scenario: Create share with share and change permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
-    And user "user2" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
       | create | no |
       | delete | no |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should be available on the webUI
     And the option to delete file "lorem.txt" should not be available on the webUI
     When the user uploads file "textfile.txt" using the webUI
-    Then as "user1" file "simple-folder/textfile.txt" should not exist
+    Then as "user0" file "simple-folder/textfile.txt" should not exist
     And file "textfile.txt" should not be listed on the webUI
 
   @skipOnOcV10.3
   Scenario: Create share with share and delete permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
-    And user "user2" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
       | change | no |
       | create | no |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should not be available on the webUI
     And it should be possible to delete file "lorem.txt" using the webUI
     When the user uploads file "textfile.txt" using the webUI
-    Then as "user1" file "simple-folder/textfile.txt" should not exist
+    Then as "user0" file "simple-folder/textfile.txt" should not exist
     And file "textfile.txt" should not be listed on the webUI
 
   @skipOnOcV10.3
   Scenario: Create share with edit and without share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
-    And user "user2" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
       | share | no |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should be available on the webUI
     And it should not be possible to share file "lorem.txt" using the webUI
     And the option to delete file "lorem.txt" should be available on the webUI
     And the option to upload file should be available on the webUI
     When the user uploads file "textfile.txt" using the webUI
-    Then as "user1" file "simple-folder/textfile.txt" should exist
+    Then as "user0" file "simple-folder/textfile.txt" should exist
     And file "textfile.txt" should be listed on the webUI
     And the content of "textfile.txt" should be the same as the local "textfile.txt"
     And it should not be possible to share file "textfile.txt" using the webUI
@@ -309,11 +309,11 @@ Feature: Sharing files and folders with internal users
   Scenario Outline: user with unusual username shares a file & folder with another internal user
     Given these users have been created with default attributes and skeleton files:
       | username   |
-      | user1      |
+      | user0      |
       | <username> |
-    And user "<username>" has shared folder "simple-folder" with user "user1"
-    And user "<username>" has shared file "testimage.jpg" with user "user1"
-    When user "user1" logs in using the webUI
+    And user "<username>" has shared folder "simple-folder" with user "user0"
+    And user "<username>" has shared file "testimage.jpg" with user "user0"
+    When user "user0" logs in using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
     And folder "simple-folder (2)" should be marked as shared by "Regular User" on the webUI
     And file "testimage (2).jpg" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
@@ -3,12 +3,12 @@ Feature: misc scenarios on sharing with internal users
 
   @TestAlsoOnExternalUserBackend @skipOnFIREFOX
   Scenario: share a file with another internal user who overwrites and unshares the file
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has logged in using the webUI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
-    And the user shares file "new-lorem.txt" with user "User One" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user shares file "new-lorem.txt" with user "User Zero" using the webUI
+    And the user re-logs in as "user0" using the webUI
     Then the content of "new-lorem.txt" should not be the same as the local "new-lorem.txt"
 		# overwrite the received shared file
     When the user uploads overwriting file "new-lorem.txt" using the webUI and retries if the file is locked
@@ -18,17 +18,17 @@ Feature: misc scenarios on sharing with internal users
     When the user unshares file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should not be listed on the webUI
 		# check that the original file owner can still see the file
-    When the user re-logs in as "user2" using the webUI
+    When the user re-logs in as "user1" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares folder "new-simple-folder" with user "User One" using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user shares folder "new-simple-folder" with user "User Zero" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
     Then the content of "lorem.txt" should not be the same as the local "lorem.txt"
 		# overwrite an existing file in the received share
@@ -42,7 +42,7 @@ Feature: misc scenarios on sharing with internal users
     When the user deletes file "data.zip" using the webUI
     Then file "data.zip" should not be listed on the webUI
 		# check that the file actions by the sharee are visible for the share owner
-    When the user re-logs in as "user2" using the webUI
+    When the user re-logs in as "user1" using the webUI
     And the user opens folder "new-simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
@@ -52,17 +52,17 @@ Feature: misc scenarios on sharing with internal users
 
   @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who unshares the folder
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has logged in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
-    And the user shares folder "new-simple-folder" with user "User One" using the webUI
+    And the user shares folder "new-simple-folder" with user "User Zero" using the webUI
 		# unshare the received shared folder and check it is gone
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user unshares folder "new-simple-folder" using the webUI
     Then folder "new-simple-folder" should not be listed on the webUI
 		# check that the folder is still visible for the share owner
-    When the user re-logs in as "user2" using the webUI
+    When the user re-logs in as "user1" using the webUI
     Then folder "new-simple-folder" should be listed on the webUI
     When the user opens folder "new-simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -72,25 +72,25 @@ Feature: misc scenarios on sharing with internal users
   Scenario: share a folder with another internal user and prohibit deleting
     Given these users have been created with default attributes and skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has logged in using the webUI
-    When the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+    And user "user1" has logged in using the webUI
+    When the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
       | delete | no |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   @skipOnFIREFOX
   Scenario: share a folder with other user and then it should be listed on Shared with You for other user
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and skeleton files
-    And user "user2" has moved file "lorem.txt" to "ipsum.txt"
-    And user "user2" has moved file "simple-folder" to "new-simple-folder"
-    And user "user2" has shared file "ipsum.txt" with user "user1"
-    And user "user2" has shared file "new-simple-folder" with user "user1"
-    When user "user1" logs in using the webUI
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user1" has moved file "lorem.txt" to "ipsum.txt"
+    And user "user1" has moved file "simple-folder" to "new-simple-folder"
+    And user "user1" has shared file "ipsum.txt" with user "user0"
+    And user "user1" has shared file "new-simple-folder" with user "user0"
+    When user "user0" logs in using the webUI
     And the user browses to the shared-with-you page
     Then file "ipsum.txt" should be listed on the webUI
     And folder "new-simple-folder" should be listed on the webUI
@@ -99,101 +99,101 @@ Feature: misc scenarios on sharing with internal users
     Given group "grp1" has been created
     And these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-      | user3    |
-    And user "user2" has been created with default attributes and skeleton files
-    And user "user1" has been added to group "grp1"
+      | user0    |
+      | user2    |
+    And user "user1" has been created with default attributes and skeleton files
+    And user "user0" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables exclude groups from sharing using the webUI
     And the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "user1" should not be able to share file "testimage.jpg" with user "user3" using the sharing API
+    Then user "user0" should not be able to share file "testimage.jpg" with user "user2" using the sharing API
 
   Scenario: user tries to share a folder from a group which is blacklisted from sharing
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-      | user3    |
-    And user "user2" has been created with default attributes and skeleton files
+      | user0    |
+      | user2    |
+    And user "user1" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
+    And user "user0" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables exclude groups from sharing using the webUI
     And the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "user1" should not be able to share folder "simple-folder" with user "User Three" using the sharing API
+    Then user "user0" should not be able to share folder "simple-folder" with user "User Two" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file received as a share
     Given these users have been created with default attributes and skeleton files:
       | username |
-      | user1    |
-      | user3    |
+      | user0    |
+      | user2    |
     And these users have been created with default attributes and without skeleton files:
       | username |
-      | user2    |
-      | user4    |
+      | user1    |
+      | user3    |
     And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user3" has shared file "/testimage.jpg" with user "user1"
+    And user "user0" has been added to group "grp1"
+    And user "user2" has shared file "/testimage.jpg" with user "user0"
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "user1" should not be able to share file "/testimage (2).jpg" with user "User Four" using the sharing API
+    Then user "user0" should not be able to share file "/testimage (2).jpg" with user "User Three" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a folder received as a share
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
       | user3    |
-      | user4    |
     And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user3" has created folder "/common"
-    And user "user3" has shared folder "/common" with user "user1"
+    And user "user0" has been added to group "grp1"
+    And user "user2" has created folder "/common"
+    And user "user2" has shared folder "/common" with user "user0"
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "user1" should not be able to share folder "/common" with user "User Four" using the sharing API
+    Then user "user0" should not be able to share folder "/common" with user "User Three" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file inside a folder received as a share
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-      | user4    |
-    And user "user3" has been created with default attributes and skeleton files
+      | user3    |
+    And user "user2" has been created with default attributes and skeleton files
     And group "grp1" has been created
-    And user "user1" has been added to group "grp1"
-    And user "user3" has created folder "/common"
-    And user "user3" has moved file "/testimage.jpg" to "/common/testimage.jpg"
-    And user "user3" has shared folder "/common" with user "user1"
+    And user "user0" has been added to group "grp1"
+    And user "user2" has created folder "/common"
+    And user "user2" has moved file "/testimage.jpg" to "/common/testimage.jpg"
+    And user "user2" has shared folder "/common" with user "user0"
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "user1" should not be able to share file "/common/testimage.jpg" with user "User Four" using the sharing API
+    Then user "user0" should not be able to share file "/common/testimage.jpg" with user "User Three" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a folder inside a folder received as a share
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
       | user3    |
-      | user4    |
-    And user "user3" has created folder "/common"
-    And user "user3" has created folder "/common/inside-common"
-    And user "user3" has shared folder "/common" with user "user1"
+    And user "user2" has created folder "/common"
+    And user "user2" has created folder "/common/inside-common"
+    And user "user2" has shared folder "/common" with user "user0"
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "user1" should not be able to share folder "/common/inside-common" with user "User Four" using the sharing API
+    Then user "user0" should not be able to share folder "/common/inside-common" with user "User Three" using the sharing API
 
   Scenario: user tries to share a file from a group which is blacklisted from sharing using webUI from files page
     Given group "grp1" has been created
-    And user "user1" has been created with default attributes and skeleton files
-    And user "user1" has been added to group "grp1"
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user0" has been added to group "grp1"
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens the sharing tab from the file action menu of file "testimage.jpg" using the webUI
     Then the user should see an error message on the share dialog saying "Sharing is not allowed"
     And the share-with field should not be visible in the details panel
@@ -202,75 +202,75 @@ Feature: misc scenarios on sharing with internal users
     Given group "grp1" has been created
     And these users have been created with default attributes and skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user1" has been added to group "grp1"
-    And user "user3" has been created with default attributes and without skeleton files
-    And user "user2" has shared file "/testimage.jpg" with user "user1"
+    And user "user0" has been added to group "grp1"
+    And user "user2" has been created with default attributes and without skeleton files
+    And user "user1" has shared file "/testimage.jpg" with user "user0"
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user browses to the shared-with-you page
     And the user opens the sharing tab from the file action menu of file "testimage (2).jpg" using the webUI
     Then the user should see an error message on the share dialog saying "Sharing is not allowed"
     And the share-with field should not be visible in the details panel
-    And user "user1" should not be able to share file "testimage (2).jpg" with user "User Three" using the sharing API
+    And user "user0" should not be able to share file "testimage (2).jpg" with user "User Two" using the sharing API
 
   @skipOnOcV10.3 @skipOnEncryptionType:user-keys @issue-encryption-126
   @mailhog
   Scenario: user should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user1" has been created with default attributes and skeleton files
-    And user "user2" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
-    And user "user1" has shared file "lorem.txt" with user "user2"
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
+    And user "user0" has shared file "lorem.txt" with user "user1"
     And the user has opened the share dialog for file "lorem.txt"
-    When the user sends the share notification by email for user "User Two" using the webUI
+    When the user sends the share notification by email for user "User One" using the webUI
     Then a notification should be displayed on the webUI with the text "Email notification was sent!"
-    And the email address "user2@example.org" should have received an email with the body containing
+    And the email address "user1@example.org" should have received an email with the body containing
       """
-      just letting you know that User One shared lorem.txt with you.
+      just letting you know that User Zero shared lorem.txt with you.
       """
 
   @mailhog @skipOnOcV10.3
   Scenario: user should get and error message when trying to send notification by email to a user who has not setup their email
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user1" has been created with default attributes and skeleton files
+    And user "user0" has been created with default attributes and skeleton files
     And these users have been created without skeleton files:
       | username | password |
-      | user0    | 1234     |
-    And user "user1" has logged in using the webUI
-    And user "user1" has shared file "lorem.txt" with user "user0"
+      | user1    | 1234     |
+    And user "user0" has logged in using the webUI
+    And user "user0" has shared file "lorem.txt" with user "user1"
     And the user has opened the share dialog for file "lorem.txt"
-    When the user sends the share notification by email for user "user0" using the webUI
+    When the user sends the share notification by email for user "user1" using the webUI
     Then dialog should be displayed on the webUI
       | title                       | content                                             |
-      | Email notification not sent | Couldn't send mail to following recipient(s): user0 |
+      | Email notification not sent | Couldn't send mail to following recipient(s): user1 |
 
   @mailhog @skipOnOcV10.3
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "user1" has been created with default attributes and skeleton files
-    And user "user2" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
-    And user "user1" has shared file "lorem.txt" with user "user2"
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
+    And user "user0" has shared file "lorem.txt" with user "user1"
     And the user has opened the share dialog for file "lorem.txt"
-    When the user sends the share notification by email for user "User Two" using the webUI
-    Then the user should not be able to send the share notification by email for user "User Two" using the webUI
+    When the user sends the share notification by email for user "User One" using the webUI
+    Then the user should not be able to send the share notification by email for user "User One" using the webUI
     When the user reloads the current page of the webUI
     And the user opens the share dialog for file "lorem.txt"
-    Then the user should not be able to send the share notification by email for user "User Two" using the webUI
+    Then the user should not be able to send the share notification by email for user "User One" using the webUI
 
   @skipOnOcV10.3
   Scenario: user should not be able to send notification by email when allow share mail notification has been disabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "no"
-    And user "user1" has been created with default attributes and skeleton files
-    And user "user2" has been created with default attributes and without skeleton files
-    And user "user1" has logged in using the webUI
-    And user "user1" has shared file "lorem.txt" with user "user2"
+    And user "user0" has been created with default attributes and skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has logged in using the webUI
+    And user "user0" has shared file "lorem.txt" with user "user1"
     When the user opens the share dialog for file "lorem.txt"
-    Then the user should not be able to send the share notification by email for user "User Two" using the webUI
+    Then the user should not be able to send the share notification by email for user "User One" using the webUI
 
   @mailhog @skipOnOcV10.3
   Scenario: user without email should be able to send notification by email when allow share mail notification has been enabled
@@ -294,44 +294,44 @@ Feature: misc scenarios on sharing with internal users
   Scenario: share a skeleton file after changing its content to a user before the user has logged in
     Given these users have been created with default attributes and skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has logged in using the webUI
-    And user "user2" has uploaded file with content "edited original content" to "/lorem.txt"
-    When the user shares file "lorem.txt" with user "User One" using the webUI
-    Then the content of file "lorem.txt" for user "user2" should be "edited original content"
-    When the user re-logs in as "user1" using the webUI
+    And user "user1" has logged in using the webUI
+    And user "user1" has uploaded file with content "edited original content" to "/lorem.txt"
+    When the user shares file "lorem.txt" with user "User Zero" using the webUI
+    Then the content of file "lorem.txt" for user "user1" should be "edited original content"
+    When the user re-logs in as "user0" using the webUI
     Then the content of "lorem.txt" should be the same as the original "lorem.txt"
-#   And the content of file "lorem.txt" for user "user1" should be "edited original content"
+#   And the content of file "lorem.txt" for user "user0" should be "edited original content"
 
   @skipOnOcV10.3
   Scenario: share with two users having same display name
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user3" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
+    And the administrator has changed the display name of user "user0" to "USER"
     And the administrator has changed the display name of user "user1" to "USER"
-    And the administrator has changed the display name of user "user2" to "USER"
     And parameter "user_additional_info_field" of app "core" has been set to "id"
-    And user "user3" has shared folder "/simple-folder" with user "user1"
-    And user "user3" has shared folder "/simple-folder" with user "user2"
-    And user "user3" has logged in using the webUI
-    When the user sets the sharing permissions of user "USER (user2)" for "simple-folder" using the webUI to
+    And user "user2" has shared folder "/simple-folder" with user "user0"
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has logged in using the webUI
+    When the user sets the sharing permissions of user "USER (user1)" for "simple-folder" using the webUI to
       | edit    | no |
       | create  | no |
-    And the user sets the sharing permissions of user "USER (user1)" for "simple-folder" using the webUI to
+    And the user sets the sharing permissions of user "USER (user0)" for "simple-folder" using the webUI to
       | share    | no |
       | delete   | no |
-    Then the information for user "user1" about the received share of folder "simple-folder" should include
+    Then the information for user "user0" about the received share of folder "simple-folder" should include
       | share_type  | user           |
       | file_target | /simple-folder |
-      | uid_owner   | user3          |
-      | share_with  | user1          |
+      | uid_owner   | user2          |
+      | share_with  | user0          |
       | permissions | 7              |
-    And the information for user "user2" about the received share of folder "simple-folder" should include
+    And the information for user "user1" about the received share of folder "simple-folder" should include
       | share_type  | user           |
       | file_target | /simple-folder |
-      | uid_owner   | user3          |
-      | share_with  | user2          |
+      | uid_owner   | user2          |
+      | share_with  | user1          |
       | permissions | 17             |

--- a/tests/acceptance/features/webUISharingInternalUsers2/adminDisablesSharePermissions.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/adminDisablesSharePermissions.feature
@@ -8,73 +8,73 @@ Feature: Sharing files and folders with internal users where admin disables diff
   Scenario: Create share when admin disables delete in share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
-      | user3    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
     And the administrator has browsed to the admin sharing settings page
     When the administrator disables permission delete for default user and group share using the webUI
-    And the user re-logs in as "user2" using the webUI
-    And the user shares folder "simple-folder" with user "User One" using the webUI
-    Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+    And the user re-logs in as "user1" using the webUI
+    And the user shares folder "simple-folder" with user "User Zero" using the webUI
+    Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User Zero"
       | change | yes |
       | create | yes |
       | delete | no  |
       | share  | yes |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should be available on the webUI
     And the option to delete file "lorem.txt" should not be available on the webUI
     And the option to upload file should be available on the webUI
-    When the user shares file "lorem.txt" with user "User Three" using the webUI
-    Then as "user3" file "lorem.txt" should exist
+    When the user shares file "lorem.txt" with user "User Two" using the webUI
+    Then as "user2" file "lorem.txt" should exist
 
   @skipOnOcV10.3
   Scenario: Create share when admin disables change in share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
-      | user3    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
     And the administrator has browsed to the admin sharing settings page
     When the administrator disables permission change for default user and group share using the webUI
-    And the user re-logs in as "user2" using the webUI
-    And the user shares folder "simple-folder" with user "User One" using the webUI
-    Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+    And the user re-logs in as "user1" using the webUI
+    And the user shares folder "simple-folder" with user "User Zero" using the webUI
+    Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User Zero"
       | change | no  |
       | create | yes |
       | delete | yes |
       | share  | yes |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should not be available on the webUI
     And the option to upload file should be available on the webUI
-    When the user shares file "lorem.txt" with user "User Three" using the webUI
-    Then as "user3" file "lorem.txt" should exist
+    When the user shares file "lorem.txt" with user "User Two" using the webUI
+    Then as "user2" file "lorem.txt" should exist
     And the option to delete file "lorem.txt" should be available on the webUI
 
   @skipOnOcV10.3
   Scenario: Create share when admin disables create and share in share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
     And the administrator has browsed to the admin sharing settings page
     When the administrator disables permission create for default user and group share using the webUI
     And the administrator disables permission share for default user and group share using the webUI
-    And the user re-logs in as "user2" using the webUI
-    And the user shares folder "simple-folder" with user "User One" using the webUI
-    Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User One"
+    And the user re-logs in as "user1" using the webUI
+    And the user shares folder "simple-folder" with user "User Zero" using the webUI
+    Then the following permissions are seen for "simple-folder" in the sharing dialog for user "User Zero"
       | change | yes |
       | create | no  |
       | delete | yes |
       | share  | no  |
-    And the user re-logs in as "user1" using the webUI
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then it should not be possible to share file "lorem.txt" using the webUI
     And the option to upload file should not be available on the webUI
@@ -85,17 +85,17 @@ Feature: Sharing files and folders with internal users where admin disables diff
   Scenario: Create share when admin disables delete in share permissions but then user enables the permission
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
     And the administrator has browsed to the admin sharing settings page
     When the administrator disables permission delete for default user and group share using the webUI
-    And the user re-logs in as "user2" using the webUI
-    And the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
-      | delete | yes |
     And the user re-logs in as "user1" using the webUI
+    And the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
+      | delete | yes |
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should be available on the webUI
     And the option to upload file should be available on the webUI
@@ -106,22 +106,22 @@ Feature: Sharing files and folders with internal users where admin disables diff
   Scenario: Create share when admin disables multiple default share permissions but then user enables a disabled permission
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
-      | user3    |
-    And user "user2" has created folder "simple-folder"
-    And user "user2" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "user1" has created folder "simple-folder"
+    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
     And the administrator has browsed to the admin sharing settings page
     When the administrator disables permission delete for default user and group share using the webUI
     And the administrator disables permission share for default user and group share using the webUI
-    And the user re-logs in as "user2" using the webUI
-    And the user shares folder "simple-folder" with user "User One" using the webUI
-    And the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
-      | share | yes |
     And the user re-logs in as "user1" using the webUI
+    And the user shares folder "simple-folder" with user "User Zero" using the webUI
+    And the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
+      | share | yes |
+    And the user re-logs in as "user0" using the webUI
     And the user opens folder "simple-folder" using the webUI
     Then the option to rename file "lorem.txt" should be available on the webUI
     And the option to upload file should be available on the webUI
     And the option to delete file "lorem.txt" should not be available on the webUI
-    When the user shares file "lorem.txt" with user "User Three" using the webUI
-    Then as "user3" file "lorem.txt" should exist
+    When the user shares file "lorem.txt" with user "User Two" using the webUI
+    Then as "user2" file "lorem.txt" should exist

--- a/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
@@ -7,266 +7,266 @@ Feature: Sharing files and folders with internal users with expiration date set/
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user3" has been created with default attributes and skeleton files
+    And user "user2" has been created with default attributes and skeleton files
 
   Scenario: expiration date is disabled for sharing with users, user shares with another user
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "no"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be visible for the user "User Two" in the share dialog
-    And the expiration date input field should be empty for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User One" in the share dialog
+    And the expiration date input field should be empty for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  |            |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario: expiration date is disabled for sharing with users but enabled for sharing with groups, user shares with another user
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "no"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be visible for the user "User Two" in the share dialog
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User One" in the share dialog
 
   Scenario: expiration date is enabled for sharing with users, user shares file with another user
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be visible for the user "User Two" in the share dialog
-    And the expiration date input field should be "+7 days" for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User One" in the share dialog
+    And the expiration date input field should be "+7 days" for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | +7 days    |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario Outline: expiration date is enforced for user, user shares file
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "<num_days>"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be visible for the user "User Two" in the share dialog
-    And the expiration date input field should be "<days>" for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User One" in the share dialog
+    And the expiration date input field should be "<days>" for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | <days>     |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
     Examples:
       | num_days | days     |
       | 3        | +3 days  |
       | 0        | today    |
 
   Scenario: expiration date is enforced for user, user shares and tries to change expiration date more than allowed
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "3"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    And the user changes expiration date for share of user "User Two" to "+4 days" in the share dialog
-    Then the expiration date input field should be "+3 days" for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    And the user changes expiration date for share of user "User One" to "+4 days" in the share dialog
+    Then the expiration date input field should be "+3 days" for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario: expiration date is enforced for user, user reshares received file with another user
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "3"
-    And user "user3" has shared file "lorem.txt" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be visible for the user "User Two" in the share dialog
-    And the expiration date input field should be "+3 days" for the user "User Two" in the share dialog
-    Then the information of the last share of user "user1" should include
+    And user "user2" has shared file "lorem.txt" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User One" in the share dialog
+    And the expiration date input field should be "+3 days" for the user "User One" in the share dialog
+    Then the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario: expiration date is enabled but not enforced for user, user reshares received file with another user
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
-    And user "user3" has shared file "lorem.txt" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be visible for the user "User Two" in the share dialog
-    And the expiration date input field should be "+7 days" for the user "User Two" in the share dialog
-    Then the information of the last share of user "user1" should include
+    And user "user2" has shared file "lorem.txt" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be visible for the user "User One" in the share dialog
+    And the expiration date input field should be "+7 days" for the user "User One" in the share dialog
+    Then the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | +7 days    |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
 
   Scenario: expiration date is enabled but not enforced for user, user reshares received file with another user, but removes default expiration date
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
-    And user "user3" has shared file "lorem.txt" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    And the user clears the expiration date input field for share of user "User Two" in the share dialog
-    Then the expiration date input field should be empty for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user2" has shared file "lorem.txt" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    And the user clears the expiration date input field for share of user "User One" in the share dialog
+    Then the expiration date input field should be empty for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  |            |
 
   Scenario: expiration date is enabled but not enforced for user, user reshares received file with another user, but changes expiration date
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
-    And user "user3" has shared file "lorem.txt" with user "user1"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    And the user changes expiration date for share of user "User Two" to "+15 days" in the share dialog
-    Then the expiration date input field should be "+15 days" for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user2" has shared file "lorem.txt" with user "user0"
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    And the user changes expiration date for share of user "User One" to "+15 days" in the share dialog
+    Then the expiration date input field should be "+15 days" for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +15 days   |
 
   Scenario: expiration date is enabled but not enforced, user shares through api and checks the expiration date on webUI
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | user       |
-      | shareWith   | user1      |
+      | shareWith   | user0      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user3" has logged in using the webUI
+    And user "user2" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt"
-    Then the expiration date input field should be "+15 days" for the user "User One" in the share dialog
+    Then the expiration date input field should be "+15 days" for the user "User Zero" in the share dialog
 
   Scenario: expiration date is enabled but not enforced, user receives a share with expiration date and reshares with expiration date less than the original
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | user       |
-      | shareWith   | user1      |
+      | shareWith   | user0      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be "+7 days" for the user "User Two" in the share dialog
-    When the user changes expiration date for share of user "User Two" to "+10 days" in the share dialog
-    Then the expiration date input field should be "+10 days" for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+7 days" for the user "User One" in the share dialog
+    When the user changes expiration date for share of user "User One" to "+10 days" in the share dialog
+    Then the expiration date input field should be "+10 days" for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +10 days   |
 
   Scenario: expiration date is enabled but not enforced, user receives a share with expiration date and reshares it, setting a date further in future than the original
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | user       |
-      | shareWith   | user1      |
+      | shareWith   | user0      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be "+7 days" for the user "User Two" in the share dialog
-    When the user changes expiration date for share of user "User Two" to "+20 days" in the share dialog
-    Then the expiration date input field should be "+20 days" for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+7 days" for the user "User One" in the share dialog
+    When the user changes expiration date for share of user "User One" to "+20 days" in the share dialog
+    Then the expiration date input field should be "+20 days" for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +20 days   |
 
   Scenario: expiration date is enabled and enforced, user receives a share with expiration date and tries to reshare with expiration date less than the original
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | user       |
-      | shareWith   | user1      |
+      | shareWith   | user0      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be "+30 days" for the user "User Two" in the share dialog
-    When the user changes expiration date for share of user "User Two" to "+20 days" in the share dialog
-    Then the expiration date input field should be "+20 days" for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+30 days" for the user "User One" in the share dialog
+    When the user changes expiration date for share of user "User One" to "+20 days" in the share dialog
+    Then the expiration date input field should be "+20 days" for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +20 days   |
 
   Scenario: expiration date is enabled and enforced, user receives a share with expiration date and tries to reshare it with a date further in future than the original
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /lorem.txt |
       | shareType   | user       |
-      | shareWith   | user1      |
+      | shareWith   | user0      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be "+30 days" for the user "User Two" in the share dialog
-    When the user changes expiration date for share of user "User Two" to "+40 days" in the share dialog
-    Then the expiration date input field should be "+30 days" for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+30 days" for the user "User One" in the share dialog
+    When the user changes expiration date for share of user "User One" to "+40 days" in the share dialog
+    Then the expiration date input field should be "+30 days" for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
       | expiration  | +30 days   |
 
   Scenario: expiration date is enabled and enforced, user receives a folder from a user share with expiration date and shares sub-folder with another user
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
-    And user "user3" has created a share with settings
+    And user "user2" has created a share with settings
       | path        | /simple-folder |
       | shareType   | user           |
-      | shareWith   | user1          |
+      | shareWith   | user0          |
       | permissions | read,share     |
       | expireDate  | +15 days       |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
-    And the user shares file "simple-empty-folder" with user "User Two" using the webUI without closing the share dialog
-    Then the expiration date input field should be "+30 days" for the user "User Two" in the share dialog
-    When the user changes expiration date for share of user "User Two" to "+20 days" in the share dialog
-    And the information of the last share of user "user1" should include
+    And the user shares file "simple-empty-folder" with user "User One" using the webUI without closing the share dialog
+    Then the expiration date input field should be "+30 days" for the user "User One" in the share dialog
+    When the user changes expiration date for share of user "User One" to "+20 days" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user                 |
       | file_target | /simple-empty-folder |
-      | uid_owner   | user1                |
+      | uid_owner   | user0                |
       | expiration  | +20 days             |
-      | share_with  | user2                |
+      | share_with  | user1                |
 
   Scenario Outline: expiration date is disabled for sharing with users, user shares file with another user and sets expiration date
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "no"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
-    When the user shares file "lorem.txt" with user "User Two" using the webUI without closing the share dialog
-    And the user changes expiration date for share of user "User Two" to "<days>" in the share dialog
-    Then the expiration date input field should be visible for the user "User Two" in the share dialog
-    And the expiration date input field should be "<days>" for the user "User Two" in the share dialog
-    And the information of the last share of user "user1" should include
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
+    When the user shares file "lorem.txt" with user "User One" using the webUI without closing the share dialog
+    And the user changes expiration date for share of user "User One" to "<days>" in the share dialog
+    Then the expiration date input field should be visible for the user "User One" in the share dialog
+    And the expiration date input field should be "<days>" for the user "User One" in the share dialog
+    And the information of the last share of user "user0" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | <days>     |
-      | uid_owner   | user1      |
+      | uid_owner   | user0      |
     Examples:
       | days     |
       | +15 days |
@@ -274,28 +274,28 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | today    |
 
   Scenario: share with multiple users and change the sharing permissions and expiration date
-    Given user "user3" has shared folder "/simple-folder" with user "user1"
-    And user "user3" has shared folder "/simple-folder" with user "user2"
-    And user "user3" has logged in using the webUI
-    When the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
+    Given user "user2" has shared folder "/simple-folder" with user "user0"
+    And user "user2" has shared folder "/simple-folder" with user "user1"
+    And user "user2" has logged in using the webUI
+    When the user sets the sharing permissions of user "User Zero" for "simple-folder" using the webUI to
       | edit    | no |
       | create  | no |
-    And the user changes expiration date for share of user "User One" to "+5 days" in the share dialog
-    Then the information for user "user1" about the received share of folder "simple-folder" should include
+    And the user changes expiration date for share of user "User Zero" to "+5 days" in the share dialog
+    Then the information for user "user0" about the received share of folder "simple-folder" should include
       | share_type  | user           |
       | file_target | /simple-folder |
       | expiration  | +5 days        |
-      | uid_owner   | user3          |
-      | share_with  | user1          |
+      | uid_owner   | user2          |
+      | share_with  | user0          |
       | permissions | 17             |
-    When the user sets the sharing permissions of user "User Two" for "simple-folder" using the webUI to
+    When the user sets the sharing permissions of user "User One" for "simple-folder" using the webUI to
       | share    | no |
       | delete   | no |
-    And the user changes expiration date for share of user "User Two" to "+7 days" in the share dialog
-    Then the information for user "user2" about the received share of folder "simple-folder" should include
+    And the user changes expiration date for share of user "User One" to "+7 days" in the share dialog
+    Then the information for user "user1" about the received share of folder "simple-folder" should include
       | share_type  | user           |
       | file_target | /simple-folder |
       | expiration  | +7 days        |
-      | uid_owner   | user3          |
-      | share_with  | user2          |
+      | uid_owner   | user2          |
+      | share_with  | user1          |
       | permissions | 7              |

--- a/tests/acceptance/features/webUISharingInternalUsers2/webUIShareDetails.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/webUIShareDetails.feature
@@ -8,10 +8,10 @@ Feature: WebUI share details for shares created using internal users
   Scenario: sharing indicator of items inside a shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user1" has logged in using the webUI
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | simple-empty-folder |
@@ -21,12 +21,12 @@ Feature: WebUI share details for shares created using internal users
   Scenario: sharing indicator of items inside a shared folder two levels down
     Given these users have been created with default attributes and skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user1" has created folder "/simple-folder/simple-empty-folder/new-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/simple-empty-folder/lorem.txt"
-    And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "/simple-folder/simple-empty-folder/new-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/simple-empty-folder/lorem.txt"
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens folder "simple-empty-folder" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -37,14 +37,14 @@ Feature: WebUI share details for shares created using internal users
   Scenario: sharing indicator of items inside a re-shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |
-      | user1    |
+      | user0    |
     And these users have been created without skeleton files:
       | username |
+      | user1    |
       | user2    |
-      | user3    |
+    And user "user0" has shared folder "simple-folder" with user "user1"
     And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has shared folder "simple-folder" with user "user3"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | simple-empty-folder |
@@ -54,8 +54,8 @@ Feature: WebUI share details for shares created using internal users
   Scenario: no sharing indicator of items inside a not shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |
-      | user1    |
-    And user "user1" has logged in using the webUI
+      | user0    |
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should not have share indicators on the webUI
       | simple-empty-folder |
@@ -65,46 +65,46 @@ Feature: WebUI share details for shares created using internal users
   Scenario: sharing details of items inside a shared folder
     Given these users have been created without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/simple-empty-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has logged in using the webUI
     And the user has opened folder "simple-folder" using the webUI
     When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
-    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
+    Then user "user1" should be listed as share receiver via "simple-folder" on the webUI
     When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
-    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
+    Then user "user1" should be listed as share receiver via "simple-folder" on the webUI
 
   @skipOnOcV10.3
   Scenario: sharing details of items inside a re-shared folder
     Given these users have been created without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
-      | user3    |
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/simple-empty-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has shared folder "simple-folder" with user "user1"
     And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user2" has shared folder "simple-folder" with user "user3"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
     And the user has opened folder "simple-folder" using the webUI
     When the user opens the sharing tab from the file action menu of folder "simple-empty-folder" using the webUI
-    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
+    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
     When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
-    Then user "user3" should be listed as share receiver via "simple-folder" on the webUI
+    Then user "user2" should be listed as share receiver via "simple-folder" on the webUI
 
   @skipOnOcV10.3
   Scenario: sharing indicator for file uploaded inside a shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
-    And user "user1" has logged in using the webUI
+    And user "user0" has shared folder "/simple-empty-folder" with user "user1"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-empty-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -114,10 +114,10 @@ Feature: WebUI share details for shares created using internal users
   Scenario: sharing indicator for folder created inside a shared folder
     Given these users have been created with default attributes and skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user1" has shared folder "/simple-empty-folder" with user "user2"
-    And user "user1" has logged in using the webUI
+    And user "user0" has shared folder "/simple-empty-folder" with user "user1"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-empty-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -127,16 +127,16 @@ Feature: WebUI share details for shares created using internal users
   Scenario: sharing details of items inside a shared folder shared with multiple users
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
-      | user3    |
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
-    And user "user1" has shared folder "simple-folder" with user "user2"
-    And user "user1" has shared folder "/simple-folder/sub-folder" with user "user3"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/sub-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"
+    And user "user0" has shared folder "simple-folder" with user "user1"
+    And user "user0" has shared folder "/simple-folder/sub-folder" with user "user2"
+    And user "user0" has logged in using the webUI
     And the user has opened folder "simple-folder/sub-folder" using the webUI
     When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
-    Then user "User Two" should be listed as share receiver via "simple-folder" on the webUI
-    And user "User Three" should be listed as share receiver via "sub-folder" on the webUI
+    Then user "User One" should be listed as share receiver via "simple-folder" on the webUI
+    And user "User Two" should be listed as share receiver via "sub-folder" on the webUI

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -8,14 +8,14 @@ Feature: Display notifications when receiving a share and follow embedded links
     Given app "notifications" has been enabled
     And these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
 
   @smokeTest
   Scenario: notification link redirection in case a share is pending
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has created folder "a-folder"
-    And user "user1" has shared folder "a-folder" with user "user2"
+    And user "user0" has created folder "a-folder"
+    And user "user0" has shared folder "a-folder" with user "user1"
     When the user follows the link of the first notification on the webUI
     Then the user should be redirected to a webUI page with the title "Shared with you - %productname%"

--- a/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithGroups.feature
@@ -8,28 +8,28 @@ Feature: Sharing files and folders with internal groups
     Given app "notifications" has been enabled
     And these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
       | user2    |
-      | user3    |
     And these groups have been created:
       | groupname |
       | grp1      |
+    And user "user0" has been added to group "grp1"
     And user "user1" has been added to group "grp1"
-    And user "user2" has been added to group "grp1"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
 
   Scenario: notifications about new share is displayed
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user3" has created folder "a-folder"
-    And user "user3" has uploaded file "filesForUpload/data.zip" to "/data.zip"
-    When user "user3" has shared folder "/a-folder" with group "grp1"
-    And user "user3" has shared file "/data.zip" with group "grp1"
+    And user "user2" has created folder "a-folder"
+    And user "user2" has uploaded file "filesForUpload/data.zip" to "/data.zip"
+    When user "user2" has shared folder "/a-folder" with group "grp1"
+    And user "user2" has shared file "/data.zip" with group "grp1"
     Then the user should see 2 notifications on the webUI with these details
-      | title                                   |
-      | "User Three" shared "a-folder" with you |
-      | "User Three" shared "data.zip" with you |
-    When the user re-logs in as "user1" using the webUI
+      | title                                 |
+      | "User Two" shared "a-folder" with you |
+      | "User Two" shared "data.zip" with you |
+    When the user re-logs in as "user0" using the webUI
     Then the user should see 2 notifications on the webUI with these details
-      | title                                   |
-      | "User Three" shared "a-folder" with you |
-      | "User Three" shared "data.zip" with you |
+      | title                                 |
+      | "User Two" shared "a-folder" with you |
+      | "User Two" shared "data.zip" with you |

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -8,35 +8,35 @@ Feature: Sharing files and folders with internal users
     Given app "notifications" has been enabled
     And these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And user "user1" has created folder "a-folder"
-    And user "user1" has uploaded file "filesForUpload/data.zip" to "/data.zip"
-    And user "user2" has logged in using the webUI
+    And user "user0" has created folder "a-folder"
+    And user "user0" has uploaded file "filesForUpload/data.zip" to "/data.zip"
+    And user "user1" has logged in using the webUI
 
   @smokeTest
   Scenario: notifications about new share is displayed when autoacepting is disabled
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has shared folder "/a-folder" with user "user2"
-    And user "user1" has shared file "/data.zip" with user "user2"
+    And user "user0" has shared folder "/a-folder" with user "user1"
+    And user "user0" has shared file "/data.zip" with user "user1"
     Then the user should see 2 notifications on the webUI with these details
-      | title                                 |
-      | "User One" shared "a-folder" with you |
-      | "User One" shared "data.zip" with you |
+      | title                                  |
+      | "User Zero" shared "a-folder" with you |
+      | "User Zero" shared "data.zip" with you |
 
   @smokeTest
   Scenario: Notification is gone after accepting a share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has shared folder "/a-folder" with user "user2"
-    And user "user1" has shared file "/data.zip" with user "user2"
+    And user "user0" has shared folder "/a-folder" with user "user1"
+    And user "user0" has shared file "/data.zip" with user "user1"
     When the user accepts all shares displayed in the notifications on the webUI
-    Then user "user2" should have 0 notifications
+    Then user "user1" should have 0 notifications
 
   @smokeTest
   Scenario: accept an offered share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has shared folder "/a-folder" with user "user2"
-    And user "user1" has shared file "/data.zip" with user "user2"
+    And user "user0" has shared folder "/a-folder" with user "user1"
+    And user "user0" has shared file "/data.zip" with user "user1"
     When the user accepts all shares displayed in the notifications on the webUI
     Then folder "a-folder" should be listed in the files page on the webUI
     And file "data.zip" should be listed in the files page on the webUI
@@ -46,8 +46,8 @@ Feature: Sharing files and folders with internal users
   @smokeTest
   Scenario: reject an offered share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "user1" has shared folder "/a-folder" with user "user2"
-    And user "user1" has shared file "/data.zip" with user "user2"
+    And user "user0" has shared folder "/a-folder" with user "user1"
+    And user "user0" has shared file "/data.zip" with user "user1"
     When the user declines all shares displayed in the notifications on the webUI
     Then folder "a-folder" should not be listed in the files page on the webUI
     And file "data.zip" should not be listed in the files page on the webUI

--- a/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
+++ b/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
@@ -5,109 +5,109 @@ Feature: Share by public link
   So that users who do not have an account on my ownCloud server can access them
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario: simple sharing by public link
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: public should be able to access a public link with correct password
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     And the public accesses the last created public link with password "pass123" using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: public should not be able to access a public link with wrong password
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | password | pass123 |
     And the public tries to access the last created public link with wrong password "pass12" using the webUI
     Then the public should not get access to the publicly shared file
 
   Scenario: user shares a public link with folder longer than 64 chars and shorter link name
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
-    And user "user1" has moved folder "simple-folder" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user0" has moved folder "simple-folder" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" using the webUI with
       | name | short_linkname |
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: public should be able to access the shared file through public link
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for file 'lorem.txt' using the webUI
     And the public accesses the last created public link using the webUI
     Then the text preview of the public link should contain "Sed ut perspiciatis"
     And the content of the file shared by the last public link should be the same as "lorem.txt"
 
   Scenario: user shares a public link via email
-    Given user "user1" has created folder "/simple-folder"
+    Given user "user0" has created folder "/simple-folder"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
     """
-    User One shared simple-folder with you
+    User Zero shared simple-folder with you
     """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
   Scenario: user shares a public link via email and sends a copy to self
-    Given user "user1" has created folder "/simple-folder"
+    Given user "user0" has created folder "/simple-folder"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email       | foo@bar.co |
       | emailToSelf | true       |
     Then the email address "foo@bar.co" should have received an email with the body containing
     """
-    User One shared simple-folder with you
+    User Zero shared simple-folder with you
     """
-    And the email address "user1@example.org" should have received an email with the body containing
+    And the email address "user0@example.org" should have received an email with the body containing
     """
-    User One shared simple-folder with you
+    User Zero shared simple-folder with you
     """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
-    And the email address "user1@example.org" should have received an email containing the last shared public link
+    And the email address "user0@example.org" should have received an email containing the last shared public link
 
   Scenario: user shares a public link via email with multiple addresses
-    Given user "user1" has created folder "/simple-folder"
+    Given user "user0" has created folder "/simple-folder"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co, foo@barr.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
     """
-    User One shared simple-folder with you
+    User Zero shared simple-folder with you
     """
     And the email address "foo@barr.co" should have received an email with the body containing
     """
-    User One shared simple-folder with you
+    User Zero shared simple-folder with you
     """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
     And the email address "foo@barr.co" should have received an email containing the last shared public link
 
   Scenario: user shares a public link via email with a personal message
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email           | foo@bar.co  |
       | personalMessage | lorem ipsum |
     Then the email address "foo@bar.co" should have received an email with the body containing
     """
-    User One shared simple-folder with you
+    User Zero shared simple-folder with you
     """
     And the email address "foo@bar.co" should have received an email with the body containing
     """
@@ -117,8 +117,8 @@ Feature: Share by public link
 
   Scenario: user shares a public link via email adding few addresses before and then removing some addresses afterwards
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has logged in using the webUI
     When the user opens the share dialog for folder "simple-folder"
     And the user opens the public link share tab
     And the user opens the create public link share popup
@@ -135,11 +135,11 @@ Feature: Share by public link
     And the user creates the public link using the webUI
     Then the email address "foo5678@bar.co" should have received an email with the body containing
     """
-    User One shared simple-folder with you
+    User Zero shared simple-folder with you
     """
     And the email address "foo1234@barr.co" should have received an email with the body containing
     """
-    User One shared simple-folder with you
+    User Zero shared simple-folder with you
     """
     And the email address "foo5678@bar.co" should have received an email containing the last shared public link
     And the email address "foo1234@barr.co" should have received an email containing the last shared public link
@@ -148,73 +148,73 @@ Feature: Share by public link
 
   Scenario: user shares a file through public link and then it appears in a Shared by link page
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has created a public link share of file "/simple-folder"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has created a public link share of file "/simple-folder"
+    And user "user0" has logged in using the webUI
     When the user browses to the shared-by-link page
     Then folder "simple-folder" should be listed on the webUI
 
   Scenario: user creates a multiple public link of a file and delete the first link
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created a public link share with settings
       | path | /lorem.txt |
       | name | first-link |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | /lorem.txt  |
       | name | second-link |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | /lorem.txt |
       | name | third-link |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user removes the public link at position 1 of file "lorem.txt" using the webUI
     Then the public link with name "first-link" should not be in the public links list
     And the number of public links should be 2
 
   Scenario: user creates a multiple public link of a file and delete the second link
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created a public link share with settings
       | path | /lorem.txt |
       | name | first-link |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | /lorem.txt  |
       | name | second-link |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | /lorem.txt |
       | name | third-link |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user removes the public link at position 2 of file "lorem.txt" using the webUI
     Then the public link with name "second-link" should not be in the public links list
     And the number of public links should be 2
 
   Scenario: user creates a multiple public link of a file and delete the third link
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created a public link share with settings
       | path | /lorem.txt |
       | name | first-link |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | /lorem.txt  |
       | name | second-link |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | /lorem.txt |
       | name | third-link |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user removes the public link at position 3 of file "lorem.txt" using the webUI
     Then the public link with name "third-link" should not be in the public links list
     And the number of public links should be 2
 
   Scenario: user creates public link with view and upload feature
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     And the public accesses the last created public link using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: user creates public link with view download and upload feature and uploads same file name and verifies no auto-renamed file seen in UI
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     When the public accesses the last created public link using the webUI
@@ -232,11 +232,11 @@ Feature: Share by public link
   Scenario: user creates a new public link using webUI without setting expiration date when default expire date is set but not enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "no"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI with
       | expiration |  |
-    And user "user1" gets the info of the last share using the sharing API
+    And user "user0" gets the info of the last share using the sharing API
     Then the fields of the last response should include
       | expiration |  |
 
@@ -244,8 +244,8 @@ Feature: Share by public link
   Scenario: user creates a new public link using webUI removing expiration date when default expire date is set and enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user tries to create a new public link for file "lorem.txt" using the webUI
       | expiration |  |
     Then the user should see an error message on the public link popup saying "Expiration date is required"
@@ -253,17 +253,17 @@ Feature: Share by public link
   Scenario: user creates a new public link using webUI when default expire date is set and enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI
-    And user "user1" gets the info of the last share using the sharing API
+    And user "user0" gets the info of the last share using the sharing API
     Then the fields of the last response should include
       | expiration | +7 days |
 
   Scenario: user creates a new public link and the public checks its content
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the user logs out of the webUI
     When the public accesses the last created public link using the webUI
@@ -272,8 +272,8 @@ Feature: Share by public link
     Then the downloaded content should be "original content"
 
   Scenario: user creates a new public link for a file and the public checks all the download links for the file
-    Given user "user1" has uploaded file with content "original content" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "original content" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI
     And the user logs out of the webUI
     When the public accesses the last created public link using the webUI

--- a/tests/acceptance/features/webUISharingPublic1/permissionsShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic1/permissionsShareByPublicLink.feature
@@ -5,12 +5,12 @@ Feature: Share by public link
   So that users who do not have an account on my ownCloud server can access them
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
   Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
-    Given user "user2" has been created with default attributes and skeleton files
-    And user "user2" has logged in using the webUI
+    Given user "user1" has been created with default attributes and skeleton files
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the public accesses the last created public link using the webUI
@@ -25,25 +25,25 @@ Feature: Share by public link
 
   @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
   Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read |
     And the public accesses the last created public link using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: user tries to create a public link with read only permission without entering share password while enforce password on read only public share is enforced
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has logged in using the webUI
     And parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
     When the user tries to create a new public link for folder "simple-folder" using the webUI
     Then the user should see an error message on the public link share dialog saying "Passwords are enforced for link shares"
     And the public link should not have been generated
 
   Scenario: user tries to create a public link with read-write permission without entering share password while enforce password on read-write public share is enforced
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has logged in using the webUI
     And parameter "shareapi_enforce_links_password_read_write_delete" of app "core" has been set to "yes"
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
@@ -51,8 +51,8 @@ Feature: Share by public link
     And the public link should not have been generated
 
   Scenario: user tries to create a public link with write only permission without entering share password while enforce password on write only public share is enforced
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has logged in using the webUI
     And parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
     When the user tries to create a new public link for folder "simple-folder" using the webUI with
       | permission | upload |
@@ -60,9 +60,9 @@ Feature: Share by public link
     And the public link should not have been generated
 
   Scenario: user creates a public link with read-write permission without entering share password while enforce password on read only public share is enforced
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "test" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     And parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
@@ -70,13 +70,13 @@ Feature: Share by public link
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user edits the permission of an already existing public link from read-write to read
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has created a public link share with settings
       | path        | /simple-folder |
       | name        | Public link    |
       | permissions | read,create    |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user opens the share dialog for folder "simple-folder"
     And the user has opened the public link share tab
     When the user changes the permission of the public link named "Public link" to "read"
@@ -85,14 +85,14 @@ Feature: Share by public link
     And it should not be possible to delete file "lorem.txt" using the webUI
 
   Scenario: user edits the permission of an already existing public link from read to read-write
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/simple-empty-folder"
-    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/simple-empty-folder"
+    And user "user0" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user0" has created a public link share with settings
       | path        | /simple-folder |
       | name        | Public link    |
       | permissions | read           |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user opens the share dialog for folder "simple-folder"
     And the user has opened the public link share tab
     When the user changes the permission of the public link named "Public link" to "read-write"
@@ -105,9 +105,9 @@ Feature: Share by public link
     And the deleted elements should not be listed on the webUI after a page reload
 
   Scenario: Permissions work correctly on public link share with upload-write-without-modify
-    Given user "user1" has created folder "simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     When the public accesses the last created public link using the webUI
@@ -116,9 +116,9 @@ Feature: Share by public link
     And the option to upload file should be available on the webUI
 
   Scenario: Permissions work correctly on public link share with read-write
-    Given user "user1" has created folder "simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
@@ -127,9 +127,9 @@ Feature: Share by public link
     And the option to upload file should be available on the webUI
 
   Scenario: User tries to upload existing file in public link share with permissions upload-write-without-modify
-    Given user "user1" has created folder "simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     When the public accesses the last created public link using the webUI
@@ -139,9 +139,9 @@ Feature: Share by public link
     And file "lorem (2).txt" should not be listed on the webUI
 
   Scenario: User tries to upload existing file in public link share with permissions read-write
-    Given user "user1" has created folder "simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
@@ -150,10 +150,10 @@ Feature: Share by public link
     And file "lorem (2).txt" should be listed on the webUI
 
   Scenario: Editing the permission on a existing share from read-write to upload-write-without-modify works correctly
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file "filesForUpload/lorem-big.txt" to "/simple-folder/lorem-big.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/simple-folder/lorem-big.txt"
+    And user "user0" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     When the public accesses the last created public link using the webUI
@@ -166,10 +166,10 @@ Feature: Share by public link
     Then the option to delete file "lorem-big.txt" should not be available on the webUI
 
   Scenario: Editing the permission on a existing share from upload-write-without-modify to read-write works correctly
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file "filesForUpload/lorem-big.txt" to "/simple-folder/lorem-big.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has uploaded file "filesForUpload/lorem-big.txt" to "/simple-folder/lorem-big.txt"
+    And user "user0" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
       | permission | upload-write-without-modify |
     When the public accesses the last created public link using the webUI

--- a/tests/acceptance/features/webUISharingPublic2/reShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/reShareByPublicLink.feature
@@ -5,43 +5,43 @@ Feature: Reshare by public link
   So that users who do not have an account on my ownCloud server can access them
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
-    And user "user2" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario: resharing by public link of a received shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "test" to "/simple-folder/randomfile.txt"
-    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
-    And user "user2" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "test" to "/simple-folder/randomfile.txt"
+    And user "user0" has shared folder "/simple-folder" with user "user1" with permissions "share,read"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the public accesses the last created public link using the webUI
     Then file "randomfile.txt" should be listed on the webUI
 
   Scenario: resharing by public link of a received shared file
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has shared file "/randomfile.txt" with user "user2" with permissions "share,read"
-    And user "user2" has logged in using the webUI
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has shared file "/randomfile.txt" with user "user1" with permissions "share,read"
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for file "randomfile.txt" using the webUI
     And the public accesses the last created public link using the webUI
     Then the text preview of the public link should contain "some content"
 
   Scenario: resharing by public link of a sub-folder in a received shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file with content "some content" to "/simple-folder/sub-folder/randomfile.txt"
-    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
-    And user "user2" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/sub-folder"
+    And user "user0" has uploaded file with content "some content" to "/simple-folder/sub-folder/randomfile.txt"
+    And user "user0" has shared folder "/simple-folder" with user "user1" with permissions "share,read"
+    And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user creates a new public link for folder "sub-folder" using the webUI
     And the public accesses the last created public link using the webUI
     Then file "randomfile.txt" should be listed on the webUI
 
   Scenario: resharing by public link of a file in a received shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "some content" to "/simple-folder/randomfile.txt"
-    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
-    And user "user2" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "some content" to "/simple-folder/randomfile.txt"
+    And user "user0" has shared folder "/simple-folder" with user "user1" with permissions "share,read"
+    And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user creates a new public link for file "randomfile.txt" using the webUI
     And the public accesses the last created public link using the webUI
@@ -49,79 +49,79 @@ Feature: Reshare by public link
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: user reshares a public link of a received share via email
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has shared folder "/simple-folder" with user "user1" with permissions "share,read"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
       """
-      User Two shared simple-folder with you
+      User One shared simple-folder with you
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: user reshares a public link of a file in a received shared folder via email
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "some content" to "/simple-folder/randomfile.txt"
-    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "some content" to "/simple-folder/randomfile.txt"
+    And user "user0" has shared folder "/simple-folder" with user "user1" with permissions "share,read"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user creates a new public link for file "randomfile.txt" using the webUI with
       | email | foo@bar.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
       """
-      User Two shared randomfile.txt with you
+      User One shared randomfile.txt with you
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: user reshares a public link of a received shared file via email
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has shared file "/randomfile.txt" with user "user2" with permissions "share,read"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has shared file "/randomfile.txt" with user "user1" with permissions "share,read"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for file "randomfile.txt" using the webUI with
       | email | foo@bar.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
       """
-      User Two shared randomfile.txt with you
+      User One shared randomfile.txt with you
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: user reshares a public link of a received shared folder via email with multiple addresses
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has shared folder "/simple-folder" with user "user1" with permissions "share,read"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co, foo@barr.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
       """
-      User Two shared simple-folder with you
+      User One shared simple-folder with you
       """
     And the email address "foo@barr.co" should have received an email with the body containing
       """
-      User Two shared simple-folder with you
+      User One shared simple-folder with you
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
     And the email address "foo@barr.co" should have received an email containing the last shared public link
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: user reshares a public link of a received shared folder via email with a personal message
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has shared folder "/simple-folder" with user "user2" with permissions "share,read"
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has shared folder "/simple-folder" with user "user1" with permissions "share,read"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user2" has logged in using the webUI
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email           | foo@bar.co  |
       | personalMessage | lorem ipsum |
     Then the email address "foo@bar.co" should have received an email with the body containing
       """
-      User Two shared simple-folder with you
+      User One shared simple-folder with you
       """
     And the email address "foo@bar.co" should have received an email with the body containing
       """

--- a/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
@@ -9,57 +9,57 @@ Feature: Share by public link
   So that public sharing is limited according to organization policy
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And using server "LOCAL"
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
-    And the public adds the public link to "%remote_server%" as user "user2" with password "%alt2%" using the webUI
+    And the public adds the public link to "%remote_server%" as user "user1" with password "%alt1%" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then folder "simple-folder" should be listed on the webUI
     When the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And the content of file "simple-folder/lorem.txt" for user "user2" on server "REMOTE" should be "original content"
+    And the content of file "simple-folder/lorem.txt" for user "user1" on server "REMOTE" should be "original content"
     And it should not be possible to delete file "lorem.txt" using the webUI
 
   @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link and overwrite file
     Given using server "REMOTE"
-    And user "user2" has been created with default attributes and without skeleton files
+    And user "user1" has been created with default attributes and without skeleton files
     And using server "LOCAL"
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
-    And the public adds the public link to "%remote_server%" as user "user2" with password "%alt2%" using the webUI
+    And the public adds the public link to "%remote_server%" as user "user1" with password "%alt1%" using the webUI
     And the user accepts the offered remote shares using the webUI
     Then folder "simple-folder" should be listed on the webUI
     When the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
-    And the content of file "simple-folder/lorem.txt" for user "user2" on server "REMOTE" should be "original content"
+    And the content of file "simple-folder/lorem.txt" for user "user1" on server "REMOTE" should be "original content"
     When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the remote server should be the same as the local "lorem.txt"
 
   Scenario: user edits a public link and does not save the changes
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has created a public link share with settings
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has created a public link share with settings
       | path     | /simple-folder |
       | name     | Public link    |
       | password | pass123        |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has opened the share dialog for folder "simple-folder"
     And the user has opened the public link share tab
     When the user opens the edit public link share popup for the link named "Public link"
@@ -69,12 +69,12 @@ Feature: Share by public link
     Then the public should not get access to the publicly shared file
 
   Scenario: user edits a name of an already existing public link
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has created a public link share with settings
       | path | /simple-folder |
       | name | Public link    |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has opened the share dialog for folder "simple-folder"
     And the user has opened the public link share tab
     When the user renames the public link name from "Public link" to "simple-folder Share"
@@ -82,13 +82,13 @@ Feature: Share by public link
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has created a public link share with settings
       | path     | /simple-folder |
       | name     | Public link    |
       | password | pass123        |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has opened the share dialog for folder "simple-folder"
     And the user has opened the public link share tab
     When the user changes the password of the public link named "Public link" to "pass1234"
@@ -96,12 +96,12 @@ Feature: Share by public link
     Then file "lorem.txt" should be listed on the webUI
 
   Scenario: user edits the password of an already existing public link and tries to access with old password
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created a public link share with settings
       | path     | /simple-folder |
       | name     | Public link    |
       | password | pass123        |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user opens the share dialog for folder "simple-folder"
     And the user has opened the public link share tab
     When the user changes the password of the public link named "Public link" to "pass1234"
@@ -109,26 +109,26 @@ Feature: Share by public link
     Then the public should not get access to the publicly shared file
 
   Scenario: user changes the expiration date of an already existing public link using webUI
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created a share with settings
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created a share with settings
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | 14-10-2038  |
       | shareType  | public_link |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "21-07-2038"
     And the user gets the info of the last share using the sharing API
     Then the fields of the last response should include
       | expiration | 21-07-2038 |
 
   Scenario: user tries to change the expiration date of the public link to past date using webUI
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created a share with settings
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created a share with settings
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | 14-10-2038  |
       | shareType  | public_link |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "14-09-2017"
     And the user gets the info of the last share using the sharing API
     Then the user should see an error message on the public link share dialog saying "Expiration date is in the past"
@@ -136,10 +136,10 @@ Feature: Share by public link
       | expiration | 14-10-2038 |
 
   Scenario: share two file with same name but different paths by public link
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI
     And the user closes the details dialog
     And the user opens folder "simple-folder" using the webUI
@@ -149,35 +149,35 @@ Feature: Share by public link
     And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
 
   Scenario: user removes the public link of a file
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created a public link share of file "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created a public link share of file "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user removes the public link of file "lorem.txt" using the webUI
     Then the public should see an error message "File not found" while accessing last created public link using the webUI
 
   Scenario: user cancel removes operation for the public link of a file
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created a public link share of file "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created a public link share of file "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user tries to remove the public link of file "lorem.txt" but later cancels the remove dialog using webUI
     And the public accesses the last created public link using the webUI
     Then the content of the file shared by the last public link should be the same as "lorem.txt"
 
   @issue-35177
   Scenario: User renames a subfolder among subfolders with same names which are shared by public links
-    Given user "user1" has created folder "nf1"
-    And user "user1" has created folder "nf1/newfolder"
-    And user "user1" has created folder "nf2"
-    And user "user1" has created folder "nf2/newfolder"
-    And user "user1" has created folder "test"
-    And user "user1" has created folder "test/test"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "nf1"
+    And user "user0" has created folder "nf1/newfolder"
+    And user "user0" has created folder "nf2"
+    And user "user0" has created folder "nf2/newfolder"
+    And user "user0" has created folder "test"
+    And user "user0" has created folder "test/test"
+    And user "user0" has created a public link share with settings
       | path | nf1/newfolder |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | nf2/newfolder |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | test/test |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has browsed to the shared-by-link page
     When the user renames folder "newfolder" to "newfolder1" using the webUI
     Then folder "newfolder1" should be listed on the webUI
@@ -187,14 +187,14 @@ Feature: Share by public link
 
   @issue-35174
   Scenario: User renames folders with different path in Shared by link page
-    Given user "user1" has created folder "nf1"
-    And user "user1" has created folder "nf1/newfolder"
-    And user "user1" has created folder "test"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "nf1"
+    And user "user0" has created folder "nf1/newfolder"
+    And user "user0" has created folder "test"
+    And user "user0" has created a public link share with settings
       | path | nf1/newfolder |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | test |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user has browsed to the shared-by-link page
     When the user renames folder "test" to "newfolder" using the webUI
     Then near folder "test" a tooltip with the text 'newfolder already exists' should be displayed on the webUI
@@ -206,13 +206,13 @@ Feature: Share by public link
   Scenario: user tries to deletes the expiration date of already existing public link using webUI when expiration date is enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created a share with settings
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created a share with settings
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | + 5 days    |
       | shareType  | public_link |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user changes the expiration of the public link named "Public link" of file "lorem.txt" to " "
     Then the user should see an error message on the public link popup saying "Expiration date is required"
     And the user gets the info of the last share using the sharing API
@@ -221,13 +221,13 @@ Feature: Share by public link
 
   Scenario: user deletes the expiration date of already existing public link using webUI when expiration date is set but not enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has created a share with settings
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has created a share with settings
       | path       | lorem.txt   |
       | name       | Public link |
       | expireDate | + 5 days    |
       | shareType  | public_link |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     And the user changes the expiration of the public link named "Public link" of file "lorem.txt" to " "
     And the user gets the info of the last share using the sharing API
     And the fields of the last response should include
@@ -237,26 +237,26 @@ Feature: Share by public link
   Scenario: user without email shares a public link via email
     Given these users have been created without skeleton files:
       | username | password |
-      | user0    | 1234     |
-    And user "user0" has created folder "/simple-folder"
+      | user1    | 1234     |
+    And user "user1" has created folder "/simple-folder"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
-    And user "user0" has logged in using the webUI
+    And user "user1" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | email | foo@bar.co |
     Then the email address "foo@bar.co" should have received an email with the body containing
 			"""
-			user0 shared simple-folder with you
+			user1 shared simple-folder with you
 			"""
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
   @skipOnOcV10.3
   Scenario: sharing indicator inside a shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/sub-folder"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user0" has created a public link share with settings
       | path | /simple-folder |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | sub-folder   |
@@ -264,10 +264,10 @@ Feature: Share by public link
 
   @skipOnOcV10.3
   Scenario: sharing indicator for file uploaded inside a shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created a public link share with settings
       | path | /simple-folder |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -275,10 +275,10 @@ Feature: Share by public link
 
   @skipOnOcV10.3
   Scenario: sharing indicator for folder created inside a shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created a public link share with settings
       | path | /simple-folder |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -286,13 +286,13 @@ Feature: Share by public link
 
   @skipOnOcV10.3
   Scenario: sharing details of items inside a shared folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/sub-folder"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user0" has created a public link share with settings
       | path | /simple-folder |
       | name | Public Link    |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder"
     And the user opens the public link share tab
@@ -300,16 +300,16 @@ Feature: Share by public link
 
   @skipOnOcV10.3
   Scenario: sharing details of multiple public link shares with different link names
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created folder "/simple-folder/sub-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created folder "/simple-folder/sub-folder"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
+    And user "user0" has created a public link share with settings
       | path | /simple-folder |
       | name | Public Link    |
-    And user "user1" has created a public link share with settings
+    And user "user0" has created a public link share with settings
       | path | /simple-folder/sub-folder      |
       | name | strängé लिंक नाम (#2 &).नेपाली |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder"
     And the user opens the public link share tab
@@ -322,20 +322,20 @@ Feature: Share by public link
 
   @skipOnOcV10.3
   Scenario: sharing detail of items in the webUI shared by public links with empty name
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
+    And user "user0" has created a public link share with settings
       | path | /simple-folder |
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for file "textfile.txt"
     And the user opens the public link share tab
     Then public link with last share token should be listed as share receiver via "simple-folder" on the webUI
 
    Scenario: add to your owncloud button is present
-     Given user "user1" has created folder "/simple-folder"
+     Given user "user0" has created folder "/simple-folder"
      And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
-     And user "user1" has logged in using the webUI
+     And user "user0" has logged in using the webUI
      When the user creates a new public link for folder "simple-folder" using the webUI with
        | permission | read |
      And the public accesses the last created public link using the webUI
@@ -343,9 +343,9 @@ Feature: Share by public link
 
   @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
   Scenario: add to your owncloud button is not present
-    Given user "user1" has created folder "/simple-folder"
+    Given user "user0" has created folder "/simple-folder"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read |
     And the public accesses the last created public link using the webUI

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -7,61 +7,60 @@ Feature: Creation of tags for the files and folders
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+      | user0    |
+    And user "user0" has logged in using the webUI
 
   Scenario: Create a new tag that does not exist for a file in the root
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user adds a tag "Top Secret" to the file using the webUI
     And the user adds a tag "Confidential" to the file using the webUI
-    Then file "/randomfile.txt" should have the following tags for user "user1"
+    Then file "/randomfile.txt" should have the following tags for user "user0"
       | name         | type   |
       | Top Secret   | normal |
       | Confidential | normal |
 
   Scenario: Create a new tag that does not exist for a file in a folder
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
     And the user adds a tag "Top Secret" to the file using the webUI
     And the user adds a tag "Top" to the file using the webUI
-    Then file "a-folder/randomfile.txt" should have the following tags for user "user1"
+    Then file "a-folder/randomfile.txt" should have the following tags for user "user0"
       | name       | type   |
       | Top Secret | normal |
       | Top        | normal |
 
   Scenario: Add a new tag that already exists for a file in a folder
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
-    And user "user1" has uploaded file with content "some content" to "/a-folder/randomfile-big.txt"
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
+    And user "user0" has uploaded file with content "some content" to "/a-folder/randomfile-big.txt"
     And the user has created a "normal" tag with name "randomfile"
     And the user has added tag "randomfile" to file "/a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile-big.txt" in folder "a-folder"
     And the user adds a tag "randomfile" to the file using the webUI
-    Then file "a-folder/randomfile.txt" should have the following tags for user "user1"
+    Then file "a-folder/randomfile.txt" should have the following tags for user "user0"
       | name       | type   |
       | randomfile | normal |
-    And file "a-folder/randomfile-big.txt" should have the following tags for user "user1"
+    And file "a-folder/randomfile-big.txt" should have the following tags for user "user0"
       | name       | type   |
       | randomfile | normal |
 
   @skipOnFIREFOX @files_sharing-app-required
   Scenario: Create and add tag on a shared file
-    Given user "user2" has been created with default attributes and without skeleton files
-    And user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user browses directly to display the details of file "randomfile.txt" in folder "/"
     When the user adds a tag "tag1" to the file using the webUI
-    And the user shares file "randomfile.txt" with user "User Two" using the webUI
-    And the user re-logs in with username "user2" and password "%alt2%" using the webUI
+    And the user shares file "randomfile.txt" with user "User One" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
     And the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user adds a tag "tag2" to the file using the webUI
-    Then file "randomfile.txt" should have the following tags for user "user1"
+    Then file "randomfile.txt" should have the following tags for user "user0"
       | name | type   |
       | tag1 | normal |
       | tag2 | normal |
-    And file "randomfile.txt" should have the following tags for user "user2"
+    And file "randomfile.txt" should have the following tags for user "user1"
       | name | type   |
       | tag1 | normal |
       | tag2 | normal |
@@ -70,24 +69,24 @@ Feature: Creation of tags for the files and folders
   Scenario: Add tags on skeleton file before sharing
     Given these users have been created with skeleton files:
       | username |
+      | user1    |
       | user2    |
-      | user3    |
-    And the user re-logs in as "user2" using the webUI
+    And the user re-logs in as "user1" using the webUI
     And the user browses directly to display the details of file "lorem.txt" in folder "/"
     When the user adds a tag "skeleton" to the file using the webUI
-    And the user shares file "lorem.txt" with user "user3" using the webUI
-    Then file "lorem (2).txt" should have the following tags for user "user3"
+    And the user shares file "lorem.txt" with user "user2" using the webUI
+    Then file "lorem (2).txt" should have the following tags for user "user2"
       | name     | type   |
       | skeleton | normal |
 
   @files_sharing-app-required
   Scenario: Check for existence of tags in shared file
-    Given user "user2" has been created with default attributes and without skeleton files
-    And user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user adds a tag "Confidential" to the file using the webUI
-    And the user shares file "randomfile.txt" with user "User Two" using the webUI
-    Then file "/randomfile.txt" should have the following tags for user "user2"
+    And the user shares file "randomfile.txt" with user "User One" using the webUI
+    Then file "/randomfile.txt" should have the following tags for user "user1"
       | name         | type   |
       | Confidential | normal |
 

--- a/tests/acceptance/features/webUITags/deleteTags.feature
+++ b/tests/acceptance/features/webUITags/deleteTags.feature
@@ -7,63 +7,62 @@ Feature: Deletion of existing tags from files and folders
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+      | user0    |
+    And user "user0" has logged in using the webUI
 
   @skipOnFIREFOX @files_sharing-app-required
   Scenario: Delete a tag in a shared file
-    Given user "user2" has been created with default attributes and without skeleton files
-    And user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user1" has been created with default attributes and without skeleton files
+    And user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user browses directly to display the details of file "randomfile.txt" in folder ""
     When the user adds a tag "tag1" to the file using the webUI
-    And the user shares file "randomfile.txt" with user "User Two" using the webUI
-    And the user re-logs in with username "user2" and password "%alt2%" using the webUI
-    Then file "randomfile.txt" should have the following tags for user "user2"
+    And the user shares file "randomfile.txt" with user "User One" using the webUI
+    And the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    Then file "randomfile.txt" should have the following tags for user "user1"
       | name | type   |
       | tag1 | normal |
     When the user browses directly to display the details of file "randomfile.txt" in folder ""
     And the user deletes tag with name "tag1" using the webUI
-    Then tag "tag1" should not exist for user "user1"
-    And tag "tag1" should not exist for user "user2"
+    Then tag "tag1" should not exist for user "user0"
+    And tag "tag1" should not exist for user "user1"
 
   Scenario: Delete a tag that already exists for a file in the root
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    Then file "randomfile.txt" should have the following tags for user "user1"
+    Then file "randomfile.txt" should have the following tags for user "user0"
       | name   | type   |
       | random | normal |
     When the user deletes tag with name "random" using the webUI
-    Then tag "random" should not exist for user "user1"
+    Then tag "random" should not exist for user "user0"
 
   Scenario: Delete a tag that already exists for a file in a folder
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
-    Then file "a-folder/randomfile.txt" should have the following tags for user "user1"
+    Then file "a-folder/randomfile.txt" should have the following tags for user "user0"
       | name   | type   |
       | random | normal |
     When the user deletes tag with name "random" using the webUI
-    Then tag "random" should not exist for user "user1"
+    Then tag "random" should not exist for user "user0"
 
   Scenario: Delete a tag that exists for multiple file
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
-    And user "user1" has created folder "a-folder"
-    And user "user1" has uploaded file with content "another content" to "/a-folder/randomfile.txt"
-    And user "user1" has uploaded file with content "more content" to "/randomfile-big.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
+    And user "user0" has created folder "a-folder"
+    And user "user0" has uploaded file with content "another content" to "/a-folder/randomfile.txt"
+    And user "user0" has uploaded file with content "more content" to "/randomfile-big.txt"
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "randomfile.txt"
     And the user has added tag "random" to file "randomfile-big.txt"
     And the user has browsed directly to display the details of file "randomfile.txt" in folder "a-folder"
     When the user deletes tag with name "random" using the webUI
-    Then tag "random" should not exist for user "user1"
+    Then tag "random" should not exist for user "user0"
 
   Scenario: Delete all tags that exist for a file
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has created a "normal" tag with name "Confidential"
     And the user has added tag "random" to file "randomfile.txt"
@@ -71,10 +70,10 @@ Feature: Deletion of existing tags from files and folders
     And the user has browsed directly to display the details of file "randomfile.txt" in folder "/"
     When the user deletes tag with name "random" using the webUI
     And the user deletes tag with name "Confidential" using the webUI
-    Then file "randomfile.txt" should have no tags for user "user1"
+    Then file "randomfile.txt" should have no tags for user "user0"
 
   Scenario: Delete multiple tags that exist for a file
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has created a "normal" tag with name "Confidential"
     And the user has created a "normal" tag with name "some-tag"
@@ -84,9 +83,9 @@ Feature: Deletion of existing tags from files and folders
     And the user has browsed directly to display the details of file "randomfile.txt" in folder "/"
     When the user deletes tag with name "random" using the webUI
     And the user deletes tag with name "Confidential" using the webUI
-    Then tag "random" should not exist for user "user1"
-    And tag "Confidential" should not exist for user "user1"
-    And file "/randomfile.txt" should have the following tags for user "user1"
+    Then tag "random" should not exist for user "user0"
+    And tag "Confidential" should not exist for user "user0"
+    And file "/randomfile.txt" should have the following tags for user "user0"
       | name     | type   |
       | some-tag | normal |
 

--- a/tests/acceptance/features/webUITags/editTags.feature
+++ b/tests/acceptance/features/webUITags/editTags.feature
@@ -7,26 +7,25 @@ Feature: Edit tags for files and folders
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
+      | user0    |
       | user1    |
-      | user2    |
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+    And user "user0" has logged in using the webUI
 
   @files_sharing-app-required
   Scenario: Change the name of a tag that already exists for a file
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user edits the tag with name "random" and sets its name to "random-big" using the webUI
-    Then file "randomfile.txt" should have the following tags for user "user1"
+    Then file "randomfile.txt" should have the following tags for user "user0"
       | name       | type   |
       | random-big | normal |
     And tag "random" should not exist for the user
 
   @files_sharing-app-required
   Scenario: Change the name of multiple tags that exist for a file
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has created a "normal" tag with name "some-tag"
     And the user has added tag "random" to file "randomfile.txt"
@@ -34,7 +33,7 @@ Feature: Edit tags for files and folders
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user edits the tag with name "random" and sets its name to "random-big" using the webUI
     And the user edits the tag with name "some-tag" and sets its name to "another-tag" using the webUI
-    Then file "randomfile.txt" should have the following tags for user "user1"
+    Then file "randomfile.txt" should have the following tags for user "user0"
       | name        | type   |
       | random-big  | normal |
       | another-tag | normal |

--- a/tests/acceptance/features/webUITags/removeTags.feature
+++ b/tests/acceptance/features/webUITags/removeTags.feature
@@ -7,29 +7,28 @@ Feature: Removal of already existing tags from files and folders
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    And the user has browsed to the login page
-    And the user has logged in with username "user1" and password "%alt1%" using the webUI
+      | user0    |
+    And user "user0" has logged in using the webUI
 
   Scenario: Remove a tag that already exists for a file in a folder
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
     And the user toggles a tag "random" on the file using the webUI
-    Then file "a-folder/randomfile.txt" should have no tags for user "user1"
+    Then file "a-folder/randomfile.txt" should have no tags for user "user0"
 
   Scenario: Remove a tag that already exists for a file in the root
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user toggles a tag "random" on the file using the webUI
-    Then file "randomfile.txt" should have no tags for user "user1"
+    Then file "randomfile.txt" should have no tags for user "user0"
 
   Scenario: Remove all tags that already exist for a file
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has created a "normal" tag with name "Confidential"
     And the user has added tag "random" to file "randomfile.txt"
@@ -37,43 +36,43 @@ Feature: Removal of already existing tags from files and folders
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user toggles a tag "random" on the file using the webUI
     And the user toggles a tag "Confidential" on the file using the webUI
-    Then file "randomfile.txt" should have no tags for user "user1"
+    Then file "randomfile.txt" should have no tags for user "user0"
 
   @files_sharing-app-required
   Scenario: Shared user removes a tag in shared file
-    Given user "user2" has been created with default attributes and without skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And the user has created a "normal" tag with name "tag1"
-    And user "user1" has uploaded file with content "does-not-matter" to "/coolnewfile.txt"
+    And user "user0" has uploaded file with content "does-not-matter" to "/coolnewfile.txt"
     And the user has added tag "tag1" to file "coolnewfile.txt"
-    And the user has shared file "coolnewfile.txt" with user "user2"
-    When the user re-logs in as "user2" using the webUI
-    Then file "coolnewfile.txt" should have the following tags for user "user2"
+    And the user has shared file "coolnewfile.txt" with user "user1"
+    When the user re-logs in as "user1" using the webUI
+    Then file "coolnewfile.txt" should have the following tags for user "user1"
       | name | type   |
       | tag1 | normal |
     When the user browses directly to display the details of file "coolnewfile.txt" in folder "/"
     And the user toggles a tag "tag1" on the file using the webUI
-    Then file "coolnewfile.txt" should have no tags for user "user2"
-    And file "coolnewfile.txt" should have no tags for user "user1"
+    Then file "coolnewfile.txt" should have no tags for user "user1"
+    And file "coolnewfile.txt" should have no tags for user "user0"
 
   @files_sharing-app-required
   Scenario: Sharer removes a tag in shared file
-    Given user "user2" has been created with default attributes and without skeleton files
+    Given user "user1" has been created with default attributes and without skeleton files
     And the user has created a "normal" tag with name "tag1"
-    And user "user1" has uploaded file with content "does-not-matter" to "/coolnewfile.txt"
+    And user "user0" has uploaded file with content "does-not-matter" to "/coolnewfile.txt"
     And the user has added tag "tag1" to file "coolnewfile.txt"
-    And the user has shared file "coolnewfile.txt" with user "user2"
-    When the user re-logs in as "user2" using the webUI
-    Then file "coolnewfile.txt" should have the following tags for user "user2"
+    And the user has shared file "coolnewfile.txt" with user "user1"
+    When the user re-logs in as "user1" using the webUI
+    Then file "coolnewfile.txt" should have the following tags for user "user1"
       | name | type   |
       | tag1 | normal |
-    When the user re-logs in with username "user1" and password "%alt1%" using the webUI
+    When the user re-logs in with username "user0" and password "%regular%" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder "/"
     And the user toggles a tag "tag1" on the file using the webUI
-    Then file "coolnewfile.txt" should have no tags for user "user2"
-    And file "coolnewfile.txt" should have no tags for user "user1"
+    Then file "coolnewfile.txt" should have no tags for user "user1"
+    And file "coolnewfile.txt" should have no tags for user "user0"
 
   Scenario: Remove multiple tags that exist for a file
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has created a "normal" tag with name "Confidential"
     And the user has created a "normal" tag with name "some-tag"
@@ -83,17 +82,17 @@ Feature: Removal of already existing tags from files and folders
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user toggles a tag "random" on the file using the webUI
     And the user toggles a tag "Confidential" on the file using the webUI
-    Then file "randomfile.txt" should have the following tags for user "user1"
+    Then file "randomfile.txt" should have the following tags for user "user0"
       | name     | type   |
       | some-tag | normal |
 
   Scenario: Remove a tag from a file and assign another tag
-    Given user "user1" has uploaded file with content "some content" to "/randomfile.txt"
+    Given user "user0" has uploaded file with content "some content" to "/randomfile.txt"
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
     And the user toggles a tag "random" on the file using the webUI
     And the user adds a tag "some-tag" to the file using the webUI
-    Then file "randomfile.txt" should have the following tags for user "user1"
+    Then file "randomfile.txt" should have the following tags for user "user0"
       | name     | type   |
       | some-tag | normal |

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -7,22 +7,22 @@ Feature: Suggestion for matching tag names
   Background:
     Given these users have been created with default attributes and without skeleton files:
       | username |
-      | user1    |
-    Given user "user1" has created a "normal" tag with name "spam"
+      | user0    |
+    Given user "user0" has created a "normal" tag with name "spam"
     And group "group1" has been created
-    And user "user1" has been added to group "group1"
-    And user "user1" has created a "normal" tag with name "ham"
-    And user "user1" has created a "normal" tag with name "notspam"
-    And user "user1" has created a "normal" tag with name "gham"
-    And user "user1" has created a "normal" tag with name "special"
-    And user "user1" has created a "normal" tag with name "specification"
+    And user "user0" has been added to group "group1"
+    And user "user0" has created a "normal" tag with name "ham"
+    And user "user0" has created a "normal" tag with name "notspam"
+    And user "user0" has created a "normal" tag with name "gham"
+    And user "user0" has created a "normal" tag with name "special"
+    And user "user0" has created a "normal" tag with name "specification"
     And the administrator has created a "not user-assignable" tag with name "Violates T&C"
     And the administrator has created a "not user-assignable" tag with name "sponsored"
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
 
   Scenario: User should get suggestion from already existing tags
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
     And the user types "sp" in the collaborative tags field using the webUI
     Then all the tags starting with "sp" in their name should be listed in the dropdown list on the webUI
@@ -32,8 +32,8 @@ Feature: Suggestion for matching tag names
     And tag "sponsored" should not be listed in the dropdown list on the webUI
 
   Scenario: User of static tags group should get suggestion for static tags
-    Given user "user1" has created folder "a-folder"
-    And user "user1" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
+    Given user "user0" has created folder "a-folder"
+    And user "user0" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
     And the administrator has created a "static" tag with name "StaticTagName" and groups "group1"
     And the user types "St" in the collaborative tags field using the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -5,8 +5,8 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has logged in using the webUI
     And the following files have been deleted
       | name          |
       | data.zip      |

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -5,8 +5,8 @@ Feature: files and folders exist in the trashbin after being deleted
   So that I can recover data easily
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest
@@ -17,10 +17,10 @@ Feature: files and folders exist in the trashbin after being deleted
       | lorem.txt                             |
       | strängé नेपाली folder                 |
       | strängé filename (duplicate #2 &).txt |
-    Then as "user1" folder "simple-folder" should exist in the trashbin
-    And as "user1" file "lorem.txt" should exist in the trashbin
-    And as "user1" folder "strängé नेपाली folder" should exist in the trashbin
-    And as "user1" file "strängé filename (duplicate #2 &).txt" should exist in the trashbin
+    Then as "user0" folder "simple-folder" should exist in the trashbin
+    And as "user0" file "lorem.txt" should exist in the trashbin
+    And as "user0" folder "strängé नेपाली folder" should exist in the trashbin
+    And as "user0" file "strängé filename (duplicate #2 &).txt" should exist in the trashbin
     And the deleted elements should be listed in the trashbin on the webUI
     And file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
@@ -52,10 +52,10 @@ Feature: files and folders exist in the trashbin after being deleted
       | data.zip      |
       | lorem.txt     |
       | simple-folder |
-    Then as "user1" file "data.zip" should exist in the trashbin
-    And as "user1" file "lorem.txt" should exist in the trashbin
-    And as "user1" folder "simple-folder" should exist in the trashbin
-    And as "user1" file "simple-folder/lorem.txt" should exist in the trashbin
+    Then as "user0" file "data.zip" should exist in the trashbin
+    And as "user0" file "lorem.txt" should exist in the trashbin
+    And as "user0" folder "simple-folder" should exist in the trashbin
+    And as "user0" file "simple-folder/lorem.txt" should exist in the trashbin
     And the deleted elements should be listed in the trashbin on the webUI
     And file "lorem.txt" should be listed in the trashbin folder "simple-folder" on the webUI
 
@@ -63,8 +63,8 @@ Feature: files and folders exist in the trashbin after being deleted
     When the user creates a folder with the name "my-empty-folder" using the webUI
     And the user creates a folder with the name "my-other-empty-folder" using the webUI
     And the user deletes folder "my-empty-folder" using the webUI
-    Then as "user1" folder "my-empty-folder" should exist in the trashbin
-    But as "user1" the folder with original path "my-other-empty-folder" should not exist in the trashbin
+    Then as "user0" folder "my-empty-folder" should exist in the trashbin
+    But as "user0" the folder with original path "my-other-empty-folder" should not exist in the trashbin
     And folder "my-empty-folder" should be listed in the trashbin on the webUI
     But folder "my-other-empty-folder" should not be listed in the trashbin on the webUI
     When the user opens trashbin folder "my-empty-folder" using the webUI
@@ -83,9 +83,9 @@ Feature: files and folders exist in the trashbin after being deleted
     And the user deletes the following elements using the webUI
       | name      |
       | lorem.txt |
-    Then as "user1" the file with original path "lorem.txt" should exist in the trashbin
-    And as "user1" the file with original path "simple-folder/lorem.txt" should exist in the trashbin
-    And as "user1" the file with original path "strängé नेपाली folder/lorem.txt" should exist in the trashbin
+    Then as "user0" the file with original path "lorem.txt" should exist in the trashbin
+    And as "user0" the file with original path "simple-folder/lorem.txt" should exist in the trashbin
+    And as "user0" the file with original path "strängé नेपाली folder/lorem.txt" should exist in the trashbin
     Then the deleted elements should be listed in the trashbin on the webUI
     And file "lorem.txt" with path "./lorem.txt" should be listed in the trashbin on the webUI
     And file "lorem.txt" with path "simple-folder/lorem.txt" should be listed in the trashbin on the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
@@ -5,8 +5,8 @@ Feature: Restore deleted files/folders
   So that I can recover accidentally deleted files/folders in ownCloud
 
   Background:
-    Given user "user1" has been created with default attributes and skeleton files
-    And user "user1" has logged in using the webUI
+    Given user "user0" has been created with default attributes and skeleton files
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
 
   @smokeTest
@@ -91,7 +91,7 @@ Feature: Restore deleted files/folders
 
   Scenario: Delete a file and then restore it when a file with the same name already exists
     Given the user has deleted file "lorem.txt"
-    And user "user1" has moved file "textfile0.txt" to "lorem.txt"
+    And user "user0" has moved file "textfile0.txt" to "lorem.txt"
     And the user has browsed to the trashbin page
     Then folder "lorem.txt" should be listed in the trashbin on the webUI
     When the user restores file "lorem.txt" from the trashbin using the webUI
@@ -99,12 +99,12 @@ Feature: Restore deleted files/folders
     When the user browses to the files page
     Then file "lorem.txt" should be listed on the webUI
     And file "lorem (restored).txt" should be listed on the webUI
-    And the content of file "lorem.txt" for user "user1" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "lorem.txt" for user "user0" should be "ownCloud test text file 0" plus end-of-line
     And the content of "lorem (restored).txt" should be the same as the original "lorem.txt"
 
   Scenario: delete a file inside a folder and then restore the file after the folder has been deleted
-    Given user "user1" has created folder "folder-to-delete"
-    And user "user1" has moved file "lorem.txt" to "folder-to-delete/file-to-delete.txt"
+    Given user "user0" has created folder "folder-to-delete"
+    And user "user0" has moved file "lorem.txt" to "folder-to-delete/file-to-delete.txt"
     And the user has deleted file "folder-to-delete/file-to-delete.txt"
     And the user has deleted folder "folder-to-delete"
     And the user has browsed to the trashbin page

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -6,7 +6,7 @@ Feature: File Upload
   So that I can store files in ownCloud
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: simple upload of a file that does not exist before
@@ -28,7 +28,7 @@ Feature: File Upload
   @smokeTest
   Scenario: chunking upload
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user uploads file "big-video.mp4" using the webUI
     Then no notification should be displayed on the webUI
     And file "big-video.mp4" should be listed on the webUI
@@ -37,16 +37,16 @@ Feature: File Upload
   @skipOnFIREFOX
   Scenario: conflict with a chunked file
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user renames file "lorem.txt" to "big-video.mp4" using the webUI
     And the user uploads overwriting file "big-video.mp4" using the webUI and retries if the file is locked
     Then file "big-video.mp4" should be listed on the webUI
     And the content of "big-video.mp4" should be the same as the local "big-video.mp4"
 
   Scenario: upload a new file into a sub folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then no notification should be displayed on the webUI
@@ -55,8 +55,8 @@ Feature: File Upload
 
   @smokeTest
   Scenario: overwrite an existing file
-    Given user "user1" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     Then no dialog should be displayed on the webUI
     And file "lorem.txt" should be listed on the webUI
@@ -65,8 +65,8 @@ Feature: File Upload
 
   @smokeTest
   Scenario: keep new and existing file
-    Given user "user1" has uploaded file with content "original content" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "original content" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user uploads file "lorem.txt" using the webUI
     And the user chooses to keep the new files in the upload dialog
     And the user chooses to keep the existing files in the upload dialog
@@ -74,35 +74,35 @@ Feature: File Upload
     Then no dialog should be displayed on the webUI
     And no notification should be displayed on the webUI
     And file "lorem.txt" should be listed on the webUI
-    And the content of file "lorem.txt" for user "user1" should be "original content"
+    And the content of file "lorem.txt" for user "user0" should be "original content"
     And file "lorem (2).txt" should be listed on the webUI
     And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
 
   Scenario: cancel conflict dialog
-    Given user "user1" has uploaded file with content "original content" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "original content" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user uploads file "lorem.txt" using the webUI
     And the user chooses "Cancel" in the upload dialog
     Then no dialog should be displayed on the webUI
     And no notification should be displayed on the webUI
     And file "lorem.txt" should be listed on the webUI
-    And the content of file "lorem.txt" for user "user1" should be "original content"
+    And the content of file "lorem.txt" for user "user0" should be "original content"
     And file "lorem (2).txt" should not be listed on the webUI
 
   Scenario: overwrite an existing file in a sub-folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
 
   Scenario: keep new and existing file in a sub-folder
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
-    And user "user1" has uploaded file with content "original content" to "/lorem.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
+    And user "user0" has uploaded file with content "original content" to "/lorem.txt"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user uploads file "lorem.txt" using the webUI
     And the user chooses to keep the new files in the upload dialog
@@ -111,39 +111,39 @@ Feature: File Upload
     Then no dialog should be displayed on the webUI
     And no notification should be displayed on the webUI
     And file "lorem.txt" should be listed on the webUI
-    And the content of file "lorem.txt" for user "user1" should be "original content"
+    And the content of file "lorem.txt" for user "user0" should be "original content"
     And file "lorem (2).txt" should be listed on the webUI
     And the content of "lorem (2).txt" should be the same as the local "lorem.txt"
 
   @files_sharing-app-required
   Scenario: upload a file into a public share
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created a public link share with settings
       | path        | /simple-folder |
       | permissions | read,create    |
     When the public accesses the last created public link using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
-    When user "user1" logs in using the webUI
+    When user "user0" logs in using the webUI
     And the content of "simple-folder/new-lorem.txt" should be the same as the local "new-lorem.txt"
 
   @files_sharing-app-required
   Scenario: upload overwriting a file into a public share
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
+    And user "user0" has created a public link share with settings
       | path        | /simple-folder     |
       | permissions | read,update,create |
     When the public accesses the last created public link using the webUI
     And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     Then file "lorem.txt" should be listed on the webUI
-    When user "user1" logs in using the webUI
+    When user "user0" logs in using the webUI
     And the content of "simple-folder/lorem.txt" should be the same as the local "lorem.txt"
 
   @files_sharing-app-required
   Scenario: upload a file into files_drop share
-    Given user "user1" has created folder "/simple-folder"
-    And user "user1" has created a public link share with settings
+    Given user "user0" has created folder "/simple-folder"
+    And user "user0" has created a public link share with settings
       | path        | /simple-folder  |
       | permissions | uploadwriteonly |
     When the public accesses the last created public link using the webUI
@@ -153,5 +153,5 @@ Feature: File Upload
       | uploaded-elements |
       | lorem.txt         |
       | lorem-big.txt     |
-    And as "user1" file "/simple-folder/lorem.txt" should exist
-    And as "user1" file "/simple-folder/lorem-big.txt" should exist
+    And as "user0" file "/simple-folder/lorem.txt" should exist
+    And as "user0" file "/simple-folder/lorem-big.txt" should exist

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -8,10 +8,10 @@ Feature: File Upload
   that is not academically correct but saves a lot of time
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   Scenario: simple upload of a file that does not exist before
-    Given user "user1" has logged in using the webUI
+    Given user "user0" has logged in using the webUI
     When the user uploads file "new-'single'quotes.txt" using the webUI
     Then file "new-'single'quotes.txt" should be listed on the webUI
     And the content of "new-'single'quotes.txt" should be the same as the local "new-'single'quotes.txt"
@@ -27,8 +27,8 @@ Feature: File Upload
   @smokeTest
   Scenario Outline: upload a new file into a sub folder
     Given a file with the size of "3000" bytes and the name "0" has been created locally
-    And user "user1" has created folder <folder-to-upload-to>
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder <folder-to-upload-to>
+    And user "user0" has logged in using the webUI
     When the user opens folder <folder-to-upload-to> using the webUI
     And the user uploads file "0" using the webUI
     Then file "0" should be listed on the webUI
@@ -52,10 +52,10 @@ Feature: File Upload
       | "strängé नेपाली folder" |
 
   Scenario: overwrite an existing file
-    Given user "user1" has uploaded file "filesForUpload/'single'quotes.txt" to "/'single'quotes.txt"
-    And user "user1" has uploaded file "filesForUpload/strängé filename (duplicate #2 &).txt" to "/strängé filename (duplicate #2 &).txt"
-    And user "user1" has uploaded file "filesForUpload/zzzz-must-be-last-file-in-folder.txt" to "/zzzz-must-be-last-file-in-folder.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file "filesForUpload/'single'quotes.txt" to "/'single'quotes.txt"
+    And user "user0" has uploaded file "filesForUpload/strängé filename (duplicate #2 &).txt" to "/strängé filename (duplicate #2 &).txt"
+    And user "user0" has uploaded file "filesForUpload/zzzz-must-be-last-file-in-folder.txt" to "/zzzz-must-be-last-file-in-folder.txt"
+    And user "user0" has logged in using the webUI
     When the user uploads overwriting file "'single'quotes.txt" using the webUI and retries if the file is locked
     Then file "'single'quotes.txt" should be listed on the webUI
     And the content of "'single'quotes.txt" should be the same as the local "'single'quotes.txt"
@@ -69,31 +69,31 @@ Feature: File Upload
     And the content of "zzzz-must-be-last-file-in-folder.txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
 
   Scenario: keep new and existing file
-    Given user "user1" has uploaded file with content "single quote content" to "/'single'quotes.txt"
-    And user "user1" has uploaded file with content "strange content" to "/strängé filename (duplicate #2 &).txt"
-    And user "user1" has uploaded file with content "zzz content" to "/zzzz-must-be-last-file-in-folder.txt"
-    And user "user1" has logged in using the webUI
+    Given user "user0" has uploaded file with content "single quote content" to "/'single'quotes.txt"
+    And user "user0" has uploaded file with content "strange content" to "/strängé filename (duplicate #2 &).txt"
+    And user "user0" has uploaded file with content "zzz content" to "/zzzz-must-be-last-file-in-folder.txt"
+    And user "user0" has logged in using the webUI
     When the user uploads file "'single'quotes.txt" keeping both new and existing files using the webUI
     Then file "'single'quotes.txt" should be listed on the webUI
-    And the content of file "'single'quotes.txt" for user "user1" should be "single quote content"
+    And the content of file "'single'quotes.txt" for user "user0" should be "single quote content"
     And file "'single'quotes (2).txt" should be listed on the webUI
     And the content of "'single'quotes (2).txt" should be the same as the local "'single'quotes.txt"
 
     When the user uploads file "strängé filename (duplicate #2 &).txt" keeping both new and existing files using the webUI
     Then file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
-    And the content of file "strängé filename (duplicate #2 &).txt" for user "user1" should be "strange content"
+    And the content of file "strängé filename (duplicate #2 &).txt" for user "user0" should be "strange content"
     And file "strängé filename (duplicate #2 &) (2).txt" should be listed on the webUI
     And the content of "strängé filename (duplicate #2 &) (2).txt" should be the same as the local "strängé filename (duplicate #2 &).txt"
 
     When the user uploads file "zzzz-must-be-last-file-in-folder.txt" keeping both new and existing files using the webUI
     Then file "zzzz-must-be-last-file-in-folder.txt" should be listed on the webUI
-    And the content of file "zzzz-must-be-last-file-in-folder.txt" for user "user1" should be "zzz content"
+    And the content of file "zzzz-must-be-last-file-in-folder.txt" for user "user0" should be "zzz content"
     And file "zzzz-must-be-last-file-in-folder (2).txt" should be listed on the webUI
     And the content of "zzzz-must-be-last-file-in-folder (2).txt" should be the same as the local "zzzz-must-be-last-file-in-folder.txt"
 
   Scenario Outline: chunking upload using difficult names
     Given a file with the size of "30000000" bytes and the name <file-name> has been created locally
-    And user "user1" has logged in using the webUI
+    And user "user0" has logged in using the webUI
     When the user uploads file <file-name> using the webUI
     Then file <file-name> should be listed on the webUI
     And the content of <file-name> should be the same as the local <file-name>
@@ -107,8 +107,8 @@ Feature: File Upload
   # upload into "simple-folder" because there is already a folder called "0" in the root
   Scenario: Upload a file called "0" using chunking
     Given a file with the size of "30000000" bytes and the name "0" has been created locally
-    And user "user1" has created folder "simple-folder"
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder "simple-folder"
+    And user "user0" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user uploads file "0" using the webUI
     Then file "0" should be listed on the webUI
@@ -116,8 +116,8 @@ Feature: File Upload
 
   Scenario Outline: upload a file with special characters into a folder with special characters using chunking and verify its content
     Given a file with the size of "30000000" bytes and the name "<file-name>" has been created locally
-    And user "user1" has created folder <folder-to-upload-to>
-    And user "user1" has logged in using the webUI
+    And user "user0" has created folder <folder-to-upload-to>
+    And user "user0" has logged in using the webUI
     When the user opens folder <folder-to-upload-to> using the webUI
     And the user uploads file "<file-name>" using the webUI
     Then file "<file-name>" should be listed on the webUI

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -6,12 +6,12 @@ Feature: Upload a file
   So that I can store it in owncloud
 
   Background:
-    Given user "user1" has been created with default attributes and without skeleton files
+    Given user "user0" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario: simple upload of a file with the size greater than the size of quota
-    Given the quota of user "user1" has been set to "10 MB"
-    And user "user1" has logged in using the webUI
+    Given the quota of user "user0" has been set to "10 MB"
+    And user "user0" has logged in using the webUI
     And the user has browsed to the files page
     And a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
     When the user uploads file "big-video.mp4" using the webUI


### PR DESCRIPTION
## Description
Adjust the UI tests so that `user0` is the primary actor.

## Related Issue
Part of issue #33596 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
