### PR TITLE
Handle exceptions for deleted share nodes while transfering ownership

### DIFF
--- a/changelog/unreleased/37568
+++ b/changelog/unreleased/37568
@@ -1,0 +1,8 @@
+Bugfix: Handle exceptions for deleted share nodes while transfering ownership
+
+Adds exception handling while collecting shares in files:transfer-ownership.
+Additionally, new option "accept-skipped-shares" has been added to
+automatically confirm to skip shares that cannot be transferred.
+
+https://github.com/owncloud/enterprise/issues/4023
+https://github.com/owncloud/core/pull/37568


### PR DESCRIPTION
When running `files:transfer-ownership`, we should not explode with exception when e.g. federated share reshare has been deleted by remote owner (thus resulting in `NotFoundException` or `NoUserException`)

This PR:
- [x] add exception handling for `NotFoundException` or `NoUserException`
- [x] prompt user if he wants to continue with transfer when 
```
$ occ files:transfer-ownership -vvv --path='test' test1 test3
Analysing files of test1 ...
    1 [============================] < 1 sec 30.0 MiB
Collecting all share information for files and folder of test1 ...
Share with id 2 points at deleted file, skipping
    1 [============================]  1 sec 32.0 MiB
There were user shares that were skipped during the analysis of the shares. Do you want to continue with the transfer ?
  [0] yes
  [1] no
 > no
Execution terminated
```
- [x] add flag `--accept-skipped-shares` to always accept skipped shares

