### PR TITLE
return HTTP 404 for upload attempt to non-existing public folders

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/PublicFilesPlugin.php
+++ b/apps/dav/lib/Files/PublicFiles/PublicFilesPlugin.php
@@ -26,6 +26,7 @@ use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
 use Sabre\DAV\Exception\InsufficientStorage;
+use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
@@ -180,7 +181,7 @@ class PublicFilesPlugin extends ServerPlugin {
 	 * @param bool $modified modified
 	 * @return bool
 	 * @throws InsufficientStorage
-	 * @throws NotFoundException
+	 * @throws NotFound
 	 */
 	public function handleBeforeCreateFile($uri, $data, $parent, $modified) {
 		$share = null;
@@ -193,7 +194,11 @@ class PublicFilesPlugin extends ServerPlugin {
 		if ($share === null) {
 			return;
 		}
-		$node = $share->getNode();
+		try {
+			$node = $share->getNode();
+		} catch (NotFoundException $e) {
+			throw new NotFound();
+		}
 		if (!$node instanceof Folder) {
 			return;
 		}

--- a/apps/dav/tests/unit/Files/PublicFiles/PublicFilesPluginTest.php
+++ b/apps/dav/tests/unit/Files/PublicFiles/PublicFilesPluginTest.php
@@ -23,7 +23,10 @@ namespace OCA\DAV\Tests\Unit\Files\PublicFiles;
 
 use OCA\DAV\Files\PublicFiles\PublicFilesPlugin;
 use OCA\DAV\Files\PublicFiles\PublicSharedRootNode;
+use OCA\DAV\Files\PublicFiles\SharedFolder;
+use OCP\Files\NotFoundException;
 use OCP\Share\IShare;
+use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
 use Sabre\DAV\Xml\Property\GetLastModified;
@@ -72,5 +75,22 @@ class PublicFilesPluginTest extends TestCase {
 			['getNodeType', 'file', PublicFilesPlugin::PUBLIC_LINK_ITEM_TYPE],
 			['getShareTime', new GetLastModified(123456), PublicFilesPlugin::PUBLIC_LINK_SHARE_DATETIME, 123456],
 		];
+	}
+
+	public function testHandleBeforeCreateFile() {
+		$this->expectException(NotFound::class);
+
+		$share = $this->createMock(IShare::class);
+		$share->expects(self::once())
+			->method('getNode')
+			->willThrowException(new NotFoundException());
+
+		$parent = $this->createMock(SharedFolder::class);
+		$parent->expects(self::once())
+			->method('getShare')
+			->willReturn($share);
+
+		$plugin = new PublicFilesPlugin();
+		$plugin->handleBeforeCreateFile(null, null, $parent, true);
 	}
 }

--- a/changelog/unreleased/37625
+++ b/changelog/unreleased/37625
@@ -1,0 +1,6 @@
+Bugfix: Return HTTP 404 for upload attempt to non-existing public folders
+
+Public files WebDAV API has been fixed to return HTTP status code 404 for upload attempt to non-existing public folders.
+
+https://github.com/owncloud/core/pull/37625
+https://github.com/owncloud/core/issues/36055

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -47,7 +47,7 @@ Feature: upload to a public link share
       | old      |
       | new      |
 
-  @issue-36055 @skipOnOcV10 @skipOnOcis @issue-ocis-reva-290
+  @skipOnOcis @issue-ocis-reva-290
   Scenario Outline: Uploading file to a public upload-only share using new public API that was deleted does not work
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share with settings
@@ -61,7 +61,7 @@ Feature: upload to a public link share
       | old      |
       | new      |
 
-  @issue-36055
+  @skipOnOcV10 @issue-ocis-reva-290
   #After fixing the issue delete this Scenario and use the commented-out step in the above scenario
   Scenario: Uploading file to a public upload-only share that was deleted does not work
     Given the administrator has enabled DAV tech_preview


### PR DESCRIPTION
## Description
`sabre/dav` is using it is own NotFound exception to return the correct HTTP status code. 
Therefore,  to return HTTP 404 for upload attempt to non-existing public folders, `\OCP\Files\NotFoundException` caught in related sabre plugin and changed with `\Sabre\DAV\Exception\NotFound`.

## Related Issue
- Fixes #36055 

## How Has This Been Tested?
Tested manually, also failing acceptance tests has been activated.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
