### PR TITLE
[Tests-Only] Make various file operations test pass on EOS

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
@@ -8,6 +8,7 @@ Feature: create folder
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
+  @skipOnOcis-EOS-Storage @issue-ocis-reva-269
   Scenario Outline: create a folder
     Given using <dav_version> DAV path
     When user "Alice" creates folder "<folder_name>" using the WebDAV API
@@ -70,7 +71,7 @@ Feature: create folder
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-168
+  @skipOnOcis @issue-ocis-reva-168 @skipOnOcis-EOS-Storage @issue-ocis-reva-269
   Scenario Outline: try to create a folder that already exists
     Given using <dav_version> DAV path
     And user "Alice" has created folder "my-data"

--- a/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
@@ -8,13 +8,25 @@ Feature: set file properties
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
   Scenario Outline: Setting custom DAV property and reading it
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustomprop.txt"
     And user "Alice" has set property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustomprop.txt" to "veryCustomPropValue"
     When user "Alice" gets a custom property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testcustomprop.txt"
     Then the response should contain a custom "very-custom-prop" property with namespace "x1='http://whatever.org/ns'" and value "veryCustomPropValue"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @skipOnOcV10 @issue-ocis-reva-276
+  # after fixing the issues delete this scenario and use the one above
+  Scenario Outline: Setting custom DAV property
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustomprop.txt"
+    When user "Alice" sets property "very-custom-prop"  with namespace "x1='http://whatever.org/ns'" of file "/testcustomprop.txt" to "veryCustomPropValue" using the WebDAV API
+    Then the HTTP status code should be "500"
     Examples:
       | dav_version |
       | old         |
@@ -32,6 +44,7 @@ Feature: set file properties
       | old         |
       | new         |
 
+  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
   Scenario Outline: Setting custom DAV property and reading it after the file is renamed
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustompropwithmove.txt"
@@ -62,6 +75,7 @@ Feature: set file properties
       | old         |
       | new         |
 
+  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
   Scenario Outline: Setting custom DAV property using one endpoint and reading it with other endpoint
     Given using <action_dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testnewold.txt"
@@ -74,6 +88,7 @@ Feature: set file properties
       | old                | new               |
       | new                | old               |
 
+  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
   Scenario: Setting custom DAV property using an old endpoint and reading it using a new endpoint
     Given using old DAV path
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testoldnew.txt"

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -41,7 +41,7 @@ Feature: get file properties
       | new         | /file ?2.txt  | dav\/files\/%username%\/file%20%3f2\.txt    |
       | new         | /file &2.txt  | dav\/files\/%username%\/file%20%262\.txt    |
 
-  @skipOnOcV10 @issue-ocis-reva-214
+  @skipOnOcV10 @issue-ocis-reva-214 @issue-ocis-reva-265 @skipOnOcis-EOS-Storage
   #after fixing all issues delete this Scenario and use the one above
   Scenario Outline: Do a PROPFIND of various file names
     Given using <dav_version> DAV path
@@ -59,6 +59,17 @@ Feature: get file properties
       | new         | /file #2.txt  | dav\/files\/%username%\/file%20%232\.txt  |
       | new         | /file ?2.txt  | dav\/files\/%username%\/file%20%3F2\.txt  |
       | new         | /file &2.txt  | dav\/files\/%username%\/file%20&2\.txt    |
+
+  @skipOnOcis-OC-Storage @issue-ocis-reva-265  @skipOnOcV10
+  #after fixing the issues merge this Scenario into the one above
+  Scenario Outline: upload a file to content
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file with content "uploaded content" to "<file_name>" using the WebDAV API
+    Then the HTTP status code should be "500"
+    Examples:
+      | dav_version | file_name     |
+      | old         | /file ?2.txt  |
+      | new         | /file ?2.txt  |
 
   @skipOnOcis @issue-ocis-reva-214
   Scenario Outline: Do a PROPFIND of various folder names
@@ -87,7 +98,7 @@ Feature: get file properties
       | new         | /folder ?2.txt  | dav\/files\/%username%\/folder%20%3f2\.txt                                     |
       | new         | /folder &2.txt  | dav\/files\/%username%\/folder%20%262\.txt                                     |
 
-  @skipOnOcV10 @issue-ocis-reva-214
+  @skipOnOcV10 @issue-ocis-reva-214 @skipOnOcis-EOS-Storage @issue-ocis-reva-265
   #after fixing all issues delete this Scenario and use the one above
   Scenario Outline: Do a PROPFIND of various folder names
     Given using <dav_version> DAV path
@@ -115,6 +126,7 @@ Feature: get file properties
       | new         | /folder ?2.txt  | dav\/files\/%username%\/folder%20%3F2\.txt                                     |
       | new         | /folder &2.txt  | dav\/files\/%username%\/folder%20&2\.txt                                       |
 
+  @skipOnOcis-EOS-Storage @issue-ocis-reva-265
   Scenario Outline: Do a PROPFIND of various files inside various folders
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<folder_name>"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -24,6 +24,7 @@ Feature: upload file
       | new         | /strängé file.txt |
       | new         | /नेपाली.txt       |
 
+  @skipOnOcis-EOS-Storage @issue-ocis-reva-265
   Scenario Outline: upload a file and check download content
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to <file_name> using the WebDAV API
@@ -41,6 +42,18 @@ Feature: upload file
       | new         | " ?fi=le&%#2 . txt" |
       | new         | " # %ab ab?=ed "    |
 
+  @skipOnOcV10 @skipOnOcis-OC-Storage @issue-ocis-reva-265
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario Outline: upload a file and check download content
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file with content "uploaded content" to <file_name> using the WebDAV API
+    Then the content of file <file_name> for user "Alice" should be ""
+    Examples:
+      | dav_version | file_name           |
+      | old         | "file ?2.txt"       |
+      | new         | "file ?2.txt"       |
+
+  @skipOnOcis-EOS-Storage @issue-ocis-reva-265
   Scenario Outline: upload a file into a folder and check download content
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<folder_name>"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Right now ocis behaves differently (partly) with EOS storage. This PR makes files operation tests like uploading, downloading, etc to pass on EOS
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
-  Part of https://github.com/owncloud/ocis/issues/253


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
