### PR TITLE
[Tests-only] Adjust public link tests for download, upload and other operations

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-282
 Feature: accessing a public link share
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-49 
 Feature: changing a public link share
 
   Background:
@@ -6,194 +6,302 @@ Feature: changing a public link share
       | username |
       | Alice    |
 
-  Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions
+  @skipOnOcis
+  Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    When the public deletes file "welcome.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public deletes file "welcome.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/welcome.txt" <should-or-not> exist
     Examples:
-      | public-webdav-api-version | permissions               | http-status-code | should-or-not |
-      | old                       | read,update,create        | 403              | should        |
-      | new                       | read,update,create        | 403              | should        |
-      | old                       | read,update,create,delete | 204              | should not    |
-      | new                       | read,update,create,delete | 204              | should not    |
+      | permissions               | http-status-code | should-or-not |
+      | read,update,create        | 403              | should        |
+      | read,update,create,delete | 204              | should not    |
 
-  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create
+  @skipOnOcis @issue-ocis-reva-292
+  Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT       |
+      | permissions | <permissions> |
+    When the public deletes file "welcome.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "<http-status-code>"
+    And as "Alice" file "PARENT/welcome.txt" <should-or-not> exist
+    Examples:
+      | permissions               | http-status-code | should-or-not |
+      | read,update,create        | 403              | should        |
+      | read,update,create,delete | 204              | should not    |
+
+  @skipOnOcis
+  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
 
-  @skipOnRansomwareProtection  @issue-ransomware-208
-  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create,delete
+  @skipOnOcis @issue-ocis-reva-292
+  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT            |
+      | permissions | read,update,create |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Alice" file "/PARENT/parent.txt" should exist
+    And as "Alice" file "/PARENT/newparent.txt" should not exist
+
+  @skipOnRansomwareProtection @issue-ransomware-208 @skipOnOcis
+  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
-
-  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT            |
-      | permissions | read,update,create |
-    When the public uploads file "lorem.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Alice" file "/PARENT/lorem.txt" should not exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
-
-  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create,delete
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-    When the public uploads file "lorem.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
-    Then the HTTP status code should be "201"
-    And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
-
-  Scenario Outline: Public cannot delete file through publicly shared link with password using an invalid password
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public deletes file "welcome.txt" from the last public share using the password "invalid" and <public-webdav-api-version> public WebDAV API
-    Then the HTTP status code should be "401"
-    And as "Alice" file "PARENT/welcome.txt" should exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
-
-  Scenario Outline: Public can delete file through publicly shared link with password using the valid password
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public deletes file "welcome.txt" from the last public share using the password "newpasswd" and <public-webdav-api-version> public WebDAV API
-    Then the HTTP status code should be "204"
-    And as "Alice" file "PARENT/welcome.txt" should not exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
-
-  Scenario Outline: Public tries to rename a file in a password protected share using an invalid password
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "invalid" and <public-webdav-api-version> public WebDAV API
-    Then the HTTP status code should be "401"
-    And as "Alice" file "/PARENT/newparent.txt" should not exist
-    And as "Alice" file "/PARENT/parent.txt" should exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
 
   @skipOnRansomwareProtection @issue-ransomware-208
