### PR TITLE
Allow setting an empty email address or display name with user:modify

### DIFF
--- a/changelog/unreleased/37424-1
+++ b/changelog/unreleased/37424-1
@@ -1,0 +1,15 @@
+Bugfix: Allow clearing a user email address or display name
+
+The occ user:modify command would not allow the email or display name of a user
+to be cleared. This problem has been fixed.
+
+The email of a user can be cleared with:
+occ user:modify <username> email ''
+
+The display name of a user can be cleared with:
+occ user:modify <username> displayname ''
+
+And the effective display name reverts to the username.
+
+https://github.com/owncloud/core/issues/37424
+https://github.com/owncloud/core/pull/37425

--- a/core/Command/User/Modify.php
+++ b/core/Command/User/Modify.php
@@ -92,11 +92,6 @@ class Modify extends Base {
 		if (\in_array($input->getArgument('key'), $this->allowedKeys, true) === false) {
 			throw new \InvalidArgumentException('Supported keys are ' . \implode(', ', $this->allowedKeys));
 		}
-
-		$value = $input->getArgument('value');
-		if (($value === '') || ($value === null)) {
-			throw new \InvalidArgumentException('The value cannot be empty');
-		}
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
@@ -117,8 +112,8 @@ class Modify extends Base {
 			return 1;
 		}
 
-		if (($key === 'email') && ($value !== null) && ($value !== '')) {
-			if ($this->mailer->validateMailAddress($value) === true) {
+		if ($key === 'email') {
+			if (($value === '') || ($this->mailer->validateMailAddress($value) === true)) {
 				$user->setEMailAddress($value);
 				$output->writeln("The email address of $uid updated to $value");
 				return 0;
@@ -127,7 +122,7 @@ class Modify extends Base {
 			return 1;
 		}
 
-		if (($key === 'displayname') && ($value !== null) && ($value !== '')) {
+		if ($key === 'displayname') {
 			if ($user->setDisplayName($value) === true) {
 				$output->writeln('The displayname of ' . $uid . ' updated to ' . $value);
 				return 0;

--- a/tests/Core/Command/User/ModifyTest.php
+++ b/tests/Core/Command/User/ModifyTest.php
@@ -67,10 +67,6 @@ class ModifyTest extends TestCase {
 			[true, 'foo', null, '', 'The key cannot be empty'],
 			[true, 'foo', '', '', 'The key cannot be empty'],
 			[true, 'foo', 'test', '', 'Supported keys are displayname, email'],
-			[true, 'foo', 'displayname', '', 'The value cannot be empty'],
-			[true, 'foo', 'email', '', 'The value cannot be empty'],
-			[true, 'foo', 'email', null, 'The value cannot be empty'],
-			[true, 'foo', 'displayname', null, 'The value cannot be empty'],
 		];
 	}
 
@@ -139,7 +135,9 @@ class ModifyTest extends TestCase {
 	public function providerExecuteMethod() {
 		return [
 			['foo', 'displayname', 'foo123'],
+			['foo', 'displayname', ''],
 			['foo', 'email', 'foo@bar.com'],
+			['foo', 'email', ''],
 			['foo', 'email', 'foo@bar.com@foobar'], //Test for invalid email
 		];
 	}
@@ -170,10 +168,12 @@ class ModifyTest extends TestCase {
 				->method('setEMailAddress')
 				->with($value)
 				->willReturn(null);
-			$validateEmail = \OC::$server->getMailer()->validateMailAddress($value);
-			$this->mailer->expects($this->once())
-				->method('validateMailAddress')
-				->willReturn($validateEmail);
+			if ($value !== '') {
+				$validateEmail = \OC::$server->getMailer()->validateMailAddress($value);
+				$this->mailer->expects($this->once())
+					->method('validateMailAddress')
+					->willReturn($validateEmail);
+			}
 		} elseif ($key === 'displayname') {
 			$user->expects($this->once())
 				->method('setDisplayName')

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -13,6 +13,16 @@ Feature: edit users
     And the user attributes returned by the API should include
       | email | brand-new-user@example.com |
 
+  Scenario: the administrator can clear a user email
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
+    When the administrator changes the email of user "brand-new-user" to "''" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'The email address of brand-new-user updated to '
+    And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | email | |
+
   Scenario: the administrator can edit a user display name
     Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the occ command
@@ -21,6 +31,16 @@ Feature: edit users
     And user "brand-new-user" should exist
     And the user attributes returned by the API should include
       | displayname | A New User |
+
+  Scenario: the administrator can clear a user display name and then it defaults to the username
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And the administrator has changed the display name of user "brand-new-user" to "A New User"
+    When the administrator changes the display name of user "brand-new-user" to "" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'The displayname of brand-new-user updated to '
+    And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | displayname | brand-new-user |
 
   @issue-23603
   Scenario: the administrator can edit a user quota


### PR DESCRIPTION
## Description
`occ user:modify <username> email ''`
`occ user:modify <username> displayname ''`

would report that the value cannot be empty.

Actually if the email address or display name gets set somehow and needs to be cleared, then there is no real reason why it should not be cleared (back to the "default" on user creation, which is no special display name and no email address).

The code is adjusted so that the empty string is allowed in these cases.

## Related Issue
- part of #37424 

## How Has This Been Tested?
Local `occ user:modify` commands.

CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
