### PR TITLE
config.php contents won't be overwritten by other files

### DIFF
--- a/changelog/unreleased/37455
+++ b/changelog/unreleased/37455
@@ -1,0 +1,11 @@
+Change: Prioritize config.php file over other configurations
+
+Previously, in case there were several configuration files, all those files
+were merged into one. If there were duplicated configuration keys, the values
+were overwritten.
+
+Now, the files are merged the same way, but if there are duplicated configuration
+keys, they won't be overwritten. This means that the config.php contents will
+always be present.
+
+https://github.com/owncloud/core/pull/37455

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -219,7 +219,13 @@ class Config {
 	/**
 	 * Loads the config file
 	 *
-	 * Reads the config file and saves it to the cache
+	 * Reads the config file and saves it to the cache.
+	 * In case of multiple cofiguration files, the contents will be mixed. In case of
+	 * duplicated keys, the keys won't be overwritten
+	 * The files will be loaded using "natural order", except for the "config.php" file.
+	 * (see https://www.php.net/manual/en/function.natsort.php)
+	 * "config.php" file will always loaded first. This means that the contents of the
+	 * "config.php" file will win over the rest of the files.
 	 *
 	 * @throws \Exception If no lock could be acquired or the config file has not been found
 	 */
@@ -253,7 +259,7 @@ class Config {
 			unset($CONFIG);
 			include $file;
 			if (isset($CONFIG) && \is_array($CONFIG)) {
-				$this->cache = \array_merge($this->cache, $CONFIG);
+				$this->cache = $this->cache + $CONFIG;  // merge but don't override
 			}
 
 			// Close the file pointer and release the lock


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Ensure config.php takes priority over other config files

## Related Issue
https://github.com/owncloud/enterprise/issues/3775#issuecomment-633996000

## Motivation and Context
If there are multiple configuration files, changing the config.php file doesn't guarantee the change will take effect.

## How Has This Been Tested?
Checked manually. The contents of the config.php takes priority over other config files that could be in the config directory.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