-  Scenario Outline: Public tries to rename a file in a password protected share using the valid password
+  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "/PARENT/parent.txt" should not exist
+    And as "Alice" file "/PARENT/newparent.txt" should exist
+
+  @skipOnOcis
+  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the old public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT            |
+      | permissions | read,update,create |
+    When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Alice" file "/PARENT/lorem.txt" should not exist
+
+  @skipOnOcis @issue-ocis-reva-292
+  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT            |
+      | permissions | read,update,create |
+    When the public uploads file "lorem.txt" with content "test" using the new public WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Alice" file "/PARENT/lorem.txt" should not exist
+
+  @skipOnOcis
+  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the old public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
+
+  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public uploads file "lorem.txt" with content "test" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
+
+  @skipOnOcis
+  Scenario: Public cannot delete file through publicly shared link with password using an invalid password with the old public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT   |
+      | permissions | change    |
+      | password    | newpasswd |
+    When the public deletes file "welcome.txt" from the last public share using the password "invalid" and old public WebDAV API
+    Then the HTTP status code should be "401"
+    And as "Alice" file "PARENT/welcome.txt" should exist
+
+  Scenario: Public cannot delete file through publicly shared link with password using an invalid password with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT   |
+      | permissions | change    |
+      | password    | newpasswd |
+    When the public deletes file "welcome.txt" from the last public share using the password "invalid" and new public WebDAV API
+    Then the HTTP status code should be "401"
+    And as "Alice" file "PARENT/welcome.txt" should exist
+
+  @skipOnOcis
+  Scenario: Public can delete file through publicly shared link with password using the valid password with the old public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT   |
+      | permissions | change    |
+      | password    | newpasswd |
+    When the public deletes file "welcome.txt" from the last public share using the password "newpasswd" and old public WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "PARENT/welcome.txt" should not exist
+
+  Scenario: Public can delete file through publicly shared link with password using the valid password with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT   |
+      | permissions | change    |
+      | password    | newpasswd |
+    When the public deletes file "welcome.txt" from the last public share using the password "newpasswd" and new public WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "PARENT/welcome.txt" should not exist
+
+  @skipOnOcis
+  Scenario: Public tries to rename a file in a password protected share using an invalid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "newpasswd" and <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "invalid" and old public WebDAV API
+    Then the HTTP status code should be "401"
+    And as "Alice" file "/PARENT/newparent.txt" should not exist
+    And as "Alice" file "/PARENT/parent.txt" should exist
+
+  Scenario: Public tries to rename a file in a password protected share using an invalid password with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT   |
+      | permissions | change    |
+      | password    | newpasswd |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "invalid" and new public WebDAV API
+    Then the HTTP status code should be "401"
+    And as "Alice" file "/PARENT/newparent.txt" should not exist
+    And as "Alice" file "/PARENT/parent.txt" should exist
+
+  @skipOnRansomwareProtection @issue-ransomware-208 @skipOnOcis
+  Scenario: Public tries to rename a file in a password protected share using the valid password with the old public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT   |
+      | permissions | change    |
+      | password    | newpasswd |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "newpasswd" and old public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/newparent.txt" should exist
     And as "Alice" file "/PARENT/parent.txt" should not exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
 
-  Scenario Outline: Public tries to upload to a password protected public share using an invalid password
+  @skipOnRansomwareProtection @issue-ransomware-208
+  Scenario: Public tries to rename a file in a password protected share using the valid password with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT   |
+      | permissions | change    |
+      | password    | newpasswd |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "newpasswd" and new public WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "/PARENT/newparent.txt" should exist
+    And as "Alice" file "/PARENT/parent.txt" should not exist
+
+  @skipOnOcis
+  Scenario: Public tries to upload to a password protected public share using an invalid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public uploads file "lorem.txt" with password "invalid" and content "test" using the <public-webdav-api-version> public WebDAV API
+    When the public uploads file "lorem.txt" with password "invalid" and content "test" using the old public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
 
-  Scenario Outline: Public tries to upload to a password protected public share using the valid password
+  Scenario: Public tries to upload to a password protected public share using an invalid password with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public uploads file "lorem.txt" with password "newpasswd" and content "test" using the <public-webdav-api-version> public WebDAV API
+    When the public uploads file "lorem.txt" with password "invalid" and content "test" using the new public WebDAV API
+    Then the HTTP status code should be "401"
+    And as "Alice" file "/PARENT/lorem.txt" should not exist
+
+  @skipOnOcis
+  Scenario: Public tries to upload to a password protected public share using the valid password with the old public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT   |
+      | permissions | change    |
+      | password    | newpasswd |
+    When the public uploads file "lorem.txt" with password "newpasswd" and content "test" using the old public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/lorem.txt" should exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
 
