### PR TITLE
[Tests-Only] Add explicit skipOnLDAP and skipOnOcis tags to tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -780,7 +780,6 @@ default:
         - WebUIPersonalSharingSettingsContext:
         - OccContext:
 
-
     webUISharingNotifications:
       paths:
         - '%paths.base%/../features/webUISharingNotifications'

--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-26 @issue-ocis-reva-27
+@api @skipOnOcis @issue-ocis-reva-26 @issue-ocis-reva-27
 Feature: CORS headers
 
   Background:

--- a/tests/acceptance/features/apiAuth/filesAppAuth.feature
+++ b/tests/acceptance/features/apiAuth/filesAppAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-28
+@api @skipOnOcis @issue-ocis-reva-28
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuth/tokenAuth.feature
+++ b/tests/acceptance/features/apiAuth/tokenAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-28 @issue-ocis-reva-37
+@api @skipOnOcis @issue-ocis-reva-28 @issue-ocis-reva-37
 Feature: tokenAuth
 
   Background:

--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis
+@api @files_sharing-app-required @skipOnOcis
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@api @files_sharing-app-required
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@api @files_sharing-app-required
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis
+@api @files_sharing-app-required @skipOnOcis
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: delete file/folder
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: LOCK file/folder
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: create folder using MKCOL
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: MOVE file/folder
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: get file info using POST
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: get file info using PROPFIND
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: PROPPATCH file/folder
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: get file info using PUT
 
   Background:

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41
 Feature: capabilities
 
   Background:

--- a/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@api @files_sharing-app-required
 Feature: default capabilities for normal user
 
   Background:

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @comments-app-required @skipOnOcis @issue-ocis-reva-38
+@api @comments-app-required @skipOnOcis @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @comments-app-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-38
+@api @comments-app-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiComments/deleteComments.feature
+++ b/tests/acceptance/features/apiComments/deleteComments.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @comments-app-required @skipOnOcis @issue-ocis-reva-38
+@api @comments-app-required @skipOnOcis @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiComments/editComments.feature
+++ b/tests/acceptance/features/apiComments/editComments.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @comments-app-required @skipOnOcis @issue-ocis-reva-38
+@api @comments-app-required @skipOnOcis @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: favorite
 
   Background:

--- a/tests/acceptance/features/apiFederation1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederation1/etagPropagation.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis
+@api @federation-app-required @files_sharing-app-required @skipOnOcis
 Feature: propagation of etags between federated and local server
 
   Background:

--- a/tests/acceptance/features/apiFederation1/federated.feature
+++ b/tests/acceptance/features/apiFederation1/federated.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis
+@api @federation-app-required @files_sharing-app-required @skipOnOcis
 Feature: federated
 
   Background:
@@ -408,7 +408,6 @@ Feature: federated
     And using server "LOCAL"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
-
 
   Scenario Outline: share of a folder to a remote user who already has a folder with the same name
     Given using server "REMOTE"

--- a/tests/acceptance/features/apiFederation2/federated.feature
+++ b/tests/acceptance/features/apiFederation2/federated.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis
+@api @federation-app-required @files_sharing-app-required @skipOnOcis
 Feature: federated
 
   Background:

--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnLDAP @skipOnOcis
 Feature: AppManagement
 
   Scenario: Two apps_path exist by default. The first one is more recent

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis
+@api @skipOnOcis
 Feature: caldav
 
   Background:

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis
+@api @skipOnOcis
 Feature: carddav
 
   Background:

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: checksums
 
   Background:

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -86,7 +86,7 @@ Feature: checksums
     When user "Alice" downloads file "/myChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
 
-  @local_storage
+  @local_storage @skipOnOcis
   Scenario Outline: Downloading a file from local storage has correct checksum
     Given using <dav_version> DAV path
     # Create the file directly in local storage, bypassing ownCloud
@@ -291,7 +291,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @local_storage @skipOnEncryptionType:user-keys @encryption-issue-42
+  @local_storage @skipOnOcis @skipOnEncryptionType:user-keys @encryption-issue-42
   Scenario Outline: Uploaded file to external storage should have the same checksum when downloaded
     Given using <dav_version> DAV path
     And file "/local_storage/chksumtst.txt" has been deleted for user "Alice"
@@ -304,7 +304,6 @@ Feature: checksums
       | dav_version |
       | old         |
       | new         |
-
 
   ## Validation Plugin or Old Endpoint Specific
   @skipOnOcis @issue-ocis-reva-17

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -1,4 +1,4 @@
-@api @local_storage @TestAlsoOnExternalUserBackend @skipOnOcis
+@api @local_storage @skipOnOcis
 Feature: external-storage
 
   Background:

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -1,4 +1,4 @@
-@api @local_storage @TestAlsoOnExternalUserBackend
+@api @local_storage @TestAlsoOnExternalUserBackend @skipOnOcis
 Feature: external-storage
 
   Background:

--- a/tests/acceptance/features/apiMain/main.feature
+++ b/tests/acceptance/features/apiMain/main.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: Other tests related to api
 
   @skipOnOcis @issue-ocis-reva-100

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-101
+@api @skipOnOcis @issue-ocis-reva-101
 Feature: quota
 
   Background:

--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-65 @issue-ocis-reva-97
+@api @skipOnOcis @issue-ocis-reva-65 @issue-ocis-reva-97
 Feature: Status
 
   @smokeTest

--- a/tests/acceptance/features/apiMain/userSync.feature
+++ b/tests/acceptance/features/apiMain/userSync.feature
@@ -18,7 +18,6 @@ Feature: Users sync
       | 1               | 100             |
       | 2               | 200             |
 
-  @TestAlsoOnExternalUserBackend
   Scenario Outline: Trying to sync a user which does not exist
     Given using OCS API version "<ocs-api-version>"
     When the administrator tries to sync user "nonexistentuser" using the OCS API
@@ -30,7 +29,6 @@ Feature: Users sync
       | 1               | 200              |
       | 2               | 404              |
 
-  @TestAlsoOnExternalUserBackend
   Scenario Outline: Trying to sync a user as another user which does not exist
     Given using OCS API version "<ocs-api-version>"
     When user "nonexistentuser" tries to sync user "Brian" using the OCS API
@@ -42,7 +40,7 @@ Feature: Users sync
       | 1               |
       | 2               |
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario Outline: Trying to sync a user by non admin user
     Given using OCS API version "<ocs-api-version>"
     When user "Alice" tries to sync user "Brian" using the OCS API
