### PR TITLE
[Tests-Only] Adjust updateShare.feature:179 for reva changes

### DIFF
--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -188,7 +188,29 @@ Feature: sharing
     And user "Carol" has shared folder "/Carol-folder" with user "Brian" with permissions "all"
     When user "Brian" moves folder "/Alice-folder/folder2" to "/Carol-folder/folder2" using the WebDAV API
     And user "Carol" gets the info of the last share using the sharing API
-    Then the OCS status message should be "Only GET, POST and PUT are allowed"
+    # Note: in the following fields, file_parent has been removed because OCIS does not report that
+    Then the fields of the last response to user "Carol" sharing with user "Brian" should include
+      | id                | A_STRING             |
+      | item_type         | folder               |
+      | item_source       | A_STRING             |
+      | share_type        | user                 |
+      | file_source       | A_STRING             |
+      | file_target       | /Carol-folder        |
+      | permissions       | all                  |
+      | stime             | A_NUMBER             |
+      | storage           | A_STRING             |
+      | mail_send         | 0                    |
+      | uid_owner         | %username%           |
+      | displayname_owner | %displayname%        |
+      | mimetype          | httpd/unix-directory |
+    # Really folder2 should be gone from Alice-folder and be found in Carol-folder
+    # like in these 2 suggested steps:
+    # And as "Alice" folder "/Alice-folder/folder2" should not exist
+    # And as "Carol" folder "/Carol-folder/folder2" should exist
+    #
+    # But this happens on OCIS:
+    And as "Alice" folder "/Alice-folder/folder2" should exist
+    And as "Carol" folder "/Carol-folder/folder2" should not exist
 
   @skipOnOcis @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: Increasing permissions is allowed for owner


### PR DESCRIPTION
## Description
OCIS Reva behavior has changed so that scenario `updateShare.feature:179` behaves more like its OC10 version `updateShare.feature:148`

This PR adjusts the scenario so that it will pass on the latest OCIS Reva. See https://github.com/cs3org/reva/pull/901 for an example of this passing: https://cloud.drone.io/cs3org/reva/1684/4/6

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
