### PR TITLE
[Tests-Only] Collect unit test coverage for newer PHP versions

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -36,8 +36,7 @@ config = {
 			'databases': [
 				'sqlite',
 				'mariadb:10.2',
-			],
-			'coverage': False
+			]
 		},
 		'external-samba-windows' : {
 			'phpVersions': [


### PR DESCRIPTION
## Description
We have some code that runs differently depending on PHP version. If we collect the code coverage from running on the different PHP versions then we will get better coverage calculations, and PRs like #37422 might pass codecov.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
