### PR TITLE
Add support to expire outgoing federated shares

### DIFF
--- a/apps/files_sharing/lib/Capabilities.php
+++ b/apps/files_sharing/lib/Capabilities.php
@@ -125,6 +125,13 @@ class Capabilities implements ICapability {
 				$res['group']['expire_date']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date_group_share', 'no') === 'yes';
 			}
 
+			$res['remote']['expire_date'] = [];
+			$res['remote']['expire_date']['enabled'] = $this->config->getAppValue('core', 'shareapi_default_expire_date_remote_share', 'no') === 'yes';
+			if ($res['remote']['expire_date']['enabled']) {
+				$res['remote']['expire_date']['days'] = $this->config->getAppValue('core', 'shareapi_expire_after_n_days_remote_share', '7');
+				$res['remote']['expire_date']['enforced'] = $this->config->getAppValue('core', 'shareapi_enforce_expire_date_remote_share', 'no') === 'yes';
+			}
+
 			$res['resharing'] = $this->config->getAppValue('core', 'shareapi_allow_resharing', 'yes') === 'yes';
 
 			$res['group_sharing'] = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') === 'yes';

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -489,4 +489,115 @@ class CapabilitiesTest extends \Test\TestCase {
 		$this->assertTrue($result['public']['multiple']);
 		$this->assertEquals('Public link', $result['public']['defaultPublicLinkShareName']);
 	}
+
+	public function testUserShareExpirationNotEnabled() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date_user_share', 'no', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['user']['expire_date']['enabled']);
+		$this->assertArrayNotHasKey('days', $result['user']['expire_date']);
+		$this->assertArrayNotHasKey('enforced', $result['user']['expire_date']);
+	}
+
+	public function testUserShareExpirationEnabled() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date_user_share', 'no', 'yes'],
+			['core', 'shareapi_expire_after_n_days_user_share', '7', '15'],
+			['core', 'shareapi_enforce_expire_date_user_share', 'no', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['user']['expire_date']['enabled']);
+		$this->assertSame('15', $result['user']['expire_date']['days']);
+		$this->assertFalse($result['user']['expire_date']['enforced']);
+	}
+
+	public function testUserShareExpirationEnabledEnforced() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date_user_share', 'no', 'yes'],
+			['core', 'shareapi_expire_after_n_days_user_share', '7', '15'],
+			['core', 'shareapi_enforce_expire_date_user_share', 'no', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['user']['expire_date']['enabled']);
+		$this->assertSame('15', $result['user']['expire_date']['days']);
+		$this->assertTrue($result['user']['expire_date']['enforced']);
+	}
+
+	public function testGroupShareExpirationNotEnabled() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date_group_share', 'no', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['group']['expire_date']['enabled']);
+		$this->assertArrayNotHasKey('days', $result['group']['expire_date']);
+		$this->assertArrayNotHasKey('enforced', $result['group']['expire_date']);
+	}
+
+	public function testGroupShareExpirationEnabled() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date_group_share', 'no', 'yes'],
+			['core', 'shareapi_expire_after_n_days_group_share', '7', '15'],
+			['core', 'shareapi_enforce_expire_date_group_share', 'no', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['group']['expire_date']['enabled']);
+		$this->assertSame('15', $result['group']['expire_date']['days']);
+		$this->assertFalse($result['group']['expire_date']['enforced']);
+	}
+
+	public function testGroupShareExpirationEnabledEnforced() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date_group_share', 'no', 'yes'],
+			['core', 'shareapi_expire_after_n_days_group_share', '7', '15'],
+			['core', 'shareapi_enforce_expire_date_group_share', 'no', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['group']['expire_date']['enabled']);
+		$this->assertSame('15', $result['group']['expire_date']['days']);
+		$this->assertTrue($result['group']['expire_date']['enforced']);
+	}
+
+	public function testRemoteShareExpirationNotEnabled() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date_remote_share', 'no', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertFalse($result['remote']['expire_date']['enabled']);
+		$this->assertArrayNotHasKey('days', $result['remote']['expire_date']);
+		$this->assertArrayNotHasKey('enforced', $result['remote']['expire_date']);
+	}
+
+	public function testRemoteShareExpirationEnabled() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date_remote_share', 'no', 'yes'],
+			['core', 'shareapi_expire_after_n_days_remote_share', '7', '15'],
+			['core', 'shareapi_enforce_expire_date_remote_share', 'no', 'no'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['remote']['expire_date']['enabled']);
+		$this->assertSame('15', $result['remote']['expire_date']['days']);
+		$this->assertFalse($result['remote']['expire_date']['enforced']);
+	}
+
+	public function testRemoteShareExpirationEnabledEnforced() {
+		$map = [
+			['core', 'shareapi_enabled', 'yes', 'yes'],
+			['core', 'shareapi_default_expire_date_remote_share', 'no', 'yes'],
+			['core', 'shareapi_expire_after_n_days_remote_share', '7', '15'],
+			['core', 'shareapi_enforce_expire_date_remote_share', 'no', 'yes'],
+		];
+		$result = $this->getResults($map);
+		$this->assertTrue($result['remote']['expire_date']['enabled']);
+		$this->assertSame('15', $result['remote']['expire_date']['days']);
+		$this->assertTrue($result['remote']['expire_date']['enforced']);
+	}
 }

--- a/changelog/unreleased/37548
+++ b/changelog/unreleased/37548
@@ -1,0 +1,18 @@
+Enhancement: Add support for date expiration on remote shares
+
+An expiration date can be set now for shares originating in your server.
+This feature behaves the same as the expiration for user, group and link shares.
+
+The expiration is controlled in the source server (server A). The target server
+(server B) won't know about the expiration. Once the share expires, the target server
+(server B) won't be able to access to those shares and it will remove them automatically
+
+This feature won't work for shares that are grabbed from a public link:
+if source server (server A) shares a file / folder via link, and an user from the
+target server (server B) add that link to his ownCloud; in this case, this "remote
+share expiration" won't apply.
+
+In addition, the same that happens with user, group and link shares, the share recipient
+won't have control over the expiration date. 
+
+https://github.com/owncloud/core/pull/37548

--- a/changelog/unreleased/37548
+++ b/changelog/unreleased/37548
@@ -9,10 +9,10 @@ The expiration is controlled in the source server (server A). The target server
 
 This feature won't work for shares that are grabbed from a public link:
 if source server (server A) shares a file / folder via link, and an user from the
-target server (server B) add that link to his ownCloud; in this case, this "remote
+target server (server B) adds that link to his ownCloud; in this case, this "remote
 share expiration" won't apply.
 
