### PR TITLE
[Tests-Only] [10.5.0] skip new 'set lock timeout' tests when running against old core versions

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -4,6 +4,7 @@ Feature: set timeouts of LOCKS
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario Outline: do not set timeout on folder and check the default timeout
     Given using <dav-path> DAV path
     And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"
@@ -60,6 +61,7 @@ Feature: set timeouts of LOCKS
       | new      | second--1       | /Second-\d{5}$/ |
       | new      | second-0        | /Second-\d{4}$/ |
 
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario Outline: set timeout over the maximum on folder
     Given using <dav-path> DAV path
     And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"


### PR DESCRIPTION
## Description
This is a cherry-pick of #37587 to the `release-10.5.0` branch. It will be nice to have this scenario skipping be the same in the release branch, in the unlikely case someone uses a QA tarball built from this release branch, and then tries to test against an old core system.

These  test scenarios were introduced for PR #36452 which is in core 10.5.0. They will not pass against older core versions, so skip in that case.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
