### PR TITLE
[Tests-Only] Use plugins/codecov:latest

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1066,7 +1066,7 @@ def javascript():
 	if params['coverage']:
 		result['steps'].append({
 			'name': 'coverage-upload',
-			'image': 'plugins/codecov:2',
+			'image': 'plugins/codecov:latest',
 			'pull': 'always',
 			'environment': {
 				'CODECOV_TOKEN': {
@@ -1239,7 +1239,7 @@ def phptests(testType):
 					if params['coverage']:
 						result['steps'].append({
 							'name': 'coverage-upload',
-							'image': 'plugins/codecov:2',
+							'image': 'plugins/codecov:latest',
 							'pull': 'always',
 							'environment': {
 								'CODECOV_TOKEN': {


### PR DESCRIPTION
## Description
From codecov support: 
"Codecov recently did some fundamental storage changes on its backend in an effort to greatly improve the reliability of our underlying storage systems. As a result the X-Amz-Acl: public-read header is no longer needed, and may result in 400 errors if used."

"Can you please update to the latest version of the uploader you are using and try again please?"

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
