### PR TITLE
[Tests-Only] Simplify adminSetsServerParameterToUsingAPI

### DIFF
--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -51,12 +51,7 @@ class AppConfigurationContext implements Context {
 	public function adminSetsServerParameterToUsingAPI(
 		$parameter, $app, $value
 	) {
-		$user = $this->featureContext->getCurrentUser();
-		$this->featureContext->setCurrentUser($this->featureContext->getAdminUsername());
-
 		$this->modifyAppConfig($app, $parameter, $value);
-
-		$this->featureContext->setCurrentUser($user);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Acceptance test step `adminSetsServerParameterToUsingAPI()` has code to switch the "current user" to admin before calling `modifyAppConfig()`. But `modifyAppConfig()` already always uses the admin username anyway (because it asks the testing app to set the parameter, and the testing app only takes requests with admin auth).

There is no need to to switch the "current user" to admin and then switch it back. Simplify the code.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
