### PR TITLE
[Tests-Only] Improve acceptance test createdUsers when a user is created twice in a test

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -60,6 +60,16 @@ class FeatureContext extends BehatVariablesContext {
 	/**
 	 * @var string
 	 */
+	private $adminDisplayName = '';
+
+	/**
+	 * @var string
+	 */
+	private $adminEmailAddress = '';
+
+	/**
+	 * @var string
+	 */
 	private $originalAdminPassword = '';
 
 	/**
@@ -1635,6 +1645,15 @@ class FeatureContext extends BehatVariablesContext {
 			$this->getAdminUsername(),
 			$this->getAdminPassword()
 		);
+	}
+
+	/**
+	 * @param $user
+	 *
+	 * @return boolean
+	 */
+	public function isAdminUsername($user) {
+		return ($user === $this->getAdminUsername());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -246,7 +246,7 @@ class OccUsersGroupsContext implements Context {
 		$this->occContext->invokingTheCommand(
 			"user:modify $username email $newEmail"
 		);
-		$this->featureContext->updateUserInCreatedUsersList($username, "email", $newEmail);
+		$this->featureContext->rememberUserEmailAddress($username, $newEmail);
 	}
 
 	/**
@@ -263,7 +263,7 @@ class OccUsersGroupsContext implements Context {
 		$this->occContext->invokingTheCommand(
 			"user:modify $username displayname '$newDisplayname'"
 		);
-		$this->featureContext->updateUserInCreatedUsersList($username, "displayname", $newDisplayname);
+		$this->featureContext->rememberUserDisplayName($username, $newDisplayname);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2033,9 +2033,19 @@ trait Provisioning {
 		];
 
 		if ($this->currentServer === 'LOCAL') {
-			$this->createdUsers[$user] = $userData;
+			// Only remember this user creation if it was expected to have been successful
+			// or the user has not been processed before. Some tests create a user the
+			// first time (successfully) and then purposely try to create the user again.
+			// The 2nd user creation is expected to fail, and in that case we want to
+			// still remember the details of the first user creation.
+			if ($shouldExist || !\array_key_exists($user, $this->createdUsers)) {
+				$this->createdUsers[$user] = $userData;
+			}
 		} elseif ($this->currentServer === 'REMOTE') {
-			$this->createdRemoteUsers[$user] = $userData;
+			// See comment above about the LOCAL case. The logic is the same for the remote case.
+			if ($shouldExist || !\array_key_exists($user, $this->createdRemoteUsers)) {
+				$this->createdRemoteUsers[$user] = $userData;
+			}
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -3986,15 +3986,11 @@ trait Provisioning {
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');
 		foreach ($this->createdUsers as $user => $userData) {
-			if (isset($userData["shouldExist"]) and $userData["shouldExist"]) {
-				$this->deleteUser($user);
-			}
+			$this->deleteUser($user);
 		}
 		$this->usingServer('REMOTE');
 		foreach ($this->createdRemoteUsers as $remoteUser => $userData) {
-			if (isset($userData["shouldExist"]) and $userData["shouldExist"]) {
-				$this->deleteUser($remoteUser);
-			}
+			$this->deleteUser($remoteUser);
 		}
 		$this->usingServer($previousServer);
 	}
@@ -4009,19 +4005,11 @@ trait Provisioning {
 		$previousServer = $this->currentServer;
 		$this->usingServer('LOCAL');
 		foreach ($this->createdGroups as $group => $groupData) {
-			if (isset($groupData["shouldExist"]) && $groupData["shouldExist"]
-				&& $groupData["possibleToDelete"]
-			) {
-				$this->cleanupGroup($group);
-			}
+			$this->cleanupGroup($group);
 		}
 		$this->usingServer('REMOTE');
 		foreach ($this->createdRemoteGroups as $remoteGroup => $groupData) {
-			if (isset($groupData["shouldExist"]) && $groupData["shouldExist"]
-				&& $groupData["possibleToDelete"]
-			) {
-				$this->cleanupGroup($remoteGroup);
-			}
+			$this->cleanupGroup($remoteGroup);
 		}
 		$this->usingServer($previousServer);
 	}

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -150,6 +150,70 @@ trait Provisioning {
 	}
 
 	/**
+	 * @param string $user
+	 * @param string $displayName
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function rememberUserDisplayName($user, $displayName) {
+		$user = $this->normalizeUsername($user);
+		if ($this->isAdminUsername($user)) {
+			$this->adminDisplayName = $displayName;
+		} else {
+			if ($this->currentServer === 'LOCAL') {
+				if (\array_key_exists($user, $this->createdUsers)) {
+					$this->createdUsers[$user]['displayname'] = $displayName;
+				} else {
+					throw new \Exception(
+						__METHOD__ . " tried to remember display name '$displayName' for non-existent local user '$user'"
+					);
+				}
+			} elseif ($this->currentServer === 'REMOTE') {
+				if (\array_key_exists($user, $this->createdRemoteUsers)) {
+					$this->createdRemoteUsers[$user]['displayname'] = $displayName;
+				} else {
+					throw new \Exception(
+						__METHOD__ . " tried to remember display name '$displayName' for non-existent remote user '$user'"
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @param string $user
+	 * @param string $emailAddress
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function rememberUserEmailAddress($user, $emailAddress) {
+		$user = $this->normalizeUsername($user);
+		if ($this->isAdminUsername($user)) {
+			$this->adminEmailAddress = $emailAddress;
+		} else {
+			if ($this->currentServer === 'LOCAL') {
+				if (\array_key_exists($user, $this->createdUsers)) {
+					$this->createdUsers[$user]['email'] = $emailAddress;
+				} else {
+					throw new \Exception(
+						__METHOD__ . " tried to remember email address '$emailAddress' for non-existent local user '$user'"
+					);
+				}
+			} elseif ($this->currentServer === 'REMOTE') {
+				if (\array_key_exists($user, $this->createdRemoteUsers)) {
+					$this->createdRemoteUsers[$user]['email'] = $emailAddress;
+				} else {
+					throw new \Exception(
+						__METHOD__ . " tried to remember email address '$emailAddress' for non-existent remote user '$user'"
+					);
+				}
+			}
+		}
+	}
+
+	/**
 	 * returns an array of the user display names, keyed by username
 	 * if no "Display Name" is set the user-name is returned instead
 	 *
@@ -1241,7 +1305,7 @@ trait Provisioning {
 			$this->getAdminPassword(),
 			$this->ocsApiVersion
 		);
-		$this->createdUsers[$user]["email"] = $email;
+		$this->rememberUserEmailAddress($user, $email);
 	}
 
 	/**
@@ -1314,7 +1378,7 @@ trait Provisioning {
 			$targetUser,
 			$email
 		);
-		$this->createdUsers[$targetUser]["email"] = $email;
+		$this->rememberUserEmailAddress($targetUser, $email);
 	}
 
 	/**
@@ -1337,7 +1401,7 @@ trait Provisioning {
 			$email
 		);
 		$this->theHTTPStatusCodeShouldBeSuccess();
-		$this->createdUsers[$targetUser]["email"] = $email;
+		$this->rememberUserEmailAddress($targetUser, $email);
 	}
 
 	/**
@@ -1350,41 +1414,41 @@ trait Provisioning {
 	 * @When /^the administrator changes the display name of user "([^"]*)" to "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
-	 * @param string $displayname
+	 * @param string $displayName
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
 	public function adminChangesTheDisplayNameOfUserUsingTheProvisioningApi(
-		$user, $displayname
+		$user, $displayName
 	) {
 		$user = $this->getActualUsername($user);
 		$this->adminChangesTheDisplayNameOfUserUsingKey(
-			$user, 'displayname', $displayname
+			$user, 'displayname', $displayName
 		);
-		$this->createdUsers[$user]["displayname"] = $displayname;
+		$this->rememberUserDisplayName($user, $displayName);
 	}
 
 	/**
 	 * @Given /^the administrator has changed the display name of user "([^"]*)" to "([^"]*)"$/
 	 *
 	 * @param string $user
-	 * @param string $displayname
+	 * @param string $displayName
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
 	public function adminHasChangedTheDisplayNameOfUser(
-		$user, $displayname
+		$user, $displayName
 	) {
 		$user = $this->getActualUsername($user);
 		if ($this->isTestingWithLdap()) {
 			$this->editLdapUserDisplayName(
-				$user, $displayname
+				$user, $displayName
 			);
 		} else {
 			$this->adminChangesTheDisplayNameOfUserUsingKey(
-				$user, 'displayname', $displayname
+				$user, 'displayname', $displayName
 			);
 		}
 		$response = UserHelper::getUser(
@@ -1394,8 +1458,8 @@ trait Provisioning {
 			$this->getAdminPassword()
 		);
 		$this->setResponse($response);
-		$this->theDisplayNameReturnedByTheApiShouldBe($displayname);
-		$this->createdUsers[$user]["displayname"] = $displayname;
+		$this->theDisplayNameReturnedByTheApiShouldBe($displayName);
+		$this->rememberUserDisplayName($user, $displayName);
 	}
 
 	/**
@@ -1408,38 +1472,38 @@ trait Provisioning {
 	 * @When /^the administrator changes the display of user "([^"]*)" to "([^"]*)" using the provisioning API$/
 	 *
 	 * @param string $user
-	 * @param string $displayname
+	 * @param string $displayName
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
 	public function adminChangesTheDisplayOfUserUsingTheProvisioningApi(
-		$user, $displayname
+		$user, $displayName
 	) {
 		$user = $this->getActualUsername($user);
 		$this->adminChangesTheDisplayNameOfUserUsingKey(
-			$user, 'display', $displayname
+			$user, 'display', $displayName
 		);
-		$this->createdUsers[$user]["displayname"] = $displayname;
+		$this->rememberUserDisplayName($user, $displayName);
 	}
 
 	/**
 	 *
 	 * @param string $user
 	 * @param string $key
-	 * @param string $displayname
+	 * @param string $displayName
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
 	public function adminChangesTheDisplayNameOfUserUsingKey(
-		$user, $key, $displayname
+		$user, $key, $displayName
 	) {
 		$result = UserHelper::editUser(
 			$this->getBaseUrl(),
 			$this->getActualUsername($user),
 			$key,
-			$displayname,
+			$displayName,
 			$this->getAdminUsername(),
 			$this->getAdminPassword(),
 			$this->ocsApiVersion
@@ -1476,7 +1540,7 @@ trait Provisioning {
 		$this->userChangesTheDisplayNameOfUserUsingKey(
 			$requestingUser, $targetUser, 'displayname', $displayName
 		);
-		$this->createdUsers[$targetUser]["displayname"] = $displayName;
+		$this->rememberUserDisplayName($targetUser, $displayName);
 	}
 
 	/**
@@ -1502,7 +1566,7 @@ trait Provisioning {
 		$this->userChangesTheDisplayNameOfUserUsingKey(
 			$requestingUser, $targetUser, 'display', $displayName
 		);
-		$this->createdUsers[$targetUser]["displayname"] = $displayName;
+		$this->rememberUserDisplayName($targetUser, $displayName);
 	}
 
 	/**
@@ -1523,7 +1587,7 @@ trait Provisioning {
 			$requestingUser, $targetUser, 'displayname', $displayName
 		);
 		$this->theHTTPStatusCodeShouldBeSuccess();
-		$this->createdUsers[$targetUser]["displayname"] = $displayName;
+		$this->rememberUserDisplayName($targetUser, $displayName);
 	}
 	/**
 	 *
@@ -3973,6 +4037,28 @@ trait Provisioning {
 		} else {
 			$this->cleanupDatabaseUsers();
 			$this->cleanupDatabaseGroups();
+			$this->resetAdminUserAttributes();
+		}
+	}
+
+	/**
+	 *
+	 * @return void
+	 */
+	public function resetAdminUserAttributes() {
+		if ($this->adminDisplayName !== '') {
+			$this->adminChangesTheDisplayNameOfUserUsingTheProvisioningApi(
+				$this->getAdminUsername(),
+				''
+			);
+		}
+		if ($this->adminEmailAddress !== '') {
+			// ToDo: set the admin email address back to empty
+			//       but see core issue 37424 - setting to empty is not working
+			$this->adminChangesTheEmailOfUserToUsingTheProvisioningApi(
+				$this->getAdminUsername(),
+				'test.admin@example.org'
+			);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2114,22 +2114,6 @@ trait Provisioning {
 	}
 
 	/**
-	 * @param string $user
-	 * @param string $key key for userData used in createdList
-	 * @param string $value value for update
-	 *
-	 * @return void
-	 */
-	public function updateUserInCreatedUsersList($user, $key, $value) {
-		$user = $this->normalizeUsername($user);
-		if ($this->currentServer === 'LOCAL') {
-			$this->createdUsers[$user][$key] = $value;
-		} elseif ($this->currentServer === 'REMOTE') {
-			$this->createdRemoteUsers[$user][$key] = $value;
-		}
-	}
-
-	/**
 	 * remember the password of a user that already exists so that you can use
 	 * ordinary test steps after changing their password.
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -155,8 +155,9 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 		$this->personalGeneralSettingsPage->changeFullname(
 			$newFullName, $this->getSession()
 		);
-		$this->featureContext->updateUserInCreatedUsersList(
-			$this->featureContext->getCurrentUser(), "displayname", $newFullName
+		$this->featureContext->rememberUserDisplayName(
+			$this->featureContext->getCurrentUser(),
+			$newFullName
 		);
 	}
 
@@ -188,8 +189,9 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 		$this->personalGeneralSettingsPage->changeEmailAddress(
 			$emailAddress, $this->getSession()
 		);
-		$this->featureContext->updateUserInCreatedUsersList(
-			$this->featureContext->getCurrentUser(), "email", $emailAddress
+		$this->featureContext->rememberUserEmailAddress(
+			$this->featureContext->getCurrentUser(),
+			$emailAddress
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -678,7 +678,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 */
 	public function theAdministratorChangesTheDisplayNameOfUserToUsingTheWebui($user, $displayName) {
 		$this->usersPage->setDisplayNameofUserTo($this->getSession(), $user, $displayName);
-		$this->featureContext->updateUserInCreatedUsersList($user, "displayname", $displayName);
+		$this->featureContext->rememberUserDisplayName($user, $displayName);
 	}
 
 	/**
@@ -730,7 +730,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		$this->usersPage->openAppSettingsMenu();
 		$this->usersPage->setSetting('Show email address');
 		$this->usersPage->changeUserEmail($this->getSession(), $username, $email);
-		$this->featureContext->updateUserInCreatedUsersList($username, "email", $email);
+		$this->featureContext->rememberUserEmailAddress($username, $email);
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) When a scenario tries to create a user twice, and the 2nd create is expected to fail, then do not remember the 2nd user create - keep the memory of the 1st successful user create. That makes sure that the relevant user attributes are remembered and that the actual existing user will get cleaned up in the after scenario.

2) Revert some extra checks in `cleanupDatabaseUsers` and `cleanupDatabaseGroups` that were short-circuiting some user and group cleanup at the end of a scenario. Even if a user or group is not expected to exist, we do want to attempt to clean it up (delete it), in case it did get accidentally created. The functions that do that already have logic so that they do not throw an exception if the delete fails but the user or group was not expected to exist anyway.

## Related Issue
Fixes #37423 

## How Has This Been Tested?
CI

In guests app:
```
 make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiGuests/guests.feature:197
 make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiGuests/guests.feature:204
```

Previously scenario at 197 would leave behind the guest user, and sccenario at 204 would fail because the user already exists.

With this change, they both pass. And at the end the guest user is correctly deleted.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