-  Scenario Outline: Public cannot rename a file in uploadwriteonly public link share
+  Scenario: Public tries to upload to a password protected public share using the valid password with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT   |
+      | permissions | change    |
+      | password    | newpasswd |
+    When the public uploads file "lorem.txt" with password "newpasswd" and content "test" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "/PARENT/lorem.txt" should exist
+
+  @skipOnOcis
+  Scenario: Public cannot rename a file in uploadwriteonly public link share with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
 
-  Scenario Outline: Public cannot delete a file in uploadwriteonly public link share
+  @skipOnOcis @issue-ocis-reva-292
+  Scenario: Public cannot rename a file in uploadwriteonly public link share with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT         |
+      | permissions | uploadwriteonly |
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Alice" file "/PARENT/parent.txt" should exist
+    And as "Alice" file "/PARENT/newparent.txt" should not exist
+
+  @skipOnOcis
+  Scenario: Public cannot delete a file in uploadwriteonly public link share with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public deletes file "welcome.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public deletes file "welcome.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/welcome.txt" should exist
-    Examples:
-      | public-webdav-api-version |
-      | old                       |
-      | new                       |
+
+  @skipOnOcis @issue-ocis-reva-292
+  Scenario: Public cannot delete a file in uploadwriteonly public link share with the new public WebDAV API
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT         |
+      | permissions | uploadwriteonly |
+    When the public deletes file "welcome.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Alice" file "PARENT/welcome.txt" should exist

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -1,11 +1,11 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-49
 Feature: create a public link share
 
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @smokeTest
-  Scenario Outline: Creating a new public link share of a file, the default permissions are read (1)
+  @smokeTest @skipOnOcis
+  Scenario Outline: Creating a new public link share of a file, the default permissions are read (1) using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And the administrator has enabled DAV tech_preview
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
@@ -27,17 +27,43 @@ Feature: create a public link share
       | name                   |                 |
     When the public downloads the last public shared file with range "bytes=0-9" using the old public WebDAV API
     Then the downloaded content should be "Random dat"
+    And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @skipOnOcis @issue-ocis-reva-12
+  Scenario Outline: Creating a new public link share of a file, the default permissions are read (1) using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And the administrator has enabled DAV tech_preview
+    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | randomfile.txt |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | item_type              | file            |
+      | mimetype               | text/plain      |
+      | file_target            | /randomfile.txt |
+      | path                   | /randomfile.txt |
+      | permissions            | read            |
+      | share_type             | public_link     |
+      | displayname_file_owner | %displayname%   |
+      | displayname_owner      | %displayname%   |
+      | uid_file_owner         | Alice           |
+      | uid_owner              | Alice           |
+      | name                   |                 |
     When the public downloads the last public shared file with range "bytes=0-9" using the new public WebDAV API
     Then the downloaded content should be "Random dat"
-    And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
     And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest
-  Scenario Outline: Creating a new public link share of a file with password
+  @smokeTest @skipOnOcis
+  Scenario Outline: Creating a new public link share of a file with password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -59,14 +85,40 @@ Feature: create a public link share
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "Random data"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
-    And the HTTP status code should be "200"
     And the public download of the last publicly shared file using the old public WebDAV API with password "%regular%" should fail with HTTP status code "401"
     And the value of the item "//s:message" in the response should be "Cannot authenticate over ajax calls"
-    And the public download of the last publicly shared file using the new public WebDAV API with password "%regular%" should fail with HTTP status code "401"
-    And the value of the item "//s:message" in the response should match "/Username or password was incorrect/"
     And the public download of the last publicly shared file using the old public WebDAV API without a password should fail with HTTP status code "401"
     And the value of the item "//s:message" in the response should be "Cannot authenticate over ajax calls"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @smokeTest @skipOnOcis @issue-ocis-reva-199