@@ -54,7 +52,6 @@ Feature: Users sync
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
-  @TestAlsoOnExternalUserBackend
   Scenario Outline: Trying to sync a user by admin using an incorrect password
     Given using OCS API version "<ocs-api-version>"
     When the administrator tries to sync user "Brian" using password "invalid" and the OCS API

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: add user
   As an admin
   I want to be able to add users

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: access user provisioning API using app password
   As an ownCloud user
   I want to be able to use the provisioning API with an app password

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: delete users
   As an admin
   I want to be able to delete users

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnOcis
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: disable user
   As an admin
   I want to be able to disable a user

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: edit users
   As an admin, subadmin or as myself
   I want to be able to edit user information

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnOcis
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: enable user
   As an admin
   I want to be able to enable a user

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @skipOnOcis
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get user
   As an admin, subadmin or as myself
   I want to be able to retrieve user information

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get users
   As an admin
   I want to be able to list the users that exist

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: remove subadmin
   As an admin
   I want to be able to remove subadmin rights to a user from a group

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: add user
   As an admin
   I want to be able to add users

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: access user provisioning API using app password
   As an ownCloud user
   I want to be able to use the provisioning API with an app password

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: delete users
   As an admin
   I want to be able to delete users

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnOcis
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: disable user
   As an admin
   I want to be able to disable a user

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: edit users
   As an admin, subadmin or as myself
   I want to be able to edit user information

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnOcis
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: enable user
   As an admin
   I want to be able to enable a user

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @skipOnOcis
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get user
   As an admin, subadmin or as myself
   I want to be able to retrieve user information

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get users
   As an admin
   I want to be able to list the users that exist

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: remove subadmin
   As an admin
   I want to be able to remove subadmin rights to a user from a group

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: add groups
   As an admin
   I want to be able to add groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: add users to group
   As a admin
   I want to be able to add users to a group

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: delete groups
   As an admin
   I want to be able to delete groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get group
   As an admin
   I want to be able to get group details

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get subadmin groups
   As an admin
   I want to be able to get the groups in which the user is subadmin

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get user groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: remove a user from a group
   As an admin
   I want to be able to remove a user from a group

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: add groups
   As an admin
   I want to be able to add groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: add users to group
   As a admin
   I want to be able to add users to a group

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: delete groups
   As an admin
   I want to be able to delete groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get group
   As an admin
   I want to be able to get group details

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get subadmin groups
   As an admin
   I want to be able to get the groups in which the user is subadmin

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: get user groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required
+@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis
 Feature: remove a user from a group
   As an admin
   I want to be able to remove a user from a group

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243 @issue-ocis-reva-249
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243 @issue-ocis-reva-249
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareReceivedInMultipleWays.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareUniqueReceivedNames.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: resources shared with the same name are received with unique names
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareWhenExcludedFromSharing.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41
 Feature: cannot share resources when in a group that is excluded from sharing
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareDefaultFolderForReceivedShares.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-42 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-42 @issue-ocis-reva-243
 Feature: shares are received in the default folder for received shares
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-243
 Feature: sharing works when a username and group name are the same
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupCaseSensitive.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-243
 Feature: share with groups, group names are case-sensitive
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: cannot share resources outside the group when share with membership groups is enabled
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareWithDisabledUser.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243
 Feature: share resources with a disabled user
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareWithInvalidPermissions.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-243
 Feature: cannot share resources with invalid permissions
 
   Background:

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: accept/decline shares coming from internal users
   As a user
   I want to have control of which received shares I accept

--- a/tests/acceptance/features/apiShareManagement/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagement/disableSharing.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: sharing
   As an admin
   I want to be able to disable sharing functionality

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-14 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-14 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -338,7 +338,7 @@ Feature: sharing
     And user "brian" should not see the following elements if the upper and lower case username are different
       | /randomfile.txt |
 
-  @skipOnLDAP
+  @skipOnLDAP @skipOnOcis
   Scenario: creating a new share with user of a group when username contains capital letters
     Given these users have been created without skeleton files:
       | username |
@@ -381,7 +381,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP
+  @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP @skipOnOcis
   Scenario Outline: share with a group and then add a user to that group
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -402,7 +402,7 @@ Feature: sharing
       | 1               |
       | 2               |
 
-  @skipOnLDAP
+  @skipOnLDAP @skipOnOcis
   # deleting an LDAP group is not relevant or possible using the provisioning API
   Scenario Outline: shares shared to deleted group should not be available
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-21 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-21 @issue-ocis-reva-243
 Feature: sharing
 
   @issue-ocis-reva-249

--- a/tests/acceptance/features/apiShareManagementBasic/excludeGroupFromReceivingShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/excludeGroupFromReceivingShares.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41
 Feature: Exclude groups from receiving shares
   As an admin
   I want to exclude groups from receiving shares

--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-14 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-14 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @issue-ocis-reva-47
+@api @files_sharing-app-required @issue-ocis-reva-47
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-282
+@api @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-282
 Feature: accessing a public link share
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-49 
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-49
 Feature: changing a public link share
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-49
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-49
 Feature: create a public link share
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-288 @issue-ocis-reva-252
+@api @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-288 @issue-ocis-reva-252
 Feature: multilinksharing
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-282
+@api @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-282
 @issue-ocis-reva-233 @issue-ocis-reva-243 @issue-ocis-reva-289
 Feature: reshare as public link
   As a user

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-252
+@api @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-252
 Feature: update a public link share
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-49
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-49
 Feature: upload to a public link share
 
   Background:

--- a/tests/acceptance/features/apiShareReshare1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare1/reShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareChain.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243
 Feature: resharing can be done on a reshared resource
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareDisabled.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243
 Feature: resharing can be disabled
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareSubfolder.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243
 Feature: a subfolder of a received share can be reshared
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-233 @issue-ocis-reva-194 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-233 @issue-ocis-reva-194 @issue-ocis-reva-243
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareReshare3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshare3/reShareUpdate.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareReshare3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshare3/reShareWithExpiryDate.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243 @issue-ocis-reva-249
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-243 @issue-ocis-reva-249
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-194 @issue-ocis-reva-243
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-194 @issue-ocis-reva-243
 Feature: updating shares to users and groups that have the same name
 
   Background:

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34
 Feature: sharees
 
   Background:

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -1,4 +1,4 @@
-@api @app-required @notifications-app-required @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @app-required @notifications-app-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: Display notifications when receiving a share
   As a user
   I want to see notifications about shares that have been offered to me

--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-51
+@api @systemtags-app-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-51
 Feature: Assign tags to file/folder
   I want to assign tags to the file/folder
   So that I can organize the files/folders easily

--- a/tests/acceptance/features/apiTags/assignTagsGroup.feature
+++ b/tests/acceptance/features/apiTags/assignTagsGroup.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-51
+@api @systemtags-app-required @skipOnOcis @issue-ocis-reva-51
 Feature: Title of your feature
   I want to use this template for my feature file
 

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-51
+@api @systemtags-app-required @skipOnOcis @issue-ocis-reva-51
 Feature: Creation of tags
   As a user
   I should be able to create tags

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-51
+@api @systemtags-app-required @skipOnOcis @issue-ocis-reva-51
 Feature: Deletion of tags
   As a user
   I want to delete the tags that are already created

--- a/tests/acceptance/features/apiTags/editTags.feature
+++ b/tests/acceptance/features/apiTags/editTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-51
+@api @systemtags-app-required @skipOnOcis @issue-ocis-reva-51
 Feature: Editing the tags
   As a user
   I want to be able to change the tags I have created

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-51
+@api @systemtags-app-required @skipOnOcis @issue-ocis-reva-51
 Feature: tags
 
   Background:

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @TestAlsoOnExternalUserBackend @files_sharing-app-required @skipOnOcis @issue-ocis-reva-51
+@api @systemtags-app-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-51
 Feature: Unassigning tags from file/folder
   As a user
   I want to be able to remove tags from file/folder

--- a/tests/acceptance/features/apiTranslation/translation.feature
+++ b/tests/acceptance/features/apiTranslation/translation.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnLDAP @skipOnOcis
 Feature: translate messages in api response to preferred language
   As a user
   I want response messages to be translated in preferred language

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_trashbin-app-required @skipOnOcis @issue-ocis-reva-52
+@api @files_trashbin-app-required @skipOnOcis @issue-ocis-reva-52
 Feature: files and folders can be deleted from the trashbin
   As a user
   I want to delete files and folders from the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_trashbin-app-required @skipOnOcis @issue-ocis-reva-52
+@api @files_trashbin-app-required @skipOnOcis @issue-ocis-reva-52
 Feature: files and folders exist in the trashbin after being deleted
   As a user
   I want deleted files and folders to be available in the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @files_trashbin-app-required @skipOnOcis @issue-ocis-reva-52
