### PR TITLE
[Tests-only] Sharing tests use string as ids

### DIFF
--- a/tests/acceptance/features/apiFederation1/federated.feature
+++ b/tests/acceptance/features/apiFederation1/federated.feature
@@ -14,18 +14,18 @@ Feature: federated
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Brian" sharing with user "Alice" should include
-      | id                     | A_NUMBER          |
+      | id                     | A_STRING          |
       | item_type              | file              |
-      | item_source            | A_NUMBER          |
+      | item_source            | A_STRING          |
       | share_type             | federated         |
-      | file_source            | A_NUMBER          |
+      | file_source            | A_STRING          |
       | path                   | /textfile0.txt    |
       | permissions            | share,read,update |
       | stime                  | A_NUMBER          |
-      | storage                | A_NUMBER          |
+      | storage                | A_STRING          |
       | mail_send              | 0                 |
       | uid_owner              | %username%        |
-      | file_parent            | A_NUMBER          |
+      | file_parent            | A_STRING          |
       | displayname_owner      | %displayname%     |
       | share_with             | %username%@REMOTE |
       | share_with_displayname | %username%@REMOTE |
@@ -41,18 +41,18 @@ Feature: federated
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "Brian" should include
-      | id                     | A_NUMBER          |
+      | id                     | A_STRING          |
       | item_type              | file              |
-      | item_source            | A_NUMBER          |
+      | item_source            | A_STRING          |
       | share_type             | federated         |
-      | file_source            | A_NUMBER          |
+      | file_source            | A_STRING          |
       | path                   | /textfile0.txt    |
       | permissions            | share,read,update |
       | stime                  | A_NUMBER          |
-      | storage                | A_NUMBER          |
+      | storage                | A_STRING          |
       | mail_send              | 0                 |
       | uid_owner              | %username%        |
-      | file_parent            | A_NUMBER          |
+      | file_parent            | A_STRING          |
       | displayname_owner      | %displayname%     |
       | share_with             | %username%@LOCAL  |
       | share_with_displayname | %username%@LOCAL  |
@@ -68,9 +68,9 @@ Feature: federated
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Brian" should include
-      | id          | A_NUMBER                                   |
+      | id          | A_STRING                                   |
       | remote      | REMOTE                                     |
-      | remote_id   | A_NUMBER                                   |
+      | remote_id   | A_STRING                                   |
       | share_token | A_TOKEN                                    |
       | name        | /textfile0.txt                             |
       | owner       | Alice                                      |
@@ -90,9 +90,9 @@ Feature: federated
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Brian" should include
-      | id          | A_NUMBER                 |
+      | id          | A_STRING                 |
       | remote      | REMOTE                   |
-      | remote_id   | A_NUMBER                 |
+      | remote_id   | A_STRING                 |
       | share_token | A_TOKEN                  |
       | name        | /textfile0.txt           |
       | owner       | Alice                    |
@@ -114,9 +114,9 @@ Feature: federated
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs-status>"
     And the fields of the last response to user "Brian" should include
-      | id          | A_NUMBER                                   |
+      | id          | A_STRING                                   |
       | remote      | REMOTE                                     |
-      | remote_id   | A_NUMBER                                   |
+      | remote_id   | A_STRING                                   |
       | share_token | A_TOKEN                                    |
       | name        | /textfile0.txt                             |
       | owner       | Alice                                      |
@@ -173,18 +173,18 @@ Feature: federated
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Brian" sharing with user "Carol" should include
-      | id                     | A_NUMBER           |
+      | id                     | A_STRING           |
       | item_type              | file               |
-      | item_source            | A_NUMBER           |
+      | item_source            | A_STRING           |
       | share_type             | user               |
-      | file_source            | A_NUMBER           |
+      | file_source            | A_STRING           |
       | path                   | /textfile0 (2).txt |
       | permissions            | share,read,update  |
       | stime                  | A_NUMBER           |
-      | storage                | A_NUMBER           |
+      | storage                | A_STRING           |
       | mail_send              | 0                  |
       | uid_owner              | %username%         |
