### PR TITLE
[Tests-Only] Fixes for scenarios where user should not be able to share resource using sharing API

### DIFF
--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
@@ -119,7 +119,7 @@ Feature: misc scenarios on sharing with internal users
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables exclude groups from sharing using the webUI
     And the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "Alice" should not be able to share folder "simple-folder" with user "Carol King" using the sharing API
+    Then user "Alice" should not be able to share folder "simple-folder" with user "Carol" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file received as a share
     Given these users have been created with default attributes and skeleton files:
@@ -136,7 +136,7 @@ Feature: misc scenarios on sharing with internal users
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "Alice" should not be able to share file "/testimage (2).jpg" with user "David Lopez" using the sharing API
+    Then user "Alice" should not be able to share file "/testimage (2).jpg" with user "David" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a folder received as a share
     Given these users have been created with default attributes and without skeleton files:
@@ -152,7 +152,7 @@ Feature: misc scenarios on sharing with internal users
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "Alice" should not be able to share folder "/common" with user "David Lopez" using the sharing API
+    Then user "Alice" should not be able to share folder "/common" with user "David" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file inside a folder received as a share
     Given these users have been created with default attributes and without skeleton files:
@@ -169,7 +169,7 @@ Feature: misc scenarios on sharing with internal users
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "Alice" should not be able to share file "/common/testimage.jpg" with user "David Lopez" using the sharing API
+    Then user "Alice" should not be able to share file "/common/testimage.jpg" with user "David" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a folder inside a folder received as a share
     Given these users have been created with default attributes and without skeleton files:
@@ -178,13 +178,15 @@ Feature: misc scenarios on sharing with internal users
       | Brian    |
       | Carol    |
       | David    |
+    And group "grp1" has been created
+    And user "Alice" has been added to group "grp1"
     And user "Carol" has created folder "/common"
     And user "Carol" has created folder "/common/inside-common"
     And user "Carol" has shared folder "/common" with user "Alice"
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
     When the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "Alice" should not be able to share folder "/common/inside-common" with user "David Lopez" using the sharing API
+    Then user "Alice" should not be able to share folder "/common/inside-common" with user "David" using the sharing API
 
   Scenario: user tries to share a file from a group which is blacklisted from sharing using webUI from files page
     Given group "grp1" has been created
@@ -215,7 +217,7 @@ Feature: misc scenarios on sharing with internal users
     And the user opens the sharing tab from the file action menu of file "testimage (2).jpg" using the webUI
     Then the user should see an error message on the share dialog saying "Sharing is not allowed"
     And the share-with field should not be visible in the details panel
-    And user "Alice" should not be able to share file "testimage (2).jpg" with user "Carol King" using the sharing API
+    And user "Alice" should not be able to share file "testimage (2).jpg" with user "Carol" using the sharing API
 
   @skipOnOcV10.3 @skipOnEncryptionType:user-keys @issue-encryption-126
   @mailhog


### PR DESCRIPTION
## Description
This PR replaces the `display names` of the targeted user with whom the share is to be created with actual `usernames` in the steps where a user should not be able to share some resource with another user using the sharing API

## Related Issue

## Motivation and Context
The steps where a user should not be able to share a resource with another user using the sharing API had been using the display name of the targeted user with whom the share is to be created, which passed but was not correct. These steps needed to use the username of the users.

## How Has This Been Tested?
-  locally
-  CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
