### PR TITLE
Make sure that either owner or initiator of federated share is not lo…

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -530,7 +530,7 @@ class FederatedShareProvider implements IShareProvider {
 			$this->revokeShare($share, false);
 		}
 
-		// send revoke notification to the other user, if initiator and owner are not the same user
+		// send revoke notification to the other user
 		if ($this->shouldNotifyRemote($share)) {
 			$remoteId = $this->getRemoteId($share);
 			if ($isOwner) {
@@ -553,7 +553,7 @@ class FederatedShareProvider implements IShareProvider {
 	 * @throws \OC\HintException
 	 */
 	protected function revokeShare($share, $isOwner) {
-		// also send a unShare request to the initiator, if this is a different user than the owner
+		// also send a unShare request to the initiator
 		if ($this->shouldNotifyRemote($share)) {
 			if ($isOwner) {
 				list(, $remote) = $this->addressHandler->splitUserRemote($share->getSharedBy());

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -381,12 +381,26 @@ class FederatedShareProvider implements IShareProvider {
 				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()))
 				->execute();
 
-		// send the updated permission to the owner/initiator, if they are not the same
-		if ($share->getShareOwner() !== $share->getSharedBy()) {
+		// send the updated permission to the owner/initiator
+		if ($this->shouldNotifyRemote($share)) {
 			$this->sendPermissionUpdate($share);
 		}
 
 		return $share;
+	}
+
+	/**
+	 * User based check
+	 *
+	 * @param IShare $share
+	 * @return bool
+	 */
+	protected function shouldNotifyRemote($share) {
+		// We notify owner/initiator, if they are not the same user and ANY of them is NOT a local user
+		// they could be both local e.g. if recipient of local share shared it via federation
+		$isRemoteUserInvolved =  $this->userManager->userExists($share->getShareOwner()) == false
+			|| $this->userManager->userExists($share->getSharedBy()) == false;
+		return $isRemoteUserInvolved && $share->getShareOwner() !== $share->getSharedBy();
 	}
 
 	/**
@@ -517,7 +531,7 @@ class FederatedShareProvider implements IShareProvider {
 		}
 
 		// send revoke notification to the other user, if initiator and owner are not the same user
-		if ($share->getShareOwner() !== $share->getSharedBy()) {
+		if ($this->shouldNotifyRemote($share)) {
 			$remoteId = $this->getRemoteId($share);
 			if ($isOwner) {
 				list(, $remote) = $this->addressHandler->splitUserRemote($share->getSharedBy());
@@ -540,7 +554,7 @@ class FederatedShareProvider implements IShareProvider {
 	 */
 	protected function revokeShare($share, $isOwner) {
 		// also send a unShare request to the initiator, if this is a different user than the owner
-		if ($share->getShareOwner() !== $share->getSharedBy()) {
+		if ($this->shouldNotifyRemote($share)) {
 			if ($isOwner) {
 				list(, $remote) = $this->addressHandler->splitUserRemote($share->getSharedBy());
 			} else {

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -536,8 +536,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 
 	public function datatTestUpdate() {
 		return [
-			// IRL it is not possible to get both true and false from userManager->userExists on the same uid
-			// so this cases are skipped
+			// IRL it is not possible to get both true and false from userManager->userExists for the same uid
+			// so these cases are skipped
 			['owner', 'owner', true, true, false], // no update: owner is the same with sharer
 			['owner', 'sharer', true, true, false],  // no update: both owner and sharer are local
 			['owner@remote', 'sharer', false, true, true],  // update: owner differs with sharer and owner is remote

--- a/changelog/unreleased/37534
+++ b/changelog/unreleased/37534
@@ -1,0 +1,8 @@
+Bugfix: Do not notify remote if both owner and sharer are local users
+
+We tried notify remote for all federated shares. When a local share was reshared
+as a federated share it caused attempts to notify a local user via federated API.
+Under these conditions permission update caused 'Invalid Federated Cloud ID' error
+in Web UI. And the sharer was not able to delete the share at his end.
+
+https://github.com/owncloud/core/pull/37534


### PR DESCRIPTION
…cal user

## Description
Do not  send update to remote for local users

## Motivation and Context
The user who received a local share and reshared it via federation can't unshare it -
The share is removed for the remote recipient but there is a stray entry in oc_share left locally

## How Has This Been Tested?
- As user **A** share a file with user **B** locally
- As user **B** reshare this file with **user C@remote** (federated)
- As user **B**
### Case 1 - As user **B** try to update permissions for C@remote 
#### Expected
1. permissions are updated for **C@remote** 
2. no errors for user **B**
####  Actual
1. :heavy_check_mark: permissions are updated for **C@remote** 
2. there is a "Invalid Federated Cloud ID" popup in UI for user **B**

### Case 2 - As user **B** try to revoke access for C@remote 
#### Expected
1. **C@remote**  can't  access the share
2. No error for user **B**
3. user **B** can't see that the file is shared with **C@remote**  any more
####  Actual
1. :heavy_check_mark: **C@remote**  can't  access the share
2. there is a "Invalid Federated Cloud ID" popup in UI for user **B**
3.  user **B** still sees  the file as shared with **C@remote** 


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
