### PR TITLE
[Tests-Only] Add PHPdoc for possible null return values of IRequest methods

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -288,7 +288,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * This method returns null if the header did not exist.
 	 *
 	 * @param string $name
-	 * @return string
+	 * @return string|null
 	 */
 	public function getHeader($name) {
 		$name = \strtoupper(\str_replace(['-'], ['_'], $name));
@@ -350,7 +350,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	/**
 	 * Shortcut for accessing an uploaded file through the $_FILES array
 	 * @param string $key the key that will be taken from the $_FILES array
-	 * @return array the file in the $_FILES element
+	 * @return array|null the file in the $_FILES element
 	 */
 	public function getUploadedFile($key) {
 		return isset($this->files[$key]) ? $this->files[$key] : null;
@@ -359,7 +359,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	/**
 	 * Shortcut for getting env variables
 	 * @param string $key the key that will be taken from the $_ENV array
-	 * @return array the value in the $_ENV element
+	 * @return array|null the value in the $_ENV element
 	 */
 	public function getEnv($key) {
 		return isset($this->env[$key]) ? $this->env[$key] : null;
@@ -368,7 +368,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	/**
 	 * Shortcut for getting cookie variables
 	 * @param string $key the key that will be taken from the $_COOKIE array
-	 * @return string the value in the $_COOKIE element
+	 * @return string|null the value in the $_COOKIE element
 	 */
 	public function getCookie($key) {
 		return isset($this->cookies[$key]) ? $this->cookies[$key] : null;

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -65,7 +65,7 @@ interface IRequest {
 	/**
 	 * @param string $name
 	 *
-	 * @return string
+	 * @return string|null
 	 * @since 6.0.0
 	 */
 	public function getHeader($name);
@@ -108,7 +108,7 @@ interface IRequest {
 	 * Shortcut for accessing an uploaded file through the $_FILES array
 	 *
 	 * @param string $key the key that will be taken from the $_FILES array
-	 * @return array the file in the $_FILES element
+	 * @return array|null the file in the $_FILES element
 	 * @since 6.0.0
 	 */
 	public function getUploadedFile($key);
@@ -117,7 +117,7 @@ interface IRequest {
 	 * Shortcut for getting env variables
 	 *
 	 * @param string $key the key that will be taken from the $_ENV array
-	 * @return array the value in the $_ENV element
+	 * @return array|null the value in the $_ENV element
 	 * @since 6.0.0
 	 */
 	public function getEnv($key);
@@ -126,7 +126,7 @@ interface IRequest {
 	 * Shortcut for getting cookie variables
 	 *
 	 * @param string $key the key that will be taken from the $_COOKIE array
-	 * @return string the value in the $_COOKIE element
+	 * @return string|null the value in the $_COOKIE element
 	 * @since 6.0.0
 	 */
 	public function getCookie($key);


### PR DESCRIPTION
## Description
Some methods in `IRequest` can return `null` if the related information does not exist in the request. But those are not documented in the PHP doc. That is causing `phpstan` in some apps to complain about code that calls these methods and then, for example, compares the return value to `null`.

Add the possibility of `null` return value to the PHP doc.

I put `[Tests-Only]` on this PR because it really only effects code-analysis tools, not actual PHP production run-time. So IMO a changelog is not needed.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