+  Scenario Outline: Creating a new public link share of a file with password using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path     | randomfile.txt |
+      | password | %public%       |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | item_type              | file            |
+      | mimetype               | text/plain      |
+      | file_target            | /randomfile.txt |
+      | path                   | /randomfile.txt |
+      | permissions            | read            |
+      | share_type             | public_link     |
+      | displayname_file_owner | %displayname%   |
+      | displayname_owner      | %displayname%   |
+      | uid_file_owner         | Alice           |
+      | uid_owner              | Alice           |
+      | name                   |                 |
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
+    And the HTTP status code should be "200"
+    And the public download of the last publicly shared file using the new public WebDAV API with password "%regular%" should fail with HTTP status code "401"
+    And the value of the item "//s:message" in the response should match "/Username or password was incorrect/"
     And the public download of the last publicly shared file using the new public WebDAV API without a password should fail with HTTP status code "401"
     And the value of the item "//s:message" in the response should match "/No 'Authorization: Basic' header found/"
     Examples:
@@ -74,7 +126,8 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share
+  @skipOnOcis
+  Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -95,15 +148,42 @@ Feature: create a public link share
       | uid_owner              | Alice           |
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
     And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @skipOnOcis @issue-ocis-reva-292
+  Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | randomfile.txt |
+      | permissions | all            |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | item_type              | file            |
+      | mimetype               | text/plain      |
+      | file_target            | /randomfile.txt |
+      | path                   | /randomfile.txt |
+      | permissions            | read            |
+      | share_type             | public_link     |
+      | displayname_file_owner | %displayname%   |
+      | displayname_owner      | %displayname%   |
+      | uid_file_owner         | Alice           |
+      | uid_owner              | Alice           |
+      | name                   |                 |
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
     And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password
+  @skipOnOcis
+  Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And the administrator has enabled DAV tech_preview
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
@@ -125,18 +205,45 @@ Feature: create a public link share
       | name                   |                      |
     When the public downloads file "/randomfile.txt" from inside the last public shared folder with range "bytes=1-7" using the old public WebDAV API
     Then the downloaded content should be "andom d"
-    When the public downloads file "/randomfile.txt" from inside the last public shared folder with range "bytes=2-7" using the new public WebDAV API
-    Then the downloaded content should be "ndom d"
     And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%" and the content should be "Random data"
-    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%" and the content should be "Random data"
     And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
-    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Creating a new public link share of a folder, with a password
+  @skipOnOcis @issue-ocis-reva-12
+  Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And the administrator has enabled DAV tech_preview
+    And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | PARENT |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | item_type              | folder               |
+      | mimetype               | httpd/unix-directory |
+      | file_target            | /PARENT              |
+      | path                   | /PARENT              |
+      | permissions            | read                 |
+      | share_type             | public_link          |
+      | displayname_file_owner | %displayname%        |
+      | displayname_owner      | %displayname%        |
+      | uid_file_owner         | Alice                |
+      | uid_owner              | Alice                |
+      | name                   |                      |
+    When the public downloads file "/randomfile.txt" from inside the last public shared folder with range "bytes=2-7" using the new public WebDAV API
+    Then the downloaded content should be "ndom d"
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%" and the content should be "Random data"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+ 
+  @skipOnOcis
+  Scenario Outline: Creating a new public link share of a folder, with a password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -158,17 +265,44 @@ Feature: create a public link share
       | uid_owner              | Alice                |
       | name                   |                      |
     And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%" and the content should be "Random data"
-    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "Random data"
     But the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API without a password
-    And the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API without a password
     And the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%regular%"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @skipOnOcis @issue-ocis-reva-292
+  Scenario Outline: Creating a new public link share of a folder, with a password using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | PARENT   |
+      | password    | %public% |
+      | permissions | change   |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | item_type              | folder               |
+      | mimetype               | httpd/unix-directory |
+      | file_target            | /PARENT              |
+      | path                   | /PARENT              |
+      | permissions            | change               |
+      | share_type             | public_link          |
+      | displayname_file_owner | %displayname%        |
+      | displayname_owner      | %displayname%        |
+      | uid_file_owner         | Alice                |
+      | uid_owner              | Alice                |
+      | name                   |                      |
+    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%" and the content should be "Random data"
+    And the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API without a password
     And the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%regular%"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest
+  @smokeTest @skipOnOcis @issue-ocis-reva-294
   Scenario Outline: Getting the share information of public link share from the OCS API does not expose sensitive information
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -212,7 +346,8 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally
+  @skipOnOcis
+  Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "Alice" has created folder "/afolder"
@@ -225,13 +360,31 @@ Feature: create a public link share
       | share_type  | public_link |
       | permissions | read        |
     And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @skipOnOcis @issue-ocis-reva-41
