### PR TITLE
[Tests-only] Adjust issue numbers for reshares

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-233
 Feature: reshare as public link
   As a user
   I want to create public link shares from files/folders shared with me

--- a/tests/acceptance/features/apiShareReshare2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareChain.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-233
 Feature: resharing can be done on a reshared resource
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareDisabled.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-233
 Feature: resharing can be disabled
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareSubfolder.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-233
 Feature: a subfolder of a received share can be reshared
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-233 @issue-ocis-reva-194
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareWithExpiryDate.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-233
 Feature: resharing a resource with an expiration date
 
   Background:
@@ -27,7 +27,7 @@ Feature: resharing a resource with an expiration date
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: User should be able to set expiration while resharing a file with group
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -77,7 +77,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API with expire days set and combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -130,7 +130,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API without expire days set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -184,7 +184,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 | 100             |
       | 2               | no                  | yes                 | 200             |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API with expire days set and with combinations of default/enforce expire date enabled and specify expire date in share
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -236,7 +236,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 | 100             |
       | 2               | no                  | yes                 | 200             |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: resharing group share with user using the sharing API with default expire date set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -264,7 +264,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: resharing group share with user using the sharing API with default expire date set and specifying expiration on share and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-233
 Feature: sharing
 
   Background:
@@ -25,6 +25,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: keep group permissions in sync
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and skeleton files
@@ -56,6 +57,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: Cannot set permissions to zero
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -88,6 +90,7 @@ Feature: sharing
       | 1               | 200              | create,delete |
       | 2               | 400              | create,delete |
 
+  @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: Cannot update a share of a file with a group to have only create and/or delete permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -170,6 +173,7 @@ Feature: sharing
     And as "Alice" folder "/Alice-folder/folder2" should not exist
     And as "Carol" folder "/Carol-folder/folder2" should exist
 
+  @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -190,6 +194,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: Forbid sharing with groups
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -202,6 +207,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
+  @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: Editing share permission of existing share is forbidden when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -227,6 +233,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 400              |
 
+  @skipOnOcis @issue-ocis-reva-194
   Scenario Outline: Deleting group share is allowed when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-194
 Feature: updating shares to users and groups that have the same name
 
   Background:


### PR DESCRIPTION
Many [public link tests](https://github.com/owncloud/ocis-reva/issues/49) were wrongly marked as such but are actually
either:
- issues with reshares, [ocis-reva-233](https://github.com/owncloud/ocis-reva/issues/233)
- issues with group shares, [ocis-reva-194](https://github.com/owncloud/ocis-reva/issues/194)

This commits adjusts the tags accordingly.
