### PR TITLE
Introduce files-multiget plugin to allow zip archive download of sele…

### DIFF
--- a/apps/dav/lib/Files/MultiGetPlugin.php
+++ b/apps/dav/lib/Files/MultiGetPlugin.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Files;
+
+use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
+use OCA\DAV\Connector\Sabre\File;
+use OCA\DAV\Files\Xml\MultiGetRequest;
+use OCP\Files\NotPermittedException;
+use OCP\IUserSession;
+use Sabre\DAV\Exception\Locked;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\INode;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use ZipStreamer\ZipStreamer;
+
+class MultiGetPlugin extends ServerPlugin {
+	public const NS_OWNCLOUD = 'http://owncloud.org/ns';
+	public const REPORT_NAME = '{http://owncloud.org/ns}files-multiget';
+
+	/** @var Server */
+	protected $server;
+	/**
+	 * @var IUserSession
+	 */
+	private $userSession;
+
+	public function __construct(IUserSession $userSession) {
+		$this->userSession = $userSession;
+	}
+
+	/**
+	 * Initializes the plugin and registers event handlers
+	 *
+	 * @param Server $server
+	 * @return void
+	 */
+	public function initialize(Server $server) {
+		$server->xml->namespaceMap[self::NS_OWNCLOUD] = 'oc';
+
+		$server->xml->elementMap[self::REPORT_NAME] = MultiGetRequest::class;
+
+		$this->server = $server;
+		$this->server->on('report', [$this, 'onReport']);
+	}
+
+	/**
+	 * Returns a list of reports this plugin supports.
+	 *
+	 * This will be used in the {DAV:}supported-report-set property.
+	 *
+	 * @param string $uri
+	 * @return array
+	 */
+	public function getSupportedReportSet($uri) {
+		return [self::REPORT_NAME];
+	}
+
+	/**
+	 * @param string $reportName
+	 * @param MultiGetRequest $report
+	 * @param string $uri
+	 * @throws Forbidden
+	 * @throws Locked
+	 * @throws NotPermittedException
+	 * @throws \Sabre\DAV\Exception\Forbidden
+	 * @throws NotFound
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function onReport($reportName, $report, $uri): void {
+		$reportTargetNode = $this->server->tree->getNodeForPath($uri);
+		if (!$reportTargetNode instanceof Directory || $reportName !== self::REPORT_NAME) {
+			return;
+		}
+
+		// Only ZIP for now ....
+		$streamer = new ZipStreamer(['zip64' => PHP_INT_SIZE !== 4]);
+		$streamer->sendHeaders();
+
+		// send cors headers
+		$requesterDomain = $this->server->httpRequest->getHeader('origin');
+		$userId = null;
+		if ($this->userSession->getUser() !== null) {
+			$userId = $this->userSession->getUser()->getUID();
+		}
+		$headers = \OC_Response::setCorsHeaders($userId, $requesterDomain);
+		foreach ($headers as $key => $value) {
+			$value = \implode(',', $value);
+			\header("$key: $value");
+		}
+
+		foreach ($report->resources as $resource) {
+			$path = $this->server->calculateUri($resource);
+			$node = $this->server->tree->getNodeForPath($path);
+			$this->addNodeToZipStreamer($node, $streamer);
+		}
+		$streamer->finalize();
+
+		// response is sent out already -> terminate here
+		exit();
+	}
+
+	/**
+	 * @param INode $node
+	 * @param ZipStreamer $streamer
+	 * @param string $basePath
+	 * @throws Forbidden
+	 * @throws NotPermittedException
+	 * @throws Locked
+	 */
+	private function addNodeToZipStreamer(INode $node, ZipStreamer $streamer, string $basePath = ''): void {
+		if ($node instanceof Directory) {
+			$streamer->addEmptyDir($basePath, ['timestamp' => $node->getLastModified()]);
+			$children = $node->getChildren();
+			foreach ($children as $child) {
+				$this->addNodeToZipStreamer($child, $streamer, $basePath . '/' . $node->getName());
+			}
+		}
+
+		if ($node instanceof File) {
+			$file = $node->getNode();
+			if ($file instanceof \OCP\Files\File) {
+				$stream = $file->fopen('r');
+				if (\is_resource($stream)) {
+					$streamer->addFileFromStream($stream, $basePath . '/' . $file->getName(), ['timestamp' => $node->getLastModified()]);
+				}
+			}
+		}
+	}
+}

