### PR TITLE
Allow the email address to be cleared via the Provisioning API

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -310,8 +310,9 @@ class Users {
 				}
 				break;
 			case 'email':
-				if (\filter_var($parameters['_put']['value'], FILTER_VALIDATE_EMAIL)) {
-					$targetUser->setEMailAddress($parameters['_put']['value']);
+				$emailAddress = $parameters['_put']['value'];
+				if (($emailAddress === '') || \filter_var($emailAddress, FILTER_VALIDATE_EMAIL)) {
+					$targetUser->setEMailAddress($emailAddress);
 				} else {
 					return new Result(null, 102);
 				}

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -989,6 +989,31 @@ class UsersTest extends OriginalTest {
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'email', 'value' => 'demo@owncloud.org']]));
 	}
 
+	public function testEditUserRegularUserSelfEditClearEmail() {
+		$loggedInUser = $this->createMock(IUser::class);
+		$loggedInUser
+			->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('UserToEdit'));
+		$targetUser = $this->createMock(IUser::class);
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($loggedInUser));
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('UserToEdit')
+			->will($this->returnValue($targetUser));
+		$targetUser
+			->expects($this->once())
+			->method('setEMailAddress')
+			->with('');
+
+		$expected = new Result(null, 100);
+		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'email', 'value' => '']]));
+	}
+
 	public function testEditUserRegularUserSelfEditChangeEmailInvalid() {
 		$loggedInUser = $this->createMock(IUser::class);
 		$loggedInUser

--- a/changelog/unreleased/37424-2
+++ b/changelog/unreleased/37424-2
@@ -1,0 +1,8 @@
+Bugfix: Allow clearing a user email address with the Provisioning API
+
+Specifying the empty string as the email address is now valid when editing a
+user with the Provisioning API. This allows the email address of a user to be
+cleared.
+
+https://github.com/owncloud/core/issues/37424
+https://github.com/owncloud/core/pull/37427

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -62,6 +62,16 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
+  Scenario: the administrator can clear an existing user email
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    When the administrator changes the email of user "brand-new-user" to "" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the email address of user "brand-new-user" should be ""
+
   @smokeTest
   Scenario: a subadmin should be able to edit the user information in their group
     Given these users have been created with default attributes and skeleton files:

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -62,6 +62,16 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
+  Scenario: the administrator can clear an existing user email
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    When the administrator changes the email of user "brand-new-user" to "" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the email address of user "brand-new-user" should be ""
+
   @smokeTest
   Scenario: a subadmin should be able to edit the user information in their group
     Given these users have been created with default attributes and skeleton files:


### PR DESCRIPTION
## Description
The Provisioning API would not allow the email address of a user to be cleared (set to the empty string - see linked issue). This PR allows the email address to be set to the empty string, so that email addresses can be cleared by suitably-privileged users.

Note: this will also be handy to have for acceptance tests - it will be possible to easily and programmatically reset a test user email address back to its "default" value, which is "no email address"

## Related Issue
Part of #37424 

## How Has This Been Tested?
CI and local `curl` requests to the Provisioning API:
```
$ curl -X PUT http://phil:phil@172.17.0.1:8080/ocs/v2.php/cloud/users/phil -d key="email" -d value="abc@example.org"
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>200</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
$ php occ user:list -a email
  - admin: test.admin@example.org
  - phil: abc@example.org
$ curl -X PUT http://phil:phil@172.17.0.1:8080/ocs/v2.php/cloud/users/phil -d key="email" -d value=""
<?xml version="1.0"?>
<ocs>
 <meta>
  <status>ok</status>
  <statuscode>200</statuscode>
  <message/>
 </meta>
 <data/>
</ocs>
$ php occ user:list -a email
  - admin: test.admin@example.org
  - phil: 
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
