### PR TITLE
[10.5.0] Add tooltip to unlock, change icon to closed lock

### DIFF
--- a/apps/files/js/filelockplugin.js
+++ b/apps/files/js/filelockplugin.js
@@ -13,7 +13,7 @@
 
 	var TEMPLATE_LOCK_STATUS_ACTION =
 		'<a class="action action-lock-status permanent" title="{{message}}" href="#">' +
-		'<span class="icon icon-lock-open" />' +
+		'<span class="icon icon-lock-closed" />' +
 		'</a>';
 
 	/**
@@ -158,7 +158,7 @@
 					displayName: t('files', 'Lock file'),
 					permissions: OC.PERMISSION_UPDATE,
 					type: OCA.Files.FileActions.TYPE_DROPDOWN,
-					iconClass: 'icon-lock-open',
+					iconClass: 'icon-lock-closed',
 					actionHandler: function (filename, context) {
 						const file = context.fileInfoModel.getFullPath();
 						context.fileInfoModel._filesClient.lock(file).then(function (result, response) {

--- a/apps/files/js/locktabview.js
+++ b/apps/files/js/locktabview.js
@@ -16,7 +16,7 @@
 		'<div class="lock-entry" data-index="{{index}}">' +
 		'<div style="display: inline;">{{displayText}}</div>' +
 		// TODO: no inline css
-		'<a href="#" class="unlock" style="float: right" title="{{unlockLabel}}">' +
+		'<a href="#" class="unlock has-tooltip" style="float: right" title="{{unlockLabel}}">' +
 		'<span class="icon icon-lock-open" style="display: block" /></a>' +
 		'</div>' +
 		'{{else}}' +
@@ -41,7 +41,8 @@
 				index: index,
 				displayText: t('files', '{owner} has locked this resource via {path}', {owner: lock.owner, path: path}),
 				locktoken: lock.locktoken,
-				lockroot: lock.lockroot
+				lockroot: lock.lockroot,
+				unlockLabel: t('files', 'Unlock')
 			};
 		});
 	}
@@ -107,6 +108,7 @@
 					emptyResultLabel: t('files', 'Resource is not locked'),
 					locks: formatLocks(this.model.get('activeLocks'))
 				}));
+				this.$el.find('.has-tooltip').tooltip();
 			},
 
 			/**

--- a/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
+++ b/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
@@ -44,7 +44,7 @@ class LockEntry extends OwncloudPage {
 	protected $lockElement;
 	protected $lockDescriptionXpath = "/div";
 	protected $lockingUserExtractPattern = "/^(.*)\shas locked/";
-	protected $unlockButtonXpath = "/a[@class='unlock']";
+	protected $unlockButtonXpath = "/a[@class='unlock has-tooltip']";
 
 	/**
 	 * sets the NodeElement for the current entry


### PR DESCRIPTION
## Description
- Changed the Icon of 'Lock file' file action from open to closed lock
- Changed the Icon for locked files  from open to closed lock in the file list
- Added 'Unlock' tooltip to the unlock icon at the 'Locks' tab

## Motivation and Context
Usability improvement for locking UI


## Screenshots (if appropriate):
![lock](https://user-images.githubusercontent.com/991300/86172076-7982fb80-bb26-11ea-932c-a2c06de589cd.png)
![unlock](https://user-images.githubusercontent.com/991300/86172081-7ab42880-bb26-11ea-86a8-3c0041a3d1ec.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
