### PR TITLE
[Tests-Only] Adjust user and display names in shareAutocompletion tests

### DIFF
--- a/tests/acceptance/features/webUISharingAutocompletion1/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion1/shareAutocompletion.feature
@@ -5,23 +5,18 @@ Feature: Autocompletion of share-with names
   So that I can efficiently share my files with other users or groups
 
   Background:
-    # Users that are in the special known users already
-    Given these users have been created with default attributes and skeleton files but not initialized:
-      | username    |
-      | Brian       |
-      | regularuser |
-    # Users that are in the special known users already without skeleton files
-    And these users have been created with default attributes and without skeleton files:
-      | username |
-      | David    |
-      | usergrp  |
+    Given these users have been created with skeleton files:
+      | username               | password  | displayname   | email        |
+      | autocomplete-test-user | %regular% | Thomas Krause | ur@oc.net.np |
+      | another-test-user      | %regular% | Another Name  | an@oc.com.np |
     # Some extra users without skeleton files to make the share autocompletion interesting
     And these users have been created without skeleton files:
-      | username  | password  | displayname     | email          |
-      | two       | %regular% | Carol King      | u2@oc.com.np   |
-      | u444      | %regular% | Four            | u3@oc.com.np   |
-      | five      | %regular% | User Group      | five@oc.net.np |
-      | usersmith | %regular% | John Finn Smith | js@oc.com.de   |
+      | username   | password  | displayname     | email          |
+      | jb1        | %regular% | James Baker     | jb@oc.com.np   |
+      | u444       | %regular% | Four            | u4@oc.com.np   |
+      | five       | %regular% | User Five       | five@oc.net.np |
+      | usersmith  | %regular% | John Finn Smith | js@oc.com.de   |
+      | anne-smith | %regular% | Anne Smith      | as@oc.com.au   |
     And these groups have been created:
       | groupname     |
       | finance1      |
@@ -33,7 +28,7 @@ Feature: Autocompletion of share-with names
 
   @smokeTest
   Scenario: autocompletion of regular existing users
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "us" in the share-with-field
@@ -43,7 +38,7 @@ Feature: Autocompletion of share-with names
 
   @smokeTest
   Scenario: autocompletion of regular existing groups
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
@@ -52,7 +47,7 @@ Feature: Autocompletion of share-with names
     And user "other" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion for a pattern that does not match any user or group
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "doesnotexist" in the share-with-field
@@ -61,22 +56,22 @@ Feature: Autocompletion of share-with names
 
   Scenario: autocomplete short user/display names when completely typed
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
-    And user "regularuser" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And these users have been created with skeleton files but not initialized:
       | username | password | displayname | email        |
-      | use      | %alt1%   | Use         | uz@oc.com.np |
+      | fiv      | %alt1%   | Someone     | fi@oc.com.np |
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "Use" in the share-with-field
-    Then only user "Use" should be listed in the autocomplete list on the webUI
-    And user "Carol King" should not be listed in the autocomplete list on the webUI
+    When the user types "fiv" in the share-with-field
+    Then only user "Someone" should be listed in the autocomplete list on the webUI
+    And user "User Five" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocomplete short group names when completely typed
     Given the administrator has set the minimum characters for sharing autocomplete to "3"
     And these groups have been created:
       | groupname |
       | fi        |
-    And user "regularuser" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
@@ -84,7 +79,7 @@ Feature: Autocompletion of share-with names
     And user "finance1" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion when minimum characters is the default (2) and not enough characters are typed
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "u" in the share-with-field
@@ -93,7 +88,7 @@ Feature: Autocompletion of share-with names
 
   Scenario: autocompletion when minimum characters is increased and not enough characters are typed
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
-    And user "regularuser" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "use" in the share-with-field
@@ -102,7 +97,7 @@ Feature: Autocompletion of share-with names
 
   Scenario: autocompletion when increasing the minimum characters for sharing autocomplete
     Given the administrator has set the minimum characters for sharing autocomplete to "3"
-    And user "regularuser" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "use" in the share-with-field
@@ -111,64 +106,64 @@ Feature: Autocompletion of share-with names
     And user "Four" should not be listed in the autocomplete list on the webUI
 
   Scenario: allow user to disable autocomplete in sharing dialog
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
     When the user disables allow finding you via autocomplete in share dialog
-    And the user re-logs in as "Brian" using the webUI
+    And the user re-logs in as "another-test-user" using the webUI
     And the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
