### PR TITLE
Set samesite=strict coockies - will work starting php 7.3

### DIFF
--- a/changelog/unreleased/37442
+++ b/changelog/unreleased/37442
@@ -1,0 +1,3 @@
+Change: Use strict samesite cookie
+
+https://github.com/owncloud/core/pull/37442

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -89,7 +89,21 @@ class CryptoWrapper {
 				if ($webRoot === '') {
 					$webRoot = '/';
 				}
-				\setcookie(self::COOKIE_NAME, $this->passphrase, 0, $webRoot, '', $secureCookie, true);
+
+				if (\version_compare(PHP_VERSION, '7.3.0') === -1) {
+					\setcookie(self::COOKIE_NAME, $this->passphrase, 0, $webRoot, '', $secureCookie, true);
+				} else {
+					$options = [
+						"expires" => 0,
+						"path" => $webRoot,
+						"domain" => '',
+						"secure" => $secureCookie,
+						"httponly" => true,
+						"samesite" => 'strict'
+					];
+
+					\setcookie(self::COOKIE_NAME, $this->passphrase, $options);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Starting with php7.3 samesite cookies can be set. This PR sets the session cookie to be samesite=stritc.

## Related Issue
https://github.com/owncloud/enterprise/issues/3890

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