-      | file_parent            | A_NUMBER           |
+      | file_parent            | A_STRING           |
       | displayname_owner      | %displayname%      |
       | share_with             | %username%         |
       | share_with_displayname | %displayname%      |
@@ -307,9 +307,9 @@ Feature: federated
       | /textfile0%20(2).txt |
     When user "Brian" gets the list of federated cloud shares using the sharing API
     Then the fields of the last response to user "Brian" should include
-      | id          | A_NUMBER                 |
+      | id          | A_STRING                 |
       | remote      | REMOTE                   |
-      | remote_id   | A_NUMBER                 |
+      | remote_id   | A_STRING                 |
       | share_token | A_TOKEN                  |
       | name        | /textfile0.txt           |
       | owner       | Alice                    |
@@ -353,9 +353,9 @@ Feature: federated
       | /textfile0%20(2).txt |
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
     Then the fields of the last response to user "Brian" should include
-      | id          | A_NUMBER                                   |
+      | id          | A_STRING                                   |
       | remote      | REMOTE                                     |
-      | remote_id   | A_NUMBER                                   |
+      | remote_id   | A_STRING                                   |
       | share_token | A_TOKEN                                    |
       | name        | /textfile0.txt                             |
       | owner       | Alice                                      |
@@ -423,7 +423,7 @@ Feature: federated
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Brian" should include
-      | id          | A_NUMBER       |
+      | id          | A_STRING       |
       | remote      | REMOTE         |
       | name        | /zzzfolder     |
       | owner       | Alice          |
@@ -450,9 +450,9 @@ Feature: federated
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Brian" should include
-      | id          | A_NUMBER                 |
+      | id          | A_STRING                 |
       | remote      | REMOTE                   |
-      | remote_id   | A_NUMBER                 |
+      | remote_id   | A_STRING                 |
       | share_token | A_TOKEN                  |
       | name        | /randomfile.txt          |
       | owner       | Alice                    |

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -330,7 +330,7 @@ Feature: accept/decline shares coming from internal users
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "Brian" should include
-      | id                     | A_NUMBER                   |
+      | id                     | A_STRING                   |
       | share_type             | user                       |
       | uid_owner              | %username%                 |
       | displayname_owner      | %displayname%              |
@@ -342,10 +342,10 @@ Feature: accept/decline shares coming from internal users
       | item_type              | file                       |
       | mimetype               | text/plain                 |
       | storage_id             | shared::/textfile0 (2).txt |
-      | storage                | A_NUMBER                   |
-      | item_source            | A_NUMBER                   |
-      | file_source            | A_NUMBER                   |
-      | file_parent            | A_NUMBER                   |
+      | storage                | A_STRING                   |
+      | item_source            | A_STRING                   |
+      | file_source            | A_STRING                   |
+      | file_parent            | A_STRING                   |
       | file_target            | /textfile0 (2).txt         |
       | share_with             | %username%                 |
       | share_with_displayname | %displayname%              |
@@ -372,7 +372,7 @@ Feature: accept/decline shares coming from internal users
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "Brian" should include
-      | id                     | A_NUMBER                                      |
+      | id                     | A_STRING                                      |
       | share_type             | user                                          |
       | uid_owner              | %username%                                    |
       | displayname_owner      | %displayname%                                 |
@@ -384,10 +384,10 @@ Feature: accept/decline shares coming from internal users
       | item_type              | file                                          |
       | mimetype               | text/plain                                    |
       | storage_id             | shared::<top_folder>/<received_textfile_name> |
-      | storage                | A_NUMBER                                      |
-      | item_source            | A_NUMBER                                      |
-      | file_source            | A_NUMBER                                      |
-      | file_parent            | A_NUMBER                                      |
+      | storage                | A_STRING                                      |
+      | item_source            | A_STRING                                      |
+      | file_source            | A_STRING                                      |
+      | file_parent            | A_STRING                                      |
       | file_target            | <top_folder>/<received_textfile_name>         |
       | share_with             | %username%                                    |
       | share_with_displayname | %displayname%                                 |

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -102,20 +102,20 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "Brian" should include
-      | id                     | A_NUMBER           |
+      | id                     | A_STRING			|
       | item_type              | file               |
