### PR TITLE
[Tests-only] Throw exception when missing env vars for skeleton

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2307,7 +2307,7 @@ trait Provisioning {
 						if (!$skeletonDir) {
 							throw new Exception('Missing SKELETON_DIR environment variable, cannot copy skeleton files');
 						}
-						if (!$revaRoot) {
+						if (!$revaRoot && OcisHelper::isTestingOnOcis()) {
 							throw new Exception('Missing OCIS_REVA_DATA_ROOT environment variable, cannot copy skeleton files');
 						}
 						$dataDir = $revaRoot . "data/$user/files";

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2303,13 +2303,18 @@ trait Provisioning {
 					);
 					if ($skeleton) {
 						$skeletonDir = \getenv("SKELETON_DIR");
-						if ($skeletonDir) {
-							$dataDir = \getenv("OCIS_REVA_DATA_ROOT") . "data/$user/files";
-							if (!\file_exists($dataDir)) {
-								\mkdir($dataDir, 0777, true);
-							}
-							OcisHelper::recurseCopy($skeletonDir, $dataDir);
+						$revaRoot = \getenv("OCIS_REVA_DATA_ROOT");
+						if (!$skeletonDir) {
+							throw new Exception('Missing SKELETON_DIR environment variable, cannot copy skeleton files');
 						}
+						if (!$revaRoot) {
+							throw new Exception('Missing OCIS_REVA_DATA_ROOT environment variable, cannot copy skeleton files');
+						}
+						$dataDir = $revaRoot . "data/$user/files";
+						if (!\file_exists($dataDir)) {
+							\mkdir($dataDir, 0777, true);
+						}
+						OcisHelper::recurseCopy($skeletonDir, $dataDir);
 					}
 				} catch (LdapException $exception) {
 					throw new Exception(


### PR DESCRIPTION
When running tests, throw an exception whenever environment variables are missing that
specify skeleton dir and reva dir locations.

Because I had one missing and was wondering why the test failed. It was difficult to debug as I needed to pause the test with `sleep()` to have a look at the home dir and notice that the skeleton was not copied...