### PR TITLE
Adjust login wording on login page

### DIFF
--- a/changelog/unreleased/37603
+++ b/changelog/unreleased/37603
@@ -1,0 +1,6 @@
+Change: Adjust wording on login page
+
+The use of "login" vs "log in" has been adjusted.
+
+https://github.com/owncloud/core/issues/37603
+https://github.com/owncloud/core/pull/37604

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -63,13 +63,13 @@ script('core', [
 				<?php p($_['user_autofocus'] ? '' : 'autofocus'); ?>
 				autocomplete="off" autocapitalize="off" autocorrect="off" required>
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
-			<input type="submit" id="submit" class="login primary icon-confirm" title="<?php p($l->t('Log in')); ?>" value="" disabled="disabled"/>
+			<input type="submit" id="submit" class="login primary icon-confirm" title="<?php p($l->t('Login')); ?>" value="" disabled="disabled"/>
 		</p>
 
 		<?php if (!empty($_['csrf_error'])) {
 		?>
 		<p class="warning">
-			<?php p($l->t('You took too long to login, please try again now')); ?>
+			<?php p($l->t('You took too long to log in, please try again now')); ?>
 		</p>
 		<?php
 	} ?>


### PR DESCRIPTION
## Description
Adjust the use of "log in" vs "login" as per comments in issue at https://github.com/owncloud/core/issues/37603#issuecomment-650053201

## Related Issue
- Fixes #37603 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
