### PR TITLE
emit events for before-after-failed link password checks

### DIFF
--- a/changelog/unreleased/37438
+++ b/changelog/unreleased/37438
@@ -1,0 +1,6 @@
+Enhancement: Add 3 new events (before-fail-after) for share password validations
+
+'share.beforepasswordcheck', 'share.afterpasswordcheck' and 'share.failedpasswordcheck'
+events have been added for share password validations.
+
+https://github.com/owncloud/core/pull/37438


### PR DESCRIPTION
## Description
This PR adds 3 new events (before-fail-after) for link password validations. 

## Related Issue
- Discovered in here: https://github.com/owncloud/brute_force_protection/pull/123#issuecomment-630781876
- Partly related https://github.com/owncloud/admin_audit/issues/229
- Continuation of https://github.com/owncloud/core/pull/37430

## How Has This Been Tested?
- The problem described in here fixed with this pr: https://github.com/owncloud/brute_force_protection/pull/123#issuecomment-630781876

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Changelog item