### PR TITLE
[Tests-Only] Correctly remember users and groups in importLdifData

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -300,11 +300,17 @@ trait Provisioning {
 	 */
 	public function theGroupShouldExist($groupname) {
 		if (\array_key_exists($groupname, $this->createdGroups)) {
-			return $this->createdGroups[$groupname]['shouldExist'];
+			if (\array_key_exists('shouldExist', $this->createdGroups[$groupname])) {
+				return $this->createdGroups[$groupname]['shouldExist'];
+			}
+			return false;
 		}
 
 		if (\array_key_exists($groupname, $this->createdRemoteGroups)) {
-			return $this->createdRemoteGroups[$groupname]['shouldExist'];
+			if (\array_key_exists('shouldExist', $this->createdRemoteGroups[$groupname])) {
+				return $this->createdRemoteGroups[$groupname]['shouldExist'];
+			}
+			return false;
 		}
 
 		throw new Exception(
@@ -489,10 +495,10 @@ trait Provisioning {
 				if (isset($item["objectclass"])) {
 					if (\in_array("posixGroup", $item["objectclass"])) {
 						\array_push($this->ldapCreatedGroups, $item["cn"][0]);
-						\array_push($this->createdGroups, $item["cn"][0]);
+						$this->addGroupToCreatedGroupsList($item["cn"][0]);
 					} elseif (\in_array("inetOrgPerson", $item["objectclass"])) {
 						\array_push($this->ldapCreatedUsers, $item["uid"][0]);
-						\array_push($this->createdUsers, $item["uid"][0]);
+						$this->addUserToCreatedUsersList($item["uid"][0], $item["userpassword"][0]);
 					}
 				}
 				$this->ldap->add($item['dn'], $item);


### PR DESCRIPTION
## Description
Fixing the problem from the linked issue:
```
  Scenario: creating two groups with the same name in different LDAP OUs at the same time   # /var/www/owncloud/testrunner/apps/user_ldap/tests/acceptance/features/apiProvisioningLDAP/groups.feature:167
    Given these users have been created with default attributes and without skeleton files: # FeatureContext::theseUsersHaveBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles()
      | username |
      | Brian    |
      | Carol    |
    When the administrator imports this ldif data:                                          # UserLdapGeneralContext::theAdminImportsThisLdifData()
      """
      dn: cn=so-far-unused-group-name,ou=TestUsers,dc=owncloud,dc=com
      cn: so-far-unused-group-name
      gidnumber: 4700
      memberuid: Carol
      objectclass: top
      objectclass: posixGroup
      
      dn: cn=so-far-unused-group-name,ou=TestGroups,dc=owncloud,dc=com
      cn: so-far-unused-group-name
      gidnumber: 4700
      memberuid: Brian
      objectclass: top
      objectclass: posixGroup
      """
    And the administrator invokes occ command "group:list"                                  # OccContext::theAdministratorInvokesOccCommand()
    Then group "so-far-unused-group-name" should exist                                      # FeatureContext::groupShouldExist()
    And user "Carol" should belong to group "so-far-unused-group-name"                      # FeatureContext::userShouldBelongToGroup()
    But user "Brian" should not belong to group "so-far-unused-group-name"                  # FeatureContext::userShouldNotBelongToGroup()
INFORMATION: There was an unexpected problem trying to delete group '0' message 'Warning: Illegal string offset 'shouldExist' in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/Provisioning.php line 303'
INFORMATION: There was an unexpected problem trying to delete group '1' message 'Warning: Illegal string offset 'shouldExist' in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/Provisioning.php line 303'
```

1) `importLdifData` was remembering `createdGroups` using the group name as the value. But `createdGroups` these days has the group name as the key, and some boolean items as an array under that. That is why the above is trying to delete groups called `0` and `1`. Fix that by calling `addGroupToCreatedGroupsList`
2) Fix a similar problem with importing users from ldif data.
3) Make `theGroupShouldExist` more robust, so that if the `shouldExist` key does not exist, it will return a "sensible" value -- I chose to return `false` (the group may or may not exist)

## Related Issue
Part of https://github.com/owncloud/user_ldap/issues/570

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
