### PR TITLE
[Tests-Only] Fix PHPdoc for Base::assign

### DIFF
--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -135,7 +135,7 @@ class Base {
 	/**
 	 * Assign variables
 	 * @param string $key key
-	 * @param array|bool|integer|string $value value
+	 * @param mixed $value value
 	 * @return bool
 	 *
 	 * This function assigns a variable. It can be accessed via $_[$key] in


### PR DESCRIPTION
## Description
`OC\Template\Base::assign` can be passed an object as `$value` as well as `array|bool|integer|string`, so set the PHPdoc to say `mixed`

The PHPdoc is causing `phpstan` to complain when code passes an object. This fixes it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
