### PR TITLE
Share sheet improvements (external sharing)

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -176,10 +176,9 @@
 	align-items: center;
 	min-height : 50px;
 	position   : relative;
-}
-
-.link-entry:not(:last-child) {
-	border-bottom: 1px solid #eee;
+	padding    : 0 5px 0 5px;
+	background : #f8f8f8;
+	border-bottom: 1px solid #aaa;
 }
 
 .link-entry .socialShareContainer {
@@ -210,7 +209,7 @@
 }
 
 .link-entry--icon-button {
-	margin-left       : 5px;
+	margin-left       : 10px;
 	opacity           : 0.333;
 	-webkit-transition: opacity 0.25s;
 	-moz-transition   : opacity 0.25s;

--- a/changelog/unreleased/37558
+++ b/changelog/unreleased/37558
@@ -1,0 +1,10 @@
+Change: Share sheet improvements (external sharing)
+
+Share Sheet for external shares was cleaned up a bit.
+
+- Color of the separator line has the same color
+- The padding of the icons has been enlarged
+- A background color was inserted
+- The padding of the content was increased on the left and right
+
+https://github.com/owncloud/core/pull/37558


### PR DESCRIPTION
## Description
To make the view of public links look syncron to the view of internal links I created this PR.

This PR contains:
- Color of the separator line has the same color
- The padding of the icons has been enlarged
- A background color was inserted
- The padding of the content was increased on the left and right

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/3979

## Motivation and Context
To make the view of public links look syncron to the view of internal links 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested in Firefox and Chrome

## Screenshots:
| Before  | After  |  
|---|---|
| <img width="438" alt="Screenshot 2020-06-19 at 00 59 19" src="https://user-images.githubusercontent.com/33026403/85080142-be26a280-b1c8-11ea-9132-e4aa55fec382.png"> | <img width="438" alt="Screenshot 2020-06-19 at 00 55 06" src="https://user-images.githubusercontent.com/33026403/85080166-ca126480-b1c8-11ea-96a0-b361701e653a.png"> |


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
