### PR TITLE
[tests-only] start uidnumbers for LDAP user higher

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -665,7 +665,9 @@ trait Provisioning {
 		// Of these, only + has to be escaped.
 		$userId = \str_replace('+', '\+', $setting["userid"]);
 		$newDN = 'uid=' . $userId . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
-		$uidNumber = \count($this->ldapCreatedUsers) + 1;
+
+		//pick a high number as uidnumber to make sure there are no conflicts with existing uidnumbers
+		$uidNumber = \count($this->ldapCreatedUsers) + 30000;
 		$entry = [];
 		$entry['cn'] = $userId;
 		$entry['sn'] = $userId;


### PR DESCRIPTION
## Description
starting the uidnumbers from 1 does not work when testing with EOS, I guess there is a conflict with existing uids

## Related Issue
part of https://github.com/owncloud/ocis/issues/253

## How Has This Been Tested?
:robot: 
https://github.com/owncloud/ocis/pull/333 (some tests fail because ocis was not updated yet)
https://github.com/owncloud/ocis-reva/pull/300

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