+@api @files_trashbin-app-required @skipOnOcis @issue-ocis-reva-52
 Feature: Restore deleted files/folders
   As a user
   I would like to restore files/folders

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -1,4 +1,4 @@
-@api @files_versions-app-required @TestAlsoOnExternalUserBackend
+@api @files_versions-app-required
 
 Feature: dav-versions
 

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
+@api @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
 Feature: there can be only one exclusive lock on a resource
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
+@api @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
 Feature: lock folders
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required @skipOnOcV10.0 @files_sharing-app-required @skipOnOcis @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @skipOnOcV10.0 @files_sharing-app-required @skipOnOcis @issue-ocis-reva-172
 Feature: persistent-locking in case of a public link
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required @skipOnOcV10.0 @files_sharing-app-required @skipOnOcis @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @skipOnOcV10.0 @files_sharing-app-required @skipOnOcis @issue-ocis-reva-172
 Feature: LOCKDISCOVERY for public links
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
+@api @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
 Feature: actions on a locked item are possible if the token is sent with the request
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcV10.0 @files_sharing-app-required @skipOnOcis @issue-ocis-reva-172 @issue-ocis-reva-11
+@api @skipOnOcV10.0 @files_sharing-app-required @skipOnOcis @issue-ocis-reva-172 @issue-ocis-reva-11
 Feature: lock should propagate correctly if a share is reshared
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @smokeTest @public_link_share-feature-required @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
 Feature: set timeouts of LOCKS
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/unlock.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
+@api @skipOnOcV10.0 @skipOnOcis @issue-ocis-reva-172
 Feature: UNLOCK locked items
 
   Background:

--- a/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-14
+@api @skipOnOcis @issue-ocis-reva-14
 Feature: move (rename) file
   As a user
   I want to be able to move and rename files asynchronously

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-14
+@api @skipOnOcis @issue-ocis-reva-14
 Feature: users cannot move (rename) a file to a blacklisted name
   As an administrator
   I want to be able to prevent users from moving (renaming) files to specified file names

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-14
+@api @skipOnOcis @issue-ocis-reva-14
 Feature: users cannot move (rename) a file to or into an excluded directory
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to rename an existing file or folder to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @issue-ocis-reva-14
+@api @issue-ocis-reva-14
 Feature: move (rename) folder
   As a user
   I want to be able to move and rename folders

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @issue-ocis-reva-14
+@api @issue-ocis-reva-14
 Feature: users cannot move (rename) a folder to a blacklisted name
   As an administrator
   I want to be able to prevent users from moving (renaming) folders to specified names

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-14
+@api @skipOnOcis @issue-ocis-reva-14
 Feature: users cannot move (rename) a folder to or into an excluded directory
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to rename an existing folder to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @issue-ocis-reva-14
+@api @issue-ocis-reva-14
 Feature: move (rename) file
   As a user
   I want to be able to move and rename files

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @issue-ocis-reva-14
+@api @issue-ocis-reva-14
 Feature: users cannot move (rename) a file to a blacklisted name
   As an administrator
   I want to be able to prevent users from moving (renaming) files to specified file names

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-14
+@api @skipOnOcis @issue-ocis-reva-14
 Feature: users cannot move (rename) a file to or into an excluded directory
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to rename an existing file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: delete file
   As a user
   I want to be able to delete files

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: delete folder
   As a user
   I want to be able to delete folders

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: delete folder contents
   As a user
   I want to be able to delete all files and folders in a folder

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: download file
   As a user
   I want to be able to download files

--- a/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
+++ b/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: refuse access
   As an administrator
   I want to refuse access to unauthenticated and disabled users

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-39
+@api @skipOnOcis @issue-ocis-reva-39
 Feature: Search
   As a user
   I would like to be able to search for files

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: previews of files downloaded through the webdav API
 
   Background:

--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: copy file
   As a user
   I want to be able to copy files

--- a/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: create folder
   As a user
   I want to be able to create folders

--- a/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-101
+@api @skipOnOcis @issue-ocis-reva-101
 Feature: get quota
   As a user
   I want to be able to find out my available storage quota

--- a/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @issue-ocis-reva-57
+@api @issue-ocis-reva-57
 Feature: set file properties
   As a user
   I want to be able to set meta-information about files

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: get file properties
   As a user
   I want to be able to get meta-information about files

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: upload file
   As a user
   I want to be able to upload files

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-56
+@api @skipOnOcis @issue-ocis-reva-56
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks asynchronously

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: users cannot upload a file to a blacklisted name
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-56
+@api @skipOnOcis @issue-ocis-reva-56
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend
+@api
 Feature: users cannot upload a file to or into an excluded directory
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-56
+@api @skipOnOcis @issue-ocis-reva-56
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-56
+@api @skipOnOcis @issue-ocis-reva-56
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-15
+@api @skipOnOcis @issue-ocis-reva-15
 Feature: users cannot upload a file to a blacklisted name using old chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-56
+@api @skipOnOcis @issue-ocis-reva-56
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-15
+@api @skipOnOcis @issue-ocis-reva-15
 Feature: users cannot upload a file to or into an excluded directory using old chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-56
+@api @skipOnOcis @issue-ocis-reva-56
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
@@ -1,4 +1,4 @@
-@api @TestAlsoOnExternalUserBackend @skipOnOcis @issue-ocis-reva-17
+@api @skipOnOcis @issue-ocis-reva-17
 Feature: upload file using old chunking
   As a user
   I want to be able to upload "large" files in chunks

--- a/tests/acceptance/features/cliAppManagement/appUpgrade.feature
+++ b/tests/acceptance/features/cliAppManagement/appUpgrade.feature
@@ -1,4 +1,4 @@
-@cli @skipWhenTestingRemoteSystems
+@cli @skipWhenTestingRemoteSystems @skipOnLDAP @skipOnOcis
 Feature: App upgrade
   As an admin
   I want to be able to upgrade my app version

--- a/tests/acceptance/features/cliAppManagement/listApps.feature
+++ b/tests/acceptance/features/cliAppManagement/listApps.feature
@@ -1,4 +1,4 @@
-@cli @skipWhenTestingRemoteSystems
+@cli @skipWhenTestingRemoteSystems @skipOnLDAP @skipOnOcis
 Feature: list apps
   As an admin
   I want to be able to get a list of apps that are enabled and/or disabled

--- a/tests/acceptance/features/cliBackground/backgroundJobs.feature
+++ b/tests/acceptance/features/cliBackground/backgroundJobs.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: change background jobs mode
   As an admin
   I want to be able to change background jobs modes

--- a/tests/acceptance/features/cliBackground/backgroundQueue.feature
+++ b/tests/acceptance/features/cliBackground/backgroundQueue.feature
@@ -1,4 +1,4 @@
-@cli @files_trashbin-app-required @files_sharing-app-required
+@cli @files_trashbin-app-required @files_sharing-app-required @skipOnLDAP @skipOnOcis
 Feature: get status, delete and execute jobs in background queue
   As an admin
   I want to be able to see, delete and execute the jobs in background queue

--- a/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
+++ b/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
@@ -1,5 +1,4 @@
-@cli @TestAlsoOnExternalUserBackend
-
+@cli @TestAlsoOnExternalUserBackend @skipOnOcis
 Feature: poll incoming shares
   As an administrator of a ownCloud Server
   I want to be able to poll incoming shares manually

--- a/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
+++ b/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
@@ -1,4 +1,4 @@
-@cli @TestAlsoOnExternalUserBackend @skipOnOcis
+@cli @skipOnOcis
 Feature: poll incoming shares
   As an administrator of a ownCloud Server
   I want to be able to poll incoming shares manually