+  Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    And user "Alice" has created folder "/afolder"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | /afolder |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | id          | A_NUMBER    |
+      | share_type  | public_link |
+      | permissions | read        |
     And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-36442
+  @issue-36442 @skipOnOcis @issue-ocis-reva-41
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -255,7 +408,7 @@ Feature: create a public link share
       | 2               | 403             | 403              |
       #| 2               | 200             | 200              |
 
-  @issue-36442
+  @issue-36442 @skipOnOcis @issue-ocis-reva-41
   Scenario Outline: Creating a public link share with create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -279,7 +432,7 @@ Feature: create a public link share
       | 2               | 403             | 403              |
       #| 2               | 200             | 200              |
 
-  @issue-36442
+  @issue-36442 @skipOnOcis @issue-ocis-reva-41
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -305,7 +458,7 @@ Feature: create a public link share
       | 2               | 400             | 400              |
       #| 2               | 200             | 200              |
 
-  @issue-36442
+  @issue-36442 @skipOnOcis @issue-ocis-reva-41
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -339,6 +492,7 @@ Feature: create a public link share
       | 2               | 403             | 403              | read,create,update,delete |
       #| 2               | 200             | 200              | read,create,update,delete  |
 
+  @skipOnOcis @issue-ocis-reva-41
   Scenario Outline: Creating a link share with read+update+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -359,6 +513,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-41
   Scenario Outline: Creating a link share with update permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -374,7 +529,8 @@ Feature: create a public link share
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
-  Scenario Outline: Creating a link share with edit permissions keeps it
+  @skipOnOcis
+  Scenario Outline: Creating a link share with edit permissions keeps it using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -383,17 +539,35 @@ Feature: create a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id          | A_NUMBER                  |
+      | id          | A_STRING                  |
       | share_type  | public_link               |
       | permissions | read,update,create,delete |
     And uploading a file should work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Creating a link share with edit permissions keeps it using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/afolder"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | /afolder                  |
+      | permissions | read,update,create,delete |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | id          | A_STRING                  |
+      | share_type  | public_link               |
+      | permissions | read,update,create,delete |
     And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Creating a link share with upload permissions keeps it
+  @skipOnOcis
+  Scenario Outline: Creating a link share with upload permissions keeps it using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -402,16 +576,34 @@ Feature: create a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id          | A_NUMBER    |
+      | id          | A_STRING    |
       | share_type  | public_link |
       | permissions | read,create |
     And uploading a file should work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Creating a link share with upload permissions keeps it using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/afolder"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | /afolder    |
+      | permissions | read,create |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | id          | A_STRING    |
+      | share_type  | public_link |
+      | permissions | read,create |
     And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-283
   Scenario Outline: Do not allow public sharing of the root
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -423,7 +615,8 @@ Feature: create a public link share
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
-  Scenario Outline: user creates a public link share of a file with file name longer than 64 chars
+  @skipOnOcis
+  Scenario Outline: user creates a public link share of a file with file name longer than 64 chars using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "long file" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -431,13 +624,27 @@ Feature: create a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "long file"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @skipOnOcis @issue-ocis-reva-278
+  Scenario Outline: user creates a public link share of a file with file name longer than 64 chars using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "long file" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "long file"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars
+  @skipOnOcis
+  Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "Alice" has uploaded file with content "Random data" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/randomfile.txt"
@@ -446,12 +653,26 @@ Feature: create a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API and the content should be "Random data"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars using the new public WebDAV API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
+    And user "Alice" has uploaded file with content "Random data" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
     And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API and the content should be "Random data"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-41
   Scenario Outline: Create a public link with default expiration date set and max expiration date enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
@@ -487,6 +708,7 @@ Feature: create a public link share
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
+  @skipOnOcis @issue-ocis-reva-199
   Scenario: Deleting a folder that has been publicly shared
     Given user "Alice" has created a public link share with settings
       | path        | PARENT |
