### PR TITLE
[Tests-Only] check for the existence of group in core db when testing with ldap

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -3239,9 +3239,9 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function groupExists($group) {
-		$baseDN = $this->getLdapBaseDN();
-		$newDN = 'cn=' . $group . ',ou=' . $this->ou . ',' . $baseDN;
 		if ($this->isTestingWithLdap() && OcisHelper::isTestingOnOcis()) {
+			$baseDN = $this->getLdapBaseDN();
+			$newDN = 'cn=' . $group . ',ou=' . $this->ou . ',' . $baseDN;
 			if ($this->ldap->getEntry($newDN) !== null) {
 				return true;
 			}

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -3241,7 +3241,7 @@ trait Provisioning {
 	public function groupExists($group) {
 		$baseDN = $this->getLdapBaseDN();
 		$newDN = 'cn=' . $group . ',ou=' . $this->ou . ',' . $baseDN;
-		if ($this->isTestingWithLdap()) {
+		if ($this->isTestingWithLdap() && OcisHelper::isTestingOnOcis()) {
 			if ($this->ldap->getEntry($newDN) !== null) {
 				return true;
 			}


### PR DESCRIPTION
## Description
check for the existence of group in core db when testing with ldap

## Related Issue
- Fixes https://github.com/owncloud/user_ldap/issues/576

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
