### PR TITLE
Handle application/gzip when installing apps on PHP 7.4

### DIFF
--- a/lib/private/Archive/Archive.php
+++ b/lib/private/Archive/Archive.php
@@ -44,6 +44,7 @@ abstract class Archive {
 		switch ($mime) {
 			case 'application/zip':
 				return new ZIP($path);
+			case 'application/gzip':
 			case 'application/x-gzip':
 				return new TAR($path);
 			case 'application/x-bzip2':

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -281,7 +281,7 @@ class Installer {
 
 		//detect the archive type
 		$mime = \OC::$server->getMimeTypeDetector()->detect($path);
-		if ($mime !=='application/zip' && $mime !== 'application/x-gzip' && $mime !== 'application/x-bzip2') {
+		if ($mime !=='application/zip' && $mime !== 'application/x-gzip' && $mime !== 'application/gzip' && $mime !== 'application/x-bzip2') {
 			throw new \Exception($l->t("Archives of type %s are not supported", [$mime]));
 		}
 


### PR DESCRIPTION
## Description
In PHP 7.4 the mime-type of a `gzip` file is now `application/gzip` rather than `application/x-gzip`. See the issue for details.

Allow `application/gzip` mine-time when doing `market:install`

## Related Issue
- Fixes #37467 

## How Has This Been Tested?
Manually before:
```
$ php --version
PHP 7.4.7 (cli) (built: Jun 12 2020 07:44:05) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.7, Copyright (c), by Zend Technologies
    with Xdebug v2.9.6, Copyright (c) 2002-2020, by Derick Rethans
$ php occ market:install activity
activity: Installing new app ...
 activity: Archives of type application/gzip are not supported 
```
And after the code fix:
```
$ php occ market:install activity
activity: Installing new app ...
activity: App installed.
```

Ack to @fmkaiser for providing the fix in the issue.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
