### PR TITLE
[Tests-Only] API test to delete Public link has been added

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
@@ -1,9 +1,10 @@
-@api
+@api @skipOnOcis
 Feature: delete a public link share
 
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
+  @issue-product-60
   Scenario Outline: Deleting a public link of a file
     Given using OCS API version "<ocs_api_version>"
     Given user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
@@ -18,6 +19,7 @@ Feature: delete a public link share
       | 1               | 100             |
       | 2               | 200             |
 
+  @issue-product-60
   Scenario Outline: Deleting a public link after renaming a file
     Given using OCS API version "<ocs_api_version>"
     Given user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"

--- a/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
@@ -14,6 +14,7 @@ Feature: delete a public link share
     When user "Alice" deletes public link share named "sharedlink" in file "test-file.txt" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs_status_code>"
+    And as user "Alice" the file "test-file.txt" should not have any shares
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -30,7 +31,42 @@ Feature: delete a public link share
     And user "Alice" deletes public link share named "sharedlink" in file "renamed-test-file.txt" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And as user "Alice" the file "renamed-test-file.txt" should not have any shares
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  @issue-product-60
+  Scenario Outline: Deleting a public link of a folder
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "test-folder"
+    And user "Alice" has created a public link share with settings
+      | path | /test-folder |
+      | name | sharedlink   |
+    When user "Alice" deletes public link share named "sharedlink" in folder "test-folder" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And as user "Alice" the folder "test-folder" should not have any shares
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @issue-product-60
+  Scenario Outline: Deleting a public link of a file in a folder
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "test-folder"
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/test-folder/testfile.txt" using the WebDAV API
+    And user "Alice" has created a public link share with settings
+      | path | /test-folder/testfile.txt |
+      | name | sharedlink                |
+    And user "Alice" deletes public link share named "sharedlink" in file "/test-folder/testfile.txt" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And as user "Alice" the file "/test-folder/testfile.txt" should not have any shares
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+

--- a/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
@@ -2,18 +2,18 @@
 Feature: delete a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @issue-product-60
   Scenario Outline: Deleting a public link of a file
     Given using OCS API version "<ocs_api_version>"
-    Given user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
+    And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
     And user "Alice" has created a public link share with settings
       | path | test-file.txt |
       | name | sharedlink    |
     When user "Alice" deletes public link share named "sharedlink" in file "test-file.txt" using the sharing API
     Then the HTTP status code should be "200"
-    Then the OCS status code should be "<ocs_status_code>"
+    And the OCS status code should be "<ocs_status_code>"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -22,7 +22,7 @@ Feature: delete a public link share
   @issue-product-60
   Scenario Outline: Deleting a public link after renaming a file
     Given using OCS API version "<ocs_api_version>"
-    Given user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
+    And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
     And user "Alice" has created a public link share with settings
       | path | test-file.txt |
       | name | sharedlink    |

--- a/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
@@ -1,0 +1,34 @@
+@api
+Feature: delete a public link share
+
+  Background:
+    Given user "Alice" has been created with default attributes and skeleton files
+
+  Scenario Outline: Deleting a public link of a file
+    Given using OCS API version "<ocs_api_version>"
+    Given user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
+    And user "Alice" has created a public link share with settings
+      | path | test-file.txt |
+      | name | sharedlink    |
+    When user "Alice" deletes public link share named "sharedlink" in file "test-file.txt" using the sharing API
+    Then the HTTP status code should be "200"
+    Then the OCS status code should be "<ocs_status_code>"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Deleting a public link after renaming a file
+    Given using OCS API version "<ocs_api_version>"
+    Given user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
+    And user "Alice" has created a public link share with settings
+      | path | test-file.txt |
+      | name | sharedlink    |
+    When user "Alice" moves file "/test-file.txt" to "/renamed-test-file.txt" using the WebDAV API
+    And user "Alice" deletes public link share named "sharedlink" in file "renamed-test-file.txt" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |


### PR DESCRIPTION
## Description
The following scenarios have been added:
- Deleting a public link of a file
- Deleting a public link after renaming a file

## Related Issue
https://github.com/owncloud/core/issues/37499

## How Has This Been Tested?
- Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
