### PR TITLE
Bump version 10.5.0beta2 in version.php

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 5, 0, 1];
+$OC_Version = [10, 5, 0, 2];
 
 // The human readable string
-$OC_VersionString = '10.5.0beta1';
+$OC_VersionString = '10.5.0beta2';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
We have succeeded with beta1 which serves as a technical exercise for the changed process. 

@phil-davis @micbar Let's roll a more useful (content-wise) beta2 -- I assume today's master is good? 