--- a/apps/dav/lib/Files/Xml/MultiGetRequest.php
+++ b/apps/dav/lib/Files/Xml/MultiGetRequest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Files\Xml;
+
+use Sabre\Uri;
+use Sabre\Xml\LibXMLException;
+use Sabre\Xml\ParseException;
+use Sabre\Xml\Reader;
+use Sabre\Xml\XmlDeserializable;
+
+class MultiGetRequest implements XmlDeserializable {
+
+	/**
+	 * An array with requested resources.
+	 *
+	 * @var array
+	 */
+	public $resources;
+
+	/**
+	 *
+	 * @param Reader $reader
+	 * @return mixed
+	 * @throws LibXMLException
+	 * @throws ParseException
+	 * @throws Uri\InvalidUriException
+	 */
+	public static function xmlDeserialize(Reader $reader) {
+		$elements = (array)$reader->parseInnerTree([]);
+
+		$resources = [];
+
+		if (!\is_array($elements)) {
+			$elements = [];
+		}
+
+		foreach ($elements as $elem) {
+			if ($elem['name'] !== '{DAV:}href') {
+				continue;
+			}
+
+			$resources[] = Uri\resolve($reader->contextUri, $elem['value']);
+		}
+
+		$obj = new self();
+		$obj->resources = $resources;
+		return $obj;
+	}
+}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -57,6 +57,7 @@ use OCA\DAV\DAV\PublicAuth;
 use OCA\DAV\DAV\ViewOnlyPlugin;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Files\FileLocksBackend;
+use OCA\DAV\Files\MultiGetPlugin;
 use OCA\DAV\Files\PreviewPlugin;
 use OCA\DAV\Files\PublicFiles\PublicFilesPlugin;
 use OCA\DAV\Files\Sharing\PublicLinkEventsPlugin;
@@ -303,6 +304,8 @@ class Server {
 						OC::$server->getGroupManager(),
 						$userFolder
 					));
+
+					$this->server->addPlugin(new MultiGetPlugin($userSession));
 				}
 				$this->server->addPlugin(
 					new FilesSearchReportPlugin(

--- a/apps/dav/tests/unit/Files/MultiGetPluginTest.php
+++ b/apps/dav/tests/unit/Files/MultiGetPluginTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace OCA\DAV\Tests\Unit\Files;
+
+use OCA\DAV\Files\MultiGetPlugin;
+use OCP\IUserSession;
+use Sabre\DAV\Server;
+use Test\TestCase;
+
+class MultiGetPluginTest extends TestCase {
+	/**
+	 * @var IUserSession|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $userSession;
+	/**
+	 * @var MultiGetPlugin
+	 */
+	private $plugin;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->plugin = new MultiGetPlugin($this->userSession);
+	}
+
+	public function testInitialize(): void {
+		$server = new Server();
+		$this->plugin->initialize($server);
+
+		$this->assertArrayHasKey(MultiGetPlugin::NS_OWNCLOUD, $server->xml->namespaceMap);
+		$this->assertArrayHasKey(MultiGetPlugin::REPORT_NAME, $server->xml->elementMap);
+	}
+
+	public function testSupportedReportSet(): void {
+		$rs = $this->plugin->getSupportedReportSet('');
+		$this->assertEquals(['{http://owncloud.org/ns}files-multiget'], $rs);
+	}
+
+	public function testFeatures(): void {
+		$features = $this->plugin->getFeatures();
+		$this->assertEquals([], $features);
+	}
+}

--- a/changelog/unreleased/37615
+++ b/changelog/unreleased/37615
@@ -1,0 +1,5 @@
+Enhancement: Files Multi-Get support 
+
+Files and folders can be downloaded as an archive which is created right away and it's content is streamed to the client
+
+https://github.com/owncloud/core/pull/37615


### PR DESCRIPTION
…cted files


## Description
A webdav report is introduced to support a multi get request - similar to the carddav multi get request.

For the Webdav API endpoint (to be implemented by either OC 10 or the download service) for both bulk download and multiple resource download:

We could use a multiget REPORT call like https://tools.ietf.org/html/rfc6352#page-31 but only deliver zip file, as requested through an "Accept" header.
The REPORT XML request body would contain a list of URLs / resources to retrieve, relative to the request path:

REPORT Request example to http://host/owncloud/remote.php/dav/files/someuser/

Headers:
```
Accept: application/zip
```

Request body:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<oc:files-multiget
    xmlns:a="DAV:"
    xmlns:oc="http://owncloud.org/ns">
    <DAV:href>first_resource</DAV:href>
    <DAV:href>second_resource</DAV:href>
    <DAV:href>some_directory</DAV:href>
</oc:multiget>
```

Response:
- content-disposition header with a file name that is either "download.zip" (or tar if tar was requested), or in case only a single item was selected, the name of said item with ".zip" appended.
- a zip file with all the above packaged in

In case of error (ex: firewall), a 403 status code would be returned and the operation is aborted.
If one of the resources does not exist, a 404 status code would be returned and the operation is aborted.

This can be used for single folder download also.

We can use the same format also for the **public dav enpoint**


## Related Issue
https://github.com/owncloud/enterprise/issues/3916

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
