### PR TITLE
[Tests-Only] Fix phpstan settings for 0.12.27

### DIFF
--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -87,7 +87,6 @@ class OC_Image implements \OCP\IImage {
 		}
 
 		if (\OC_Util::fileInfoLoaded()) {
-			/* @phpstan-ignore-next-line */
 			$this->fileInfo = new finfo(FILEINFO_MIME_TYPE);
 		}
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,28 +4,16 @@ parameters:
   excludes_analyse:
     - %currentWorkingDirectory%/core/templates/*
     - %currentWorkingDirectory%/core/routes.php
-    - %currentWorkingDirectory%/core/register_command.php
     - %currentWorkingDirectory%/core/ajax/update.php
-    - %currentWorkingDirectory%/core/ajax/share.php
     - %currentWorkingDirectory%/apps/*/tests*
-    - %currentWorkingDirectory%/apps/*/templates/*
     - %currentWorkingDirectory%/apps/*/appinfo/routes.php
     - %currentWorkingDirectory%/apps/*/composer/*
     - %currentWorkingDirectory%/apps/*/3rdparty/*
     - %currentWorkingDirectory%/apps/files_external/ajax/oauth2.php
-    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Backend/DAV.php
-    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Backend/Google.php
-    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Backend/SMB.php
-    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Backend/SMB_OC.php
     - %currentWorkingDirectory%/apps/files_external/lib/Lib/Storage/Google.php
     - %currentWorkingDirectory%/apps/files_external/lib/Lib/Storage/SMB.php
-    - %currentWorkingDirectory%/apps/files_external/3rdparty/aws-sdk-php/Symfony/Component/ClassLoader/Tests/Fixtures/Apc/fallback/Namespaced/FooBar.php
-    - %currentWorkingDirectory%/apps/files_sharing/ajax/shareinfo.php
     - %currentWorkingDirectory%/settings/templates/*
     - %currentWorkingDirectory%/settings/routes.php
-    # specific app excludes
-    # eventually move into app directories and use neon includes for better separation
-    - %currentWorkingDirectory%/apps/dav/bin
   ignoreErrors:
     - '#Undefined variable: \$OC_[a-zA-Z0-9\\_]+#'
     - '#Undefined variable: \$vendor#'


### PR DESCRIPTION
## Description
`phpstan` https://github.com/phpstan/phpstan/releases/tag/0.12.27 was released last night. That fixed some problems with `0.12.26` so now we can reverse some of the changes that were made yesterday to make `0.12.26` pass.

## Related Issue
- Fixes #37495 

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
