### PR TITLE
[tests-only] allow colon in etags

### DIFF
--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -42,7 +42,7 @@ Feature: sharing
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     Examples:
       | dav-path |
       | old      |
@@ -61,7 +61,7 @@ Feature: sharing
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     Examples:
       | dav-path |
       | old      |
@@ -110,7 +110,7 @@ Feature: sharing
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the following headers should match these regular expressions for user "Brian"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -14,7 +14,7 @@ Feature: upload to a public link share
     And the public uploads file "test.txt" with content "test2" with auto-rename mode using the old public WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
 
@@ -29,7 +29,7 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test2" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
 
@@ -82,7 +82,7 @@ Feature: upload to a public link share
     When the public uploads file "test-old.txt" with content "test-old" using the old public WebDAV API
     Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
     And the following headers should match these regular expressions
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
 
   Scenario: Uploading to a public upload-only share
     Given the administrator has enabled DAV tech_preview
@@ -92,7 +92,7 @@ Feature: upload to a public link share
     When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
     And the following headers should match these regular expressions
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
 
   Scenario: Uploading to a public upload-only share with password
     Given user "Alice" has created a public link share with settings
@@ -243,7 +243,7 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     When the public uploads file "test.txt" with content "test2" using the old public WebDAV API
     # Uncomment these once the issue is fixed
     # Then the HTTP status code should be "201"
@@ -261,7 +261,7 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     When the public uploads file "test.txt" with content "test2" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -21,7 +21,7 @@ Feature: Restore deleted files/folders
     When user "Brian" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And as "Brian" the file with original path "/renamed_shared/shared_file.txt" should not exist in the trashbin
     And user "Brian" should see the following elements
       | /renamed_shared/                |
@@ -46,7 +46,7 @@ Feature: Restore deleted files/folders
     When user "Alice" restores the folder with original path "/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And as "Alice" the folder with original path "/textfile0.txt" should not exist in the trashbin
     And user "Alice" should see the following elements
       | /FOLDER/           |
@@ -102,7 +102,7 @@ Feature: Restore deleted files/folders
     When user "Alice" restores the file with original path "<delete-path>" to "<restore-path>" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And as "Alice" the file with original path "<delete-path>" should not exist in the trashbin
     And as "Alice" file "<restore-path>" should exist
     And as "Alice" file "<delete-path>" should not exist
@@ -198,7 +198,7 @@ Feature: Restore deleted files/folders
     And user "Alice" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And as "Alice" the file with original path "/new-folder/new-file.txt" should not exist in the trashbin
     And as "Alice" file "/new-folder/new-file.txt" should exist
     Examples:
@@ -219,7 +219,7 @@ Feature: Restore deleted files/folders
     When user "Alice" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And user "Alice" should see the following elements
       | /local_storage/                  |

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -14,7 +14,7 @@ Feature: move (rename) file
     When user "Alice" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And the content of file "/FOLDER/textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | dav_version |
@@ -27,7 +27,7 @@ Feature: move (rename) file
     When user "Alice" moves file "/textfile0.txt" to "/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And the content of file "/textfile1.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -150,7 +150,7 @@ Feature: Search
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVW\|RMDNVW)$                                                                                 |
       | {DAV:}getlastmodified                      | ^[MTWFS][uedhfriatno]{2},\s(\d){2}\s[JFMAJSOND][anebrpyulgctov]{2}\s\d{4}\s\d{2}:\d{2}:\d{2} GMT$ |
-      | {DAV:}getetag                              | ^\"[a-f0-9]{1,32}\"$                                                                              |
+      | {DAV:}getetag                              | ^\"[a-f0-9:]{1,32}\"$                                                                              |
       | {DAV:}getcontenttype                       | text\/plain                                                                                       |
       | {http://owncloud.org/ns}size               | 15                                                                                                |
       | {http://owncloud.org/ns}owner-id           | %username%                                                                                             |
@@ -177,7 +177,7 @@ Feature: Search
       | {http://owncloud.org/ns}fileid             | \d*                                                                                               |
       | {http://owncloud.org/ns}permissions        | ^(RDNVCK\|RMDNVCK)$                                                                               |
       | {DAV:}getlastmodified                      | ^[MTWFS][uedhfriatno]{2},\s(\d){2}\s[JFMAJSOND][anebrpyulgctov]{2}\s\d{4}\s\d{2}:\d{2}:\d{2} GMT$ |
-      | {DAV:}getetag                              | ^\"[a-f0-9]{1,32}\"$                                                                              |
+      | {DAV:}getetag                              | ^\"[a-f0-9:]{1,32}\"$                                                                              |
       | {http://owncloud.org/ns}size               | 0                                                                                                 |
       | {http://owncloud.org/ns}owner-id           | %username%                                                                                             |
       | {http://owncloud.org/ns}owner-display-name | %displayname%                                                                                        |

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -373,7 +373,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName      |
       | d:getetag  |
-    Then the single response should contain a property "d:getetag" with value like '%\"[a-z0-9]{1,32}\"%'
+    Then the single response should contain a property "d:getetag" with value like '%\"[a-z0-9:]{1,32}\"%'
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -6,14 +6,14 @@ Feature: upload file
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: upload a file and check download content
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "<file_name>" using the WebDAV API
     Then the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And the content of file "<file_name>" for user "Alice" should be "uploaded content"
     Examples:
       | dav_version | file_name         |

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -19,7 +19,7 @@ Feature: upload file using new chunking
       | 3      | CCCCC   |
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9]{1,32}"$/ |
+      | ETag | /^"[a-f0-9:]{1,32}"$/ |
     And as "Alice" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "AAAAABBBBBCCCCC"
     And the log file should not contain any log-entries containing these attributes:

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
@@ -18,8 +18,8 @@ Feature: upload file using old chunking
       | 3      | CCCCC   |
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
-      #| ETag | /^"[a-f0-9]{1,32}"$/ |
-      | ETag | /^[a-f0-9]{1,32}$/ |
+      #| ETag | /^"[a-f0-9:]{1,32}"$/ |
+      | ETag | /^[a-f0-9:]{1,32}$/ |
     Then as "Alice" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "AAAAABBBBBCCCCC"
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -141,7 +141,7 @@ trait WebDav {
 		if ($eTag === null) {
 			$eTag = $this->getEtagFromResponseXmlObject();
 		}
-		if (\preg_match("/^\"[a-f0-9]{1,32}\"$/", $eTag)
+		if (\preg_match("/^\"[a-f0-9:]{1,32}\"$/", $eTag)
 		) {
 			return true;
 		} else {


### PR DESCRIPTION
## Description
on EOS storage etags look like `"1879048192:368d066a"` so allow those etags in the test results

## Related Issue
part of https://github.com/owncloud/ocis/issues/253

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