--- a/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
+++ b/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
@@ -1,4 +1,4 @@
-@cli @external_storage
+@cli @external_storage @skipOnLDAP @skipOnOcis
 Feature: using files external service with storage as webdav_owncloud
 
 As a user

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: create local storage from the command line
   As an admin
   I want to create local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: create local storage from the command line
   As an admin
   I want to create local storage available to a specific group(s) from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroupsAndUsers.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroupsAndUsers.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: create local storage from the command line
   As an admin
   I want to create local storage available to a specific user(s) group(s) from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: create local storage from the command line
   As an admin
   I want to create local storage available to a specific user(s) from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: create read-only local storage from the command line
   As an admin
   I want to create read-only local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnlyAndShare.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnlyAndShare.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: create local storage and enable read-only and sharing from the command line
   As an admin
   I want to create read-only local storage and enable sharing from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadWriteAndShare.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadWriteAndShare.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: create local storage and enable sharing from the command line
   As an admin
   I want to create read-write local storage and enable sharing from the command line

--- a/tests/acceptance/features/cliLocalStorage/deleteLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/deleteLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: delete local storage from the command line
   As an admin
   I want to delete local storage

--- a/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: export created local storage mounts from the command line
   As an admin
   I want to export all created local storage mounts from the command line

--- a/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: import exported local storage mounts from the command line
   As an admin
   I want to import exported local storage mounts from the command line

--- a/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: list created local storage from the command line
   As an admin
   I want to list all created local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/manageBackendConfig.feature
+++ b/tests/acceptance/features/cliLocalStorage/manageBackendConfig.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: manage backend configuration for a mount using occ command
   As an admin
   I want to configure a local storage mount

--- a/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: manage options for a mount using occ command
   As an admin
   I want to add options for a local storage mount

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @TestAlsoOnExternalUserBackend @skipOnOcis
+@cli @local_storage @skipOnOcis
 Feature: Scanning files on local storage
   As an admin
   I want to be able to control the scanning of local storage for changes

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @TestAlsoOnExternalUserBackend
+@cli @local_storage @TestAlsoOnExternalUserBackend @skipOnOcis
 Feature: Scanning files on local storage
   As an admin
   I want to be able to control the scanning of local storage for changes

--- a/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
+++ b/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: show available backends using occ command
   As an admin
   I want to list backends

--- a/tests/acceptance/features/cliLocalStorage/verifyMountConfiguration.feature
+++ b/tests/acceptance/features/cliLocalStorage/verifyMountConfiguration.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @local_storage
+@cli @local_storage @skipOnLDAP @skipOnOcis
 Feature: verify mount configuration using occ command
   As an admin
   I want to verify mount configuration for created local storage

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -1,4 +1,4 @@
-@cli @TestAlsoOnExternalUserBackend @skipOnOcis
+@cli @skipOnOcis
 Feature: add and delete app configs using occ command
 
   As an administrator

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -1,4 +1,4 @@
-@cli @TestAlsoOnExternalUserBackend
+@cli @TestAlsoOnExternalUserBackend @skipOnOcis
 Feature: add and delete app configs using occ command
 
   As an administrator

--- a/tests/acceptance/features/cliMain/fileVersions.feature
+++ b/tests/acceptance/features/cliMain/fileVersions.feature
@@ -1,4 +1,4 @@
-@cli @TestAlsoOnExternalUserBackend @skipOnOcis
+@cli @skipOnOcis
 Feature: check file versions
 
   Scenario: user clears the versions of a file

--- a/tests/acceptance/features/cliMain/fileVersions.feature
+++ b/tests/acceptance/features/cliMain/fileVersions.feature
@@ -1,5 +1,4 @@
-@cli @TestAlsoOnExternalUserBackend
-
+@cli @TestAlsoOnExternalUserBackend @skipOnOcis
 Feature: check file versions
 
   Scenario: user clears the versions of a file

--- a/tests/acceptance/features/cliMain/filesChecksum.feature
+++ b/tests/acceptance/features/cliMain/filesChecksum.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @TestAlsoOnExternalUserBackend
+@cli @local_storage @TestAlsoOnExternalUserBackend @skipOnOcis
 Feature: files checksum command
 
   @skipOnEncryptionType:user-keys @issue-encryption-182

--- a/tests/acceptance/features/cliMain/filesChecksum.feature
+++ b/tests/acceptance/features/cliMain/filesChecksum.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @TestAlsoOnExternalUserBackend @skipOnOcis
+@cli @local_storage @skipOnOcis
 Feature: files checksum command
 
   @skipOnEncryptionType:user-keys @issue-encryption-182

--- a/tests/acceptance/features/cliMain/logManage.feature
+++ b/tests/acceptance/features/cliMain/logManage.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: manage logging configuration
   As an admin
   I want to be able to manage the logging configuration

--- a/tests/acceptance/features/cliMain/logOwnCloud.feature
+++ b/tests/acceptance/features/cliMain/logOwnCloud.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: manipulate the ownCloud logging backend
   As an admin
   I want to be able to manipulate the ownCloud logging backend

--- a/tests/acceptance/features/cliMain/maintenance.feature
+++ b/tests/acceptance/features/cliMain/maintenance.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @TestAlsoOnExternalUserBackend @skipOnOcis
+@cli @local_storage @skipOnOcis
 Feature: Maintenance command
 
   As an admin

--- a/tests/acceptance/features/cliMain/maintenance.feature
+++ b/tests/acceptance/features/cliMain/maintenance.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @TestAlsoOnExternalUserBackend
+@cli @local_storage @TestAlsoOnExternalUserBackend @skipOnOcis
 Feature: Maintenance command
 
   As an admin

--- a/tests/acceptance/features/cliMain/securityCertificates.feature
+++ b/tests/acceptance/features/cliMain/securityCertificates.feature
@@ -1,4 +1,4 @@
-@cli
+@cli @skipOnOcis
 Feature: security certificates
   As an admin
   I want to be able to manage the ownCloud security certificates

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -1,4 +1,4 @@
-@cli
+@cli @skipOnOcis
 Feature: transfer-ownership
 
   @smokeTest

--- a/tests/acceptance/features/cliProvisioning/addGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addGroup.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: add group
   As an admin
   I want to be able to add groups

--- a/tests/acceptance/features/cliProvisioning/addToGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addToGroup.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: add users to group
   As a admin
   I want to be able to add users to a group

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: add a user using the using the occ command
 
   As an administrator

--- a/tests/acceptance/features/cliProvisioning/deleteGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteGroup.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: delete groups
   As an admin
   I want to be able to delete groups

--- a/tests/acceptance/features/cliProvisioning/deleteUser.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: delete users
   As an admin
   I want to be able to delete users

--- a/tests/acceptance/features/cliProvisioning/disableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/disableApp.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @comments-app-required
+@cli @comments-app-required @skipOnLDAP @skipOnOcis
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/cliProvisioning/disableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/disableUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: disable user
   As an admin
   I want to be able to disable a user

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: edit users
   As an admin
   I want to be able to edit user information

--- a/tests/acceptance/features/cliProvisioning/enableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/enableApp.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/cliProvisioning/enableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/enableUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: enable user
   As an admin
   I want to be able to enable a user

--- a/tests/acceptance/features/cliProvisioning/getAppInfo.feature
+++ b/tests/acceptance/features/cliProvisioning/getAppInfo.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @comments-app-required
+@cli @comments-app-required @skipOnLDAP @skipOnOcis
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/cliProvisioning/getApps.feature
+++ b/tests/acceptance/features/cliProvisioning/getApps.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -1,4 +1,4 @@
-@cli
+@cli @skipOnOcis
 Feature: get group
   As an admin
   I want to be able to get group details

