### PR TITLE
Use BackendUserIterator with uid filter for user:sync --uid

### DIFF
--- a/changelog/unreleased/37398
+++ b/changelog/unreleased/37398
@@ -1,0 +1,8 @@
+Bugfix: Adjust user:sync --uid to use user backend iterator
+
+It fixes the behavior for user:sync --uid that attempts to retrieve all
+user backend users without limit at offset, that is not supported by LDAP backend.
+Instead, proper iterator and search query has been used
+
+https://github.com/owncloud/core/pull/37398
+https://github.com/owncloud/enterprise/issues/3981

--- a/core/Migrations/Version20170221114437.php
+++ b/core/Migrations/Version20170221114437.php
@@ -4,7 +4,7 @@ namespace OC\Migrations;
 use OC\User\AccountMapper;
 use OC\User\AccountTermMapper;
 use OC\User\Database;
-use OC\User\Sync\AllUsersIterator;
+use OC\User\Sync\BackendUsersIterator;
 use OC\User\SyncService;
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;
@@ -25,7 +25,7 @@ class Version20170221114437 implements ISimpleMigration {
 		// insert/update known users
 		$out->info("Insert new users ...");
 		$out->startProgress($backend->countUsers());
-		$syncService->run($backend, new AllUsersIterator($backend), function () use ($out) {
+		$syncService->run($backend, new BackendUsersIterator($backend), function () use ($out) {
 			$out->advance();
 		});
 		$out->finishProgress();

--- a/lib/private/User/Sync/BackendUsersIterator.php
+++ b/lib/private/User/Sync/BackendUsersIterator.php
@@ -22,7 +22,7 @@ namespace OC\User\Sync;
 
 use OCP\UserInterface;
 
-class AllUsersIterator extends UsersIterator {
+class BackendUsersIterator extends UsersIterator {
 	/**
 	 * @var UserInterface
 	 */
@@ -41,13 +41,17 @@ class AllUsersIterator extends UsersIterator {
 	/** @var bool false if the backend returned less than LIMIT results */
 	private $hasMoreData = false;
 
-	public function __construct(UserInterface $backend) {
+	/** @var string search for the uid string in backend */
+	private $search;
+
+	public function __construct(UserInterface $backend, $filterUID = '') {
 		$this->backend = $backend;
+		$this->search = $filterUID;
 	}
 
 	public function rewind() {
 		parent::rewind();
-		$this->data = $this->backend->getUsers('', self::LIMIT, 0);
+		$this->data = $this->backend->getUsers($this->search, self::LIMIT, 0);
 		$this->dataPos = 0;
 		$this->endPos = \count($this->data);
 		$this->hasMoreData = $this->endPos >= self::LIMIT;
@@ -59,7 +63,7 @@ class AllUsersIterator extends UsersIterator {
 		if ($this->hasMoreData && $this->dataPos >= $this->endPos) {
 			$this->page++;
 			$offset = $this->page * self::LIMIT;
-			$this->data = $this->backend->getUsers('', self::LIMIT, $offset);
+			$this->data = $this->backend->getUsers($this->search, self::LIMIT, $offset);
 			$this->dataPos = 0;
 			$this->endPos = \count($this->data);
 			$this->hasMoreData = $this->endPos >= self::LIMIT;

--- a/tests/lib/Command/User/SyncBackendTest.php
+++ b/tests/lib/Command/User/SyncBackendTest.php
@@ -213,7 +213,7 @@ class SyncBackendTest extends TestCase {
 
 	public function executeProvider() {
 		return [
-			['foo', 'Syncing foo ...'],
+			['foo', 'Searching for foo ...'],
 			[null, 'Analysing known accounts ...'],
 		];
 	}

--- a/tests/lib/User/Sync/BackendUsersIteratorTest.php
+++ b/tests/lib/User/Sync/BackendUsersIteratorTest.php
@@ -25,13 +25,13 @@ use OCP\UserInterface;
 use Test\TestCase;
 
 /**
- * Class AllUsersIteratorTest
+ * Class BackendUsersIteratorTest
  *
  * @package OC\User\Sync
  *
  * @see http://php.net/manual/en/class.iterator.php for the order of calls on an iterator
  */
-class AllUsersIteratorTest extends TestCase {
+class BackendUsersIteratorTest extends TestCase {
 
 	/**
 	 * @var UserInterface|\PHPUnit\Framework\MockObject\MockObject
@@ -47,7 +47,7 @@ class AllUsersIteratorTest extends TestCase {
 
 		$this->backend = $this->createMock(UserInterface::class);
 
-		$this->iterator = new AllUsersIterator($this->backend);
+		$this->iterator = new BackendUsersIterator($this->backend);
 	}
 
 	/**

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -26,7 +26,7 @@ namespace Test\User;
 use OC\User\Account;
 use OC\User\AccountMapper;
 use OC\User\Database;
-use OC\User\Sync\AllUsersIterator;
+use OC\User\Sync\BackendUsersIterator;
 use OC\User\SyncService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
@@ -119,7 +119,7 @@ class SyncServiceTest extends TestCase {
 		// Ignore state flag
 
 		$s = new SyncService($this->config, $this->logger, $this->mapper);
-		$s->run($backend, new AllUsersIterator($backend));
+		$s->run($backend, new BackendUsersIterator($backend));
 
 		static::invokePrivate($s, 'syncHome', [$account, $backend]);
 	}
@@ -142,7 +142,7 @@ class SyncServiceTest extends TestCase {
 		$this->logger->expects($this->at(1))->method('logException');
 
 		$s = new SyncService($this->config, $this->logger, $this->mapper);
-		$s->run($backend, new AllUsersIterator($backend));
+		$s->run($backend, new BackendUsersIterator($backend));
 	}
 
 	public function testSyncHomeLogsWhenBackendDiffersFromExisting() {


### PR DESCRIPTION
Commit https://github.com/owncloud/core/commit/dd8440595146b577e598d981610530cf1cb8c630 introduced a problem that when searching for a user in LDAP backend that does not fit in LDAP Paging Size made `user:sync --uid` break (essentially not finding it and attempting to remove

How tested?
- [x] unit tests
- [x] insert 1000 users, including `1_aaliyah_abernathy`, `aaliyah_abernathy` and `aaliyah_abernathy_1` **at the beginning**, searched for `aaliyah_abernathy` - without this fix it works, with this fix it also it works
- [x] insert 1000 users, including `1_abagail_zieme`, `abagail_zieme` and `abagail_zieme_1` **at the end**, searched for `abagail_zieme` - without this fix it wont work, with this fix it works (fixes https://github.com/owncloud/enterprise/issues/3981)