### PR TITLE
[Tests-only] Get webdav share-permissions for owned file

### DIFF
--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-47
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @issue-ocis-reva-47
 Feature: sharing
 
   Background:
@@ -8,7 +8,7 @@ Feature: sharing
       | Alice    |
       | Brian    |
 
-  @smokeTest
+  @smokeTest @skipOnOcis @issue-ocis-reva-47
   Scenario Outline: Correct webdav share-permissions for owned file
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -21,6 +21,21 @@ Feature: sharing
       | old      |
       | new      |
 
+  @issue-ocis-reva-47 @skipOnOcV10
+  #after fixing the issues delete this Scenario and use the one above
+  Scenario Outline: Empty webdav share-permissions for owned file
+    Given using <dav-path> DAV path
+    And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
+    When user "Alice" gets the following properties of file "/tmp.txt" using the WebDAV API
+      | propertyName          |
+      | ocs:share-permissions |
+    Then the single response should contain a property "ocs:share-permissions" with value ""
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received file with edit and reshare permissions
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -34,6 +49,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received group shared file with edit and reshare permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -53,6 +69,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -65,6 +82,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received group shared file with edit permissions but no reshare permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -84,6 +102,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -96,6 +115,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received group shared file with reshare permissions but no edit permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -115,6 +135,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for owned folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -127,6 +148,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -140,6 +162,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -158,6 +181,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but edit
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -170,6 +194,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but edit
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -189,6 +214,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but create
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -201,6 +227,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but create
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -220,6 +247,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but delete
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -232,6 +260,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but delete
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -251,6 +280,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but share
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -263,6 +293,7 @@ Feature: sharing
       | old      |
       | new      |
 
+  @skipOnOcis
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but share
     Given using <dav-path> DAV path
     And group "grp1" has been created


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds test to get webdav share-permissions for owned file. `ocs:share-permissions` is returned empty in case of `ocis` and this PR verifies that.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis-reva/issues/47

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- https://github.com/owncloud/ocis/pull/302
- https://github.com/owncloud/ocis-reva/pull/242

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