@@ -495,6 +717,7 @@ Feature: create a public link share
     Then the public download of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API should fail with HTTP status code "404"
     And the public download of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API should fail with HTTP status code "404"
 
+  @skipOnOcis @issue-ocis-reva-292
   Scenario: try to download from a public share that has upload only permissions
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -507,7 +730,7 @@ Feature: create a public link share
     Then the value of the item "//s:message" in the response should be ""
     And the HTTP status code should be "404"
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-278
   Scenario: Get the size of a file shared by public link
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"

--- a/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-288 @issue-ocis-reva-252
 Feature: multilinksharing
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
@@ -1,5 +1,5 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49
-@issue-ocis-reva-233 @issue-ocis-reva-243
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-282
+@issue-ocis-reva-233 @issue-ocis-reva-243 @issue-ocis-reva-289
 Feature: reshare as public link
   As a user
   I want to create public link shares from files/folders shared with me

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-252
 Feature: update a public link share
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -1,10 +1,10 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49
+@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-49
 Feature: upload to a public link share
 
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @smokeTest
+  @smokeTest @skipOnOcis
   Scenario: Uploading same file to a public upload-only share multiple times via old API
     # The old API needs to have the header OC-Autorename: 1 set to do the autorename
     Given user "Alice" has created a public link share with settings
@@ -18,7 +18,7 @@ Feature: upload to a public link share
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
 
-  @smokeTest
+  @smokeTest @skipOnOcis @issue-ocis-reva-286
   Scenario: Uploading same file to a public upload-only share multiple times via new API
     # The new API does the autorename automatically in upload-only folders
     Given the administrator has enabled DAV tech_preview
@@ -33,8 +33,8 @@ Feature: upload to a public link share
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
 
-  @issue-36055
-  Scenario Outline: Uploading file to a public upload-only share that was deleted does not work
+  @skipOnOcis
+  Scenario Outline: Uploading file to a public upload-only share using old public API that was deleted does not work
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share with settings
       | path        | FOLDER |
@@ -42,8 +42,20 @@ Feature: upload to a public link share
     When user "Alice" deletes file "/FOLDER" using the WebDAV API
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "404"
-    #And uploading a file should not work using the new public WebDAV API
-    #And the HTTP status code should be "404"
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @issue-36055 @skipOnOcV10 @skipOnOcis @issue-ocis-reva-290
+  Scenario Outline: Uploading file to a public upload-only share using new public API that was deleted does not work
+    Given using <dav-path> DAV path
+    And user "Alice" has created a public link share with settings
+      | path        | FOLDER |
+      | permissions | create |
+    When user "Alice" deletes file "/FOLDER" using the WebDAV API
+    Then uploading a file should not work using the new public WebDAV API
+    And the HTTP status code should be "404"
     Examples:
       | dav-path |
       | old      |
@@ -60,14 +72,16 @@ Feature: upload to a public link share
     And the public uploads file "does-not-matter.txt" with content "does not matter" using the new public WebDAV API
     Then the HTTP status code should be "500"
 
-  Scenario: Uploading file to a public read-only share folder does not work
+  @skipOnOcis
+  Scenario: Uploading file to a public read-only share folder with old public API does not work
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | read   |
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "403"
 
-  Scenario: Uploading file to a public read-only share folder does not work
+  @skipOnOcis @issue-ocis-reva-292
+  Scenario: Uploading file to a public read-only share folder with new public API does not work
     Given the administrator has enabled DAV tech_preview
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
@@ -75,7 +89,8 @@ Feature: upload to a public link share
     Then uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "403"
 
-  Scenario: Uploading to a public upload-only share
+  @skipOnOcis
+  Scenario: Uploading to a public upload-only share with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
@@ -84,7 +99,7 @@ Feature: upload to a public link share
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:]{1,32}"$/ |
 
-  Scenario: Uploading to a public upload-only share
+  Scenario: Uploading to a public upload-only share with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | FOLDER |
@@ -94,7 +109,8 @@ Feature: upload to a public link share
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:]{1,32}"$/ |
 
