### PR TITLE
[Tests-only] Use valid Depth values in tests

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -132,6 +132,10 @@ class WebDavHelper {
 			}
 			$propertyBody .= "<$namespacePrefix:$property/>";
 		}
+		$folderDepth = (string) $folderDepth;
+		if ($folderDepth !== '0' && $folderDepth !== '1' && $folderDepth !== 'infinity') {
+			throw new InvalidArgumentException('Invalid depth value ' . $folderDepth);
+		}
 		$headers = ['Depth' => $folderDepth];
 		$body = "<?xml version=\"1.0\"?>
 				<d:propfind

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -1142,7 +1142,7 @@ class TagsContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$this->featureContext->getPasswordForUser($user),
-			$fullPath, $properties, 'systemtags',
+			$fullPath, $properties, 1, 'systemtags',
 			$this->featureContext->getDavPathVersion('systemtags')
 		);
 		$this->featureContext->setResponse($response);

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1416,7 +1416,7 @@ trait WebDav {
 		$user, $elements, $expectedToBeListed = true
 	) {
 		$this->verifyTableNodeColumnsCount($elements, 1);
-		$responseXmlObject = $this->listFolder($user, "/", 5);
+		$responseXmlObject = $this->listFolder($user, "/", "infinity");
 		$elementRows = $elements->getRows();
 		$elementsSimplified = $this->simplifyArray($elementRows);
 		foreach ($elementsSimplified as $expectedElement) {


### PR DESCRIPTION
Added validation to prevent using invalid depths and causing failure
against OCIS servers.
Fixes occurrences of invalid depth values and used infinity instead.

Context: https://github.com/owncloud/ocis-reva/pull/221#issuecomment-632592440