-    And the user types "reg" in the share-with-field
-    Then user "Regular User" should not be listed in the autocomplete list on the webUI
+    And the user types "auto" in the share-with-field
+    Then user "Thomas Krause" should not be listed in the autocomplete list on the webUI
 
   Scenario: user disables autocomplete in sharing dialog but the sharer types full username
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
     When the user disables allow finding you via autocomplete in share dialog
-    And the user re-logs in as "Brian" using the webUI
+    And the user re-logs in as "another-test-user" using the webUI
     And the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
-    And the user types "regularuser" in the share-with-field
-    Then user "Regular User" should be listed in the autocomplete list on the webUI
+    And the user types "autocomplete-test-user" in the share-with-field
+    Then user "Thomas Krause" should be listed in the autocomplete list on the webUI
 
   Scenario: user disables autocomplete in sharing dialog but the sharer types full display name
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
     When the user disables allow finding you via autocomplete in share dialog
-    And the user re-logs in as "Brian" using the webUI
+    And the user re-logs in as "another-test-user" using the webUI
     And the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
-    And the user types "Regular User" in the share-with-field
-    Then user "Regular User" should be listed in the autocomplete list on the webUI
+    And the user types "Thomas Krause" in the share-with-field
+    Then user "Thomas Krause" should be listed in the autocomplete list on the webUI
 
   Scenario: allow user to enable autocomplete in sharing dialog
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
     When the user enables allow finding you via autocomplete in share dialog
-    And the user re-logs in as "Brian" using the webUI
+    And the user re-logs in as "another-test-user" using the webUI
     And the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
-    And the user types "reg" in the share-with-field
-    Then user "Regular User" should be listed in the autocomplete list on the webUI
+    And the user types "auto" in the share-with-field
+    Then user "Thomas Krause" should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
 
   Scenario: admin disables share dialog user enumeration
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    And user "regularuser" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     When the user browses to the personal sharing settings page
     Then allow finding you via autocomplete checkbox should not be displayed on the personal sharing settings page
 
   Scenario: admin disables share dialog user enumeration and types full user name of user in sharing dialog
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    And user "regularuser" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "Brian" in the share-with-field
-    Then user "Brian Murphy" should be listed in the autocomplete list on the webUI
+    When the user types "usersmith" in the share-with-field
+    Then user "John Finn Smith" should be listed in the autocomplete list on the webUI
 
   Scenario: admin disables share dialog user enumeration and types full display name of user in sharing dialog
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    And user "regularuser" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "Brian Murphy" in the share-with-field
-    Then user "Brian Murphy" should be listed in the autocomplete list on the webUI
+    When the user types "John Finn Smith" in the share-with-field
+    Then user "John Finn Smith" should be listed in the autocomplete list on the webUI

--- a/tests/acceptance/features/webUISharingAutocompletion2/shareAutocompletionWithDifferentPatterns.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion2/shareAutocompletionWithDifferentPatterns.feature
@@ -5,23 +5,18 @@ Feature: Autocompletion of share-with names
   So that I can efficiently share my files with other users or groups
 
   Background:
-    # Users that are in the special known users already
-    Given these users have been created with default attributes and skeleton files but not initialized:
-      | username    |
-      | Brian       |
-      | regularuser |
-    # Users that are in the special known users already without skeleton files
-    And these users have been created with default attributes and without skeleton files:
-      | username |
-      | David    |
-      | usergrp  |
+    Given these users have been created with skeleton files:
+      | username               | password  | displayname   | email        |
+      | autocomplete-test-user | %regular% | Thomas Krause | ur@oc.net.np |
+      | another-test-user      | %regular% | Another Name  | an@oc.com.np |
     # Some extra users without skeleton files to make the share autocompletion interesting
     And these users have been created without skeleton files:
-      | username  | password  | displayname     | email          |
-      | two       | %regular% | Carol King      | u2@oc.com.np   |
-      | u444      | %regular% | Four            | u3@oc.com.np   |
-      | five      | %regular% | User Group      | five@oc.net.np |
-      | usersmith | %regular% | John Finn Smith | js@oc.com.de   |
+      | username   | password  | displayname     | email          |
+      | jb1        | %regular% | James Baker     | jb@oc.com.np   |
+      | u444       | %regular% | Four            | u4@oc.com.np   |
+      | five       | %regular% | User Five       | five@oc.net.np |
+      | usersmith  | %regular% | John Finn Smith | js@oc.com.de   |
+      | anne-smith | %regular% | Anne Smith      | as@oc.com.au   |
     And these groups have been created:
       | groupname     |
       | finance1      |
