### PR TITLE
[Tests-Only] Added API test scenario for overwriting a file with Mtime

### DIFF
--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -166,3 +166,16 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
+  @issue-ocis-reva-174
+  Scenario Outline: overwriting a file changes its mtime
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "first time upload content" to "file.txt"
+    When user "Alice" uploads a file with content "Overwrite file" and mtime "Thu, 08 Aug 2019 04:18:13 GMT" to "file.txt" using the WebDAV API
+    Then as "Alice" file "file.txt" should exist
+    And as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the content of file "file.txt" for user "Alice" should be "Overwrite file"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2158,6 +2158,35 @@ trait WebDav {
 	}
 
 	/**
+	 * @When user :user uploads a file with content :content and mtime :mtime to :destination using the WebDAV API
+	 *
+	 * @param string $user
+	 * @param string $content
+	 * @param string $mtime
+	 * @param string $destination
+	 *
+	 * @return void
+	 */
+	public function userUploadsAFileWithContentAndMtimeTo(
+		$user,
+		$content,
+		$mtime,
+		$destination
+	) {
+		$user = $this->getActualUsername($user);
+		$mtime = new DateTime($mtime);
+		$mtime = $mtime->format('U');
+		$this->makeDavRequest(
+			$user,
+			"PUT",
+			$destination,
+			["X-OC-Mtime" => $mtime],
+			$content
+		);
+		$this->theHTTPStatusCodeShouldBeOr("201", "204");
+	}
+
+	/**
 	 * @When user :user uploads file with checksum :checksum and content :content to :destination using the WebDAV API
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
API test scenario for a file with the new Mtime is added. Follow up of https://github.com/owncloud/core/pull/37553
 
## Related Issue
- fixes https://github.com/owncloud/ocis-reva/issues/273

## How Has This Been Tested?
- Test in ocis: https://github.com/owncloud/ocis/pull/351
- Test in ocis-reva: https://github.com/owncloud/ocis-reva/pull/324

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
