### PR TITLE
Fix logging when logger has no writeExtra method

### DIFF
--- a/changelog/unreleased/37453
+++ b/changelog/unreleased/37453
@@ -1,0 +1,10 @@
+Bugfix: Logging of extra fields when logger does not have a writeExtra method
+
+If a logger in use does not have a writeExtra method then an error message would
+be generated when a log entry with extra data happens.
+
+This problem has been corrected. In this case the basic log information will be
+written without the extra data.
+
+https://github.com/owncloud/core/issues/37453
+https://github.com/owncloud/core/pull/37454

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -394,7 +394,7 @@ class Log implements ILogger {
 		if ($level >= $minLevel) {
 			$logger = $this->logger;
 			// check if logger supports extra fields
-			if (!empty($extraFields) && \is_callable($logger, 'writeExtra')) {
+			if (!empty($extraFields) && \is_callable([$logger, 'writeExtra'])) {
 				\call_user_func([$logger, 'writeExtra'], $app, $formattedMessage, $level, $logConditionFile, $extraFields);
 			} else {
 				\call_user_func([$logger, 'write'], $app, $formattedMessage, $level, $logConditionFile);

--- a/tests/lib/LoggerWithoutWriteExtraTest.php
+++ b/tests/lib/LoggerWithoutWriteExtraTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright (c) 2020 Phil Davis <phil@jankaritech.com>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test;
+
+use OC\Log;
+use OCP\IConfig;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class LoggerWithoutWriteExtraTest extends TestCase {
+	/** @var \OCP\ILogger */
+	private $logger;
+	private static $logs = [];
+
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
+	private $config;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		self::$logs = [];
+		$this->config = $this->getMockBuilder(
+			'\OC\SystemConfig')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->logger = new Log(
+			'Test\LoggerWithoutWriteExtraTest',
+			$this->config,
+			null,
+			new EventDispatcher()
+		);
+	}
+
+	private function getLogs() {
+		return self::$logs;
+	}
+
+	public static function write($app, $message, $level) {
+		self::$logs[]= "$level $message";
+	}
+
+	public function testExtraFields() {
+		$extraFields = [
+			'one' => 'un',
+			'two' => 'deux',
+			'three' => 'trois',
+		];
+
+		// with extra fields but logger class has no "writeExtra" method, calls "write"
+		// the extra fields to not end up anywhere (ignored)
+		$this->logger->info(
+			'extra fields test', [
+				'extraFields' => $extraFields
+			]
+		);
+
+		// without fields calls "write" always
+		$this->logger->info('no fields');
+
+		$logLines = $this->getLogs();
+
+		$this->assertEquals('1 extra fields test', $logLines[0]);
+		$this->assertEquals('1 no fields', $logLines[1]);
+	}
+}


### PR DESCRIPTION
## Description
- Correct the call to `\is_callable` - the first parameter should be an array whose entries are the object concerned and the name of the hoped-for method in the object.
- Add a unit test

## Related Issue
- Fixes #37453 

## How Has This Been Tested?
`LoggerWithoutWriteExtraTest.php` is a cut-down version of `LoggerTest.php` that does not have a `writeExtra` method, and just has the relevant test case.

Without the fix in ` lib/private/Log.php` the test fails:
```
PHPUnit 8.5.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.6 with Xdebug 2.9.5
Configuration: /home/phil/git/owncloud/core/tests/phpunit-autotest.xml

E                                                                   1 / 1 (100%)

Time: 110 ms, Memory: 24.00 MB

There was 1 error:

1) Test\LoggerWithoutWriteExtraTest::testExtraFields
call_user_func() expects parameter 1 to be a valid callback, class 'Test\LoggerWithoutWriteExtraTest' does not have a method 'writeExtra'

/home/phil/git/owncloud/core/lib/private/Log.php:398
/home/phil/git/owncloud/core/lib/private/Log.php:247
/home/phil/git/owncloud/core/tests/lib/LoggerWithoutWriteExtraTest.php:59

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
Makefile:189: recipe for target 'test-php-unit' failed
make: *** [test-php-unit] Error 2
```

That reproduces the error reported in the issue.

With the fix, the test passes.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