--- a/tests/acceptance/features/cliProvisioning/getGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroups.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: get groups
   As an admin
   I want to be able to get a list of groups

--- a/tests/acceptance/features/cliProvisioning/getUser.feature
+++ b/tests/acceptance/features/cliProvisioning/getUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: get user
   As an admin
   I want to be able to retrieve user information

--- a/tests/acceptance/features/cliProvisioning/getUserGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getUserGroups.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: get user groups
   As an admin
   I want to be able to get group membership information

--- a/tests/acceptance/features/cliProvisioning/getUsers.feature
+++ b/tests/acceptance/features/cliProvisioning/getUsers.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: get users
   As an admin
   I want to be able to list the users that exist

--- a/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: remove a user from a group
   As an admin
   I want to be able to remove a user from a group

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @mailhog
+@cli @mailhog @skipOnLDAP @skipOnOcis
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password

--- a/tests/acceptance/features/cliProvisioning/userLastSeen.feature
+++ b/tests/acceptance/features/cliProvisioning/userLastSeen.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: get user last seen
   As an admin
   I want to be able get user last seen

--- a/tests/acceptance/features/cliProvisioning/userReport.feature
+++ b/tests/acceptance/features/cliProvisioning/userReport.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: get user report
   As an admin
   I want to be able get user report

--- a/tests/acceptance/features/cliProvisioning/userSettings.feature
+++ b/tests/acceptance/features/cliProvisioning/userSettings.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP
+@cli @skipOnLDAP @skipOnOcis
 Feature: user settings
   As an admin
   I want to be able set user settings

--- a/tests/acceptance/features/cliTrashbin/trashbin.feature
+++ b/tests/acceptance/features/cliTrashbin/trashbin.feature
@@ -1,4 +1,4 @@
-@cli @TestAlsoOnExternalUserBackend @files_trashbin-app-required @skipOnOcis
+@cli @files_trashbin-app-required @skipOnOcis
 Feature: files and folders can be deleted from the trashbin
   As an admin
   I want to delete files and folders from the trashbin

--- a/tests/acceptance/features/cliTrashbin/trashbin.feature
+++ b/tests/acceptance/features/cliTrashbin/trashbin.feature
@@ -1,4 +1,4 @@
-@cli @TestAlsoOnExternalUserBackend @files_trashbin-app-required
+@cli @TestAlsoOnExternalUserBackend @files_trashbin-app-required @skipOnOcis
 Feature: files and folders can be deleted from the trashbin
   As an admin
   I want to delete files and folders from the trashbin

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -62,7 +62,7 @@ Feature: add users
       | "a1" | "%alt1%"    |
       | "-1" | "%alt1%"    |
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: use the webUI to create a simple user with an Email address but without a password
     When the administrator creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
     Then the email address "guiusr1@owncloud" should have received an email with the body containing
@@ -73,7 +73,7 @@ Feature: add users
       Access it:
       """
 
-  @smokeTest @skipOnOcV10.0 @skipOnOcV10.1 @skipOnOcV10.2 @skipOnOcV10.3
+  @smokeTest @skipOnLDAP @skipOnOcV10.0 @skipOnOcV10.1 @skipOnOcV10.2 @skipOnOcV10.3
   Scenario Outline: user sets his own password after being created with an Email address only
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI

--- a/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminAppsSettings.feature
@@ -8,13 +8,13 @@ Feature: admin apps settings
   Background:
     Given the administrator has browsed to the admin apps settings page
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: admin disables an app
     Given app "comments" has been enabled
     When the administrator disables app "comments" using the webUI
     Then app "comments" should be disabled
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: admin enables an app
     Given app "comments" has been disabled
     And the administrator has browsed to the disabled apps page

--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -8,7 +8,7 @@ Feature: admin general settings
     Given the administrator has changed their own email address to "admin@owncloud.com"
     And the administrator has browsed to the admin general settings page
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: administrator sets email server settings
     When the administrator sets the following email server settings using the webUI
       | setting                 | value          |
@@ -26,33 +26,33 @@ Feature: admin general settings
       If you received this email, the settings seem to be correct.
       """
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: administrator sets legal URLs
     When the administrator sets the value of imprint url to "imprinturl.html" using the webUI
     And the administrator logs out of the webUI
     Then the imprint url on the login page should link to "imprinturl.html"
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: administrator sets legal URLs
     When the administrator sets the value of privacy policy url to "privacy_policy.html" using the webUI
     And the administrator logs out of the webUI
     Then the privacy policy url on the login page should link to "privacy_policy.html"
 
-  @smokeTest @skipOnDockerContainerTesting @TestAlsoOnExternalUserBackend
+  @smokeTest @skipOnDockerContainerTesting
   Scenario: administrator sets update channel
     Given the administrator has invoked occ command "config:app:set core OC_Channel --value git"
     When the user reloads the current page of the webUI
     And the administrator sets the value of update channel to "daily" using the webUI
     Then the update channel should be "daily"
 
-  @smokeTest @skipOnFIREFOX @skipOnDockerContainerTesting @TestAlsoOnExternalUserBackend
+  @smokeTest @skipOnFIREFOX @skipOnDockerContainerTesting
   Scenario: administrator changes the cron job
     Given the administrator has invoked occ command "config:app:set core backgroundjobs_mode --value ajax"
     When the user reloads the current page of the webUI
     And the administrator sets the value of cron job to "webcron" using the webUI
     Then the background jobs mode should be "webcron"
 
-  @smokeTest @skipOnDockerContainerTesting @TestAlsoOnExternalUserBackend
+  @smokeTest @skipOnDockerContainerTesting
   Scenario: administrator changes the log level
     Given the administrator has invoked occ command "config:system:set loglevel --value 0"
     When the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -4,7 +4,7 @@ Feature: admin sharing settings
   I want to be able to manage sharing settings on the ownCloud server
   So that I can enable, disable, allow or restrict different sharing behaviour
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: disable share API
     Given the administrator has browsed to the admin sharing settings page
     When the administrator disables the share API using the webUI
@@ -34,7 +34,6 @@ Feature: admin sharing settings
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables enforce password protection for read-only links using the webUI
     Then the "public@@@password@@@enforced_for@@@read_only" capability of files sharing app should be "1"
-
 
   Scenario: enable enforce password protection for read and write links
     Given the administrator has browsed to the admin sharing settings page
@@ -67,13 +66,12 @@ Feature: admin sharing settings
     When the administrator enables restrict users to only share with their group members using the webUI
     Then the "share_with_group_members_only" capability of files sharing app should be "1"
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: enable share API
     Given parameter "shareapi_enabled" of app "core" has been set to "no"
     And the administrator has browsed to the admin sharing settings page
     When the administrator enables the share API using the webUI
     Then the "api_enabled" capability of files sharing app should be "1"
-
 
   Scenario: enable public sharing
     Given parameter "shareapi_allow_links" of app "core" has been set to "no"

--- a/tests/acceptance/features/webUICreateDelete/createFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFolders.feature
@@ -19,7 +19,7 @@ Feature: create folders
       | folder-!@#$%^&* ! |
       | नेपालि            |
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Create a folder inside another folder
     When the user creates a folder with the name "top-folder" using the webUI
     And the user opens folder "top-folder" using the webUI