-In addition, the same that happens with user, group and link shares, the share recipient
+In addition, the same as happens with user, group and link shares, the share recipient
 won't have control over the expiration date. 
 
 https://github.com/owncloud/core/pull/37548

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -86,6 +86,14 @@ $defaultExpireDateGroup = (int) $config->getAppValue('core', 'shareapi_expire_af
 $value = $config->getAppValue('core', 'shareapi_enforce_expire_date_group_share', 'no');
 $enforceDefaultExpireDateGroup =  ($value === 'yes') ? true : false;
 
+$value = $config->getAppValue('core', 'shareapi_default_expire_date_remote_share', 'no');
+$defaultExpireDateRemoteEnabled = ($value === 'yes') ? true :false;
+
+$defaultExpireDateRemote = (int) $config->getAppValue('core', 'shareapi_expire_after_n_days_remote_share', '7');
+
+$value = $config->getAppValue('core', 'shareapi_enforce_expire_date_remote_share', 'no');
+$enforceDefaultExpireDateRemote =  ($value === 'yes') ? true : false;
+
 $enforceLinkPasswordReadWriteDelete = $config->getAppValue('core', 'shareapi_enforce_links_password_read_write_delete', 'no') === 'yes';
 $outgoingServer2serverShareEnabled = $config->getAppValue('files_sharing', 'outgoing_server2server_share_enabled', 'yes') === 'yes';
 
@@ -191,14 +199,18 @@ $array = [
 				'enforceLinkPasswordReadWrite' => $enforceLinkPasswordReadWrite,
 				'enforceLinkPasswordReadWriteDelete' => $enforceLinkPasswordReadWriteDelete,
 				'enforceLinkPasswordWriteOnly' => $enforceLinkPasswordWriteOnly,
-				
+
 				'defaultExpireDateUserEnabled' => $defaultExpireDateUserEnabled,
 				'defaultExpireDateUser' => $defaultExpireDateUser,
 				'enforceDefaultExpireDateUser' => $enforceDefaultExpireDateUser,
-				
+
 				'defaultExpireDateGroupEnabled' => $defaultExpireDateGroupEnabled,
 				'defaultExpireDateGroup' => $defaultExpireDateGroup,
 				'enforceDefaultExpireDateGroup' => $enforceDefaultExpireDateGroup,
+
+				'defaultExpireDateRemoteEnabled' => $defaultExpireDateRemoteEnabled,
+				'defaultExpireDateRemote' => $defaultExpireDateRemote,
+				'enforceDefaultExpireDateRemote' => $enforceDefaultExpireDateRemote,
 
 				'sharingDisabledForUser' => \OCP\Util::isSharingDisabledForUser(),
 				'resharingAllowed' => \OCP\Share::isResharingAllowed(),

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -34,6 +34,9 @@
 			isDefaultExpireDateEnforced: oc_appconfig.core.defaultExpireDateEnforced === true,
 			isDefaultExpireDateEnabled: oc_appconfig.core.defaultExpireDateEnabled === true,
 			isRemoteShareAllowed: oc_appconfig.core.remoteShareAllowed,
+			defaultExpireDateRemote: oc_appconfig.core.defaultExpireDateRemote,
+			isDefaultExpireDateRemoteEnabled: oc_appconfig.core.defaultExpireDateRemoteEnabled,
+			isDefaultExpireDateRemoteEnforced: oc_appconfig.core.enforceDefaultExpireDateRemote,
 			defaultExpireDate: oc_appconfig.core.defaultExpireDate,
 			isResharingAllowed: oc_appconfig.core.resharingAllowed,
 			allowGroupSharing: oc_appconfig.core.allowGroupSharing
@@ -132,14 +135,14 @@
 		 * @returns {boolean}
 		 */
 		isDefaultExpireDateGroupEnabled: function() {
-			return this.get('isDefaultExpireDateGroupEnabled')
+			return this.get('isDefaultExpireDateGroupEnabled');
 		},
 
 		/**
 		 * @returns {boolean}
 		 */
 		isDefaultExpireDateGroupEnforced: function() {
-			return this.get('isDefaultExpireDateGroupEnforced')
+			return this.get('isDefaultExpireDateGroupEnforced');
 		},
 
 		/**
@@ -147,13 +150,41 @@
 		 */
 		getDefaultExpireDateGroup: function(format) {
 			format = format || false;
-			defaultExpireDateGroup = parseInt(this.get('defaultExpireDateGroup'), 10)
+			defaultExpireDateGroup = parseInt(this.get('defaultExpireDateGroup'), 10);
 
 			if (format) {
-				return moment().add(defaultExpireDateGroup, 'days').format(format)
+				return moment().add(defaultExpireDateGroup, 'days').format(format);
 			}
 
-			return defaultExpireDateGroup
+			return defaultExpireDateGroup;
+		},
+
+		/**
+		 * @returns {boolean}
+		 */
+		isDefaultExpireDateRemoteEnabled: function() {
+			return this.get('isDefaultExpireDateRemoteEnabled');
+		},
+
+		/**
+		 * @returns {boolean}
+		 */
+		isDefaultExpireDateRemoteEnforced: function() {
+			return this.get('isDefaultExpireDateRemoteEnforced');
+		},
+
+		/**
+		 * @returns {number/string}
+		 */
+		getDefaultExpireDateRemote: function(format) {
+			format = format || false;
+			defaultExpireDateRemote = parseInt(this.get('defaultExpireDateRemote'), 10);
+
+			if (format) {
+				return moment().add(defaultExpireDateRemote, 'days').format(format);
+			}
+
+			return defaultExpireDateRemote;
 		},
 	});
 

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -54,6 +54,14 @@
 		'				{{/unless}}' +
 		'			</label>' +
 		'			{{/if}}' +
+		'			{{#if isRemoteShare}}' +
+		'			<label for="expiration-{{name}}-{{cid}}-{{shareWith}}-{{shareType}}">{{expirationLabel}}: ' +
+		'				<input type="text" id="expiration-{{name}}-{{cid}}-{{shareWith}}-{{shareType}}" value="{{expirationDate}}" class="expiration expiration-remote" placeholder="{{expirationDatePlaceholder}}" />' +
+		'				{{#unless isDefaultExpireDateRemoteEnforced}}' +
+		'				<button class="removeExpiration">Remove</button>' +
+		'				{{/unless}}' +
+		'			</label>' +
+		'			{{/if}}' +
 		'		</div>' +
 		'		<div class="coreShareOptions">' +
 		'			{{#if isResharingAllowed}} {{#if sharePermissionPossible}}' +
@@ -220,6 +228,7 @@
 				expirationDatePlaceholder: t('core', 'Choose an expiration date'),
 				isDefaultExpireDateUserEnforced: this.configModel.isDefaultExpireDateUserEnforced(),
 				isDefaultExpireDateGroupEnforced: this.configModel.isDefaultExpireDateGroupEnforced(),
+				isDefaultExpireDateRemoteEnforced: this.configModel.isDefaultExpireDateRemoteEnforced(),
 				expirationDate: this.model.getExpirationDate(shareIndex),
 				wasMailSent: this.model.notificationMailWasSent(shareIndex),
 				shareWith: shareWith,
@@ -312,6 +321,13 @@
 				self._setDatepicker(this, {
 					maxDate  : self.configModel.getDefaultExpireDateGroup(),
 					enforced : self.configModel.isDefaultExpireDateGroupEnforced()
+				});
+			});
+
+			this.$el.find('.expiration-remote:not(.hasDatepicker)').each(function(){
+				self._setDatepicker(this, {
+					maxDate  : self.configModel.getDefaultExpireDateRemote(),
+					enforced : self.configModel.isDefaultExpireDateRemoteEnforced()
 				});
 			});
 

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -264,6 +264,7 @@
 				deletePermissionPossible: this.model.deletePermissionPossible(),
 				defaultExpireDateUserEnabled: this.configModel.isDefaultExpireDateUserEnabled(),
 				defaultExpireDateGroupEnabled: this.configModel.isDefaultExpireDateGroupEnabled(),
