### PR TITLE
[Tests-Only] Only do 'manual' skeleton copy when testing on OCIS

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2301,14 +2301,16 @@ trait Provisioning {
 						$initialize,
 						$settings
 					);
-					if ($skeleton) {
+					// If the user should have skeleton files, and we are testing on OCIS
+					// then do some work to "manually" put the skeleton files in place.
+					if ($skeleton && OcisHelper::isTestingOnOcis()) {
 						$skeletonDir = \getenv("SKELETON_DIR");
 						$revaRoot = \getenv("OCIS_REVA_DATA_ROOT");
 						if (!$skeletonDir) {
-							throw new Exception('Missing SKELETON_DIR environment variable, cannot copy skeleton files');
+							throw new Exception('Missing SKELETON_DIR environment variable, cannot copy skeleton files for OCIS');
 						}
-						if (!$revaRoot && OcisHelper::isTestingOnOcis()) {
-							throw new Exception('Missing OCIS_REVA_DATA_ROOT environment variable, cannot copy skeleton files');
+						if (!$revaRoot) {
+							throw new Exception('Missing OCIS_REVA_DATA_ROOT environment variable, cannot copy skeleton files for OCIS');
 						}
 						$dataDir = $revaRoot . "data/$user/files";
 						if (!\file_exists($dataDir)) {


### PR DESCRIPTION
## Description
PR #37363 added code in `Provisioning.php` `createUser()` to "manually" copy skeleton files for a new user. That was intended to only do it for the case when testing on OCIS, because in that case there is not "backend" support in OCIS for defining a skeleton directory.

But the code was also running when LDAP users were created in the user_ldap app tests (running with ownCloud10 core). As it happens, it did nothing and did not cause a problem.

Yesterday, PR #37482 added some checking to that code, so that it throws an exception if a developer forgets to define the `SKELETON_DIR` environment variable. When user_ldap nightlies ran last night, the exception was thrown.

This PR adjusts the "special" "copy skeleton files" code so that it only runs when `isTestingOnOcis`

## Related Issue
https://github.com/owncloud/user_ldap/issues/570

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