@@ -32,28 +27,28 @@ Feature: Autocompletion of share-with names
     And the administrator has added system config key "user_ldap.enable_medial_search" with value "true" and type "boolean"
 
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (folder)
-    Given user "regularuser" has shared folder "simple-folder" with user "Brian"
-    And user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has shared folder "simple-folder" with user "usersmith"
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "user" in the share-with-field
-    Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "Brian Murphy"
+    Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "John Finn Smith"
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern that matches regular existing users but also a user with whom the item is already shared (file)
-    Given user "regularuser" has shared file "data.zip" with user "usergrp"
-    And user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has shared file "data.zip" with user "usersmith"
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for file "data.zip"
     When the user types "user" in the share-with-field
-    Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "User Grp"
+    Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI except user "John Finn Smith"
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (folder)
-    Given user "regularuser" has shared folder "simple-folder" with group "finance1"
-    And user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has shared folder "simple-folder" with group "finance1"
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "fi" in the share-with-field
@@ -62,8 +57,8 @@ Feature: Autocompletion of share-with names
     And user "Four" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern that matches regular existing groups but also a group with whom the item is already shared (file)
-    Given user "regularuser" has shared file "data.zip" with group "finance1"
-    And user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has shared file "data.zip" with group "finance1"
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for file "data.zip"
     When the user types "fi" in the share-with-field
@@ -72,7 +67,7 @@ Feature: Autocompletion of share-with names
     And user "Four" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the name of existing users contains the pattern somewhere in the middle
-    Given user "Brian" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "se" in the share-with-field
@@ -81,24 +76,24 @@ Feature: Autocompletion of share-with names
     And user "Four" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the name of existing users contain the pattern at the end
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "r3" in the share-with-field
-    Then all users and groups that contain the string "r3" in their name should be listed in the autocomplete list on the webUI
+    When the user types "ith" in the share-with-field
+    Then all users and groups that contain the string "ith" in their name should be listed in the autocomplete list on the webUI
     And the users own name should not be listed in the autocomplete list on the webUI
-    And user "Brian Murphy" should not be listed in the autocomplete list on the webUI
+    And user "User Five" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the username of existing user contains the pattern somewhere in the middle
     Given user "ivan" has been created with default attributes and skeleton files
-    And user "Brian" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "iv" in the share-with-field
     Then all users and groups that contain the string "iv" in their name should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the name of existing group contains the pattern somewhere in the middle
-    Given user "Brian" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "anc" in the share-with-field
@@ -106,17 +101,14 @@ Feature: Autocompletion of share-with names
     But group "other" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the username of the existing user contains the pattern somewhere in the end
-    Given these users have been created with default attributes and skeleton files but not initialized:
-      | username     | displayname |
-      | regularuser3 | Guest User  |
-    And user "Brian" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "David" in the share-with-field
-    Then all users and groups that contain the string "David" in their name should be listed in the autocomplete list on the webUI
+    When the user types "user" in the share-with-field
+    Then all users and groups that contain the string "user" in their name should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the name of existing group contains the pattern at the end
-    Given user "Brian" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "ce2" in the share-with-field
@@ -126,35 +118,35 @@ Feature: Autocompletion of share-with names
     And group "users-finance" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere in the middle
-    Given user "Brian" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "finn" in the share-with-field
     Then only user "John Finn Smith" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere at the end
-    Given user "Brian" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "group" in the share-with-field
-    Then only user "User Group" should be listed in the autocomplete list on the webUI
+    When the user types "baker" in the share-with-field
+    Then only user "James Baker" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the beginning
-    Given user "Brian" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "u2" in the share-with-field
-    Then only user "Carol King" should be listed in the autocomplete list on the webUI
+    When the user types "ur" in the share-with-field
+    Then only user "Four" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the middle
-    Given user "Brian" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "net" in the share-with-field
-    Then only user "User Group" should be listed in the autocomplete list on the webUI
+    Then only user "User Five" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the end
-    Given user "Brian" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "de" in the share-with-field
@@ -165,7 +157,7 @@ Feature: Autocompletion of share-with names
     Given these groups have been created:
       | groupname |
       | nanumber  |
