### PR TITLE
[Tests-only] Get content-length response header of an image and a pdf

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -92,3 +92,57 @@ Feature: download file
     When user "Alice" gets the size of file "test-file.txt" using the WebDAV API
     Then the HTTP status code should be "207"
     And the size of the file should be "19"
+
+  @issue-ocis-296 @skipOnOcis
+  Scenario Outline: Get the content-length response header of a pdf file
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/simple.pdf" to "/simple.pdf"
+    When user "Alice" downloads file "/simple.pdf" using the WebDAV API
+    Then the following headers should be set
+      | header           | value   |
+      | Content-Length   | 9622    |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @issue-ocis-296 @skipOnOcV10
+  #after fixing the issues delete this Scenario and use the one above
+  Scenario Outline: Get the content-length response header of a pdf file
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/simple.pdf" to "/simple.pdf"
+    When user "Alice" downloads file "/simple.pdf" using the WebDAV API
+    Then the following headers should not be set
+      | header             |
+      | Content-Length     |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @issue-ocis-296 @skipOnOcis
+  Scenario Outline: Get the content-length response header of an image file
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/testavatar.png" to "/testavatar.png"
+    When user "Alice" downloads file "/testavatar.png" using the WebDAV API
+    Then the following headers should be set
+      | header             | value  |
+      | Content-Length     | 35323  |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @issue-ocis-296 @skipOnOcV10
+  #after fixing the issues delete this Scenario and use the one above
+  Scenario Outline: Get the content-length response header of an image file
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/testavatar.png" to "/testavatar.png"
+    When user "Alice" downloads file "/testavatar.png" using the WebDAV API
+    Then the following headers should not be set
+      | header             |
+      | Content-Length     |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds acceptance test to get `Content-Length` header of an image and a pdf file.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/296

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- https://github.com/owncloud/ocis-reva/pull/234
- https://github.com/owncloud/ocis/pull/297
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