+				defaultExpireDateRemoteEnabled: this.configModel.isDefaultExpireDateRemoteEnabled(),
 				sharePermission: OC.PERMISSION_SHARE,
 				createPermission: OC.PERMISSION_CREATE,
 				updatePermission: OC.PERMISSION_UPDATE,

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -169,14 +169,15 @@
 			if (
 				this.configModel.isDefaultExpireDateUserEnabled() && (
 					shareType === OC.Share.SHARE_TYPE_USER ||
-					shareType === OC.Share.SHARE_TYPE_GUEST ||
-					shareType === OC.Share.SHARE_TYPE_REMOTE )
+					shareType === OC.Share.SHARE_TYPE_GUEST)
 				) {
 				properties.expireDate = this.configModel.getDefaultExpireDateUser('YYYY-MM-DD')
 			}
 
 			else if (this.configModel.isDefaultExpireDateGroupEnabled() && shareType === OC.Share.SHARE_TYPE_GROUP) {
 				properties.expireDate = this.configModel.getDefaultExpireDateGroup('YYYY-MM-DD')
+			} else if (this.configModel.isDefaultExpireDateRemoteEnabled() && shareType === OC.Share.SHARE_TYPE_REMOTE) {
+				properties.expireDate = this.configModel.getDefaultExpireDateRemote('YYYY-MM-DD')
 			}
 
 			// Get default permissions

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -435,6 +435,11 @@ class Manager implements IManager {
 				$thereIsDefault = $this->shareApiLinkDefaultExpireDate();
 				$defaultDays = $this->shareApiLinkDefaultExpireDays();
 				break;
+			case \OCP\Share::SHARE_TYPE_REMOTE:
+				$isEnforced = $this->shareApiLinkDefaultExpireDateEnforcedForRemotes();
+				$thereIsDefault = $this->shareApiLinkDefaultExpireDateForRemotes();
+				$defaultDays = $this->shareApiLinkDefaultExpireDaysForRemotes();
+				break;
 			default:
 				$isEnforced = false;
 				break;
@@ -1726,6 +1731,33 @@ class Manager implements IManager {
 	 */
 	public function shareApiLinkDefaultExpireDaysForGroups() {
 		return (int)$this->config->getAppValue('core', 'shareapi_expire_after_n_days_group_share', '7');
+	}
+
+	/**
+	 * Is default expire date enabled for remote shares
+	 *
+	 * @return bool
+	 */
+	public function shareApiLinkDefaultExpireDateForRemotes() {
+		return $this->config->getAppValue('core', 'shareapi_default_expire_date_remote_share', 'no') === 'yes';
+	}
+
+	/**
+	 * Is default expire date enforced for remote shares
+	 *`
+	 * @return bool
+	 */
+	public function shareApiLinkDefaultExpireDateEnforcedForRemotes() {
+		return $this->shareApiLinkDefaultExpireDateForRemotes() &&
+			$this->config->getAppValue('core', 'shareapi_enforce_expire_date_remote_share', 'no') === 'yes';
+	}
+
+	/**
+	 * Number of default expire days for remote shares
+	 * @return int
+	 */
+	public function shareApiLinkDefaultExpireDaysForRemotes() {
+		return (int)$this->config->getAppValue('core', 'shareapi_expire_after_n_days_remote_share', '7');
 	}
 
 	/**

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -120,6 +120,10 @@ class FileSharing implements ISettings {
 		$template->assign('shareExpireAfterNDaysGroupShare', $this->config->getAppValue('core', 'shareapi_expire_after_n_days_group_share', '7'));
 		$template->assign('shareEnforceExpireDateGroupShare', $this->config->getAppValue('core', 'shareapi_enforce_expire_date_group_share', 'no'));
 
+		$template->assign('shareDefaultExpireDateSetRemoteShare', $this->config->getAppValue('core', 'shareapi_default_expire_date_remote_share', 'no'));
+		$template->assign('shareExpireAfterNDaysRemoteShare', $this->config->getAppValue('core', 'shareapi_expire_after_n_days_remote_share', '7'));
+		$template->assign('shareEnforceExpireDateRemoteShare', $this->config->getAppValue('core', 'shareapi_enforce_expire_date_remote_share', 'no'));
+
 		$template->assign('autoAcceptShare', $this->config->getAppValue('core', 'shareapi_auto_accept_share', 'yes'));
 
 		$permList = [

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -98,6 +98,18 @@ $(document).ready(function(){
 		$("#setDefaultExpireDateGroupShare").toggleClass('hidden', !this.checked);
 	});
 
+	$('#shareapiExpireAfterNDaysRemoteShare').change(function() {
+		var value = parseInt($(this).val(), 10)
+
+		if (value <= 0 || isNaN(value)) {
+			$(this).val(7);
+		}
+	});
+
+	$('#shareapiDefaultExpireDateRemoteShare').change(function() {
+		$("#setDefaultExpireDateRemoteShare").toggleClass('hidden', !this.checked);
+	});
+
 	$('#allowLinks').change(function() {
 		$("#publicLinkSettings").toggleClass('hidden', !this.checked);
 		$('#setDefaultExpireDate').toggleClass('hidden', !(this.checked && $('#shareapiDefaultExpireDate')[0].checked));

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -145,6 +145,29 @@
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') {
 	p('hidden');
 }?>">
+		<input type="checkbox" name="shareapi_default_expire_date_remote_share" id="shareapiDefaultExpireDateRemoteShare" class="checkbox"
+					   value="1" <?php if ($_['shareDefaultExpireDateSetRemoteShare'] === 'yes') {
+	print_unescaped('checked="checked"');
+} ?> />
+		<label for="shareapiDefaultExpireDateRemoteShare"><?php p($l->t('Set default expiration date for remote shares'));?></label><br/>
+		<span id="setDefaultExpireDateRemoteShare" class="indent <?php if ($_['shareDefaultExpireDateSetRemoteShare'] === 'no' || $_['shareAPIEnabled'] === 'no') {
+	p('hidden');
+}?>">
+			<?php p($l->t('Expire after ')); ?>
+			<input type="number" name='shareapi_expire_after_n_days_remote_share' id="shareapiExpireAfterNDaysRemoteShare" min="0" placeholder="<?php p('7')?>"
+				   value='<?php p($_['shareExpireAfterNDaysRemoteShare']) ?>' />
+			<?php p($l->t('days')); ?><br/>
+			<?php if ($_['shareEnforceExpireDateRemoteShare'] === 'yes'): ?>
+				<input type="checkbox" name="shareapi_enforce_expire_date_remote_share" id="shareapiEnforceExpireDateRemoteShare" class="checkbox" value="1" checked="checked" />
+			<?php else: ?>
+				<input type="checkbox" name="shareapi_enforce_expire_date_remote_share" id="shareapiEnforceExpireDateRemoteShare" class="checkbox" value="1" />
+			<?php endif; ?>
+			<label class="indent" for="shareapiEnforceExpireDateRemoteShare"><?php p($l->t('Enforce as maximum expiration date'));?></label><br/>
+		</span>
+	</p>
+	<p class="<?php if ($_['shareAPIEnabled'] === 'no') {
+	p('hidden');
+}?>">
 		<input type="checkbox" name="shareapi_auto_accept_share" id="autoAcceptShare" class="checkbox"
 			value="1" <?php if ($_['autoAcceptShare'] === 'yes') {
 	print_unescaped('checked="checked"');

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -80,13 +80,26 @@ Feature: capabilities
   Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
+      | capability    | path_to_element                                          | value             |
+      | files_sharing | user@@@expire_date@@@enabled                             | EMPTY             |
+      | files_sharing | group@@@expire_date@@@enabled                            | EMPTY             |
+      | files_sharing | providers_capabilities@@@ocinternal@@@user@@@element[0]  | shareExpiration   |
+      | files_sharing | providers_capabilities@@@ocinternal@@@group@@@element[0] | shareExpiration   |
+      | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[0]  | shareExpiration   |
+      | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[1]  | passwordProtected |
+
+  @smokeTest @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  # These are a new combination of capabilities after 10.5.0
+  Scenario: the default capabilities should include share expiration for all of user, group, link and remote (federated)
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
       | capability    | path_to_element                                                       | value             |
       | files_sharing | user@@@expire_date@@@enabled                                          | EMPTY             |
       | files_sharing | group@@@expire_date@@@enabled                                         | EMPTY             |
+      | files_sharing | remote@@@expire_date@@@enabled                                        | EMPTY             |
       | files_sharing | providers_capabilities@@@ocinternal@@@user@@@element[0]               | shareExpiration   |
       | files_sharing | providers_capabilities@@@ocinternal@@@group@@@element[0]              | shareExpiration   |
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[0]               | shareExpiration   |
-      | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[1]               | passwordProtected |
       | files_sharing | providers_capabilities@@@ocFederatedSharing@@@remote@@@element[0]     | shareExpiration   |
 
   @smokeTest @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -80,14 +80,14 @@ Feature: capabilities
   Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
-      | capability    | path_to_element                                          | value             |
-      | files_sharing | user@@@expire_date@@@enabled                             | EMPTY             |
-      | files_sharing | group@@@expire_date@@@enabled                            | EMPTY             |
-      | files_sharing | providers_capabilities@@@ocinternal@@@user@@@element[0]  | shareExpiration   |
-      | files_sharing | providers_capabilities@@@ocinternal@@@group@@@element[0] | shareExpiration   |
-      | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[0]  | shareExpiration   |
-      | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[1]  | passwordProtected |
-      | files_sharing | providers_capabilities@@@ocFederatedSharing@@@remote     | EMPTY             |
+      | capability    | path_to_element                                                       | value             |
+      | files_sharing | user@@@expire_date@@@enabled                                          | EMPTY             |
+      | files_sharing | group@@@expire_date@@@enabled                                         | EMPTY             |
+      | files_sharing | providers_capabilities@@@ocinternal@@@user@@@element[0]               | shareExpiration   |
+      | files_sharing | providers_capabilities@@@ocinternal@@@group@@@element[0]              | shareExpiration   |
+      | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[0]               | shareExpiration   |
+      | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[1]               | passwordProtected |
+      | files_sharing | providers_capabilities@@@ocFederatedSharing@@@remote@@@element[0]     | shareExpiration   |
 
   @smokeTest @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   # These are new capabilities after 10.5.0

--- a/tests/acceptance/features/apiFederation2/federated.feature
+++ b/tests/acceptance/features/apiFederation2/federated.feature
@@ -484,3 +484,156 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario Outline: Federated share a file with another server with expiration date
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Brian" sharing with user "Alice" should include
+      | id                     | A_NUMBER          |
+      | item_type              | file              |
+      | item_source            | A_NUMBER          |
+      | share_type             | federated         |
+      | file_source            | A_NUMBER          |
+      | path                   | /textfile0.txt    |
+      | permissions            | share,read,update |
+      | stime                  | A_NUMBER          |
+      | storage                | A_NUMBER          |
+      | mail_send              | 0                 |
+      | uid_owner              | %username%        |
+      | file_parent            | A_NUMBER          |
+      | displayname_owner      | %displayname%     |
+      | share_with             | %username%@REMOTE |
+      | share_with_displayname | %username%@REMOTE |
+      | expiration             | +7 days           |
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario Outline: Federated sharing with default expiration date enabled but not enforced, user shares without specifying expireDate
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Brian" sharing with user "Alice" should include
+      | expiration |  |
+    Examples:
+      | ocs_api_version | ocs-status |
+      | 1               | 100        |
+#      | 2               | 200        |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario Outline: Federated sharing with default expiration date enabled and enforced, user shares without specifying expireDate
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
+    When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Brian" sharing with user "Alice" should include
+      | expiration | +7days |
+    Examples:
+      | ocs_api_version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario Outline: Federated sharing with default expiration date disabled
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "no"
+    When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Brian" sharing with user "Alice" should include
+      | expiration |  |
+    Examples:
+      | ocs_api_version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario Outline: Expiration date is enforced for federated share, user modifies expiration date
+    Given using OCS API version "<ocs-api-version>"
+    And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
+    And user "Brian" updates the last share using the sharing API with
+      | expireDate | +3 days |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Brian" sharing with user "Alice" should include
+      | expiration | +3 days |
+    Examples:
+      | ocs-api-version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario Outline: Federated sharing with default expiration date enabled and enforced, user shares with expiration date more than the default
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
+    And user "Brian" updates the last share using the sharing API with
+      | expireDate | +10 days |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario Outline: User modifies expiration date for federated reshare of a file with another server with default expiration date
+    Given using OCS API version "<ocs_api_version>"
+    And using server "LOCAL"
+    And user "Carol" has been created with default attributes and without skeleton files
+    And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    And user "Brian" has shared file "/textfile0.txt" with user "Carol" with permissions "read,update,share"
+    When user "Carol" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
+    And user "Carol" updates the last share using the sharing API with
+      | expireDate | +3 days |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs-status>"
+    And the fields of the last response to user "Carol" sharing with user "Alice" should include
+      | expiration | +3 days |
+
+    Examples:
+      | ocs_api_version | ocs-status |
+      | 1               | 100        |
+      | 2               | 200        |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario Outline: User modifies expiration date more than the default for federated reshare of a file
+    Given using OCS API version "<ocs_api_version>"
+    And using server "LOCAL"
+    And user "Carol" has been created with default attributes and without skeleton files
+    And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    And user "Brian" has shared file "/textfile0.txt" with user "Carol" with permissions "read,update,share"
+    When user "Carol" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
+    And user "Carol" updates the last share using the sharing API with
+      | expireDate | +10 days |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And the information of the last share of user "Carol" should include
+      | expiration | +7 days |
+
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2946,6 +2946,20 @@ trait Sharing {
 			],
 			[
 				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'remote@@@expire_date@@@enabled',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_default_expire_date_remote_share',
+				'testingState' => false
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
+				'capabilitiesParameter' => 'remote@@@expire_date@@@enforced',
+				'testingApp' => 'core',
+				'testingParameter' => 'shareapi_enforce_expire_date_remote_share',
+				'testingState' => false
+			],
+			[
+				'capabilitiesApp' => 'files_sharing',
 				'capabilitiesParameter' => 'federation@@@outgoing',
 				'testingApp' => 'files_sharing',
 				'testingParameter' => 'outgoing_server2server_share_enabled',

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -130,6 +130,16 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @Then the default expiration date checkbox for remote shares should be enabled on the webUI
+	 *
+	 * @return void
+	 */
+	public function setDefaultExpirationDateForRemoteCheckboxSharesShouldBeEnabled() {
+		$checkboxElement = $this->adminSharingSettingsPage->getDefaultExpirationForRemoteShareElement();
+		$this->assertCheckBoxIsChecked($checkboxElement);
+	}
+
+	/**
 	 * @Then the enforce maximum expiration date checkbox for user shares should be enabled on the webUI
 	 *
 	 * @return void
@@ -146,6 +156,16 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	 */
 	public function enforceMaximumExpirationDateForGroupSharesCheckboxShouldBeEnabled() {
 		$checkboxElement = $this->adminSharingSettingsPage->getEnforceExpireDateGroupShareElement();
+		$this->assertCheckBoxIsChecked($checkboxElement);
+	}
+
+	/**
+	 * @Then the enforce maximum expiration date checkbox for remote shares should be enabled on the webUI
+	 *
+	 * @return void
+	 */
+	public function enforceMaximumExpirationDateForRemoteSharesCheckboxShouldBeEnabled() {
+		$checkboxElement = $this->adminSharingSettingsPage->getEnforceExpireDateRemoteShareElement();
 		$this->assertCheckBoxIsChecked($checkboxElement);
 	}
 
@@ -181,6 +201,24 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 			$expirationDays,
 			__METHOD__
 			. " The expiration date for group shares was expected to be set to '$days' days, "
+			. "but was actually set to '$expirationDays' days"
+		);
+	}
+
+	/**
+	 * @Then the expiration date for remote shares should set to :days days on the webUI
+	 *
+	 * @param int $days
+	 *
+	 * @return void
+	 */
+	public function expirationDateForRemoteSharesShouldBeSetToXDays($days) {
+		$expirationDays = $this->adminSharingSettingsPage->getRemoteShareExpirationDays();
+		Assert::assertEquals(
+			$days,
+			$expirationDays,
+			__METHOD__
+			. " The expiration date for remote shares was expected to be set to '$days' days, "
 			. "but was actually set to '$expirationDays' days"
 		);
 	}
