### PR TITLE
[Tests-Only] Clear admin email address in acceptance tests afterScenario

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -4037,11 +4037,9 @@ trait Provisioning {
 			);
 		}
 		if ($this->adminEmailAddress !== '') {
-			// ToDo: set the admin email address back to empty
-			//       but see core issue 37424 - setting to empty is not working
 			$this->adminChangesTheEmailOfUserToUsingTheProvisioningApi(
 				$this->getAdminUsername(),
-				'test.admin@example.org'
+				''
 			);
 		}
 	}


### PR DESCRIPTION
## Description
Issue #37424 has been fixed by PR #37427 

Now make use of that in acceptance tests. If an admin email address was set during a test scenario, then clear it at the end in the `afterScenario` code.

## Related Issue
- #37424 

## How Has This Been Tested?
- have a local admin account with no email address (the default)
- run this test scenario:
```
make test-acceptance-webui BEHAT_FEATURE=tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature:12
```
- check the admin account settings, personal, general
- the email address is empty - good
(previously an email address was being "left behind", which could effect later test scenarios)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
