### PR TITLE
[Tests-Only] Do not rely on welcome.txt existing in acceptance tests

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature
@@ -243,8 +243,9 @@ Feature: get file properties
   @skipOnOcis
   Scenario Outline: Doing a PROPFIND with a web login should work with CSRF token on the new backend
     Given using <dav_version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     And user "Alice" has logged in to a web-style session
-    When the client sends a "PROPFIND" to "/remote.php/dav/files/%username%/welcome.txt" of user "Alice" with requesttoken
+    When the client sends a "PROPFIND" to "/remote.php/dav/files/%username%/somefile.txt" of user "Alice" with requesttoken
     Then the HTTP status code should be "207"
     Examples:
       | dav_version |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -733,6 +733,11 @@ trait Sharing {
 	 * @return void
 	 */
 	public function shouldNotBeAbleToCreatePublicLinkShare($sharer, $filepath) {
+		$this->asFileOrFolderShouldExist(
+			$this->getActualUsername($sharer),
+			"entry",
+			$filepath
+		);
 		$this->createAPublicShare($sharer, $filepath);
 		Assert::assertEquals(
 			404,
@@ -1434,6 +1439,11 @@ trait Sharing {
 	 */
 	public function userTriesToShareFileUsingTheSharingApi($sharer, $filepath, $userOrGroupShareType, $sharee, $permissions = null) {
 		$sharee = $this->getActualUsername($sharee);
+		$this->asFileOrFolderShouldExist(
+			$this->getActualUsername($sharer),
+			"entry",
+			$filepath
+		);
 		$this->createShare(
 			$sharer, $filepath, $userOrGroupShareType, $sharee, null, null, $permissions
 		);
@@ -1460,6 +1470,7 @@ trait Sharing {
 		$sharer, $filepath, $userOrGroupShareType, $sharee, $permissions = null
 	) {
 		$sharee = $this->getActualUsername($sharee);
+		$this->asFileOrFolderShouldExist($sharer, "entry", $filepath);
 		$this->createShare(
 			$sharer, $filepath, $userOrGroupShareType, $sharee, null, null, $permissions
 		);
@@ -2333,6 +2344,7 @@ trait Sharing {
 	 */
 	public function checkPublicSharesAreEmpty($user, $path) {
 		$user = $this->getActualUsername($user);
+		$this->asFileOrFolderShouldExist($user, "entry", $path);
 		$dataResponded = $this->getShares($user, $path);
 		//It shouldn't have public shares
 		Assert::assertEquals(

--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
@@ -102,11 +102,12 @@ Feature: misc scenarios on sharing with internal users
       | Alice    |
       | Carol    |
     And user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     And user "Alice" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables exclude groups from sharing using the webUI
     And the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "Alice" should not be able to share file "testimage.jpg" with user "Carol" using the sharing API
+    Then user "Alice" should not be able to share file "somefile.txt" with user "Carol" using the sharing API
 
   Scenario: user tries to share a folder from a group which is blacklisted from sharing
     Given these users have been created with default attributes and without skeleton files:
@@ -115,11 +116,12 @@ Feature: misc scenarios on sharing with internal users
       | Carol    |
     And user "Brian" has been created with default attributes and skeleton files
     And group "grp1" has been created
+    And user "Alice" has created folder "new-folder"
     And user "Alice" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables exclude groups from sharing using the webUI
     And the administrator adds group "grp1" to the exclude group from sharing list using the webUI
-    Then user "Alice" should not be able to share folder "simple-folder" with user "Carol" using the sharing API
+    Then user "Alice" should not be able to share folder "new-folder" with user "Carol" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file received as a share
     Given these users have been created with default attributes and skeleton files:


### PR DESCRIPTION
## Description
PR #37539 reduced the use of the skeleton in various API test scenarios.

Without the explicit skeleton, in some CI scenarios we end up having the "built-in"  default skeleton that has the Paris and Squirrel images and a `welcome.txt`. There are some tests that use `welcome.txt` and expect it to already exist.

But in other CI scenarios (e.g. https://drone.owncloud.com/owncloud/admin_audit/1520/58/14 admin_audit) the skeleton is completely empty. So when we create users "without skeleton files" then we really should not rely on any file existing.

Last night `admin_audit` CI  failed with:
```
--- Failed scenarios:

    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature:251
    /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavProperties/getFileProperties.feature:252

142 scenarios (140 passed, 2 failed)
1049 steps (1047 passed, 2 failed)
```

1) Fix the scenario so that it does not depend on `welcome.txt`

Also there are sharing scenarios that check that  some attempt at sharing a file/folder does not succeed. If the file/folder does not even exist then these tests can easily "pass" (i.e. the sharing fails) because the file/folder does not exist, not because the sharing itself was prohibited.

2) Add checks to those test steps to make sure that the file/folder exists before attempting the sharing action. This will ensure that the test fails if somehow the file/folder does not exist.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