-      | item_source            | A_NUMBER           |
+      | item_source            | A_STRING           |
       | share_type             | user               |
       | share_with             | %username%         |
-      | file_source            | A_NUMBER           |
+      | file_source            | A_STRING           |
       | file_target            | /file_to_share.txt |
       | path                   | /file_to_share.txt |
       | permissions            | share,read,update  |
       | stime                  | A_NUMBER           |
-      | storage                | A_NUMBER           |
+      | storage                | A_STRING           |
       | mail_send              | 0                  |
       | uid_owner              | %username%         |
-      | file_parent            | A_NUMBER           |
+      | file_parent            | A_STRING           |
       | share_with_displayname | %displayname%      |
       | displayname_owner      | %displayname%      |
       | mimetype               | text/plain         |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -356,7 +356,7 @@ Feature: create a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id          | A_NUMBER    |
+      | id          | A_STRING    |
       | share_type  | public_link |
       | permissions | read        |
     And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
@@ -375,7 +375,7 @@ Feature: create a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id          | A_NUMBER    |
+      | id          | A_STRING    |
       | share_type  | public_link |
       | permissions | read        |
     And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
@@ -393,7 +393,7 @@ Feature: create a public link share
       | path        | /afolder    |
       | permissions | read,create |
     # And the fields of the last response to user "Alice" should include
-    #  | id          | A_NUMBER    |
+    #  | id          | A_STRING    |
     #  | share_type  | public_link |
     #  | permissions | read        |
     Then the OCS status code should be "<ocs_status_code>"
@@ -417,7 +417,7 @@ Feature: create a public link share
       | path        | /afolder |
       | permissions | create   |
     # And the fields of the last response to user "Alice" should include
-    #  | id          | A_NUMBER    |
+    #  | id          | A_STRING    |
     #  | share_type  | public_link |
     #  | permissions | read        |
     Then the OCS status code should be "<ocs_status_code>"
@@ -443,7 +443,7 @@ Feature: create a public link share
     When user "Alice" tries to update the last share using the sharing API with
       | permissions | read,create |
     # And the fields of the last response to user "Alice" should include
-    #  | id          | A_NUMBER    |
+    #  | id          | A_STRING    |
     #  | share_type  | public_link |
     #  | permissions | read        |
     Then the OCS status code should be "<ocs_status_code>"
@@ -469,7 +469,7 @@ Feature: create a public link share
     When user "Alice" tries to update the last share using the sharing API with
       | permissions | <permission> |
     # And the fields of the last response to user "Alice" should include
-    #  | id          | A_NUMBER    |
+    #  | id          | A_STRING    |
     #  | share_type  | public_link |
     #  | permissions | read        |
     Then the OCS status code should be "<ocs_status_code>"
@@ -503,7 +503,7 @@ Feature: create a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id          | A_NUMBER    |
+      | id          | A_STRING    |
       | share_type  | public_link |
       | permissions | read        |
     And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -16,20 +16,20 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id                | A_NUMBER             |
+      | id                | A_STRING             |
       | item_type         | folder               |
-      | item_source       | A_NUMBER             |
+      | item_source       | A_STRING             |
       | share_type        | public_link          |
-      | file_source       | A_NUMBER             |
+      | file_source       | A_STRING             |
       | file_target       | /FOLDER              |
       | permissions       | read                 |
       | stime             | A_NUMBER             |
       | expiration        | +3 days              |
       | token             | A_TOKEN              |
-      | storage           | A_NUMBER             |
+      | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | Alice                |
-      | file_parent       | A_NUMBER             |
+      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -65,20 +65,20 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id                | A_NUMBER             |
+      | id                | A_STRING             |
       | item_type         | folder               |
-      | item_source       | A_NUMBER             |
+      | item_source       | A_STRING             |
       | share_type        | public_link          |
-      | file_source       | A_NUMBER             |
+      | file_source       | A_STRING             |
       | file_target       | /FOLDER              |
       | permissions       | read                 |
       | stime             | A_NUMBER             |
       | expiration        | +3 days              |
       | token             | A_TOKEN              |
