### PR TITLE
[Tests-Only] Added API test for public link Mtime

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -493,4 +493,61 @@ class WebDavHelper {
 			($davPathVersion === $chunkingVersion)
 		);
 	}
+
+	/**
+	 * get Mtime of File in a public link share
+	 *
+	 * @param string $baseUrl
+	 * @param string $fileName
+	 * @param string $token
+	 * @param int $davVersionToUse
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
+	public static function getMtimeOfFileinPublicLinkShare(
+		$baseUrl,
+		$fileName,
+		$token,
+		$davVersionToUse=2
+	) {
+		$response = self::propfind(
+			$baseUrl,
+			null,
+			null,
+			"/public-files/{$token}/{$fileName}",
+			['d:getlastmodified'],
+			1,
+			null,
+			$davVersionToUse
+		);
+		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
+		$xmlPart = $responseXmlObject->xpath("//d:getlastmodified");
+
+		return $xmlPart[0]->__toString();
+	}
+
+	/**
+	 * get Mtime of a resource
+	 *
+	 * @param string $user
+	 * @param string $password
+	 * @param string $baseUrl
+	 * @param string $resource
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
+	public static function getMtimeOfResource($user,
+		$password,
+		$baseUrl,
+		$resource
+	) {
+		$response = self::propfind(
+			$baseUrl, $user, $password, $resource, ["getlastmodified"]
+		);
+		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
+		$xmlpart = $responseXmlObject->xpath("//d:getlastmodified");
+		return $xmlpart[0]->__toString();
+	}
 }

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -881,6 +881,87 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @When the public uploads file :fileName to the last shared folder with mtime :mtime using the :davVersion public WebDAV API
+	 *
+	 * @param String $fileName
+	 * @param String $mtime
+	 * @param String $davVersion
+	 *
+	 * @return void
+	 */
+	public function thePublicUploadsFileToLastSharedFolderWithMtimeUsingTheWebdavApi(
+		$fileName,
+		$mtime,
+		$davVersion="old"
+	) {
+		$mtime = new DateTime($mtime);
+		$mtime = $mtime->format('U');
+
+		$this->publicUploadContent(
+			$fileName,
+			'',
+			'test',
+			false,
+			["X-OC-Mtime" => $mtime],
+			$davVersion
+		);
+	}
+
+	/**
+	 * @Then the mtime of file :fileName in the last shared public link using the WebDAV API should be :mtime
+	 *
+	 * @param string $fileName
+	 * @param string $mtime
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theMtimeOfFileInTheLastSharedPublicLinkUsingTheWebdavApiShouldBe(
+		$fileName,
+		$mtime
+	) {
+		$tokenArray = $this->featureContext->getLastShareData()->data->token;
+		$token = (string)$tokenArray[0];
+		$baseUrl = $this->featureContext->getBaseUrl();
+		if (\TestHelpers\OcisHelper::isTestingOnOcis()) {
+			$mtime = \explode(" ", $mtime);
+			\array_pop($mtime);
+			$mtime = \implode(" ", $mtime);
+			Assert::assertContains(
+				$mtime,
+				\TestHelpers\WebDavHelper::getMtimeOfFileinPublicLinkShare($baseUrl, $fileName, $token)
+			);
+		} else {
+			Assert::assertEquals(
+				$mtime,
+				\TestHelpers\WebDavHelper::getMtimeOfFileinPublicLinkShare($baseUrl, $fileName, $token)
+			);
+		}
+	}
+
+	/**
+	 * @Then the mtime of file :fileName in the last shared public link using the WebDAV API should not be :mtime
+	 *
+	 * @param string $fileName
+	 * @param string $mtime
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theMtimeOfFileInTheLastSharedPublicLinkUsingTheWebdavApiShouldNotBe(
+		$fileName,
+		$mtime
+	) {
+		$tokenArray = $this->featureContext->getLastShareData()->data->token;
+		$token = (string)$tokenArray[0];
+		$baseUrl = $this->featureContext->getBaseUrl();
+		Assert::assertNotEquals(
+			$mtime,
+			\TestHelpers\WebDavHelper::getMtimeOfFileinPublicLinkShare($baseUrl, $fileName, $token)
+		);
+	}
+
+	/**
 	 * Uploads a file through the public WebDAV API and sets the response in FeatureContext
 	 *
 	 * @param string $filename

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2077,6 +2077,7 @@ trait WebDav {
 
 	/**
 	 * @When user :user uploads file to :destination with mtime :mtime using the WebDAV API
+	 * @Given user :user has uploaded a file to :destination with mtime :mtime using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param string $destination
@@ -2106,13 +2107,31 @@ trait WebDav {
 	) {
 		$user = $this->getActualUsername($user);
 		$password = $this->getPasswordForUser($user);
-		$this->response = WebDavHelper::propfind(
-			$this->getBaseUrl(), $user, $password, $resource, ["getlastmodified"]
-		);
-		$reponseXmlObject = HttpRequestHelper::getResponseXml($this->response);
-		$xmlpart = $reponseXmlObject->xpath("//d:getlastmodified");
+		$baseUrl = $this->getBaseUrl();
 		Assert::assertEquals(
-			$mtime, $xmlpart[0]->__toString()
+			$mtime,
+			\TestHelpers\WebDavHelper::getMtimeOfResource($user, $password, $baseUrl, $resource)
+		);
+	}
+
+	/**
+	 * @Then as :user the mtime of the file :resource should not be :mtime
+	 *
+	 * @param string $user
+	 * @param string $resource
+	 * @param string $mtime
+	 *
+	 * @return void
+	 */
+	public function theMtimeOfTheFileShouldNotBe(
+		$user, $resource, $mtime
+	) {
+		$user = $this->getActualUsername($user);
+		$password = $this->getPasswordForUser($user);
+		$baseUrl = $this->getBaseUrl();
+		Assert::assertNotEquals(
+			$mtime,
+			\TestHelpers\WebDavHelper::getMtimeOfResource($user, $password, $baseUrl, $resource)
 		);
 	}
 


### PR DESCRIPTION
## Description
API Acceptance test for public link mtime is added 

## Related Issue
Fixes https://github.com/owncloud/ocis-reva/issues/296

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/331
- https://github.com/owncloud/ocis-reva/pull/318

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
