### PR TITLE
[Tests-Only] Adjust code and settings so phpstan 0.12.26 passes

### DIFF
--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -87,6 +87,7 @@ class OC_Image implements \OCP\IImage {
 		}
 
 		if (\OC_Util::fileInfoLoaded()) {
+			/* @phpstan-ignore-next-line */
 			$this->fileInfo = new finfo(FILEINFO_MIME_TYPE);
 		}
 

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1340,6 +1340,7 @@ class OC_Util {
 		}
 		// Zend Opcache
 		if (\function_exists('accelerator_reset')) {
+			/* @phpstan-ignore-next-line */
 			accelerator_reset();
 		}
 		// Opcache (PHP >= 5.5)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,16 +1,6 @@
 parameters:
-  bootstrap: %currentWorkingDirectory%/lib/base.php
-  autoload_directories:
-    - %currentWorkingDirectory%/apps/files_sharing/appinfo/Migrations
-    - %currentWorkingDirectory%/apps/dav/appinfo/Migrations
-    - %currentWorkingDirectory%/apps/federatedfilesharing/appinfo/Migrations
-    - %currentWorkingDirectory%/apps/files_external/appinfo/Migrations
-    - %currentWorkingDirectory%/apps/files_external/lib
-    - %currentWorkingDirectory%/apps/files_external/3rdparty
-    - %currentWorkingDirectory%/apps/files_sharing/appinfo/Migrations
-    - %currentWorkingDirectory%/apps/files_trashbin/appinfo/Migrations
-    - %currentWorkingDirectory%/core/Migrations
-    - %currentWorkingDirectory%/tests/lib/Util/User
+  bootstrapFiles:
+    - %currentWorkingDirectory%/lib/base.php
   excludes_analyse:
     - %currentWorkingDirectory%/core/templates/*
     - %currentWorkingDirectory%/core/routes.php
@@ -22,6 +12,13 @@ parameters:
     - %currentWorkingDirectory%/apps/*/appinfo/routes.php
     - %currentWorkingDirectory%/apps/*/composer/*
     - %currentWorkingDirectory%/apps/*/3rdparty/*
+    - %currentWorkingDirectory%/apps/files_external/ajax/oauth2.php
+    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Backend/DAV.php
+    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Backend/Google.php
+    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Backend/SMB.php
+    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Backend/SMB_OC.php
+    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Storage/Google.php
+    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Storage/SMB.php
     - %currentWorkingDirectory%/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/Fixtures/Apc/fallback/Namespaced/FooBar.php
     - %currentWorkingDirectory%/apps/files_sharing/ajax/shareinfo.php
     - %currentWorkingDirectory%/settings/templates/*
@@ -32,7 +29,7 @@ parameters:
   ignoreErrors:
     - '#Undefined variable: \$OC_[a-zA-Z0-9\\_]+#'
     - '#Undefined variable: \$vendor#'
-    - '#Undefined variable: \$baseuri#'
+    - '#Instantiated class Test\\Util\\User\\Dummy not found.#'
     # errors below are to be addressed by own pull requests - non trivial changes required
     - '#Unsafe usage of new static().#'
     - '#Cannot instantiate interface OCP\\Files\\ObjectStore\\IObjectStore.#'


### PR DESCRIPTION
## Description
In `phpstan.neon` for 0.12.26 :
- `bootstrap` becomes `bootstrapFiles`
- `autoload_directories` is no longer needed
- ignore various code like `apps/files_external/lib/Lib/Backend/DAV.php` that report problems - see issue #37498 

This gets CI passing again, and the issues can be looked at separately.

## Related Issue
- Fixes #37495 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
