### PR TITLE
[Tests-Only] Skip new tests for clearing display name and email when testing on old oC10

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -70,6 +70,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: the administrator can clear an existing user email
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -70,6 +70,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: the administrator can clear an existing user email
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -13,6 +13,7 @@ Feature: edit users
     And the user attributes returned by the API should include
       | email | brand-new-user@example.com |
 
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: the administrator can clear a user email
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
@@ -32,6 +33,7 @@ Feature: edit users
     And the user attributes returned by the API should include
       | displayname | A New User |
 
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: the administrator can clear a user display name and then it defaults to the username
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "A New User"


### PR DESCRIPTION
## Description
PRs #37425 and #37427 fix bugs related to clearing email address and display name using the Provisioning API or the `occ user:modify` command. Those tests will only pass on an ownCloud 10.5.0 or later system.

Skip them for 10.3 and 10.4 systems (which is a far back as we will run the current test suite).

I annoy myself by forgetting to put these skip tags in the original PRs!

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