--- a/tests/acceptance/features/webUICreateDelete/createFoldersEdgeCases.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFoldersEdgeCases.feature
@@ -37,7 +37,7 @@ Feature: create folder
       | "?&%0"    |
       | "^#2929@" |
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario Outline: Create a sub-folder inside an existing folder with problematic name
     Given user "Alice" has created folder <folder>
     And the user has reloaded the current page of the webUI

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -11,7 +11,7 @@ Feature: deleting files and folders
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Delete files & folders one by one and check its existence after page reload
     When the user deletes the following elements using the webUI
       | name                                  |
@@ -61,7 +61,7 @@ Feature: deleting files and folders
       | question?       |
       | &and#hash       |
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   @skipOnEncryption @encryption-issue-74
   Scenario: Delete multiple files at once
     When the user batch deletes these files using the webUI

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -5,7 +5,7 @@ Feature: Mark file as favorite
   I would like to mark any file/folder as favorite
   So that I can find my favorite file/folder easily
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: mark a file as favorite and list it in favorites page
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/data.zip" to "/data.zip"

--- a/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
+++ b/tests/acceptance/features/webUIFavorites/unfavoriteFile.feature
@@ -12,7 +12,7 @@ Feature: Unmark file/folder as favorite
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: unmark a file as favorite from files page
     Given the user has marked file "data.zip" as favorite using the webUI
     When the user unmarks the favorited file "data.zip" using the webUI
@@ -27,7 +27,7 @@ Feature: Unmark file/folder as favorite
     When the user browses to the favorites page
     Then folder "simple-folder" should not be listed in the favorites page on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: unmark a file as favorite from favorite page
     Given the user has marked file "data.zip" as favorite using the webUI
     And the user has browsed to the favorites page

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -8,7 +8,7 @@ Feature: browse directly to details tab
     Given user "Alice" has been created with default attributes and skeleton files
     And user "Alice" has logged in using the webUI
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario Outline: Browse directly to the sharing details of a file
     When the user browses directly to display the "sharing" details of file "<file>" in folder "<folder>"
     Then the thumbnail should be visible in the details panel

--- a/tests/acceptance/features/webUIFiles/hiddenFile.feature
+++ b/tests/acceptance/features/webUIFiles/hiddenFile.feature
@@ -10,7 +10,7 @@ Feature: Hide file/folders
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: create a hidden folder
     When the user creates a folder with the name ".xyz" using the webUI
     Then folder ".xyz" should not be listed on the webUI

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -10,7 +10,7 @@ Feature: Search
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: Simple search
     When the user searches for "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -20,7 +20,6 @@ Feature: login users
     Then the username field on the login page should have placeholder text "Login"
     And the password field on the login page should have placeholder text "Password"
 
-  @TestAlsoOnExternalUserBackend
   Scenario: simple user login
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -28,7 +27,7 @@ Feature: login users
     When user "Alice" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @TestAlsoOnExternalUserBackend @skipOnOcV10.3 @skipOnOcV10.4
+  @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: simple user login should work when strict_login_enforced is set
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -37,12 +36,12 @@ Feature: login users
     When user "Alice" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: admin login
     When the administrator logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @smokeTest @TestAlsoOnExternalUserBackend
+  @smokeTest
   Scenario: admin login with invalid password
     Given the user has browsed to the login page
     When the administrator tries to login with an invalid password "%regular%" using the webUI

--- a/tests/acceptance/features/webUILogin/loginWithEmailAddress.feature
+++ b/tests/acceptance/features/webUILogin/loginWithEmailAddress.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @TestAlsoOnExternalUserBackend
+@webUI @insulated @disablePreviews
 Feature: login users
   As a user
   I want to be able to log into my account using my email address

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -11,7 +11,7 @@ Feature: reset the password
     And the user has browsed to the login page
     And the user has logged in with username "Alice" and invalid password "%alt2%" using the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: send password reset email
     When the user requests the password reset link using the webUI
     Then a message with this text should be displayed on the webUI:
@@ -24,7 +24,7 @@ Feature: reset the password
       """
 
   @skipOnEncryption @skipOnOcV10.0 @skipOnOcV10.1
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from the email address of user "Alice"

--- a/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
+++ b/tests/acceptance/features/webUILogin/resetPasswordUsingEmail.feature
@@ -11,7 +11,7 @@ Feature: reset the password using an email address
     And the user has browsed to the login page
     And user "Alice" logs in with email and invalid password "%alt2%" using the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: send password reset email
     When the user requests the password reset link using the webUI
     Then a message with this text should be displayed on the webUI:
@@ -23,7 +23,7 @@ Feature: reset the password using an email address
       Use the following link to reset your password: <a href=
       """
 
-  @skipOnEncryption @smokeTest
+  @skipOnEncryption @smokeTest @skipOnLDAP
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI
     And the user follows the password reset link from the email address of user "Alice"

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -13,7 +13,7 @@ Feature: move files
     When the user renames file "data.zip" to "simple-folder/data.zip" using the webUI
     Then near file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: move a file into a folder
     When the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
     Then file "data.zip" should not be listed on the webUI
@@ -42,7 +42,7 @@ Feature: move files
       | Could not move "strängé filename (duplicate #2 &).txt", target exists |
     And file "strängé filename (duplicate #2 &).txt" should be listed on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Move multiple files at once
     When the user batch moves these files into folder "simple-empty-folder" using the webUI
       | name        |

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -9,7 +9,7 @@ Feature: Change own email address on the personal settings page
     And user "Alice" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   @skipOnFIREFOX
   Scenario: Change email address
     When the user changes the email address to "new-address@owncloud.com" using the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -9,7 +9,7 @@ Feature: Change own full name on the personal settings page
     And user "Alice" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Change full name
     When the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
     And the user reloads the current page of the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changePasswordFromSetting.feature
@@ -9,7 +9,7 @@ Feature: Change Login Password
     And user "Alice" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Change password
     When the user changes the password to "%alt3%" using the webUI
     And the user re-logs in with username "Alice" and password "%alt3%" using the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -9,7 +9,7 @@ Feature: personal general settings
     And user "Alice" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: change language
     When the user changes the language to "Русский" using the webUI
     Then the user should be redirected to a webUI page with the title "Настройки - %productname%"

--- a/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalSecuritySettings.feature
@@ -9,13 +9,13 @@ Feature: personal security settings
     And user "Alice" has logged in using the webUI
     And the user has browsed to the personal security settings page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: login with new app password
     When the user creates a new App password using the webUI
     And the user re-logs in with username "Alice" and generated app password using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: delete the app password
     When the user creates a new App password using the webUI
     And the user deletes the app password

--- a/tests/acceptance/features/webUIRenameFiles/renameFile.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFile.feature
@@ -7,7 +7,7 @@ Feature: rename files
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario Outline: Rename a file using special characters
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     And user "Alice" has logged in using the webUI
@@ -53,7 +53,7 @@ Feature: rename files
       | "'single'quotes.txt"                    | "single-quotes.txt"                   |
       | "?quot=OC&OC2 #OC%  3   "               | "sin#gle-qu&%%%%otes=.txt "           |
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Rename a file using special characters and check its existence after page reload
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     And user "Alice" has uploaded file with content "more content" to "/zzzz-must-be-last-file-in-folder.txt"

--- a/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/disableSharing.feature
@@ -7,7 +7,6 @@ Feature: disable sharing
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Users tries to share via WebUI when Sharing is disabled
     Given user "Alice" has created folder "simple-folder"

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -19,7 +19,7 @@ Feature: restrict resharing
     And user "Brian" has created folder "simple-folder"
     And user "Brian" has logged in using the webUI
 
