### PR TITLE
[Tests-Only] Test that displayname can be cleared using the Provisioning API

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -44,6 +44,14 @@ Feature: edit users
     And the OCS status code should be "100"
     And the display name of user "brand-new-user" should be "A New User"
 
+  Scenario: the administrator can clear a user display name and then it defaults to the username
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And the administrator has changed the display name of user "brand-new-user" to "A New User"
+    When the administrator changes the display name of user "brand-new-user" to "" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And the display name of user "brand-new-user" should be "brand-new-user"
+
   @smokeTest
   Scenario: the administrator can edit a user quota
     Given user "brand-new-user" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -44,6 +44,14 @@ Feature: edit users
     And the OCS status code should be "200"
     And the display name of user "brand-new-user" should be "A New User"
 
+  Scenario: the administrator can clear a user display name and then it defaults to the username
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And the administrator has changed the display name of user "brand-new-user" to "A New User"
+    When the administrator changes the display name of user "brand-new-user" to "" using the provisioning API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the display name of user "brand-new-user" should be "brand-new-user"
+
   @smokeTest
   Scenario: the administrator can edit a user quota
     Given user "brand-new-user" has been created with default attributes and skeleton files


### PR DESCRIPTION
## Description
The display name of a user can be cleared using the Provisioning API (and then it defaults back to being the username). Add a test scenario that covers this. That will ensure that there is no accidental regression of this.

Note: the `occ user:modify <username> displayname ''` command does not allow setting the display name to the empty string. See code and tests in PR #37425 for the fix for that.

## Related Issue
Noticed while looking into #37424 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
