### PR TITLE
share manager should emit share.link auth events to catch all accesses

### DIFF
--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -182,13 +182,10 @@ class ShareController extends Controller {
 	 * @return bool
 	 */
 	private function linkShareAuth(\OCP\Share\IShare $share, $password = null) {
-		$beforeEvent = new GenericEvent(null, ['shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.beforelinkauth', $beforeEvent);
 		if ($password !== null) {
 			if ($this->shareManager->checkPassword($share, $password)) {
 				$this->session->set('public_link_authenticated', (string)$share->getId());
 			} else {
-				$this->emitAccessShareHook($share, 403, 'Wrong password');
 				return false;
 			}
 		} else {
@@ -198,8 +195,6 @@ class ShareController extends Controller {
 				return false;
 			}
 		}
-		$afterEvent = new GenericEvent(null, ['shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.afterlinkauth', $afterEvent);
 		return true;
 	}
 

--- a/changelog/unreleased/37430
+++ b/changelog/unreleased/37430
@@ -1,0 +1,6 @@
+Bugfix: Emit link share auth events on DAV access to password-protected links
+
+DAV access for the password-protected links was not emitting link share auth events that need to be emitted.
+This problem has been fixed.
+
+https://github.com/owncloud/core/pull/37430


### PR DESCRIPTION
## Description
Currently, WebDAV access for the password-protected public links is not emitting any link share auth events. These events are only emitted when ShareController used.

This PR moves link share auth events emitting logic to share manager to cover all access cases.
## Related Issue
- Discovered in here: https://github.com/owncloud/brute_force_protection/pull/123#issuecomment-630781876
- Partly related https://github.com/owncloud/admin_audit/issues/229

## How Has This Been Tested?
- The problem described in here fixed with this pr: https://github.com/owncloud/brute_force_protection/pull/123#issuecomment-630781876

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Changelog item