### PR TITLE
Add file action to explicitly lock a file

### DIFF
--- a/apps/dav/lib/Connector/Sabre/PublicDavLocksPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/PublicDavLocksPlugin.php
@@ -22,6 +22,7 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use Sabre\DAV\Locks\Backend\BackendInterface;
+use Sabre\DAV\Locks\LockInfo;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\INode;
 use Sabre\DAV\Exception\MethodNotAllowed;
@@ -84,5 +85,19 @@ class PublicDavLocksPlugin extends \Sabre\DAV\Locks\Plugin {
 		} else {
 			throw new MethodNotAllowed('Locking not allowed from public endpoint');
 		}
+	}
+
+	/**
+	 * Generates the response for successful LOCK requests.
+	 * @todo this method can be removed once upstream released a new version with this fix https://github.com/sabre-io/dav/pull/1273
+	 *
+	 * @return string
+	 */
+	protected function generateLockResponse(LockInfo $lockInfo) {
+		$contextUri = $this->server->getBaseUri();
+
+		return $this->server->xml->write('{DAV:}prop', [
+			'{DAV:}lockdiscovery' => new LockDiscovery([$lockInfo]),
+		], $contextUri);
 	}
 }

--- a/apps/files/js/locktabview.js
+++ b/apps/files/js/locktabview.js
@@ -62,7 +62,6 @@
 				var self = this;
 				var $target = $(event.target).closest('.lock-entry');
 				var lockIndex = parseInt($target.attr('data-index'), 10);
-
 				var currentLock = this.model.get('activeLocks')[lockIndex];
 
 				// FIXME: move to FileInfoModel
@@ -75,7 +74,6 @@
 							// implicit clone of array else backbone doesn't fire change event
 							var locks = _.without(self.model.get('activeLocks') || [], currentLock);
 							self.model.set('activeLocks', locks);
-							self.render();
 						}
 						else if (result.status === 403) {
 							OC.Notification.show(t('files', 'Could not unlock, please contact the lock owner {owner}', {owner: currentLock.owner}));
@@ -121,7 +119,21 @@
 			canDisplay: function(fileInfo) {
 				// don't display if no lock is set
 				return fileInfo && fileInfo.get('activeLocks') && fileInfo.get('activeLocks').length > 0;
-			}
+			},
+
+			setFileInfo: function(fileInfo) {
+				if (this.model !== fileInfo) {
+					this.model = fileInfo;
+					this.render();
+					if (fileInfo) {
+						const self = this;
+						this.model.on('change', function(data) {
+							self.render();
+						});
+					}
+				}
+			},
+
 		});
 
 	OCA.Files.LockTabView = LockTabView;

--- a/apps/files/lib/App.php
+++ b/apps/files/lib/App.php
@@ -44,13 +44,17 @@ class App {
 	}
 
 	public static function extendJsConfig($array) {
-		$maxChunkSize = (int)(\OC::$server->getConfig()->getAppValue('files', 'max_chunk_size', (10 * 1024 * 1024)));
-		$uploadStallTimeout = (int)(\OC::$server->getConfig()->getAppValue('files', 'upload_stall_timeout', 60)); // in seconds
-		$uploadStallRetries = (int)(\OC::$server->getConfig()->getAppValue('files', 'upload_stall_retries', 100));
+		$config = \OC::$server->getConfig();
+		$maxChunkSize = (int)($config->getAppValue('files', 'max_chunk_size', (10 * 1024 * 1024)));
+		$uploadStallTimeout = (int)($config->getAppValue('files', 'upload_stall_timeout', 60)); // in seconds
+		$uploadStallRetries = (int)($config->getAppValue('files', 'upload_stall_retries', 100));
+		$enableLockFileAction = (boolean)($config->getAppValue('files', 'enable_lock_file_action', false));
+
 		$array['array']['oc_appconfig']['files'] = [
 			'max_chunk_size' => $maxChunkSize,
 			'upload_stall_timeout' => $uploadStallTimeout,
-			'upload_stall_retries' => $uploadStallRetries
+			'upload_stall_retries' => $uploadStallRetries,
+			'enable_lock_file_action' => $enableLockFileAction
 		];
 	}
 }

--- a/apps/files/tests/js/filelockpluginSpec.js
+++ b/apps/files/tests/js/filelockpluginSpec.js
@@ -16,6 +16,9 @@ describe('OCA.Files.LockPlugin tests', function() {
 	var currentUserStub;
 
 	beforeEach(function() {
+		oc_appconfig = oc_appconfig || {};
+		oc_appconfig.files = oc_appconfig.files || {};
+		oc_appconfig.files.enable_lock_file_action = true;
 		var $content = $('<div id="content"></div>');
 		$('#testArea').append($content);
 		// dummy file list
@@ -134,8 +137,8 @@ describe('OCA.Files.LockPlugin tests', function() {
 			requestDeferred = new $.Deferred();
 			requestStub = sinon.stub(dav.Client.prototype, 'propFind').returns(requestDeferred.promise());
 		});
-		afterEach(function() { 
-			requestStub.restore(); 
+		afterEach(function() {
+			requestStub.restore();
 		});
 
 		function makeLockXml(owner) {
@@ -186,7 +189,7 @@ describe('OCA.Files.LockPlugin tests', function() {
 
 			return xml;
 		}
-		
+
 		it('parses lock information from response XML to JSON', function(done) {
 			var xml = dav.Client.prototype.parseMultiStatus(makeLockXml('lock owner'));
 			var promise = fileList.reload();

--- a/changelog/unreleased/37460
+++ b/changelog/unreleased/37460
@@ -1,0 +1,3 @@
+Change: Add file action to lock a file
+
+https://github.com/owncloud/core/pull/37460

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -763,6 +763,43 @@
 			return promise;
 		},
 
+		lock: function(path, options) {
+			if (!path) {
+				throw 'Missing argument "path"';
+			}
+			var self = this;
+			var deferred = $.Deferred();
+			var promise = deferred.promise();
+
+			options = _.extend({
+				'pathIsUrl' : false
+			}, options);
+
+			const lockBody = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+				"<d:lockinfo xmlns:d='DAV:'>\n" +
+				"	<d:lockscope>\n" +
+				"		<d:exclusive/>\n" +
+				"	</d:lockscope>\n" +
+				"</d:lockinfo>\n";
+
+			this._client.request(
+				'LOCK',
+				options.pathIsUrl ? path : this._buildUrl(path),
+				{},
+				lockBody
+			).then(
+				function(result) {
+					if (self._isSuccessStatus(result.status)) {
+						deferred.resolve(result.status, result);
+					} else {
+						result = _.extend(result, self._getSabreException(result));
+						deferred.reject(result.status, result);
+					}
+				}
+			);
+			return promise;
+		},
+
 		/**
 		 * Creates a directory
 		 *


### PR DESCRIPTION
## Description
A new file action to lock a file/folder will be added with this PR.

## Related Issue
https://github.com/owncloud/enterprise/issues/3131

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):
![Screenshot from 2020-05-28 16-03-15](https://user-images.githubusercontent.com/1005065/83151382-c70de200-a0fc-11ea-9de8-a56de619f0c0.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