-  Scenario: Uploading to a public upload-only share with password
+  @skipOnOcis
+  Scenario: Uploading to a public upload-only share with password with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
@@ -102,7 +118,7 @@ Feature: upload to a public link share
     When the public uploads file "test-old.txt" with password "%public%" and content "test-old" using the old public WebDAV API
     Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
 
-  Scenario: Uploading to a public upload-only share with password
+  Scenario: Uploading to a public upload-only share with password with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | FOLDER   |
@@ -111,7 +127,8 @@ Feature: upload to a public link share
     When the public uploads file "test-new.txt" with password "%public%" and content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
 
-  Scenario: Uploading to a public read/write share with password
+  @skipOnOcis
+  Scenario: Uploading to a public read/write share with password with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
@@ -119,7 +136,7 @@ Feature: upload to a public link share
     When the public uploads file "test-old.txt" with password "%public%" and content "test-old" using the old public WebDAV API
     Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
 
-  Scenario: Uploading to a public read/write share with password
+  Scenario: Uploading to a public read/write share with password with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | FOLDER   |
@@ -128,7 +145,8 @@ Feature: upload to a public link share
     When the public uploads file "test-new.txt" with password "%public%" and content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
 
-  Scenario: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work
+  @skipOnOcis
+  Scenario: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with old public API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | change |
@@ -136,7 +154,8 @@ Feature: upload to a public link share
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "507"
 
-  Scenario: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work
+  @skipOnOcis @issue-ocis-reva-195
+  Scenario: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with new public API
     Given the administrator has enabled DAV tech_preview
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
@@ -145,7 +164,8 @@ Feature: upload to a public link share
     And uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "507"
 
-  Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work
+  @skipOnOcis
+  Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with old public API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | create |
@@ -153,7 +173,8 @@ Feature: upload to a public link share
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "507"
 
-  Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work
+  @skipOnOcis @issue-ocis-reva-195
+  Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with new public API
     Given the administrator has enabled DAV tech_preview
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
@@ -162,7 +183,8 @@ Feature: upload to a public link share
     And uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "507"
 
-  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder
+  @skipOnOcis
+  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
@@ -170,7 +192,8 @@ Feature: upload to a public link share
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "403"
 
-  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder
+  @skipOnOcis @issue-ocis-reva-41
+  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | FOLDER |
@@ -179,7 +202,8 @@ Feature: upload to a public link share
     And uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "403"
 
-  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder
+  @skipOnOcis
+  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder with old public API
     Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "Alice" has created a public link share with settings
       | path        | FOLDER |
@@ -188,7 +212,8 @@ Feature: upload to a public link share
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "403"
 
-  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder
+  @skipOnOcis @issue-ocis-reva-41
+  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder with new public API
     Given the administrator has enabled DAV tech_preview
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "Alice" has created a public link share with settings
@@ -198,7 +223,8 @@ Feature: upload to a public link share
     And uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "403"
 
-  Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder
+  @skipOnOcis
+  Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
@@ -207,7 +233,8 @@ Feature: upload to a public link share
     When the public uploads file "test-old.txt" with content "test-old" using the old public WebDAV API
     Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
 
-  Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder
+  @skipOnOcis @issue-ocis-reva-41
+  Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | FOLDER |
@@ -217,8 +244,8 @@ Feature: upload to a public link share
     When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
 
-  @smokeTest
-  Scenario: Uploading to a public upload-write and no edit and no overwrite share
+  @smokeTest @skipOnOcis
+  Scenario: Uploading to a public upload-write and no edit and no overwrite share with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
@@ -226,7 +253,7 @@ Feature: upload to a public link share
     Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
 
   @smokeTest
-  Scenario: Uploading to a public upload-write and no edit and no overwrite share
+  Scenario: Uploading to a public upload-write and no edit and no overwrite share with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | FOLDER          |
@@ -234,8 +261,8 @@ Feature: upload to a public link share
     When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
 
-  @smokeTest
-  Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times
+  @smokeTest @skipOnOcis
+  Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with old public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | FOLDER          |
@@ -252,8 +279,8 @@ Feature: upload to a public link share
     Then the HTTP status code should be "403"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
 
