### PR TITLE
[Tests-only] allow to define a command to delete the user data

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -44,7 +44,13 @@ class OcisHelper {
 	 * @return void
 	 */
 	public static function deleteRevaUserData($user = "") {
-		self::recurseRmdir(self::getOcisRevaDataRoot() . "/data/" . $user);
+		$deleteCmd = \getenv("DELETE_USER_DATA_CMD");
+		if ($deleteCmd !== false) {
+			$deleteCmd = \sprintf($deleteCmd, $user);
+			\exec($deleteCmd);
+		} else {
+			self::recurseRmdir(self::getOcisRevaDataRoot() . "/data/" . $user);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
in some env. e.g. with EOS we don't have an easy way to delete the user data after deleting the user
This fix allows to define a command to run whatever magic is needed to delete the data

## Related Issue
part of https://github.com/owncloud/ocis/issues/253

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
