### PR TITLE
[Tests-Only] API test for upload file with Mtime

### DIFF
--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -98,12 +98,40 @@ Feature: upload file
       | new         | /upload...1.. | abc...txt.. |
       | new         | /...          | ...         |
 
+  @skipOnOcis
   Scenario Outline: upload file with mtime
     Given using <dav_version> DAV path
     When user "Alice" uploads file to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     Then as "Alice" file "file.txt" should exist
     And the HTTP status code should be "201"
     And as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis
+  Scenario Outline: upload a file with mtime in a folder
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "testFolder"
+    When user "Alice" uploads file to "/testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Then as "Alice" file "/testFolder/file.txt" should exist
+    And the HTTP status code should be "201"
+    And as "Alice" the mtime of the file "/testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis
+  Scenario Outline: moving a file does not changes its mtime
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "testFolder"
+    When user "Alice" uploads file to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" moves file "file.txt" to "/testFolder/file.txt" using the WebDAV API
+    Then as "Alice" file "/testFolder/file.txt" should exist
+    And the HTTP status code should be "201"
+    And as "Alice" the mtime of the file "/testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -98,7 +98,7 @@ Feature: upload file
       | new         | /upload...1.. | abc...txt.. |
       | new         | /...          | ...         |
 
-  @skipOnOcis
+  @skipOnOcis @issue-ocis-reva-174
   Scenario Outline: upload file with mtime
     Given using <dav_version> DAV path
     When user "Alice" uploads file to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
@@ -110,7 +110,7 @@ Feature: upload file
       | old         |
       | new         |
 
-  @skipOnOcis
+  @skipOnOcis @issue-ocis-reva-174
   Scenario Outline: upload a file with mtime in a folder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "testFolder"
@@ -123,7 +123,7 @@ Feature: upload file
       | old         |
       | new         |
 
-  @skipOnOcis
+  @skipOnOcis @issue-ocis-reva-174
   Scenario Outline: moving a file does not changes its mtime
     Given using <dav_version> DAV path
     And user "Alice" has created folder "testFolder"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -97,3 +97,14 @@ Feature: upload file
       | new         | /upload.1     | abc.txt     |
       | new         | /upload...1.. | abc...txt.. |
       | new         | /...          | ...         |
+
+  Scenario Outline: upload file with mtime
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Then as "Alice" file "file.txt" should exist
+    And the HTTP status code should be "201"
+    And as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2080,8 +2080,7 @@ trait WebDav {
 	 *
 	 * @param string $user
 	 * @param string $destination
-	 * @param string $mtime API uses mtime as time in millisecond since epoch
-	 * 						Human readable format is taken as input and then converted into milliseconds
+	 * @param string $mtime Time in human readable format is taken as input which is converted into milliseconds that is used by API
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Description
API test for upload a file with Mtime header.

## Related Issue
https://github.com/owncloud/ocis-reva/issues/273

## How Has This Been Tested?
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
