### PR TITLE
Fix files_external:export so the output can be successfully imported

### DIFF
--- a/apps/files_external/lib/Command/Export.php
+++ b/apps/files_external/lib/Command/Export.php
@@ -52,6 +52,7 @@ class Export extends ListCommand {
 		$listInput->setOption('output', 'json_pretty');
 		$listInput->setOption('show-password', true);
 		$listInput->setOption('full', true);
+		$listInput->setOption('importable-format', true);
 		$listCommand->execute($listInput, $output);
 	}
 }

--- a/apps/files_external/tests/Command/ListCommandTest.php
+++ b/apps/files_external/tests/Command/ListCommandTest.php
@@ -243,4 +243,77 @@ EOS
 			$this->assertEquals($expectedResult, $output);
 		}
 	}
+	public function providesImportableFormat() {
+		return [
+			[
+				['importable-format' => true, 'short' => false, 'output' => 'json'],
+				[
+					['mount_id' => 1, 'mount_point' => '/ownCloud', 'storage' => 'Local', 'authentication_type' => 'password::password'],
+					['mount_id' => 2, 'mount_point' => '/SFTP', 'storage' => 'Local', 'authentication_type' => 'password::sessioncredentials'],
+				],
+				[
+					['mount_id' => 1, 'mount_point' => '/ownCloud'],
+					['mount_id' => 2, 'mount_point' => '/SFTP'],
+				]
+			],
+			[
+				['importable-format' => true, 'short' => false],
+				<<<EOS
++----------+-------------+-------------------------+------------------------------+---------------+---------+
+| Mount ID | Mount Point | Storage                 | Authentication Type          | Configuration | Options |
++----------+-------------+-------------------------+------------------------------+---------------+---------+
+| 1        | /ownCloud   | \OC\Files\Storage\Local | password::password           |               |         |
+| 2        | /SFTP       | \OC\Files\Storage\Local | password::sessioncredentials |               |         |
++----------+-------------+-------------------------+------------------------------+---------------+---------+
+
+EOS
+				,
+				[
+					['mount_id' => 1, 'mount_point' => '/ownCloud', 'storage' => 'Local'],
+					['mount_id' => 2, 'mount_point' => '/SFTP', 'storage' => 'Local'],
+				]
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider providesImportableFormat
+	 * @param $options
+	 * @param $expectedResult
+	 * @param $mountOptions
+	 */
+	public function testImportableFormat($options, $expectedResult, $mountOptions) {
+		$l10n = $this->createMock('\OCP\IL10N', null, [], '', false);
+		$session = $this->createMock('\OCP\ISession');
+		$crypto = $this->createMock('\OCP\Security\ICrypto');
+		$instance = $this->getInstance();
+		// FIXME: use mock of IStorageConfig
+		$mount1 = new StorageConfig();
+		$mount1->setId($mountOptions[0]['mount_id']);
+		$mount1->setMountPoint($mountOptions[0]['mount_point']);
+		$mount1->setAuthMechanism(new Password());
+		$mount1->setBackend(new Local($l10n, new NullMechanism()));
+		$mount2 = new StorageConfig();
+		$mount2->setId($mountOptions[1]['mount_id']);
+		$mount2->setMountPoint($mountOptions[1]['mount_point']);
+		$mount2->setAuthMechanism(new SessionCredentials($session, $crypto));
+		$mount2->setBackend(new Local($l10n, new NullMechanism()));
+		$input = $this->getInput($instance, ['user_id' => 'user1'], $options);
+		$output = new BufferedOutput();
+
+		$instance->listMounts('user1', [$mount1, $mount2], $input, $output);
+		$output = $output->fetch();
+		if (isset($options['output']) && ($options['output'] === 'json')) {
+			$results = \json_decode($output, true);
+			$countResults = \count($results);
+
+			for ($i = 0; $i < $countResults; $i++) {
+				$this->assertEquals($expectedResult[$i]['mount_id'], $results[$i]['mount_id']);
+				$this->assertEquals($expectedResult[$i]['mount_point'], $results[$i]['mount_point']);
+				$this->assertEquals($expectedResult[$i]['authentication_type'], $results[$i]['authentication_type']);
+			}
+		} else {
+			$this->assertEquals($expectedResult, $output);
+		}
+	}
 }

--- a/changelog/unreleased/37054
+++ b/changelog/unreleased/37054
@@ -1,0 +1,7 @@
+Bugfix: Correct files_external:export output so it can be imported
+
+The output of files_external:export was not suitable to be used as input to
+files_external:import. This has been corrected.
+
+https://github.com/owncloud/core/issues/37054
+https://github.com/owncloud/core/pull/37513

--- a/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
@@ -13,17 +13,38 @@ Feature: export created local storage mounts from the command line
   Scenario: export the created mounts
     When the administrator exports the local storage mounts using the occ command
     Then the following local storage should be listed:
-      | MountPoint         | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
-      | /local_storage2    | Local   | None               | datadir:      |                      | All             |                  |
-      | /new_local_storage | Local   | None               | datadir:      |                      | All             |                  |
-      | /local_storage     | Local   | None               | datadir:      | enable_sharing: true | All             |                  |
+      | MountPoint         | Storage                 | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage2    | \OC\Files\Storage\Local | null::null         | datadir:      |                      |                 |                  |
+      | /new_local_storage | \OC\Files\Storage\Local | null::null         | datadir:      |                      |                 |                  |
+      | /local_storage     | \OC\Files\Storage\Local | null::null         | datadir:      | enable_sharing: true |                 |                  |
 
-  @issue-37054
   Scenario: export the created mounts when the system language is "de"
     Given the administrator has set the system language to "de"
     When the administrator exports the local storage mounts using the occ command
     Then the following local storage should be listed:
-      | MountPoint         | Storage | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
-      | /local_storage2    | Lokal   | Keine              | datadir:      |                      | All             |                  |
-      | /new_local_storage | Lokal   | Keine              | datadir:      |                      | All             |                  |
-      | /local_storage     | Lokal   | Keine              | datadir:      | enable_sharing: true | All             |                  |
+      | MountPoint         | Storage                 | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage2    | \OC\Files\Storage\Local | null::null         | datadir:      |                      |                 |                  |
+      | /new_local_storage | \OC\Files\Storage\Local | null::null         | datadir:      |                      |                 |                  |
+      | /local_storage     | \OC\Files\Storage\Local | null::null         | datadir:      | enable_sharing: true |                 |                  |
+
+  Scenario: export the created mounts with various user and group settings
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Carol    |
+    And group "grp1" has been created
+    And group "grp2" has been created
+    And group "grp3" has been created
+    And the administrator has added user "Alice" as the applicable user for local storage mount "local_storage2"
+    And the administrator has added user "Brian" as the applicable user for local storage mount "new_local_storage"
+    And the administrator has added user "Carol" as the applicable user for local storage mount "new_local_storage"
+    And the administrator has added group "grp1" as the applicable group for local storage mount "local_storage2"
+    And the administrator has added group "grp2" as the applicable group for local storage mount "new_local_storage"
+    And the administrator has added group "grp3" as the applicable group for local storage mount "new_local_storage"
+    When the administrator exports the local storage mounts using the occ command
+    Then the following local storage should be listed:
+      | MountPoint         | Storage                 | AuthenticationType | Configuration | Options              | ApplicableUsers | ApplicableGroups |
+      | /local_storage2    | \OC\Files\Storage\Local | null::null         | datadir:      |                      | Alice           | grp1             |
+      | /new_local_storage | \OC\Files\Storage\Local | null::null         | datadir:      |                      | Brian, Carol    | grp2, grp3       |
+      | /local_storage     | \OC\Files\Storage\Local | null::null         | datadir:      | enable_sharing: true |                 |                  |

--- a/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
@@ -4,13 +4,59 @@ Feature: import exported local storage mounts from the command line
   I want to import exported local storage mounts from the command line
   So that I can create previously exported local storage mounts
 
-  @issue-37054
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+
   Scenario: import local storage mounts from a file
     Given the administrator has created the local storage mount "local_storage2"
-    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
     And the administrator has exported the local storage mounts using the occ command
     And the administrator has created a file "data/exportedMounts.json" with the last exported content using the testing API
+    And the administrator has deleted local storage "local_storage" using the occ command
     And the administrator has deleted local storage "local_storage2" using the occ command
     When the administrator imports the local storage mount from file "data/exportedMounts.json" using the occ command
-    # change the then step once the issue is fixed, and the import works well
-    Then the command output should contain the text "An unhandled exception has been thrown:"
+    And the administrator lists the local storage using the occ command
+    Then the following local storage should be listed:
+      | MountPoint         | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
+      | /local_storage2    | Local   | None               | datadir:      |         | All             |                  |
+    And as "Alice" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage2.txt" for user "Alice" should be "this is a file in local storage2"
+
+  Scenario: import local storage mounts from a file with various user and group settings
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+      | Carol    |
+    And group "grp1" has been created
+    And group "grp2" has been created
+    And group "grp3" has been created
+    And the administrator has created the local storage mount "local_storage2"
+    And the administrator has created the local storage mount "local_storage3"
+    And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
+    And the administrator has uploaded file with content "this is a file in local storage3" to "/local_storage3/file-in-local-storage3.txt"
+    And the administrator has added user "Alice" as the applicable user for local storage mount "local_storage2"
+    And the administrator has added user "Brian" as the applicable user for local storage mount "local_storage3"
+    And the administrator has added user "Carol" as the applicable user for local storage mount "local_storage3"
+    And the administrator has added group "grp1" as the applicable group for local storage mount "local_storage2"
+    And the administrator has added group "grp2" as the applicable group for local storage mount "local_storage3"
+    And the administrator has added group "grp3" as the applicable group for local storage mount "local_storage3"
+    And the administrator has exported the local storage mounts using the occ command
+    And the administrator has created a file "data/exportedMounts.json" with the last exported content using the testing API
+    And the administrator has deleted local storage "local_storage" using the occ command
+    And the administrator has deleted local storage "local_storage2" using the occ command
+    And the administrator has deleted local storage "local_storage3" using the occ command
+    When the administrator imports the local storage mount from file "data/exportedMounts.json" using the occ command
+    And the administrator lists the local storage using the occ command
+    Then the following local storage should be listed:
+      | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
+      | /local_storage2 | Local   | None               | datadir:      |         | Alice           | grp1             |
+      | /local_storage3 | Local   | None               | datadir:      |         | Brian, Carol    | grp2, grp3       |
+      | /local_storage  | Local   | None               | datadir:      |         | All             |                  |
+    And as "Alice" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage2.txt" for user "Alice" should be "this is a file in local storage2"
+    And as "Brian" folder "/local_storage3" should exist
+    And the content of file "/local_storage3/file-in-local-storage3.txt" for user "Brian" should be "this is a file in local storage3"
+    But as "Alice" folder "/local_storage3" should not exist
+    And as "Brian" folder "/local_storage2" should not exist


### PR DESCRIPTION
## Description
The output of `php occ files_external:export` was containing problems like:
- "storage" had a human-friendly text like "Local", when it needs the more technical `\OC\Files\Storage\Local` class name
- "authentication_type" had a human-friendly text like "None", when it needs the more technical `null::null` or `password::password`
- "applicable_users" was being output as "All" (when no specific users were set), or a comma-separated string of applicable users. For import, it needs to be an array of usernames (empty if there are no users specified)
- "applicable_groups" was being output as "" (when no specific groups were set), or a comma-separated string of applicable groups. For import, it needs to be an array of group names (empty if there are no groups specified)

A new option to `files_external:list` has been added - `-i` or `--importable-format` - when this is specified and a JSON output is requested, the items above are corrected in the JSON to be in a format that can be used for import.

`files_external:export` calls `list` with this new option set. (It already called `list` to do its work anyway).

Extra unit and acceptance tests have been added to cover the new `list` option, and the export and import of various combinations of mounts.

## Related Issue
- Fixes #37054 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