-  @smokeTest
-  Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times
+  @smokeTest @skipOnOcis @issue-ocis-reva-286
+  Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
       | path        | FOLDER          |

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -583,19 +583,22 @@ class OCSContext implements Context {
 	 * @throws Exception
 	 */
 	public function theOCSStatusCodeShouldBe($statusCode, $message = "") {
-		if ($message === "") {
-			$message = "OCS status code is not the expected value";
-		}
-
 		$responseStatusCode = $this->getOCSResponseStatusCode(
 			$this->featureContext->getResponse()
 		);
 		if (\is_array($statusCode)) {
+			if ($message === "") {
+				$message = "OCS status code is not any of the expected values " . \implode(",", $statusCode) . " got " . $responseStatusCode;
+			}
 			Assert::assertContainsEquals(
 				$responseStatusCode, $statusCode,
 				$message
 			);
 		} else {
+			if ($message === "") {
+				$message = "OCS status code is not the expected value " . $statusCode . " got " . $responseStatusCode;
+			}
+
 			Assert::assertEquals(
 				$statusCode, $responseStatusCode,
 				$message

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -905,7 +905,7 @@ trait Sharing {
 			$this->sharingApiVersion
 		);
 		$this->lastShareData = $this->getResponseXml();
-		if ($shareType === 'public_link') {
+		if ($shareType === 'public_link' && isset($this->lastShareData->data)) {
 			$linkName = (string) $this->lastShareData->data[0]->name;
 			$linkUrl = (string) $this->lastShareData->data[0]->url;
 			$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
@@ -929,6 +929,7 @@ trait Sharing {
 		if (($contentExpected === "ANY_VALUE")
 			|| (($contentExpected === "A_TOKEN") && (\strlen($value) === 15))
 			|| (($contentExpected === "A_NUMBER") && \is_numeric($value))
+			|| (($contentExpected === "A_STRING") && \is_string($value))
 			|| (($contentExpected === "AN_URL") && $this->isAPublicLinkUrl($value))
 			|| (($field === 'remote') && (\rtrim($value, "/") === $contentExpected))
 			|| ($contentExpected === $value)


### PR DESCRIPTION
Enabled some tests and tagged others that are not working yet.

For https://github.com/owncloud/ocis-reva/issues/49.
A lot blocked by https://github.com/owncloud/ocis-reva/issues/282

- ~~REQUIRES: https://github.com/cs3org/reva/pull/822 for some tests to work.~~
- ~~REQUIRES: https://github.com/cs3org/reva/pull/872 for some tests to work.~~
- REQUIRES: https://github.com/cs3org/reva/pull/877


~~Still need to investigate some of the tests tagged with "issue-ocis-reva-49" where the download returns an empty string.~~

### Raised and tagged issues:

- Webdav PUT response must always be 201 for upload-only shares: https://github.com/owncloud/ocis-reva/issues/286
- public link permission handling: https://github.com/owncloud/ocis-reva/issues/292 
- ~~rename and delete not implemented in public links: https://github.com/owncloud/ocis-reva/issues/293~~ resolved in the PR
- prevent sharing root folder: https://github.com/owncloud/ocis-reva/issues/283
- split old and new endpoint tests: https://github.com/owncloud/ocis-reva/issues/282
- OCS API expiration date should allow dates without time component: https://github.com/owncloud/ocis-reva/issues/288
- [x] OCS API support for legacy "publicUpload" attribute https://github.com/owncloud/ocis-reva/issues/289 => fixed in ocis-reva 0.6.0 but tests remains disabled because of other issues
- 500 error instead of 404 when accessing non-existing link: https://github.com/owncloud/ocis-reva/issues/290
- share_with field must contain special value for public links that have a password: https://github.com/owncloud/ocis-reva/issues/294
- single file shares: https://github.com/owncloud/ocis-reva/issues/278

### TODOs:
- [x] investigate why remaining tests tagged with `@issue-ocis-reva-49` are failing with empty downloads in apiSharePublicLink1/createPublicLinkShare.feature
- [x] process the other test files: