### PR TITLE
use relative path in shared_by_email activity

### DIFF
--- a/apps/files_sharing/lib/Controller/NotificationController.php
+++ b/apps/files_sharing/lib/Controller/NotificationController.php
@@ -25,6 +25,7 @@ use OC\OCS\Result;
 use OC\Share\MailNotifications;
 use OCP\AppFramework\OCSController;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -88,7 +89,7 @@ class NotificationController extends OCSController {
 					$link,
 					$personalNote
 				);
-			} catch (GenericShareException $e) {
+			} catch (GenericShareException | NotFoundException $e) {
 				$code = $e->getCode() === 0 ? 403 : $e->getCode();
 				return new Result(null, $code, $e->getHint());
 			}

--- a/changelog/unreleased/37555
+++ b/changelog/unreleased/37555
@@ -1,0 +1,6 @@
+Bugfix: Use relative path in shared_with_email activity
+
+"shared_with_email" activity email was including the complete path of the shared node.
+This path has changed with the relative path of the sender user folder.
+
+https://github.com/owncloud/core/pull/37555

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -30,7 +30,9 @@
 
 namespace OC\Share;
 
+use OCP\Files\IRootFolder;
 use OCP\Files\Node;
+use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -71,6 +73,8 @@ class MailNotifications {
 	private $eventDispatcher;
 	/** @var \OCP\Activity\IManager */
 	private $activityManager;
+	/** @var IRootFolder */
+	private $rootFolder;
 
 	/**
 	 * @param IManager $shareManager
@@ -92,7 +96,8 @@ class MailNotifications {
 		Defaults $defaults,
 		IURLGenerator $urlGenerator,
 		EventDispatcher $eventDispatcher,
-		\OCP\Activity\IManager $activityManager
+		\OCP\Activity\IManager $activityManager,
+		IRootFolder $rootFolder
 	) {
 		$this->shareManager = $shareManager;
 		$this->l = $l10n;
@@ -103,6 +108,7 @@ class MailNotifications {
 		$this->urlGenerator = $urlGenerator;
 		$this->eventDispatcher = $eventDispatcher;
 		$this->activityManager = $activityManager;
+		$this->rootFolder = $rootFolder;
 	}
 
 	/**
@@ -213,6 +219,7 @@ class MailNotifications {
 	 * @param string $link the share link
 	 * @param string $personalNote sender note
 	 * @throws GenericShareException
+	 * @throws NotFoundException
 	 * @return string[] $result of failed recipients
 	 */
 	public function sendLinkShareMail($sender, $recipients, $link, $personalNote = null) {
@@ -272,7 +279,8 @@ class MailNotifications {
 		$failedRecipients =  $this->sendLinkShareMailFromBody($recipients, $subject, $htmlBody, $textBody, $from, $replyTo);
 		if (empty($failedRecipients)) {
 			$event = $this->activityManager->generateEvent();
-			$path = $shareNode->getPath();
+			$userFolder = $this->rootFolder->getUserFolder($sender->getUID());
+			$path = $userFolder->getRelativePath($shareNode->getPath());
 			$event->setApp(\OCA\Files_Sharing\Activity::FILES_SHARING_APP)
 				->setType(\OCA\Files_Sharing\Activity::TYPE_SHARED)
 				->setAuthor($currentUser)

--- a/lib/private/Share/MailNotifications.php
+++ b/lib/private/Share/MailNotifications.php
@@ -279,8 +279,11 @@ class MailNotifications {
 		$failedRecipients =  $this->sendLinkShareMailFromBody($recipients, $subject, $htmlBody, $textBody, $from, $replyTo);
 		if (empty($failedRecipients)) {
 			$event = $this->activityManager->generateEvent();
+			// it can be a re-share, get actual share file node
 			$userFolder = $this->rootFolder->getUserFolder($sender->getUID());
-			$path = $userFolder->getRelativePath($shareNode->getPath());
+			$shareFileNodes = $userFolder->getById($shareNode->getId(), true);
+			$shareFileNode = $shareFileNodes[0] ?? null;
+			$path = $userFolder->getRelativePath($shareFileNode->getPath());
 			$event->setApp(\OCA\Files_Sharing\Activity::FILES_SHARING_APP)
 				->setType(\OCA\Files_Sharing\Activity::TYPE_SHARED)
 				->setAuthor($currentUser)


### PR DESCRIPTION
## Description
Do not use the absolute Webdav Path for the `shared_by_email` activity.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4045

## Motivation and Context
Do not display unecessary information.

## How Has This Been Tested?
- manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

## Tasks
- [x] Needs Changelog item
- [x] Needs manual testing