### PR TITLE
[Tests-Only] Check if a group exists when testing with Ldap

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -46,6 +46,11 @@ trait Provisioning {
 	private $createdUsers = [];
 
 	/**
+	 * @var string
+	 */
+	private $ou = "TestGroups";
+
+	/**
 	 * list of users that were created on the remote server during test runs
 	 * key is the lowercase username, value is an array of user attributes
 	 *
@@ -696,8 +701,8 @@ trait Provisioning {
 	 * @throws LdapException
 	 */
 	public function createLdapGroup($group) {
-		$ou = "TestGroups";
-		$newDN = 'cn=' . $group . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
+		$baseDN = $this->getLdapBaseDN();
+		$newDN = 'cn=' . $group . ',ou=' . $this->ou . ',' . $baseDN;
 		$entry = [];
 		$entry['cn'] = $group;
 		$entry['objectclass'][] = 'posixGroup';
@@ -3224,6 +3229,14 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function groupExists($group) {
+		$baseDN = $this->getLdapBaseDN();
+		$newDN = 'cn=' . $group . ',ou=' . $this->ou . ',' . $baseDN;
+		if ($this->isTestingWithLdap()) {
+			if ($this->ldap->getEntry($newDN) !== null) {
+				return true;
+			}
+			return false;
+		}
 		$group = \rawurlencode($group);
 		$fullUrl = $this->getBaseUrl() . "/ocs/v2.php/cloud/groups/$group";
 		$this->response = HttpRequestHelper::get(


### PR DESCRIPTION
## Description
Check if a group exists when testing with Ldap

## Related Issue
https://github.com/owncloud/ocis-reva/issues/233

## Motivation and Context
The existence of a group was not checked for created groups when testing with LDAP. 

## How Has This Been Tested?
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
