### PR TITLE
[Tests-Only] skip new importLocalStorage scenarios on old oC10 and encryption

### DIFF
--- a/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
@@ -9,6 +9,7 @@ Feature: import exported local storage mounts from the command line
       | username |
       | Alice    |
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnEncryption @issue-encryption-203
   Scenario: import local storage mounts from a file
     Given the administrator has created the local storage mount "local_storage2"
     And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
@@ -24,6 +25,7 @@ Feature: import exported local storage mounts from the command line
     And as "Alice" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "Alice" should be "this is a file in local storage2"
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnEncryption @issue-encryption-203
   Scenario: import local storage mounts from a file with various user and group settings
     Given these users have been created with default attributes and without skeleton files:
       | username |


### PR DESCRIPTION
## Description
These test scenarios were changed/added yesterday in PR #37513 that fixed the files_external export->import. They will not pass on older ownCloud10 versions, so skip them in that case.

Also there is trouble when recreating a local storage mount when there are files in it and encryption is on - https://github.com/owncloud/encryption/issues/203 - so `skipOnEncryption`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
