### PR TITLE
Add additional caching in the RootCollection and SMB classes

### DIFF
--- a/apps/dav/lib/Files/RootCollection.php
+++ b/apps/dav/lib/Files/RootCollection.php
@@ -27,6 +27,8 @@ use Sabre\DAV\SimpleCollection;
 use Sabre\DAVACL\AbstractPrincipalCollection;
 
 class RootCollection extends AbstractPrincipalCollection {
+	/** @var INode[] [uid => INode]*/
+	private $cachedPrincipalRootNodes = [];
 
 	/**
 	 * This method returns a node for a principal.
@@ -41,11 +43,25 @@ class RootCollection extends AbstractPrincipalCollection {
 	public function getChildForPrincipal(array $principalInfo) {
 		list(, $name) = \Sabre\Uri\split($principalInfo['uri']);
 		$user = \OC::$server->getUserSession()->getUser();
-		if ($user === null || $name !== $user->getUID()) {
+
+		$uid = '';
+		if ($user !== null) {
+			$uid = $user->getUID();
+		}
+
+		if (isset($this->cachedPrincipalRootNodes[$uid])) {
+			// $user = null will be automatically converted to an empty string
+			// when it's stored as an array key. There won't be a valid user with
+			// an empty string as uid
+			return $this->cachedPrincipalRootNodes[$uid];
+		}
+
+		if ($uid === '' || $name !== $uid) {
 			// a user is only allowed to see their own home contents, so in case another collection
 			// is accessed, we return a simple empty collection for now
 			// in the future this could be considered to be used for accessing shared files
-			return new SimpleCollection($name);
+			$this->cachedPrincipalRootNodes[$uid] = new SimpleCollection($name);
+			return $this->cachedPrincipalRootNodes[$uid];
 		}
 		$home = new FilesHome($principalInfo);
 		$view = \OC\Files\Filesystem::getView();
@@ -54,8 +70,9 @@ class RootCollection extends AbstractPrincipalCollection {
 			$rootNode = new Directory($view, $rootInfo, $home);
 			$home->init($rootNode, $view, \OC::$server->getMountManager());
 		}
+		$this->cachedPrincipalRootNodes[$uid] = $home;
 
-		return $home;
+		return $this->cachedPrincipalRootNodes[$uid];
 	}
 
 	public function getName() {

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -223,6 +223,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 			$result = [];
 			$children = $this->share->dir($path);
 			foreach ($children as $fileInfo) {
+				$fullPath = "{$path}/{$fileInfo->getName()}";
+				if (isset($this->statCache[$fullPath])) {
+					// reference in the cache might have its fileinfo's mode
+					// already resolved, so use that
+					$fileInfo = $this->statCache[$fullPath];
+				}
 				// check if the file is readable before adding it to the list
 				// can't use "isReadable" function here, use smb internals instead
 				try {
@@ -231,7 +237,7 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 					} else {
 						$result[] = $fileInfo;
 						//remember entry so we can answer file_exists and filetype without a full stat
-						$this->statCache[$path . '/' . $fileInfo->getName()] = $fileInfo;
+						$this->statCache[$fullPath] = $fileInfo;
 					}
 				} catch (NotFoundException $e) {
 					$this->swallow(__FUNCTION__, $e);

--- a/changelog/unreleased/37451
+++ b/changelog/unreleased/37451
@@ -1,0 +1,6 @@
+Enhancement: Boost performance of external storages
+
+We've cached some additional information that will boost the performance of
+external storages. This boost will be particularly noticeable for SMB connections
+
+https://github.com/owncloud/core/pull/37451


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Optimize access to the SMB storage. The focus has been to optimize the usage of the `opendir` in the SMB storage because there were several calls to the `opendir` method:
* The SMB's `opendir` method was overriding the class cache. This was a problem because the `FileInfo` objects has an internal cache for the dos mode. By overriding the cache, we were forced to request again the dos mode to the external SMB server.
  Now we're checking the cache and prioritize that information, which should have the dos mode already cached.
* Several instances of the `FilesHome` object were being created. This was likely disturbing the caching mechanism in the dav layer, causing additional calls to the backend (at least one additional call to the `opendir` method in the SMB backend)
  Now we're returning the same node instance when asked in order to reuse the cache mechanism.

With these changes, it's expected to have only 2 calls to the SMB's `opendir` method. These 2 calls come from the automatic scan that happen when we get the cache entry (the first one), and when we actually ask for the folder contents (the second one).

## Related Issue
https://github.com/owncloud/enterprise/issues/4007

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually checking the curl timings. The following results come from the same local environment using 4e04c49174b2739a68a8016ce95f06b5d502a874 (current master) as base.
```
----without any change-----
curl -w "@curl-timing-format.txt" -o /dev/null -s -X PROPFIND -u admin:admin 'http://10.0.2.27:6080/remote.php/dav/files/admin/SMB/'
         time_total:  0,389524
         time_total:  0,359545
         time_total:  0,368743
         time_total:  0,354103
         time_total:  0,370374
         time_total:  0,371718
         time_total:  0,343153
         time_total:  0,342084

-------------------------------------
----with just the change in the SMB.php file----
curl -w "@curl-timing-format.txt" -o /dev/null -s -X PROPFIND -u admin:admin 'http://10.0.2.27:6080/remote.php/dav/files/admin/SMB/'
         time_total:  0,324680
         time_total:  0,344775
         time_total:  0,333347
         time_total:  0,333059
         time_total:  0,357924
         time_total:  0,327403
         time_total:  0,304593
         time_total:  0,327727
         time_total:  0,329288

-------------------------------------
----with the whole PR----
juan@juan-VirtualBox:~$ curl -w "@curl-timing-format.txt" -o /dev/null -s -X PROPFIND -u admin:admin 'http://10.0.2.27:6080/remote.php/dav/files/admin/SMB/'
         time_total:  0,283274
         time_total:  0,270603
         time_total:  0,277665
         time_total:  0,281935
         time_total:  0,303008
         time_total:  0,287516
         time_total:  0,264756
         time_total:  0,282469
         time_total:  0,425668
         time_total:  0,278654
         time_total:  0,283069

```
The performance improvement should be noticeable for the SMB connection. Other backends should also get some benefit due to the cache in the RootCollection.php file, although not tested.

## Screenshots (if appropriate):

Number of calls before this PR:
![Screenshot from 2020-05-26 18-05-20](https://user-images.githubusercontent.com/1477829/82923843-cc8fee80-9f7b-11ea-9ba9-25a03d3e81f0.png)

Number of class after this PR:
![Screenshot from 2020-05-26 18-05-57](https://user-images.githubusercontent.com/1477829/82923928-e8939000-9f7b-11ea-8643-ad2d694e928a.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
