### PR TITLE
[Tests-only] Improve error message when XML is expected

### DIFF
--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -334,7 +334,16 @@ class HttpRequestHelper {
 	public static function getResponseXml($response) {
 		// rewind just to make sure we can re-parse it in case it was parsed already...
 		$response->getBody()->rewind();
-		return new SimpleXMLElement($response->getBody()->getContents());
+		$contents = $response->getBody()->getContents();
+		try {
+			return new SimpleXMLElement($contents);
+		} catch (\Exception $e) {
+			if ($contents === '') {
+				throw new \Exception("Received empty response where XML was expected");
+			}
+			$message = "Exception parsing response body: \"" . $contents . "\"";
+			throw new \Exception($message, 0, $e);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Whenever we expect an XML response, throw a more clear exception.
In case the body is malformed, embed it in the exception message to get
it in the test output.
