### PR TITLE
Ajaxify Cors section in Personal settings

### DIFF
--- a/changelog/unreleased/37560
+++ b/changelog/unreleased/37560
@@ -1,0 +1,7 @@
+Bugfix: Show error message at Settings Personal CORS
+
+Skipping a protocol at Settings Personal CORS silently refused to add the domain.
+Proper error message added.
+
+
+https://github.com/owncloud/core/pull/37560

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -185,7 +185,8 @@ class Application extends App {
 				$c->query('UserSession'),
 				$c->query('Logger'),
 				$c->query('URLGenerator'),
-				$c->query('Config')
+				$c->query('Config'),
+				$c->query('L10N')
 			);
 		});
 

--- a/settings/js/panels/cors.js
+++ b/settings/js/panels/cors.js
@@ -1,33 +1,64 @@
+var PersonalCors = {
+    renderRow: function(domain){
+        var col1 = $('<td></td>').text(domain);
+        var input = $('<input type="button" class="button icon-delete removeDomainButton" />').data('domain', domain)
+        var col2 = $('<td />').append(input);
+        var row = $('<tr></tr>').append(col1).append(col2);
+        $('#cors .grid tbody').append(row);
+    },
+    render: function (data) {
+        $("#cors .grid tbody tr").remove();
+        for (var p in data) {
+            PersonalCors.renderRow(data[p]);
+        }
+        var numDomains = $("#cors .grid tbody tr").length;
+        if (numDomains === 0) {
+            $("#noDomains").show();
+            $("#cors .grid").hide();
+        } else {
+            $("#noDomains").hide();
+            $("#cors .grid").show();
+        }
+    }
+};
+
 $(document).ready(function () {
-    $('.removeDomainButton').on('click', function () {
-        var id = $(this).attr('data-id');
-        var confirmText = $(this).attr('data-confirm');
-        var token = OC.requestToken;
+    $('#cors').on('click', '.removeDomainButton', function () {
         var $el = $(this);
 
         OC.dialogs.confirm(
-            t('settings', confirmText), t('settings','CORS'),
+            t('settings', 'Are you sure you want to remove this domain?'), t('settings','CORS'),
             function (result) {
                 if (result) {
+                    var domain = encodeURIComponent($el.data('domain'));
                     $.ajax({
                         type: 'DELETE',
-                        url: OC.generateUrl('/settings/domains/{id}', {id: id}),
-                        data: {
-                            requesttoken: token
+                        url: OC.generateUrl('/settings/domains/{domain}', {domain: domain}),
+                        data: {}
+                    }).success(function(response) {
+                        if (response.domains) {
+                            PersonalCors.render(response.domains)
                         }
-                    }).success(function() {
-                        var numDomains = $("#cors .grid tbody tr").length;
-                        if ($el.closest('tr').length === 1 && numDomains === 1) {
-                            // Means only one domain row remains and that is to be deleted
-                            // Show the No domains text
-                            $("#noDomains").text("No Domains.");
-                            // Remove the domain listing table
-                            $("#cors .grid").remove();
-                        }
-                        $el.closest('tr').remove();
                     });
                 }
             }, true
         );
 	});
+    $('#corsAddNewDomain').on('click', function() {
+        $('#corsAddNewDomain').attr('disabled', true);
+        $.post(
+            OC.generateUrl('/settings/domains'),
+            { domain : $('#domain').val()},
+            function(response) {
+                if (response.message) {
+                    OC.Notification.showTemporary(response.message);
+                }
+                if (response.domains) {
+                    PersonalCors.render(response.domains)
+                }
+                $('#domain').val('');
+                $('#corsAddNewDomain').attr('disabled', false);
+            }
+        )
+    });
 });

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -64,7 +64,7 @@ $application->registerRoutes($this, [
 		['name' => 'Users#changeMail', 'url' => '/settings/mailaddress/change/{token}/{userId}', 'verb' => 'GET'],
 		['name' => 'Cors#getDomains', 'url' => '/settings/domains', 'verb' => 'GET'],
 		['name' => 'Cors#addDomain', 'url' => '/settings/domains', 'verb' => 'POST'],
-		['name' => 'Cors#removeDomain', 'url' => '/settings/domains/{id}', 'verb' => 'DELETE'],
+		['name' => 'Cors#removeDomain', 'url' => '/settings/domains/{domain}', 'verb' => 'DELETE'],
 		['name' => 'LegalSettings#setImprintUrl', 'url' => '/settings/admin/legal/imprint', 'verb' => 'POST'],
 		['name' => 'LegalSettings#setPrivacyPolicyUrl', 'url' => '/settings/admin/legal/privacypolicy', 'verb' => 'POST'],
 		['name' => 'ChangePassword#changePassword', 'url' => '/users/changepassword', 'verb' => 'POST'],

--- a/settings/templates/panels/personal/cors.php
+++ b/settings/templates/panels/personal/cors.php
@@ -24,42 +24,32 @@ script('settings', 'panels/cors');
 	<h2 class="app-name">CORS</h2>
 	<span class="app-name">Cross-Origin Resource Sharing</span>
 
-    <h3><?php p($l->t('White-listed Domains')); ?></h3>
-    <p id="noDomains">
-        <?php if (empty($_['domains'])) {
-	p($l->t('No Domains.'));
-} ?>
-    </p>
+	<h3><?php p($l->t('White-listed Domains')); ?></h3>
+	<p id="noDomains" <?php if (!empty($_['domains'])) { ?>class="hidden"<?php } ?>>
+		<?php p($l->t('No Domains.')); ?>
+	</p>
 
-    <?php if (!empty($_['domains'])) {
-	?>
-    <table class="grid">
-        <thead>
-        <tr>
-            <th id="headerName" scope="col"><?php p($l->t('Domain')); ?></th>
-            <th id="headerRemove">&nbsp;</th>
-        </tr>
-        </thead>
-        <tbody>
-            <?php foreach ($_['domains'] as $id => $domain) {
-		?>
-                <tr>
-                    <td><?php p($domain); ?></td>
-                    <td>
-                        <input data-id="<?php p($id); ?>" type="button" class="button icon-delete removeDomainButton" data-confirm="<?php p($l->t('Are you sure you want to remove this domain?')); ?>" value="">
-                    </td>
-                </tr>
-            <?php
-	} ?>
-        </tbody>
-    </table>
-    <?php
-} ?>
+	<table class="grid">
+		<thead>
+		<tr>
+			<th id="headerName" scope="col"><?php p($l->t('Domain')); ?></th>
+			<th id="headerRemove">&nbsp;</th>
+		</tr>
+		</thead>
+		<tbody>
+			<?php foreach ($_['domains'] as $id => $domain) { ?>
+				<tr>
+					<td><?php p($domain); ?></td>
+					<td>
+						<input data-domain="<?php p($domain) ?>" type="button" class="button icon-delete removeDomainButton" value="">
+					</td>
+				</tr>
+			<?php } ?>
+		</tbody>
+	</table>
 
-    <h3><?php p($l->t('Add Domain')); ?></h3>
-    <form action="<?php p($_['urlGenerator']->linkToRoute('settings.Cors.addDomain')); ?>" method="post">
+	<h3><?php p($l->t('Add Domain')); ?></h3>
 		<input id="domain" name="domain" type="text" placeholder="<?php p($l->t('Domain')); ?>">
-		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
-		<input type="submit" class="button" value="<?php p($l->t('Add')); ?>">
-    </form>
+		<input id="corsAddNewDomain" type="submit" class="button" value="<?php p($l->t('Add')); ?>">
+	</form>
 </div>

--- a/tests/Settings/Panels/Personal/CorsTest.php
+++ b/tests/Settings/Panels/Personal/CorsTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author Viktar Dubiniuk
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+namespace Settings\Panels\Personal;
+
+use OC\Settings\Panels\Personal\Cors;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class CorsTest extends \Test\TestCase {
+	/** @var Cors */
+	protected $panel;
+
+	/** @var IUserSession | MockObject */
+	protected $userSession;
+
+	/** @var IURLGenerator | MockObject */
+	protected $urlGenerator;
+
+	/** @var IConfig | MockObject */
+	protected $config;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->config = $this->createMock(IConfig::class);
+
+		$this->panel = new Cors(
+			$this->userSession,
+			$this->urlGenerator,
+			$this->config
+		);
+	}
+
+	public function testGetPanel() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->config->method('getUserValue')->willReturn('["http:\/\/www.test.com"]');
+		$panelHtml = $this->panel->getPanel()->fetchPage();
+
+		$this->assertStringContainsString('id="cors"', $panelHtml);
+		$this->assertStringContainsString('http://www.test.com"', $panelHtml);
+	}
+}


### PR DESCRIPTION
## Description
CORS section silently fail when a new domain is incorrect

## Motivation and Context

## How Has This Been Tested?
1. Open  Settings -> Personal -> Security 
2. Add domain e.g. 'localhost' to the CORS section
#### Expected 
Domain is not added, Error message
#### Actual
Domain is not added, No error message

# Screenshot
![Screenshot_20200622_165612](https://user-images.githubusercontent.com/991300/85296185-ae99a900-b4a9-11ea-9325-55e246cddd78.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
