### PR TITLE
[Tests-Only] Adjust tests so they run with numeric usernames

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -335,7 +335,7 @@ Feature: sharing
     #And user "brian" should see the following elements
     #  | /randomfile.txt |
     #And the content of file "randomfile.txt" for user "brian" should be "Random data"
-    And user "brian" should not see the following elements
+    And user "brian" should not see the following elements if the upper and lower case username are different
       | /randomfile.txt |
 
   @skipOnLDAP

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1421,6 +1421,26 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^user "([^"]*)" should not see the following elements if the upper and lower case username are different/
+	 *
+	 * @param string $user
+	 * @param TableNode $elements
+	 *
+	 * @return void
+	 * @throws InvalidArgumentException
+	 *
+	 */
+	public function userShouldNotSeeTheElementsIfUpperAndLowerCaseUsernameDifferent($user, $elements) {
+		$effectiveUser = $this->getActualUsername($user);
+		if (\strtoupper($effectiveUser) === \strtolower($effectiveUser)) {
+			$expectedToBeListed = true;
+		} else {
+			$expectedToBeListed = false;
+		}
+		$this->checkElementList($user, $elements, $expectedToBeListed);
+	}
+
+	/**
 	 * asserts that a the user can or cannot see a list of files/folders by propfind
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -50,7 +50,7 @@ class SharingDialog extends OwncloudPage {
 	private $suffixToIdentifyUsers = " User";
 	private $suffixToIdentifyRemoteUsers = " Federated";
 	private $sharerInformationXpath = ".//*[@class='reshare']";
-	private $sharedWithAndByRegEx = "^(?:[A-Z]\s)?Shared with you(?: and the group (.*))? by (.*)$";
+	private $sharedWithAndByRegEx = "Shared with you(?: and the group (.*))? by (.*)$";
 	private $permissionsFieldByUserNameWithExtraInfo = "//*[@id='shareWithList']//span[contains(text(), '%s')]/parent::li[@data-share-with='%s']";
 	private $permissionsFieldByUserName = "//*[@id='shareWithList']//span[contains(text(), '%s')]/parent::li";
 	private $permissionsFieldByGroupName = "//*[@id='shareWithList']//span[contains(text(), '%s (group)')]/parent::li";


### PR DESCRIPTION
## Description
Adjust the acceptance tests so that they can run OK with usernames that do not have any alphabetic characters (e.g. "000" "1.1" etc)

## Related Issue
- Fixes #37493 

## Motivation and Context
Have flexible acceptance tests.

## How Has This Been Tested?
CI

See demonstration PR #37475 that runs the acceptance tests with usernames like "000" "1.1"

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
