### PR TITLE
[10.5.0]  Allow root of the external storage to be an absolute URL

### DIFF
--- a/apps/files_sharing/tests/External/StorageTest.php
+++ b/apps/files_sharing/tests/External/StorageTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_Sharing\Tests\External;
+
+use OCA\Files_Sharing\External\Manager;
+use OCA\Files_Sharing\External\Storage;
+use OCP\ICertificateManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+/**
+ * Class StorageTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Sharing\Tests\External
+ */
+class StorageTest extends TestCase {
+	/** @var Manager | MockObject */
+	private $manager;
+
+	/** @var ICertificateManager|MockObject  */
+	protected $certManager;
+
+	/** @var Storage  */
+	protected $storage;
+
+	public function endpointDataProvider() {
+		return [
+			['localhost', false],
+			['localhost/', false],
+			['localhost/url', false],
+			['http://localhost', true],
+			['http://localhost/', true],
+			['http://localhost/url', true],
+			['https://localhost', true],
+			['https://localhost/', true],
+			['https://localhost/url', true],
+		];
+	}
+
+	/**
+	 * @dataProvider endpointDataProvider
+	 * @param string $endpoint
+	 * @param bool $isOcm
+	 */
+	public function testIsOcmEndpoint($endpoint, $isOcm) {
+		$this->storage = $this->createMock(Storage::class);
+		$isOcmEndpoint = $this->invokePrivate($this->storage, 'isOcmWebDavEndpoint', [$endpoint]);
+		$this->assertEquals($isOcm, $isOcmEndpoint);
+	}
+
+	public function ocmUrlDataProvider() {
+		return [
+			['http://localhost', false, 'localhost', ''],
+			['http://localhost/', false, 'localhost', '/'],
+			['http://localhost/url', false, 'localhost', '/url'],
+			['https://localhost', true, 'localhost', ''],
+			['https://localhost/', true, 'localhost', '/'],
+			['https://localhost/url', true, 'localhost', '/url'],
+		];
+	}
+
+	/**
+	 * @dataProvider ocmUrlDataProvider
+	 * @param string $endpoint
+	 * @param bool $secure
+	 * @param string $host
+	 * @param string $root
+	 */
+	public function testParseOcmUrl($endpoint, $secure, $host, $root) {
+		$this->storage = $this->createMock(Storage::class);
+		$ocmParams = $this->invokePrivate($this->storage, 'parseOcmUrl', [$endpoint]);
+		$this->assertEquals($secure, $ocmParams['secure']);
+		$this->assertEquals($host, $ocmParams['host']);
+		$this->assertEquals($root, $ocmParams['root']);
+	}
+}


### PR DESCRIPTION
Resubmit of https://github.com/owncloud/core/pull/37621 breaking the branch protection curse

## Description
Webdav endpoint will become an absolute URL after the proposal https://github.com/cs3org/OCM-API/pull/37 is merged  
The storage expects a relative Webdav endpoint URL at the moment.

This pull request makes the storage compatible with both absolute and relative Webdav endpoint URLs

## Motivation and Context
This will make 10.5.0 forward compatible after https://github.com/cs3org/OCM-API/pull/37 is merged  

## How Has This Been Tested?
A. Unit tests. 
B.
1. Install 1 oc instance (1) with patched `apps/federatedfilesharing/lib/Controller/OcmController.php` as per  https://github.com/owncloud/core/pull/36043/files
2. Install OC instance (2) with this patch
3. make sure that is possible to browse federated shares from (1) to (2) and from (2) to (1)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