-    And user "Brian" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the administrator has added system config key "groups.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
@@ -181,7 +173,7 @@ Feature: Autocompletion of share-with names
       | groupname         |
       | ncell-customers   |
       | customers-finance |
-    And user "Brian" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the administrator has added system config key "groups.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
@@ -193,7 +185,7 @@ Feature: Autocompletion of share-with names
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname |
       | ivan     | Ivan        |
-    And user "Brian" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
@@ -202,20 +194,20 @@ Feature: Autocompletion of share-with names
 
   Scenario: autocompletion of a pattern where the user name contains the pattern somewhere in the end but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
-      | username     | displayname |
-      | regularuser3 | Guest User  |
-    And user "Brian" has logged in using the webUI
+      | username              | displayname |
+      | autocomplete-test-jb1 | Guest User  |
+    And user "autocomplete-test-user" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "David" in the share-with-field
-    Then only user "David Lopez" should be listed in the autocomplete list on the webUI
+    When the user types "jb1" in the share-with-field
+    Then only user "James Baker" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere in the middle but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname   |
-      | Carol    | finnance typo |
-    And user "Brian" has logged in using the webUI
+      | someone  | finnance typo |
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has opened the share dialog for folder "simple-folder"
@@ -225,50 +217,50 @@ Feature: Autocompletion of share-with names
   Scenario: autocompletion of a pattern where the display name of existing user contains the pattern somewhere in the end but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname |
-      | Carol    | Group User  |
-    And user "Brian" has logged in using the webUI
+      | someone  | Smith User  |
+    And user "autocomplete-test-user" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "group" in the share-with-field
-    Then only user "Group User" should be listed in the autocomplete list on the webUI
+    When the user types "smith" in the share-with-field
+    Then only user "Smith User" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the beginning but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname | email              |
-      | Carol    | Carol       | hello2u2@oc.com.np |
-    And user "Brian" has logged in using the webUI
+      | someone  | Some One    | hello2js@oc.com.np |
+    And user "autocomplete-test-user" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
-    When the user types "u2" in the share-with-field
-    Then only user "Carol King" should be listed in the autocomplete list on the webUI
+    When the user types "js" in the share-with-field
+    Then only user "John Finn Smith" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the middle but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname | email         |
-      | Carol    | Carol       | net@oc.com.np |
-    And user "Brian" has logged in using the webUI
+      | someone  | Some One    | net@oc.com.np |
+    And user "autocomplete-test-user" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "net" in the share-with-field
-    Then only user "Carol" should be listed in the autocomplete list on the webUI
+    Then only user "Some One" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the end but accounts medial search is disabled
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username | displayname | email        |
-      | Carol    | Carol       | de@oc.com.np |
-    And user "Brian" has logged in using the webUI
+      | someone  | Some One    | de@oc.com.np |
+    And user "autocomplete-test-user" has logged in using the webUI
     And the administrator has added system config key "accounts.enable_medial_search" with value "false" and type "boolean"
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "de" in the share-with-field
-    Then only user "Carol" should be listed in the autocomplete list on the webUI
+    Then only user "Some One" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern when admin disables username autocompletion in share dialog
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
-    And user "regularuser" has logged in using the webUI
+    And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
     When the user types "user" in the share-with-field
@@ -276,12 +268,12 @@ Feature: Autocompletion of share-with names
     And the autocomplete list should not be displayed on the webUI
 
   Scenario: autocompletion of pattern when user disables and then enables autocompletion in sharing dialog
-    Given user "regularuser" has logged in using the webUI
+    Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the personal sharing settings page
     When the user disables allow finding you via autocomplete in share dialog
     And the user enables allow finding you via autocomplete in share dialog
-    And the user re-logs in as "Brian" using the webUI
+    And the user re-logs in as "another-test-user" using the webUI
     And the user browses to the files page
     And the user opens the share dialog for folder "simple-folder"
-    And the user types "reg" in the share-with-field
-    Then user "Regular User" should be listed in the autocomplete list on the webUI
+    And the user types "test" in the share-with-field
+    Then user "Thomas Krause" should be listed in the autocomplete list on the webUI


### PR DESCRIPTION
## Description
shareAutocompletion tests need to have specific mixes of usernames, display names and group names. Adjust the tests so they have their own set of these and do not depend on user names and display names that come from the "default" set (which might get substituted with other values for special test runs)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
