### PR TITLE
[Tests-only] This PR get rids of unnecessary skeleton directory creation

### DIFF
--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -116,7 +116,7 @@ Feature: favorite
   @skipOnOcis @issue-ocis-reva-21
   Scenario Outline: moving a favorite file out of a share keeps favorite state
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with user "Brian"
@@ -185,7 +185,7 @@ Feature: favorite
   @skipOnOcis @issue-ocis-reva-21
   Scenario Outline: sharer file favorite state should not change the favorite state of sharee
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has moved file "/textfile0.txt" to "/favoriteFile.txt"
     And user "Alice" has shared file "/favoriteFile.txt" with user "Brian"
     When user "Alice" favorites element "/favoriteFile.txt" using the WebDAV API
@@ -200,7 +200,7 @@ Feature: favorite
   @skipOnOcis @issue-ocis-reva-21
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has moved file "/textfile0.txt" to "/favoriteFile.txt"
     And user "Alice" has shared file "/favoriteFile.txt" with user "Brian"
     When user "Brian" favorites element "/favoriteFile.txt" using the WebDAV API

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -2,7 +2,7 @@
 Feature: checksums
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   Scenario Outline: Uploading a file with checksum should work
     Given using <dav_version> DAV path
@@ -143,7 +143,7 @@ Feature: checksums
   @skipOnOcis @issue-ocis-reva-196
   Scenario: Sharing a file with checksum should return the checksum in the propfind using new DAV path
     Given using new DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" shares file "/myChecksumFile.txt" with user "Brian" using the sharing API
     And user "Brian" requests the checksum of "/myChecksumFile.txt" via propfind
@@ -153,7 +153,7 @@ Feature: checksums
   @skipOnOcis @issue-ocis-reva-196
   Scenario: Sharing and modifying a file should return correct checksum in the propfind using new DAV path
     Given using new DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" shares file "/myChecksumFile.txt" with user "Brian" using the sharing API
     And user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/myChecksumFile.txt" using the WebDAV API
@@ -352,9 +352,10 @@ Feature: checksums
   @skipOnOcis @issue-ocis-reva-196
   Scenario Outline: Uploading a file with invalid SHA1 checksum overwriting an existing file
     Given using <dav_version> DAV path
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:f005ba11f005ba11f005ba11f005ba11f005ba11" using the WebDAV API
-    Then as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:0c1d334e686d1039c9ead0dbc047f02dbf696be8 MD5:d991cd854c53729d066c6ed5e34bcda3 ADLER32:8685092b"
-    And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
+    And user "Brian" has been created with default attributes and skeleton files
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:f005ba11f005ba11f005ba11f005ba11f005ba11" using the WebDAV API
+    Then as user "Brian" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:0c1d334e686d1039c9ead0dbc047f02dbf696be8 MD5:d991cd854c53729d066c6ed5e34bcda3 ADLER32:8685092b"
+    And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
     Examples:
       | dav_version |
       | old         |
@@ -363,23 +364,25 @@ Feature: checksums
   @skipOnOcis @issue-ocis-reva-56
   Scenario: Upload overwriting a file with new chunking and correct checksum
     Given using new DAV path
-    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
-    And user "Alice" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
+    And user "Brian" has been created with default attributes and skeleton files
+    When user "Brian" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "Brian" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Brian" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "Brian" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
     Then the HTTP status code should be "204"
-    And the content of file "/textfile0.txt" for user "Alice" should be "BBBBBCCCCC"
+    And the content of file "/textfile0.txt" for user "Brian" should be "BBBBBCCCCC"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
   @skipOnOcis @issue-ocis-reva-56
   Scenario: Upload overwriting a file with new chunking and invalid checksum
     Given using new DAV path
-    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
-    And user "Alice" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:f005ba11" using the WebDAV API
+    And user "Brian" has been created with default attributes and skeleton files
+    When user "Brian" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "Brian" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Brian" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "Brian" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:f005ba11" using the WebDAV API
     Then the HTTP status code should be "400"
-    And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
 
   Scenario Outline: Uploading a file with checksum should work for file with special characters
     When user "Alice" uploads file "filesForUpload/textfile.txt" to <renamed_file> with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -3,7 +3,7 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -127,7 +127,7 @@ Feature: sharing
   @skipOnOcis @issue-ocis-reva-21
   Scenario Outline: Get a share with a user that didn't receive the share
     Given using OCS API version "<ocs_api_version>"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     When user "Carol" gets the info of the last share using the sharing API
     Then the OCS status code should be "404"

--- a/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
@@ -6,7 +6,7 @@ Feature: move (rename) folder
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @issue-ocis-reva-211 @skipOnOcis
   Scenario Outline: Renaming a folder to a backslash should return an error

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
@@ -6,7 +6,7 @@ Feature: users cannot move (rename) a folder to a blacklisted name
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @issue-ocis-reva-211 @skipOnOcis
   Scenario Outline: Rename a folder to a name that is banned by default
@@ -51,11 +51,12 @@ Feature: users cannot move (rename) a folder to a blacklisted name
   @skipOnOcV10.3 @skipOnOcis
   Scenario Outline: rename a folder to a folder name that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/testshare"
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has created folder "/testshare"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
     And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
-    When user "Alice" moves folder "/testshare" to these foldernames using the webDAV API then the results should be as listed
+    When user "Brian" moves folder "/testshare" to these foldernames using the webDAV API then the results should be as listed
       | foldername                             | http-code | exists |
       | .ext                                   | 403       | no     |
       | filename.ext                           | 403       | no     |

--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -6,7 +6,7 @@ Feature: get file properties
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Do a PROPFIND of various file names
@@ -152,7 +152,7 @@ Feature: get file properties
   @skipOnOcis @issue-ocis-reva-11
   Scenario Outline: A file that is shared to a user has a share-types property
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has created a share with settings
       | path        | test  |
@@ -212,7 +212,7 @@ Feature: get file properties
   @skipOnOcis @issue-ocis-reva-11
   Scenario Outline: A file that is shared by user,group and link has a share-types property
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Alice" has created folder "/test"
     And user "Alice" has created a share with settings

--- a/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/setFileProperties.feature
@@ -6,7 +6,7 @@ Feature: set file properties
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Setting custom DAV property and reading it
@@ -47,7 +47,7 @@ Feature: set file properties
   @files_sharing-app-required @skipOnOcis  @issue-ocis-reva-217
   Scenario Outline: Setting custom DAV property on a shared file as an owner and reading as a recipient
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustompropshared.txt"
     And user "Alice" has created a share with settings
       | path        | testcustompropshared.txt |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Get rid of unnecessary creation of skeleton files.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/37526

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- https://github.com/owncloud/ocis-reva/pull/272
https://github.com/owncloud/ocis/pull/319

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
