### PR TITLE
php occ maintenance:mimetype:update-js

### DIFF
--- a/changelog/unreleased/36509
+++ b/changelog/unreleased/36509
@@ -8,4 +8,5 @@ https://github.com/owncloud/core/issues/37467
 https://github.com/owncloud/core/pull/37559
 https://github.com/owncloud/core/issues/37564
 https://github.com/owncloud/core/pull/37565
+https://github.com/owncloud/core/pull/37570
 https://www.php.net/supported-versions.php

--- a/core/js/mimetypelist.js
+++ b/core/js/mimetypelist.js
@@ -12,6 +12,7 @@ OC.MimeTypeList={
     "application/epub+zip": "text",
     "application/font-sfnt": "image",
     "application/font-woff": "image",
+    "application/gzip": "package/x-generic",
     "application/illustrator": "image",
     "application/javascript": "text/code",
     "application/json": "text/code",


### PR DESCRIPTION
## Description
After issue #37467 and PR #37565 added `application/gzip` to various mimetype files, we need to also do:
```
php occ maintenance:mimetype:update-js
```
To update ` core/js/mimetypelist.js`

## Related Issue
#37564 

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
