### PR TITLE
[10.5.0] Make login page consistent with strict_login_enforced config

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -198,6 +198,8 @@ class LoginController extends Controller {
 			}
 		}
 
+		$parameters['strictLoginEnforced'] = $this->config->getSystemValue('strict_login_enforced', false);
+
 		return new TemplateResponse(
 			$this->appName, 'login', $parameters, 'guest'
 		);

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -48,11 +48,11 @@ script('core', [
 	?> shake<?php
 } ?>">
 			<input type="text" name="user" id="user"
-				placeholder="<?php p($l->t('Username or email')); ?>"
+				placeholder="<?php $_['strictLoginEnforced'] === true ? p($l->t('Login')) : p($l->t('Username or email')); ?>"
 				value="<?php p($_['loginName']); ?>"
 				<?php p($_['user_autofocus'] ? 'autofocus' : ''); ?>
 				autocomplete="on" autocapitalize="off" autocorrect="off" required>
-			<label for="user" class="infield"><?php p($l->t('Username or email')); ?></label>
+			<label for="user" class="infield"><?php $_['strictLoginEnforced'] === true ? p($l->t('Login')) : p($l->t('Username or email')); ?></label>
 		</p>
 
 		<p class="groupbottom<?php if (!empty($_['invalidpassword'])) {

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -152,7 +152,8 @@ class LoginControllerTest extends TestCase {
 			'resetPasswordLink' => null,
 			'alt_login' => [],
 			'rememberLoginAllowed' => false,
-			'rememberLoginState' => 0
+			'rememberLoginState' => 0,
+			'strictLoginEnforced' => false
 		];
 
 		$this->licenseManager->method('getLicenseMessageFor')
@@ -247,7 +248,8 @@ class LoginControllerTest extends TestCase {
 			'resetPasswordLink' => null,
 			'alt_login' => [],
 			'rememberLoginAllowed' => false,
-			'rememberLoginState' => 0
+			'rememberLoginState' => 0,
+			'strictLoginEnforced' => false
 		];
 
 		if ($shouldShowMessage) {
@@ -304,6 +306,7 @@ class LoginControllerTest extends TestCase {
 				'rememberLoginAllowed' => \OC_Util::rememberLoginAllowed(),
 				'rememberLoginState' => 0,
 				'resetPasswordLink' => null,
+				'strictLoginEnforced' => false
 			],
 			'guest'
 		);
@@ -338,11 +341,12 @@ class LoginControllerTest extends TestCase {
 			->method('isLoggedIn')
 			->willReturn(false);
 		$this->config
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getSystemValue')
 			->willReturnMap([
 				['lost_password_link', false],
-				['login.alternatives', '', '']
+				['login.alternatives', '', ''],
+				['strict_login_enforced', false],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user
@@ -371,7 +375,8 @@ class LoginControllerTest extends TestCase {
 				'alt_login' => [],
 				'rememberLoginAllowed' => \OC_Util::rememberLoginAllowed(),
 				'rememberLoginState' => 0,
-				'resetPasswordLink' => false
+				'resetPasswordLink' => false,
+				'strictLoginEnforced' => false
 			],
 			'guest'
 		);
@@ -384,11 +389,12 @@ class LoginControllerTest extends TestCase {
 			->method('isLoggedIn')
 			->willReturn(false);
 		$this->config
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('getSystemValue')
 			->willReturnMap([
 				['lost_password_link', false],
-				['login.alternatives', '', '']
+				['login.alternatives', '', ''],
+				['strict_login_enforced', false],
 			]);
 		$user = $this->createMock(IUser::class);
 		$user
@@ -417,7 +423,8 @@ class LoginControllerTest extends TestCase {
 				'alt_login' => [],
 				'rememberLoginAllowed' => \OC_Util::rememberLoginAllowed(),
 				'rememberLoginState' => 0,
-				'resetPasswordLink' => false
+				'resetPasswordLink' => false,
+				'strictLoginEnforced' => false
 			],
 			'guest'
 		);

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -573,6 +573,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
+        - OccContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -262,6 +262,34 @@ class WebUILoginContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When user :user logs in with their email address using the webUI
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function userLogsInWithTheirEmailAddressUsingTheWebui($user) {
+		$user = $this->featureContext->getActualUsername($user);
+		$email = $this->featureContext->getEmailAddressForUser($user);
+		$password = $this->featureContext->getPasswordForUser($user);
+		$this->loginPage->loginAs($email, $password, 'LoginPage');
+	}
+
+	/**
+	 * @Given user :user has logged in with their email address using the webUI
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function userHasLoggedInWithTheirEmailAddressUsingTheWebui($user) {
+		$this->userLogsInWithTheirEmailAddressUsingTheWebui($user);
+		$this->webUILoginShouldHaveBeenSuccessful();
+	}
+
+	/**
 	 * @Given user :user logs in with email and invalid password :password using the webUI
 	 *
 	 * @param string $user
@@ -448,6 +476,40 @@ class WebUILoginContext extends RawMinkContext implements Context {
 			$page
 		);
 		$this->webUILoginShouldHaveBeenSuccessful();
+	}
+
+	/**
+	 * @Then the username field on the login page should have placeholder text :expectedPlaceholderText
+	 *
+	 * @param string $expectedPlaceholderText
+	 *
+	 * @return void
+	 */
+	public function usernameFieldOnLoginPageShouldHavePlaceholderText(string $expectedPlaceholderText) {
+		$actualPlaceholderText = $this->loginPage->getUserPlaceholderText();
+		Assert::assertEquals(
+			$expectedPlaceholderText,
+			$actualPlaceholderText,
+			__METHOD__
+			. " The username placeholder text was expected to be '$expectedPlaceholderText', but got '$actualPlaceholderText' instead."
+		);
+	}
+
+	/**
+	 * @Then the password field on the login page should have placeholder text :expectedPlaceholderText
+	 *
+	 * @param string $expectedPlaceholderText
+	 *
+	 * @return void
+	 */
+	public function passwordFieldOnLoginPageShouldHavePlaceholderText(string $expectedPlaceholderText) {
+		$actualPlaceholderText = $this->loginPage->getPasswordPlaceholderText();
+		Assert::assertEquals(
+			$expectedPlaceholderText,
+			$actualPlaceholderText,
+			__METHOD__
+			. " The password placeholder text was expected to be '$expectedPlaceholderText', but got '$actualPlaceholderText' instead."
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -126,6 +126,36 @@ class LoginPage extends OwncloudPage {
 
 	/**
 	 *
+	 * @return string
+	 */
+	public function getUserPlaceholderText() {
+		$userInputField = $this->findById($this->userInputId);
+		$this->assertElementNotNull(
+			$userInputField,
+			__METHOD__ .
+			" id $this->userInputId could not find user input field"
+		);
+		$placeholderText = $userInputField->getAttribute('placeholder');
+		return $placeholderText;
+	}
+
+	/**
+	 *
+	 * @return string
+	 */
+	public function getPasswordPlaceholderText() {
+		$passwordInputField = $this->findById($this->passwordInputId);
+		$this->assertElementNotNull(
+			$passwordInputField,
+			__METHOD__ .
+			" id $this->passwordInputId could not find password input field"
+		);
+		$placeholderText = $passwordInputField->getAttribute('placeholder');
+		return $placeholderText;
+	}
+
+	/**
+	 *
 	 * @return NodeElement
 	 * @throws ElementNotFoundException
 	 *

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -8,11 +8,31 @@ Feature: login users
   I want only authorised users to log in
   So that unauthorised access is impossible
 
+  Scenario: login page username and password field placeholder text
+    When the user browses to the login page
+    Then the username field on the login page should have placeholder text "Username or email"
+    And the password field on the login page should have placeholder text "Password"
+
+  Scenario: login page username and password field placeholder text when strict_login_enforced is set
+    Given the administrator has added system config key "strict_login_enforced" with value "true" and type "boolean"
+    When the user browses to the login page
+    Then the username field on the login page should have placeholder text "Login"
+    And the password field on the login page should have placeholder text "Password"
+
   @TestAlsoOnExternalUserBackend
   Scenario: simple user login
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
+    When user "Alice" logs in using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
+
+  @TestAlsoOnExternalUserBackend
+  Scenario: simple user login should work when strict_login_enforced is set
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+    And the administrator has added system config key "strict_login_enforced" with value "true" and type "boolean"
     When user "Alice" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 

--- a/tests/acceptance/features/webUILogin/loginWithEmailAddress.feature
+++ b/tests/acceptance/features/webUILogin/loginWithEmailAddress.feature
@@ -1,0 +1,28 @@
+@webUI @insulated @disablePreviews @TestAlsoOnExternalUserBackend
+Feature: login users
+  As a user
+  I want to be able to log into my account using my email address
+  So that I have access to my files
+
+  As an admin
+  I want only authorised users to log in
+  So that unauthorised access is impossible
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+    And the user has browsed to the login page
+
+  Scenario: user login with email address
+    When user "Alice" logs in with their email address using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
+
+  Scenario: user login with email address but invalid password should fail
+    When user "Alice" logs in with email and invalid password "%alt2%" using the webUI
+    Then the user should be redirected to a webUI page with the title "%productname%"
+
+  Scenario: user login with email address should fail when strict_login_enforced is set
+    Given the administrator has added system config key "strict_login_enforced" with value "true" and type "boolean"
+    When user "Alice" logs in with their email address using the webUI
+    Then the user should be redirected to a webUI page with the title "%productname%"


### PR DESCRIPTION
## Description
Cherry-pick commits from PR #37591 to `release-10.5.0` branch.

This gets this change into the next 10.5.0 release candidate.

The orignal PR is going into `master` so that the translations will get across to Transifex for action.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