@@ -360,6 +398,17 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @When the administrator enforces maximum expiration date for remote shares using the webUI
+	 *
+	 * @return void
+	 */
+	public function administratorEnforcesMaximumExpirationDateForRemoteShares() {
+		$this->adminSharingSettingsPage->enforceMaximumExpirationDateForRemoteShares(
+			$this->getSession()
+		);
+	}
+
+	/**
 	 * @When the administrator updates the user share expiration date to :days days using the webUI
 	 *
 	 * @param int $days
@@ -382,12 +431,34 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @When the administrator updates the remote share expiration date to :days days using the webUI
+	 *
+	 * @param int $days
+	 *
+	 * @return void
+	 */
+	public function administratorUpdatesRemoteShareExpirationTo($days) {
+		$this->adminSharingSettingsPage->setExpirationDaysForRemoteShare($days, $this->getSession());
+	}
+
+	/**
 	 * @When the administrator enables default expiration date for group shares using the webUI
 	 *
 	 * @return void
 	 */
 	public function theAdministratorEnablesDefaultExpirationDateForGroupShares() {
 		$this->adminSharingSettingsPage->enableDefaultExpirationDateForGroupShares(
+			$this->getSession()
+		);
+	}
+
+	/**
+	 * @When the administrator enables default expiration date for remote shares using the webUI
+	 *
+	 * @return void
+	 */
+	public function theAdministratorEnablesDefaultExpirationDateForRemoteShares() {
+		$this->adminSharingSettingsPage->enableDefaultExpirationDateForRemoteShares(
 			$this->getSession()
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -163,11 +163,12 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^the user shares (?:file|folder) "([^"]*)" with (?:(remote|federated)\s)?user "([^"]*)" using the webUI without closing the share dialog$/
+	 * @When /^the user shares (?:file|folder) "([^"]*)" with (?:(remote|federated)\s)?user "([^"]*)" ?(?:with displayname "([^"]*)")? using the webUI without closing the share dialog$/
 	 *
 	 * @param string $folder
 	 * @param string $remote (remote|federated|)
 	 * @param string $name
+	 * @param string|null $displayname
 	 * @param int $maxRetries
 	 * @param bool $quiet
 	 *
@@ -176,8 +177,11 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 *
 	 */
 	public function theUserSharesWithUserWithoutClosingDialog(
-		$folder, $remote, $name, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false
+		$folder, $remote, $name, $displayname = null, $maxRetries = STANDARD_RETRY_COUNT, $quiet = false
 	) {
+		if ($remote === "remote" || $remote === "federated") {
+			$name = $this->featureContext->substituteInLineCodes($displayname, $name);
+		}
 		$this->theUserSharesUsingWebUIWithoutClosingDialog($folder, "user", $remote, $name, $maxRetries, $quiet);
 	}
 
@@ -201,18 +205,22 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the expiration date input field should (not |)be visible for the (user|group) "([^"]*)" in the share dialog$/
+	 * @Then /^the expiration date input field should (not |)be visible for the (user|group|federated user) "([^"]*)" ?(?:with displayname "([^"]*)")? in the share dialog$/
 	 *
 	 * @param string $shouldOrNot
 	 * @param string $type
 	 * @param string $receiver
+	 * @param string|null $displayname
 	 *
 	 * @return void
 	 */
-	public function expirationFieldVisibleForUser($shouldOrNot, $type, $receiver) {
+	public function expirationFieldVisibleForUser($shouldOrNot, $type, $receiver, $displayname = null) {
 		if ($type === "user") {
 			$receiver = $this->featureContext->getActualUsername($receiver);
 			$receiver = $this->featureContext->getDisplayNameForUser($receiver);
+		} elseif ($type === "federated user") {
+			$receiver = $this->featureContext->getActualUsername($receiver);
+			$receiver = $this->featureContext->substituteInLineCodes($displayname, $receiver);
 		}
 		$expected = ($shouldOrNot === "");
 		$this->sharingDialog->openShareActionsDropDown($type, $receiver);
@@ -225,18 +233,22 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the expiration date input field should be empty for the (user|group) "([^"]*)" in the share dialog$/
+	 * @Then /^the expiration date input field should be empty for the (user|group|federated user) "([^"]*)" ?(?:with displayname "([^"]*)")? in the share dialog$/
 	 *
 	 * @param string $type
 	 * @param string $receiver
+	 * @param string|null $displayname
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function expirationFieldEmptyForUser($type, $receiver) {
+	public function expirationFieldEmptyForUser($type, $receiver, $displayname = null) {
 		if ($type === "user") {
 			$receiver = $this->featureContext->getActualUsername($receiver);
 			$receiver = $this->featureContext->getDisplayNameForUser($receiver);
+		} elseif ($type === "federated user") {
+			$receiver = $this->featureContext->getActualUsername($receiver);
+			$receiver = $this->featureContext->substituteInLineCodes($displayname, $receiver);
 		}
 		$expirationDateInInputField = $this->sharingDialog->getExpirationDateFor($receiver, $type);
 		Assert::assertEquals(
@@ -248,18 +260,22 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^the user changes expiration date for share of (user|group) "([^"]*)" to "([^"]*)" in the share dialog$/
+	 * @When /^the user changes expiration date for share of (user|group|federated user) "([^"]*)" ?(?:with displayname "([^"]*)")? to "([^"]*)" in the share dialog$/
 	 *
 	 * @param string $type
 	 * @param string $receiver
+	 * @param string|null $displayname
 	 * @param string $days
 	 *
 	 * @return void
 	 */
-	public function expirationDateChangedTo($type, $receiver, $days) {
+	public function expirationDateChangedTo($type, $receiver, $displayname = null, $days = '') {
 		if ($type === "user") {
 			$receiver = $this->featureContext->getActualUsername($receiver);
 			$receiver = $this->featureContext->getDisplayNameForUser($receiver);
+		} elseif ($type === "federated user") {
+			$receiver = $this->featureContext->getActualUsername($receiver);
+			$receiver = $this->featureContext->substituteInLineCodes($displayname, $receiver);
 		}
 		$expectedDate = \date('d-m-Y', \strtotime($days));
 		$this->sharingDialog->openShareActionsDropDown($type, $receiver);
@@ -267,19 +283,23 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the expiration date input field should be "([^"]*)" for the (user|group) "([^"]*)" in the share dialog$/
+	 * @Then /^the expiration date input field should be "([^"]*)" for the (user|group|federated user) "([^"]*)" ?(?:with displayname "([^"]*)")? in the share dialog$/
 	 *
 	 * @param string $days
 	 * @param string $type
 	 * @param string $receiver
+	 * @param string|null $displayname
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function expirationDateShouldBe($days, $type, $receiver) {
+	public function expirationDateShouldBe($days, $type, $receiver, $displayname = null) {
 		if ($type === "user") {
 			$receiver = $this->featureContext->getActualUsername($receiver);
 			$receiver = $this->featureContext->getDisplayNameForUser($receiver);
+		} elseif ($type === "federated user") {
+			$receiver = $this->featureContext->getActualUsername($receiver);
+			$receiver = $this->featureContext->substituteInLineCodes($displayname, $receiver);
 		}
 		if (\strtotime($days) !== false) {
 			$expectedExpirationDate = \date('d-m-Y', \strtotime($days));
@@ -335,7 +355,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			$folder, $this->getSession()
 		);
 		if ($userOrGroup === "user") {
-			if ($remote === "remote") {
+			if ($remote === "remote" || $remote === "federated") {
 				$this->sharingDialog->shareWithRemoteUser(
 					$name, $this->getSession(), $maxRetries, $quiet
 				);

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -88,12 +88,17 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $defaultExpirationDateForUserCheckboxId = 'shareapiDefaultExpireDateUserShare';
 	protected $defaultExpirationDateForGroupCheckboxXpath = '//label[@for="shareapiDefaultExpireDateGroupShare"]';
 	protected $defaultExpirationDateForGroupCheckboxId = 'shareapiDefaultExpireDateGroupShare';
+	protected $defaultExpirationDateForRemoteCheckboxXpath = '//label[@for="shareapiDefaultExpireDateRemoteShare"]';
+	protected $defaultExpirationDateForRemoteCheckboxId = 'shareapiDefaultExpireDateRemoteShare';
 	protected $userShareExpirationDateFieldXpath = '//input[@id="shareapiExpireAfterNDaysUserShare"]';
 	protected $groupShareExpirationDateFieldXpath = '//input[@id="shareapiExpireAfterNDaysGroupShare"]';
+	protected $remoteShareExpirationDateFieldXpath = '//input[@id="shareapiExpireAfterNDaysRemoteShare"]';
 	protected $enforceExpirationDateUserShareCheckboxXpath = '//span[@id="setDefaultExpireDateUserShare"]//label[contains(text(),"expiration date")]';
 	protected $enforceExpirationDateUserShareCheckboxId = 'shareapiEnforceExpireDateUserShare';
 	protected $enforceExpirationDateGroupShareCheckboxXpath = '//span[@id="setDefaultExpireDateGroupShare"]//label[contains(text(),"expiration date")]';
 	protected $enforceExpirationDateGroupShareCheckboxId = 'shareapiEnforceExpireDateGroupShare';
+	protected $enforceExpirationDateRemoteShareCheckboxXpath = '//span[@id="setDefaultExpireDateRemoteShare"]//label[contains(text(),"expiration date")]';
+	protected $enforceExpirationDateRemoteShareCheckboxId = 'shareapiEnforceExpireDateRemoteShare';
 
 	/**
 	 * toggle the Share API
@@ -370,6 +375,13 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	/**
 	 * @return NodeElement|null
 	 */
+	public function getDefaultExpirationForRemoteShareElement() {
+		return $this->findById($this->defaultExpirationDateForRemoteCheckboxId);
+	}
+
+	/**
+	 * @return NodeElement|null
+	 */
 	public function getEnforceExpireDateUserShareElement() {
 		return $this->findById($this->enforceExpirationDateUserShareCheckboxId);
 	}
@@ -379,6 +391,13 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	 */
 	public function getEnforceExpireDateGroupShareElement() {
 		return $this->findById($this->enforceExpirationDateGroupShareCheckboxId);
+	}
+
+	/**
+	 * @return NodeElement|null
+	 */
+	public function getEnforceExpireDateRemoteShareElement() {
+		return $this->findById($this->enforceExpirationDateRemoteShareCheckboxId);
 	}
 
 	/**
@@ -403,6 +422,19 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 			$expirationDay,
 			__METHOD__ .
 			" could not find group share expiration day field"
+		);
+		return $expirationDay->getValue($expirationDay);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRemoteShareExpirationDays() {
+		$expirationDay = $this->find("xpath", $this->remoteShareExpirationDateFieldXpath);
+		$this->assertElementNotNull(
+			$expirationDay,
+			__METHOD__ .
+			" could not find remote share expiration day field"
 		);
 		return $expirationDay->getValue($expirationDay);
 	}
@@ -456,6 +488,22 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	}
 
 	/**
+	 * enforce mamixum expiration date for remote share
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function enforceMaximumExpirationDateForRemoteShares(Session $session) {
+		$this->toggleCheckbox(
+			$session,
+			"enables",
+			$this->enforceExpirationDateRemoteShareCheckboxXpath,
+			$this->enforceExpirationDateRemoteShareCheckboxId
+		);
+	}
+
+	/**
 	 *
 	 * @return NodeElement|NULL
 	 * @throws ElementNotFoundException
@@ -481,6 +529,21 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 			$expirationDateField,
 			__METHOD__ .
 			" xpath $this->groupShareExpirationDateFieldXpath could not find set-group-share-expiration-field"
+		);
+		return $expirationDateField;
+	}
+
+	/**
+	 *
+	 * @return NodeElement|NULL
+	 * @throws ElementNotFoundException
+	 */
+	private function findRemoteShareExpirationField() {
+		$expirationDateField = $this->find("xpath", $this->remoteShareExpirationDateFieldXpath);
+		$this->assertElementNotNull(
+			$expirationDateField,
+			__METHOD__ .
+			" xpath $this->remoteShareExpirationDateFieldXpath could not find set-remote-share-expiration-field"
 		);
 		return $expirationDateField;
 	}
@@ -518,6 +581,22 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	}
 
 	/**
+	 * set expiration date for remote share
+	 *
+	 * @param int $date
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function setExpirationDaysForRemoteShare(
+		$date, Session $session
+	) {
+		$expirationDateField = $this->findRemoteShareExpirationField();
+		$this->fillFieldAndKeepFocus($expirationDateField, $date . "\n", $session);
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
 	 * enable default expiration date for group share
 	 *
 	 * @param Session $session
@@ -530,6 +609,22 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 			"enables",
 			$this->defaultExpirationDateForGroupCheckboxXpath,
 			$this->defaultExpirationDateForGroupCheckboxId
+		);
+	}
+
+	/**
+	 * enable default expiration date for remote share
+	 *
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function enableDefaultExpirationDateForRemoteShares(Session $session) {
+		$this->toggleCheckbox(
+			$session,
+			"enables",
+			$this->defaultExpirationDateForRemoteCheckboxXpath,
+			$this->defaultExpirationDateForRemoteCheckboxId
 		);
 	}
 

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -459,14 +459,14 @@ class SharingDialog extends OwncloudPage {
 		$this->assertElementNotNull(
 			$permissionsField,
 			__METHOD__
-			. " xpath $xpathLocator could not find share permissions field for user "
+			. " xpath $xpathLocator could not find share permissions field for $userOrGroup "
 			. $shareReceiverName
 		);
 		$shareOptionsLocator = $permissionsField->find("xpath", $this->shareOptionsXpath);
 		$this->assertElementNotNull(
 			$shareOptionsLocator,
 			__METHOD__
-			. " xpath $this->shareOptionsXpath could not find share options for user "
+			. " xpath $this->shareOptionsXpath could not find share options for $userOrGroup "
 			. $shareReceiverName
 		);
 		$shareOptionsStyle = $shareOptionsLocator->getAttribute("style");
@@ -480,7 +480,7 @@ class SharingDialog extends OwncloudPage {
 		$this->assertElementNotNull(
 			$showCrudsBtn,
 			__METHOD__
-			. " xpath $this->showCrudsXpath could not find show-cruds button for user "
+			. " xpath $this->showCrudsXpath could not find show-cruds button for $userOrGroup "
 			. $shareReceiverName
 		);
 		$showCrudsBtn->click();

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -163,6 +163,12 @@ Feature: admin sharing settings
     When the administrator enables default expiration date for group shares using the webUI
     Then the config key "shareapi_default_expire_date_group_share" of app "core" should have value "yes"
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario: enable default expiration date for remote shares
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables default expiration date for remote shares using the webUI
+    Then the config key "shareapi_default_expire_date_remote_share" of app "core" should have value "yes"
+
   @skipOnOcV10.3
   Scenario: set a different default expiration days for user shares
     Given the administrator has browsed to the admin sharing settings page
@@ -176,6 +182,13 @@ Feature: admin sharing settings
     When the administrator enables default expiration date for group shares using the webUI
     And the administrator updates the group share expiration date to "11" days using the webUI
     Then the config key "shareapi_expire_after_n_days_group_share" of app "core" should have value "11"
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario: set a different default expiration days for remote shares
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables default expiration date for remote shares using the webUI
+    And the administrator updates the remote share expiration date to "18" days using the webUI
+    Then the config key "shareapi_expire_after_n_days_remote_share" of app "core" should have value "18"
 
   @skipOnOcV10.3
   Scenario: set default expiration days for user shares and enforce as maximum expiration days
@@ -191,6 +204,13 @@ Feature: admin sharing settings
     And the administrator enforces maximum expiration date for group shares using the webUI
     Then the config key "shareapi_enforce_expire_date_group_share" of app "core" should have value "yes"
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario: set default expiration days for remote shares and enforce as maximum expiration days
+    Given the administrator has browsed to the admin sharing settings page
+    When the administrator enables default expiration date for remote shares using the webUI
+    And the administrator enforces maximum expiration date for remote shares using the webUI
+    Then the config key "shareapi_enforce_expire_date_remote_share" of app "core" should have value "yes"
+
   @skipOnOcV10.3
   Scenario: check previously set default expiration days for user shares
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -204,6 +224,13 @@ Feature: admin sharing settings
     When the administrator browses to the admin sharing settings page
     Then the default expiration date checkbox for group shares should be enabled on the webUI
     And the expiration date for group shares should set to "7" days on the webUI
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario: check previously set default expiration days for remote shares
+    Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    When the administrator browses to the admin sharing settings page
+    Then the default expiration date checkbox for remote shares should be enabled on the webUI
+    And the expiration date for remote shares should set to "7" days on the webUI
 
   @skipOnOcV10.3
   Scenario: check previously enforced maximum expiration days for user shares
@@ -219,6 +246,13 @@ Feature: admin sharing settings
     When the administrator browses to the admin sharing settings page
     Then the enforce maximum expiration date checkbox for group shares should be enabled on the webUI
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario: check previously enforced maximum expiration days for remote shares
+    Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
+    When the administrator browses to the admin sharing settings page
+    Then the enforce maximum expiration date checkbox for remote shares should be enabled on the webUI
+
   @skipOnOcV10.3
   Scenario: check previously set expiration days for user shares
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -232,3 +266,10 @@ Feature: admin sharing settings
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "5"
     When the administrator browses to the admin sharing settings page
     Then the expiration date for group shares should set to "5" days on the webUI
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario: check previously set expiration days for remote shares
+    Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "5"
+    When the administrator browses to the admin sharing settings page
+    Then the expiration date for remote shares should set to "5" days on the webUI

--- a/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
@@ -17,10 +17,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has created folder "simple-empty-folder"
     And user "Alice" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "Alice" has logged in using the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
   Scenario: test the single steps of sharing a folder to a remote server
+    Given user "Alice" has logged in using the webUI
     When the user shares folder "simple-folder" with remote user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     And the user shares folder "simple-empty-folder" with remote user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
@@ -41,7 +41,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
     And user "Brian" from server "REMOTE" has shared "simple-empty-folder" with user "Alice" from server "LOCAL"
     And user "Carol" from server "REMOTE" has shared "lorem.txt" with user "Alice" from server "LOCAL"
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     Then dialogs should be displayed on the webUI
       | title        | content                                                                                                  | user  |
       | Remote share | Do you want to add the remote share /simple-folder from %username%@%remote_server_without_scheme%?       | Alice |
@@ -61,6 +61,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: sharing indicator inside folder shared using federated sharing
     Given user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" from server "LOCAL" has shared "/simple-folder" with user "Alice" from server "REMOTE"
+    And user "Alice" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     Then the following resources should have share indicators on the webUI
       | lorem.txt  |
@@ -69,6 +70,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   @skipOnOcV10.3
   Scenario: sharing indicator for file uploaded inside folder shared using federated sharing
     Given user "Alice" from server "LOCAL" has shared "/simple-folder" with user "Alice" from server "REMOTE"
+    And user "Alice" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -77,6 +79,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   @skipOnOcV10.3
   Scenario: sharing indicator for folder created inside folder shared using federated sharing
     Given user "Alice" from server "LOCAL" has shared "/simple-folder" with user "Alice" from server "REMOTE"
+    And user "Alice" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user creates a folder with the name "sub-folder" using the webUI
     Then the following resources should have share indicators on the webUI
@@ -87,6 +90,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
     And user "Alice" from server "LOCAL" has shared "/simple-folder" with user "Alice" from server "REMOTE"
+    And user "Alice" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder"
     Then federated user "Alice" with displayname "%username%@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
@@ -100,6 +104,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/sub-folder/textfile.txt"
     And user "Alice" from server "LOCAL" has shared "/simple-folder" with user "Alice" from server "REMOTE"
     And user "Alice" has shared folder "simple-folder/sub-folder" with user "Brian"
+    And user "Alice" has logged in using the webUI
     When the user opens folder "simple-folder/sub-folder" using the webUI
     And the user opens the share dialog for file "textfile.txt"
     Then federated user "Alice" with displayname "%username%@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
@@ -109,6 +114,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: expiration date is disabled for federation sharing, sharer checks the expiration date of a federation share
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "no"
     And user "Alice" from server "LOCAL" has shared "lorem.txt" with user "Alice" from server "REMOTE"
+    And user "Alice" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt"
     Then the expiration date input field should be visible for the federated user "Alice" with displayname "%username%@%remote_server% (federated)" in the share dialog
     And the expiration date input field should be empty for the federated user "Alice" with displayname "%username%@%remote_server% (federated)" in the share dialog
@@ -123,6 +129,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     And user "Alice" from server "LOCAL" has shared "lorem.txt" with user "Alice" from server "REMOTE"
+    And user "Alice" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt"
     Then the expiration date input field should be visible for the federated user "Alice" with displayname "%username%@%remote_server% (federated)" in the share dialog
     And the expiration date input field should be "+7 days" for the federated user "Alice" with displayname "%username%@%remote_server% (federated)" in the share dialog
@@ -138,6 +145,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "<num_days>"
     And user "Alice" from server "LOCAL" has shared "lorem.txt" with user "Alice" from server "REMOTE"
+    And user "Alice" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt"
     Then the expiration date input field should be visible for the federated user "Alice" with displayname "%username%@%remote_server% (federated)" in the share dialog
     And the expiration date input field should be "<days>" for the federated user "Alice" with displayname "%username%@%remote_server% (federated)" in the share dialog
@@ -157,6 +165,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "3"
     And user "Alice" from server "LOCAL" has shared "lorem.txt" with user "Alice" from server "REMOTE"
+    And user "Alice" has logged in using the webUI
     When the user opens the share dialog for file "lorem.txt"
     And the user changes expiration date for share of federated user "Alice" with displayname "%username%@%remote_server% (federated)" to "+4 days" in the share dialog
 #    Cannot set expiration date more than 3 days in the future
@@ -177,7 +186,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" from server "REMOTE" has shared "lorem.txt" with user "Alice" from server "LOCAL"
     And user "Alice" from server "LOCAL" accepts the last pending share using the sharing API
     And using server "LOCAL"
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user shares file "lorem (2).txt" with user "Brian" using the webUI without closing the share dialog
     And the user changes expiration date for share of user "Brian" to "+10 days" in the share dialog
     Then the expiration date input field should be "+ 10 days" for the user "Brian" in the share dialog
@@ -198,7 +207,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" from server "REMOTE" has shared "lorem.txt" with user "Alice" from server "LOCAL"
     And user "Alice" from server "LOCAL" accepts the last pending share using the sharing API
     And using server "LOCAL"
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user shares file "lorem (2).txt" with federated user "Brian" with displayname "%username%@%remote_server_without_scheme%" using the webUI without closing the share dialog
     And the user changes expiration date for share of federated user "Brian" with displayname "%username%@%remote_server_without_scheme% (federated)" to "+4 days" in the share dialog
     Then the expiration date input field should be "+ 4 days" for the federated user "Brian" with displayname "%username%@%remote_server_without_scheme% (federated)" in the share dialog
@@ -218,7 +227,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" from server "REMOTE" has shared "lorem.txt" with user "Alice" from server "LOCAL"
     And user "Alice" from server "LOCAL" accepts the last pending share using the sharing API
     And using server "LOCAL"
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user shares file "lorem (2).txt" with user "Brian" using the webUI without closing the share dialog
     Then the expiration date input field should be empty for the user "Brian" in the share dialog
     And the information of the last share of user "Alice" should include
@@ -238,7 +247,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" from server "REMOTE" has shared "lorem.txt" with user "Alice" from server "LOCAL"
     And user "Alice" from server "LOCAL" accepts the last pending share using the sharing API
     And using server "LOCAL"
-    And the user has reloaded the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user shares file "lorem (2).txt" with federated user "Brian" with displayname "%username%@%remote_server_without_scheme%" using the webUI without closing the share dialog
     Then the expiration date input field should be empty for the federated user "Brian" with displayname "%username%@%remote_server_without_scheme% (federated)" in the share dialog
     And the information of the last share of user "Alice" should include


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Add support to expire federated shares the same way it was added for user and group shares.
New settings to add a default date and enforce it as maximum also included (the same way as for user and group shares)

## Related Issue
https://github.com/owncloud/enterprise/issues/3969

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested:
* expiration date for federated shares is stored and retrieved
* default expiration used when the share is created from the web UI
* maximum expiration enforced in the web UI if the setting is active

## Screenshots (if appropriate):
(orange bars are scrollbars, nothing to do with the page style)

![Screenshot from 2020-06-17 17-59-11](https://user-images.githubusercontent.com/1477829/84921305-99490700-b0c4-11ea-816d-2723dd09b0b4.png)

![Screenshot from 2020-06-17 18-00-19](https://user-images.githubusercontent.com/1477829/84921335-a239d880-b0c4-11ea-9bf3-0f5aa5d77990.png)

![Screenshot from 2020-06-17 18-01-10](https://user-images.githubusercontent.com/1477829/84921353-a6fe8c80-b0c4-11ea-812b-fc280ca39304.png)

We might need to review how we can deal with long sharee's names. Text is moved below, which looks bad compared with how shorter names are handled (local user shares)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
