### PR TITLE
[Tests-Only] Remove useless comment fields in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/CommentsContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsContext.php
@@ -67,14 +67,10 @@ class CommentsContext implements Context {
 			"POST",
 			$commentsPath,
 			['Content-Type' => 'application/json'],
-			'{"actorId":"Alice",
-			"actorDisplayName":"Alice",
-			"actorType":"users",
+			'{"actorType":"users",
 			"verb":"comment",
-			"message":"' . $content . '",
-			"creationDateTime":"Thu, 18 Feb 2016 17:04:18 GMT",
-			"objectType":"files"}',
-			"uploads"
+			"message":"' . $content . '"}',
+			"comments"
 		);
 		$this->featureContext->setResponse($response);
 		$responseHeaders = $response->getHeaders();


### PR DESCRIPTION
## Description
https://doc.owncloud.com/server/developer_manual/webdav_api/comments.html#create-comments

When creating a comment, actually the API only allows you to specify `message` `actorType` and `verb` Attributes like `actorId` and `actorDisplayName` are derived from the authenticated user that adds the comment . They cannot be specified differently in the POST API  request that adds the comment. The backend code ignores and "extra" attributes in the JSON.

To reduce future confusion, remove these "useless" attributes from the JSON sent by the acceptance tests.

Note: PR #37404 demonstrates that when setting these values to "random values" and sending them, the tests still pass. That confirms that the values are ignored.

## Related Issue
- Fixes #37402 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