-  @skipOnMICROSOFTEDGE @skipOnFIREFOX @TestAlsoOnExternalUserBackend @files_sharing-app-required
+  @skipOnMICROSOFTEDGE @skipOnFIREFOX @files_sharing-app-required
   @smokeTest @skipOnOcV10.3
   Scenario: share a folder with another internal user and prohibit resharing
     Given the setting "Allow resharing" in the section "Sharing" has been enabled
@@ -30,7 +30,7 @@ Feature: restrict resharing
     And the user re-logs in as "Alice" using the webUI
     Then it should not be possible to share folder "simple-folder (2)" using the webUI
 
-  @TestAlsoOnExternalUserBackend @files_sharing-app-required
+  @files_sharing-app-required
   @smokeTest
   Scenario: forbid resharing globally
     Given the setting "Allow resharing" in the section "Sharing" has been disabled

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -21,7 +21,6 @@ Feature: restrict Sharing
     And user "Brian" has created folder "simple-folder"
     And user "Brian" has logged in using the webUI
 
-  @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Restrict users to only share with users in their groups
     Given the setting "Restrict users to only share with users in their groups" in the section "Sharing" has been enabled
@@ -31,7 +30,6 @@ Feature: restrict Sharing
     And the user re-logs in as "Alice" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
-  @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Restrict users to only share with groups they are member of
     Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been enabled
@@ -41,7 +39,6 @@ Feature: restrict Sharing
     And the user re-logs in as "Alice" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
-  @TestAlsoOnExternalUserBackend
   Scenario: Do not restrict users to only share with groups they are member of
     Given user "David" has been created with default attributes and without skeleton files
     And user "David" has been added to group "grp2"
@@ -52,7 +49,6 @@ Feature: restrict Sharing
     And the user re-logs in as "David" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
-  @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: Forbid sharing with groups
     Given the setting "Allow sharing with groups" in the section "Sharing" has been disabled

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -13,7 +13,7 @@ Feature: accept/decline shares coming from internal users
     And user "Alice" has been added to group "grp1"
     And user "Brian" has been added to group "grp1"
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Auto-accept disabled results in "Pending" shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Brian" has shared folder "/simple-folder" with group "grp1"
@@ -52,7 +52,7 @@ Feature: accept/decline shares coming from internal users
     Then folder "simple-folder" shared by "Carol" should be in state "Pending" in the shared-with-you page on the webUI
     And folder "simple-folder" shared by "Brian" should be in state "Pending" in the shared-with-you page on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: accept an offered share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Brian" has shared folder "/simple-folder" with user "Alice"
@@ -81,7 +81,7 @@ Feature: accept/decline shares coming from internal users
       | /ReceivedShares     |
       | /My/Received/Shares |
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: decline an offered (pending) share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Brian" has shared folder "/simple-folder" with user "Alice"
@@ -93,7 +93,7 @@ Feature: accept/decline shares coming from internal users
     And folder "simple-folder" should not be listed in the files page on the webUI
     And file "testimage.jpg" should not be listed in the files page on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: decline an accepted share (with page-reload in between)
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Brian" has shared folder "/simple-folder" with user "Alice"
@@ -163,7 +163,7 @@ Feature: accept/decline shares coming from internal users
     Then folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And folder "simple-folder" should not be listed in the files page on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: unshare an accepted share on the "All files" page
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Brian" has shared folder "/simple-folder" with user "Alice"
@@ -178,7 +178,7 @@ Feature: accept/decline shares coming from internal users
     And folder "simple-folder" should be in state "Declined" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Declined" in the shared-with-you page on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Auto-accept shares
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been enabled
     And user "Brian" has shared folder "/simple-folder" with group "grp1"

--- a/tests/acceptance/features/webUISharingAutocompletion1/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion1/shareAutocompletion.feature
@@ -26,7 +26,7 @@ Feature: Autocompletion of share-with names
       | other         |
     And the administrator has added system config key "user_ldap.enable_medial_search" with value "true" and type "boolean"
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: autocompletion of regular existing users
     Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
@@ -36,7 +36,7 @@ Feature: Autocompletion of share-with names
     And the users own name should not be listed in the autocomplete list on the webUI
     And user "Four" should not be listed in the autocomplete list on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: autocompletion of regular existing groups
     Given user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page

--- a/tests/acceptance/features/webUISharingAutocompletion1/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion1/shareAutocompletion.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@webUI @insulated @disablePreviews @files_sharing-app-required
 Feature: Autocompletion of share-with names
   As a user
   I want to share files, with minimal typing, to the right people or groups

--- a/tests/acceptance/features/webUISharingAutocompletion2/shareAutocompletionWithDifferentPatterns.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion2/shareAutocompletionWithDifferentPatterns.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@webUI @insulated @disablePreviews @files_sharing-app-required
 Feature: Autocompletion of share-with names
   As a user
   I want to share files, with minimal typing, to the right people or groups

--- a/tests/acceptance/features/webUISharingExternal1/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUISharingExternal1/adminSharingSettings.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @federation-app-required @disablePreviews @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@webUI @insulated @federation-app-required @disablePreviews @files_sharing-app-required
 Feature: Manage Trusted servers from the webUI
   As an administrator
   I want to add, view, delete and edit trusted servers from the webUI

--- a/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
@@ -1,4 +1,4 @@
-@webUI @federation-app-required @insulated @disablePreviews @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@webUI @federation-app-required @insulated @disablePreviews @files_sharing-app-required
 Feature: Federation Sharing - sharing with users on other cloud storages
   As a user
   I want to share files with any users on other cloud storages

--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
@@ -1,4 +1,4 @@
-@webUI @federation-app-required @insulated @disablePreviews @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@webUI @federation-app-required @insulated @disablePreviews @files_sharing-app-required
 Feature: Federation Sharing - sharing with users on other cloud storages
   As a user
   I want to share files with any users on other cloud storages
@@ -19,7 +19,6 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "Alice" has logged in using the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
-
 
   Scenario: declining a federation share on the webUI
     Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"

--- a/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
@@ -1,4 +1,4 @@
-@webUI @federation-app-required @insulated @disablePreviews @TestAlsoOnExternalUserBackend @files_sharing-app-required
+@webUI @federation-app-required @insulated @disablePreviews @files_sharing-app-required
 Feature: Federation Sharing - sharing with users on other cloud storages
   As a user
   I want to share files with any users on other cloud storages

--- a/tests/acceptance/features/webUISharingInternalGroups1/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups1/shareWithGroups.feature
@@ -16,7 +16,6 @@ Feature: Sharing files and folders with internal groups
     And user "Alice" has been added to group "grp1"
     And user "Brian" has been added to group "grp1"
 
-  @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a folder with an internal group
     Given user "Carol" has logged in using the webUI
@@ -33,7 +32,7 @@ Feature: Sharing files and folders with internal groups
     And file "testimage.jpg" should be listed on the webUI
     And file "testimage.jpg" should be marked as shared with "grp1" by "Carol" on the webUI
 
-  @TestAlsoOnExternalUserBackend @skipOnFIREFOX
+  @skipOnFIREFOX
   Scenario: share a file with an internal group a member overwrites and unshares the file
     Given user "Carol" has logged in using the webUI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
@@ -54,7 +53,6 @@ Feature: Sharing files and folders with internal groups
     When the user re-logs in as "Carol" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-  @TestAlsoOnExternalUserBackend
   Scenario: share a folder with an internal group and a member uploads, overwrites and deletes files
     Given user "Carol" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
@@ -85,7 +83,6 @@ Feature: Sharing files and folders with internal groups
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
     And file "data.zip" should not be listed on the webUI
 
