### PR TITLE
[Tests-Only] Treat public link share id as string in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2363,13 +2363,13 @@ trait Sharing {
 	 * @param string $path to share
 	 * @param string $name of share
 	 *
-	 * @return int|null
+	 * @return string|null
 	 */
 	public function getPublicShareIDByName($user, $path, $name) {
 		$dataResponded = $this->getShares($user, $path);
 		foreach ($dataResponded as $elementResponded) {
 			if ((string) $elementResponded->name[0] === $name) {
-				return (int) $elementResponded->id[0];
+				return (string) $elementResponded->id[0];
 			}
 		}
 		return null;


### PR DESCRIPTION
## Description
The acceptance tests have code to find the public link share id that has a given name. In core that share id usually looks like a number (int). But actually it is just a string that identifies the public link share.

In other implementations (e.g. OCIS) it might be alphanumeric. So treat it as a general string.

PR #37608 brought this up. IMO rather than have different code if running-on-OCIS, we can always treat this as a string.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
