### PR TITLE
[Tests-Only] Remove old unsupported .codecov.yml ci section settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,3 @@
 codecov:
   ci:
     - drone.owncloud.com
-    - !jenkins.owncloud.org
-    - !travisci


### PR DESCRIPTION
## Description
codecov advised:

--------------------------------

Hi Phil,
​
I did a little digging here and I noticed that your yaml is invalid. Unfortunately, we don't support ! in the ci section.
​
I'm not sure if this will fix your issue, but I think it'll get us closer to resolving. Would you be able to change this and see if we are still getting the issue?

Ticket: https://codecov.freshdesk.com/helpdesk/tickets/3244

Best,
Tom

--------------------------------

We can remove these anyway, because we do not have any Jenkins or TravisCI jobs running regularly for core repo any more anyway.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
