### PR TITLE
[10.5.0] Allow root of the external storage to be an absolute URL

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -96,8 +96,25 @@ class Storage extends DAV implements ISharedStorage {
 			$this->memcacheFactory,
 			\OC::$server->getHTTPClientService()
 		);
+		$webDavEndpoint = $discoveryManager->getWebDavEndpoint($this->remote);
+		// OCM 1.0 endpoint is absolute, OC legacy is relative. Let's check which one we have
+		$isOcmWebDavEndpoint = \preg_match('#https?://#', $webDavEndpoint) === 1;
+		if ($isOcmWebDavEndpoint) {
+			// proto is anything before ://
+			// host starts just after a proto and ends before the first slash
+			// root starts from the first slash until the end and could be empty
+			\preg_match_all(
+				'#^(?<proto>https?)://(?<host>[^/]*)(?<root>.*)$#',
+				$webDavEndpoint,
+				$matches
+			);
+			$this->secure = $matches['proto'][0] === 'https';
+			$this->host = $matches['host'][0];
+			$this->root = isset($matches['root'][0]) ? $matches['root'][0] : '/';
+		} else {
+			$this->root = \rtrim($this->root, '/') . $webDavEndpoint;
+		}
 
-		$this->root = \rtrim($this->root, '/') . $discoveryManager->getWebDavEndpoint($this->remote);
 		if (!$this->root || $this->root[0] !== '/') {
 			$this->root = '/' . $this->root;
 		}


### PR DESCRIPTION
## Description
Webdav endpoint will become an absolute URL after the proposal https://github.com/cs3org/OCM-API/pull/37 is merged  
The storage expects a relative Webdav endpoint URL at the moment.

This pull request makes the storage compatible with both absolute and relative Webdav endpoint URLs

## Motivation and Context
This will make 10.5.0 forward compatible after https://github.com/cs3org/OCM-API/pull/37 is merged  

## How Has This Been Tested?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
