### PR TITLE
fix typo in error message 'An error occurred while sending email'

### DIFF
--- a/core/js/sharedialogmailview.js
+++ b/core/js/sharedialogmailview.js
@@ -153,7 +153,7 @@
 					$formSendIndicator.addClass('hidden');
 					deferred.resolve();
 				}).fail(function(error) {
-					OC.dialogs.info(error.message, t('core', 'An error occured while sending email'));
+					OC.dialogs.info(error.message, t('core', 'An error occurred while sending email'));
 					$formSendIndicator.addClass('hidden');
 					$formItems.prop('disabled', false);
 					deferred.reject();


### PR DESCRIPTION
## Description
I noticed this old branch when cleaning up. It just a typo that I noticed in a message. It will need a general update of the Transifex translations (the "input" message in English will change, and just the mapping to existing translations will need to be updated). So I guess we should only merge something like this when there is a chance to fixup the translation mapping and get that also pushed back to `core` repo before release.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
