### PR TITLE
Add new system config to enforce strict login check for password in user backend

### DIFF
--- a/changelog/unreleased/37569
+++ b/changelog/unreleased/37569
@@ -1,0 +1,9 @@
+Security: Add new system config to enforce strict login check with user backend
+
+Adds new system config to enforce strict login check for password
+in user backend, meaning only login name typed by user would be validated.
+With this configuration enabled, e.g. additional check for email will
+not be performed.
+
+https://github.com/owncloud/core/pull/37569
+https://github.com/owncloud/user_ldap/pull/581

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -237,6 +237,14 @@ $CONFIG = [
 'token_auth_enforced' => false,
 
 /**
+ * Enforce strict login check with user backend
+ * If enabled, strict login check for password in user backend will be enforced,
+ * meaning only the login name typed by the user would  be validated. With this
+ * configuration enabled, e.g. an additional check for email will not be performed.
+ */
+'strict_login_enforced' => false,
+
+/**
  * Define additional login buttons on the logon screen
  * Provides the ability to create additional login buttons on the logon screen, for e.g., SSO integration
  *  'login.alternatives' => [

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -219,7 +219,7 @@ class LoginController extends Controller {
 		$originalUser = $user;
 		// TODO: Add all the insane error handling
 		$loginResult = $this->userSession->login($user, $password);
-		if ($loginResult !== true) {
+		if ($loginResult !== true && $this->config->getSystemValue('strict_login_enforced', false) !== true) {
 			$users = $this->userManager->getByEmail($user);
 			// we only allow login by email if unique
 			if (\count($users) === 1) {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -360,6 +360,10 @@ class Session implements IUserSession, Emitter {
 			throw new PasswordLoginForbiddenException();
 		}
 		if (!$this->login($user, $password)) {
+			if ($this->config->getSystemValue('strict_login_enforced', false) === true) {
+				return false;
+			}
+
 			$users = $this->manager->getByEmail($user);
 			if (\count($users) === 1) {
 				return $this->login($users[0]->getUID(), $password);
@@ -397,6 +401,9 @@ class Session implements IUserSession, Emitter {
 		);
 		$user = $this->manager->get($username);
 		if ($user === null) {
+			if ($this->config->getSystemValue('strict_login_enforced', false) === true) {
+				return false;
+			}
 			$users = $this->manager->getByEmail($username);
 			if (empty($users)) {
 				return false;

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -439,7 +439,19 @@ class SessionTest extends TestCase {
 		$userSession->logClientIn('john', 'doe', $request);
 	}
 
-	public function testLogClientInUnexist() {
+	public function dataLogClientInUnexist() {
+		return [
+			[false, 2],
+			[true, 0],
+		];
+	}
+
+	/**
+	 * @dataProvider dataLogClientInUnexist
+	 * @param $strictLoginCheck
+	 * @param $expectedGetByEmailCalls
+	 */
+	public function testLogClientInUnexist($strictLoginCheck, $expectedGetByEmailCalls) {
 		$manager = $this->getMockBuilder(Manager::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -457,11 +469,19 @@ class SessionTest extends TestCase {
 			->method('getToken')
 			->with('doe')
 			->will($this->throwException(new InvalidTokenException()));
-		$this->config->expects($this->once())
+		$this->config->expects($this->at(0))
 			->method('getSystemValue')
 			->with('token_auth_enforced', false)
 			->will($this->returnValue(false));
-		$manager->expects($this->any())
+		$this->config->expects($this->at(1))
+			->method('getSystemValue')
+			->with('strict_login_enforced', false)
+			->willReturn($strictLoginCheck);
+		$this->config->expects($this->at(2))
+			->method('getSystemValue')
+			->with('strict_login_enforced', false)
+			->willReturn($strictLoginCheck);
+		$manager->expects($this->exactly($expectedGetByEmailCalls))
 			->method('getByEmail')
 			->willReturn([]);
 


### PR DESCRIPTION
When in LDAP config user login attributes are setuped disallowing login by email, verify settings as below work correctly:

![](https://user-images.githubusercontent.com/12248713/85134233-76416300-b23c-11ea-95fc-db223823f2c4.png)

However, as of at least OC9.X, when logging in with LDAP with loginname and password, OC always retries to get a user, and try login agains LDAP also with email. For some customers this should not be allowed.

This PR:
- [x] adds new system config `/occ config:system:set --type boolean --value true strict_login_enforced` that disallows to retry with email
- [x] add unit tests