### PR TITLE
[Tests-Only] [10.5.0] Skip strict_login_enforced acceptance tests on old ownCloud versions

### DIFF
--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -13,6 +13,7 @@ Feature: login users
     Then the username field on the login page should have placeholder text "Username or email"
     And the password field on the login page should have placeholder text "Password"
 
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: login page username and password field placeholder text when strict_login_enforced is set
     Given the administrator has added system config key "strict_login_enforced" with value "true" and type "boolean"
     When the user browses to the login page
@@ -27,7 +28,7 @@ Feature: login users
     When user "Alice" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @TestAlsoOnExternalUserBackend
+  @TestAlsoOnExternalUserBackend @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: simple user login should work when strict_login_enforced is set
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/webUILogin/loginWithEmailAddress.feature
+++ b/tests/acceptance/features/webUILogin/loginWithEmailAddress.feature
@@ -22,6 +22,7 @@ Feature: login users
     When user "Alice" logs in with email and invalid password "%alt2%" using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
 
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: user login with email address should fail when strict_login_enforced is set
     Given the administrator has added system config key "strict_login_enforced" with value "true" and type "boolean"
     When user "Alice" logs in with their email address using the webUI


### PR DESCRIPTION
## Description
Backport #37601 to `release-10.5.1`  so that the test infrastructure there is consistent.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