-  @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a folder with an internal group and a member unshares the folder
     Given user "Carol" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -4,7 +4,6 @@ Feature: Sharing files and folders with internal users
   I want to share files and folders with other users
   So that those users can access the files and folders
 
-  @TestAlsoOnExternalUserBackend
   @smokeTest
   Scenario: share a file & folder with another internal user
     Given these users have been created with default attributes and skeleton files:

--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
@@ -1,7 +1,7 @@
 @webUI @insulated @disablePreviews @files_sharing-app-required
 Feature: misc scenarios on sharing with internal users
 
-  @TestAlsoOnExternalUserBackend @skipOnFIREFOX
+  @skipOnFIREFOX
   Scenario: share a file with another internal user who overwrites and unshares the file
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and skeleton files
@@ -21,7 +21,6 @@ Feature: misc scenarios on sharing with internal users
     When the user re-logs in as "Brian" using the webUI
     Then the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-  @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and skeleton files
@@ -50,7 +49,6 @@ Feature: misc scenarios on sharing with internal users
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
     But file "data.zip" should not be listed on the webUI
 
-  @TestAlsoOnExternalUserBackend
   Scenario: share a folder with another internal user who unshares the folder
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and skeleton files
@@ -68,7 +66,7 @@ Feature: misc scenarios on sharing with internal users
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the original "simple-folder/lorem.txt"
 
-  @skipOnMICROSOFTEDGE @TestAlsoOnExternalUserBackend @skipOnOcV10.3
+  @skipOnMICROSOFTEDGE @skipOnOcV10.3
   Scenario: share a folder with another internal user and prohibit deleting
     Given these users have been created with default attributes and skeleton files:
       | username |

--- a/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
+++ b/tests/acceptance/features/webUISharingNotifications/notificationLink.feature
@@ -12,7 +12,7 @@ Feature: Display notifications when receiving a share and follow embedded links
       | Brian    |
     And user "Brian" has logged in using the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: notification link redirection in case a share is pending
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Alice" has created folder "a-folder"

--- a/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingNotifications/shareWithUsers.feature
@@ -14,7 +14,7 @@ Feature: Sharing files and folders with internal users
     And user "Alice" has uploaded file "filesForUpload/data.zip" to "/data.zip"
     And user "Brian" has logged in using the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: notifications about new share is displayed when autoacepting is disabled
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Alice" has shared folder "/a-folder" with user "Brian"
@@ -24,7 +24,7 @@ Feature: Sharing files and folders with internal users
       | "%displayname%" shared "a-folder" with you | Alice |
       | "%displayname%" shared "data.zip" with you | Alice |
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Notification is gone after accepting a share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Alice" has shared folder "/a-folder" with user "Brian"
@@ -32,7 +32,7 @@ Feature: Sharing files and folders with internal users
     When the user accepts all shares displayed in the notifications on the webUI
     Then user "Brian" should have 0 notifications
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: accept an offered share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Alice" has shared folder "/a-folder" with user "Brian"
@@ -43,7 +43,7 @@ Feature: Sharing files and folders with internal users
     And folder "a-folder" should be in state "" in the shared-with-you page on the webUI
     And file "data.zip" should be in state "" in the shared-with-you page on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: reject an offered share
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
     And user "Alice" has shared folder "/a-folder" with user "Brian"

--- a/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
+++ b/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
@@ -7,7 +7,7 @@ Feature: Share by public link
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: simple sharing by public link
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/lorem.txt"

--- a/tests/acceptance/features/webUISharingPublic2/reShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/reShareByPublicLink.feature
@@ -8,7 +8,7 @@ Feature: Reshare by public link
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: resharing by public link of a received shared folder
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/randomfile.txt"

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -15,7 +15,7 @@ Feature: files and folders can be deleted from the trashbin
       | simple-folder |
     And the user has browsed to the trashbin page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Delete files and check that they are gone
     When the user deletes file "lorem.txt" using the webUI
     And the user opens folder "simple-folder" using the webUI

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -9,7 +9,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Delete files & folders one by one and check that they are all in the trashbin
     When the user deletes the following elements using the webUI
       | name                                  |

--- a/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
@@ -9,7 +9,7 @@ Feature: Restore deleted files/folders
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Restore files
     When the user deletes file "data.zip" using the webUI
     Then file "data.zip" should be listed in the trashbin on the webUI
@@ -26,7 +26,7 @@ Feature: Restore deleted files/folders
     When the user browses to the files page
     Then folder "folder with space" should be listed on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: Select some trashbin files and restore them in a batch
     Given the following files have been deleted
       | name          |

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -8,7 +8,7 @@ Feature: File Upload
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario Outline: simple upload of a file that does not exist before
     Given user "<username>" has been created with default attributes and without skeleton files
     And user "<username>" has logged in using the webUI
@@ -25,7 +25,7 @@ Feature: File Upload
       | -123     |
       | 0.0      |
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: chunking upload
     Given a file with the size of "30000000" bytes and the name "big-video.mp4" has been created locally
     And user "Alice" has logged in using the webUI
@@ -53,7 +53,7 @@ Feature: File Upload
     And file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" should be the same as the local "new-lorem.txt"
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: overwrite an existing file
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "Alice" has logged in using the webUI
@@ -63,7 +63,7 @@ Feature: File Upload
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
     But file "lorem (2).txt" should not be listed on the webUI
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: keep new and existing file
     Given user "Alice" has uploaded file with content "original content" to "/lorem.txt"
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
+++ b/tests/acceptance/features/webUIUpload/uploadEdgecases.feature
@@ -24,7 +24,7 @@ Feature: File Upload
     Then file "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be listed on the webUI
     And the content of "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt" should be the same as the local "zzzz-zzzz-will-be-at-the-end-of-the-folder-when-uploaded.txt"
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario Outline: upload a new file into a sub folder
     Given a file with the size of "3000" bytes and the name "0" has been created locally
     And user "Alice" has created folder <folder-to-upload-to>

--- a/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
+++ b/tests/acceptance/features/webUIUpload/uploadFileGreaterThanQuotaSize.feature
@@ -8,7 +8,7 @@ Feature: Upload a file
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest @skipOnLDAP
   Scenario: simple upload of a file with the size greater than the size of quota
     Given the quota of user "Alice" has been set to "10 MB"
     And user "Alice" has logged in using the webUI


### PR DESCRIPTION
## Description
There is some confusion between the use of the tag `TestAlsoOnExternalUserBackend` and the tags `skipOnLDAP` `skipOnOCIS`

Other repos run the API/CLI/webUI acceptance tests and use these tags, e.g. in `user_ldap`, `ocis`  and `ocis-reva`. They filter scenarios with filter tags expressions like:
```
~@skipOnOcis&&~@skipOnOcis-OC-Storage&&~@skipOnLDAP&&@TestAlsoOnExternalUserBackend&&~@local_storage
```

At the moment you have to put `TestAlsoOnExternalUserBackend` tag to get any scenario to run at all in those repos. That seems a redundant requirement, and causes problems when it is (accidentally) forgotten. e.g. #37608 https://github.com/owncloud/core/pull/37608/files#diff-9beaec11c272107847d1e7d034ce679e removed the `skipOnOcis` tag from some scenarios, but actually that did not actually cause them to run in the OCIS API acceptance tests.

We can avoid this problem by:

1) make sure that all tests that are not to be run on LDAP/OCIS are tagged with `skipOnLDAP`/`skipOnOcis` as appropriate.
2) Remove the `TestAlsoOnExternalUserBackend` tag from all test pipelines in other repos.
3) Confirm that the same number of tests are being run and pass as before
4) Remove the `TestAlsoOnExternalUserBackend` tag from all feature files.




## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