-      | storage           | A_NUMBER             |
+      | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | Alice                |
-      | file_parent       | A_NUMBER             |
+      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -97,19 +97,19 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id                | A_NUMBER             |
+      | id                | A_STRING             |
       | item_type         | folder               |
-      | item_source       | A_NUMBER             |
+      | item_source       | A_STRING             |
       | share_type        | public_link          |
-      | file_source       | A_NUMBER             |
+      | file_source       | A_STRING             |
       | file_target       | /FOLDER              |
       | permissions       | read                 |
       | stime             | A_NUMBER             |
       | token             | A_TOKEN              |
-      | storage           | A_NUMBER             |
+      | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | Alice                |
-      | file_parent       | A_NUMBER             |
+      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -128,19 +128,19 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id                | A_NUMBER                  |
+      | id                | A_STRING                  |
       | item_type         | folder                    |
-      | item_source       | A_NUMBER                  |
+      | item_source       | A_STRING                  |
       | share_type        | public_link               |
-      | file_source       | A_NUMBER                  |
+      | file_source       | A_STRING                  |
       | file_target       | /FOLDER                   |
       | permissions       | read,update,create,delete |
       | stime             | A_NUMBER                  |
       | token             | A_TOKEN                   |
-      | storage           | A_NUMBER                  |
+      | storage           | A_STRING                  |
       | mail_send         | 0                         |
       | uid_owner         | Alice                     |
-      | file_parent       | A_NUMBER                  |
+      | file_parent       | A_STRING                  |
       | displayname_owner | %displayname%             |
       | url               | AN_URL                    |
       | mimetype          | httpd/unix-directory      |
@@ -159,19 +159,19 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id                | A_NUMBER             |
+      | id                | A_STRING             |
       | item_type         | folder               |
-      | item_source       | A_NUMBER             |
+      | item_source       | A_STRING             |
       | share_type        | public_link          |
-      | file_source       | A_NUMBER             |
+      | file_source       | A_STRING             |
       | file_target       | /FOLDER              |
       | permissions       | read,update,create   |
       | stime             | A_NUMBER             |
       | token             | A_TOKEN              |
-      | storage           | A_NUMBER             |
+      | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | Alice                |
-      | file_parent       | A_NUMBER             |
+      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -190,19 +190,19 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id                | A_NUMBER                  |
+      | id                | A_STRING                  |
       | item_type         | folder                    |
-      | item_source       | A_NUMBER                  |
+      | item_source       | A_STRING                  |
       | share_type        | public_link               |
-      | file_source       | A_NUMBER                  |
+      | file_source       | A_STRING                  |
       | file_target       | /FOLDER                   |
       | permissions       | read,update,create,delete |
       | stime             | A_NUMBER                  |
       | token             | A_TOKEN                   |
-      | storage           | A_NUMBER                  |
+      | storage           | A_STRING                  |
       | mail_send         | 0                         |
       | uid_owner         | Alice                     |
-      | file_parent       | A_NUMBER                  |
+      | file_parent       | A_STRING                  |
       | displayname_owner | %displayname%             |
       | url               | AN_URL                    |
       | mimetype          | httpd/unix-directory      |

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -38,18 +38,18 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with group "grp1" should include
-      | id                | A_NUMBER       |
+      | id                | A_STRING       |
       | item_type         | file           |
-      | item_source       | A_NUMBER       |
+      | item_source       | A_STRING       |
       | share_type        | group          |
-      | file_source       | A_NUMBER       |
+      | file_source       | A_STRING       |
       | file_target       | /textfile0.txt |
       | permissions       | read           |
       | stime             | A_NUMBER       |
-      | storage           | A_NUMBER       |
+      | storage           | A_STRING       |
       | mail_send         | 0              |
       | uid_owner         | %username%     |
-      | file_parent       | A_NUMBER       |
+      | file_parent       | A_STRING       |
       | displayname_owner | %displayname%  |
       | mimetype          | text/plain     |
     Examples:
@@ -127,18 +127,18 @@ Feature: sharing
     When user "Brian" moves folder "/folder1/folder2" to "/moved-out/folder2" using the WebDAV API
     And user "Brian" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Brian" sharing with user "Carol" should include
-      | id                | A_NUMBER             |
+      | id                | A_STRING             |
       | item_type         | folder               |
-      | item_source       | A_NUMBER             |
+      | item_source       | A_STRING             |
       | share_type        | user                 |
-      | file_source       | A_NUMBER             |
+      | file_source       | A_STRING             |
       | file_target       | /folder2             |
       | permissions       | all                  |
       | stime             | A_NUMBER             |
-      | storage           | A_NUMBER             |
+      | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | %username%           |
-      | file_parent       | A_NUMBER             |
+      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | mimetype          | httpd/unix-directory |
     And as "Alice" folder "/folder1/folder2" should not exist
@@ -158,18 +158,18 @@ Feature: sharing
     When user "Brian" moves folder "/Alice-folder/folder2" to "/Carol-folder/folder2" using the WebDAV API
     And user "Carol" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Carol" sharing with user "Brian" should include
-      | id                | A_NUMBER             |
+      | id                | A_STRING             |
       | item_type         | folder               |
-      | item_source       | A_NUMBER             |
+      | item_source       | A_STRING             |
       | share_type        | user                 |
-      | file_source       | A_NUMBER             |
+      | file_source       | A_STRING             |
       | file_target       | /Carol-folder        |
       | permissions       | all                  |
       | stime             | A_NUMBER             |
-      | storage           | A_NUMBER             |
+      | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | %username%           |
-      | file_parent       | A_NUMBER             |
+      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | mimetype          | httpd/unix-directory |
     And as "Alice" folder "/Alice-folder/folder2" should not exist
@@ -237,13 +237,13 @@ Feature: sharing
     When user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Alice" sharing with group "grp1" should include
       | item_type         | file                |
-      | item_source       | A_NUMBER            |
+      | item_source       | A_STRING            |
       | share_type        | group               |
       | file_target       | /textfile0.txt      |
       | permissions       | read, update, share |
       | mail_send         | 0                   |
       | uid_owner         | %username%          |
-      | file_parent       | A_NUMBER            |
+      | file_parent       | A_STRING            |
       | displayname_owner | %displayname%       |
     Examples:
       | ocs_api_version | http_status_code |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -790,7 +790,7 @@ trait Sharing {
 	public function updateLastShareWithSettings($user, $body) {
 		$user = $this->getActualUsername($user);
 
-		$share_id = (string) $this->lastShareData->data[0]->id;
+		$share_id = $this->lastShareData->data[0]->id;
 
 		$this->verifyTableNodeRows(
 			$body,
@@ -929,7 +929,7 @@ trait Sharing {
 		if (($contentExpected === "ANY_VALUE")
 			|| (($contentExpected === "A_TOKEN") && (\strlen($value) === 15))
 			|| (($contentExpected === "A_NUMBER") && \is_numeric($value))
-			|| (($contentExpected === "A_STRING") && \is_string($value))
+			|| (($contentExpected === "A_STRING") && \is_string($value) && $value !== "")
 			|| (($contentExpected === "AN_URL") && $this->isAPublicLinkUrl($value))
 			|| (($field === 'remote') && (\rtrim($value, "/") === $contentExpected))
 			|| ($contentExpected === $value)
@@ -1583,7 +1583,7 @@ trait Sharing {
 	public function getLastShareIdOf($user) {
 		$user = $this->getActualUsername($user);
 		if (isset($this->lastShareData->data[0]->id)) {
-			return (int) $this->lastShareData->data[0]->id;
+			return $this->lastShareData->data[0]->id;
 		}
 
 		$this->getListOfShares($user);
@@ -2369,7 +2369,7 @@ trait Sharing {
 		$dataResponded = $this->getShares($user, $path);
 		foreach ($dataResponded as $elementResponded) {
 			if ((string) $elementResponded->name[0] === $name) {
-				return (string) $elementResponded->id[0];
+				return $elementResponded->id[0];
 			}
 		}
 		return null;


### PR DESCRIPTION
Adjust sharing test expectations to expect ids of shares and files as
string instead of int.

This aligns with the requirements from OCIS.

Partly for https://github.com/owncloud/ocis-reva/issues/252 as it blocks some tests