### PR TITLE
[Tests-Only] Remove file_parent share response attribute from accceptance tests

### DIFF
--- a/tests/acceptance/features/apiFederation1/federated.feature
+++ b/tests/acceptance/features/apiFederation1/federated.feature
@@ -25,7 +25,6 @@ Feature: federated
       | storage                | A_STRING          |
       | mail_send              | 0                 |
       | uid_owner              | %username%        |
-      | file_parent            | A_STRING          |
       | displayname_owner      | %displayname%     |
       | share_with             | %username%@REMOTE |
       | share_with_displayname | %username%@REMOTE |
@@ -52,7 +51,6 @@ Feature: federated
       | storage                | A_STRING          |
       | mail_send              | 0                 |
       | uid_owner              | %username%        |
-      | file_parent            | A_STRING          |
       | displayname_owner      | %displayname%     |
       | share_with             | %username%@LOCAL  |
       | share_with_displayname | %username%@LOCAL  |
@@ -184,7 +182,6 @@ Feature: federated
       | storage                | A_STRING           |
       | mail_send              | 0                  |
       | uid_owner              | %username%         |
-      | file_parent            | A_STRING           |
       | displayname_owner      | %displayname%      |
       | share_with             | %username%         |
       | share_with_displayname | %displayname%      |

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -345,7 +345,6 @@ Feature: accept/decline shares coming from internal users
       | storage                | A_STRING                   |
       | item_source            | A_STRING                   |
       | file_source            | A_STRING                   |
-      | file_parent            | A_STRING                   |
       | file_target            | /textfile0 (2).txt         |
       | share_with             | %username%                 |
       | share_with_displayname | %displayname%              |
@@ -387,7 +386,6 @@ Feature: accept/decline shares coming from internal users
       | storage                | A_STRING                                      |
       | item_source            | A_STRING                                      |
       | file_source            | A_STRING                                      |
-      | file_parent            | A_STRING                                      |
       | file_target            | <top_folder>/<received_textfile_name>         |
       | share_with             | %username%                                    |
       | share_with_displayname | %displayname%                                 |

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -115,7 +115,6 @@ Feature: sharing
       | storage                | A_STRING           |
       | mail_send              | 0                  |
       | uid_owner              | %username%         |
-      | file_parent            | A_STRING           |
       | share_with_displayname | %displayname%      |
       | displayname_owner      | %displayname%      |
       | mimetype               | text/plain         |

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -29,7 +29,6 @@ Feature: update a public link share
       | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | Alice                |
-      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -78,7 +77,6 @@ Feature: update a public link share
       | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | Alice                |
-      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -109,7 +107,6 @@ Feature: update a public link share
       | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | Alice                |
-      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -140,7 +137,6 @@ Feature: update a public link share
       | storage           | A_STRING                  |
       | mail_send         | 0                         |
       | uid_owner         | Alice                     |
-      | file_parent       | A_STRING                  |
       | displayname_owner | %displayname%             |
       | url               | AN_URL                    |
       | mimetype          | httpd/unix-directory      |
@@ -171,7 +167,6 @@ Feature: update a public link share
       | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | Alice                |
-      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -202,7 +197,6 @@ Feature: update a public link share
       | storage           | A_STRING                  |
       | mail_send         | 0                         |
       | uid_owner         | Alice                     |
-      | file_parent       | A_STRING                  |
       | displayname_owner | %displayname%             |
       | url               | AN_URL                    |
       | mimetype          | httpd/unix-directory      |

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -49,7 +49,6 @@ Feature: sharing
       | storage           | A_STRING       |
       | mail_send         | 0              |
       | uid_owner         | %username%     |
-      | file_parent       | A_STRING       |
       | displayname_owner | %displayname%  |
       | mimetype          | text/plain     |
     Examples:
@@ -138,7 +137,6 @@ Feature: sharing
       | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | %username%           |
-      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | mimetype          | httpd/unix-directory |
     And as "Alice" folder "/folder1/folder2" should not exist
@@ -169,7 +167,6 @@ Feature: sharing
       | storage           | A_STRING             |
       | mail_send         | 0                    |
       | uid_owner         | %username%           |
-      | file_parent       | A_STRING             |
       | displayname_owner | %displayname%        |
       | mimetype          | httpd/unix-directory |
     And as "Alice" folder "/Alice-folder/folder2" should not exist
@@ -265,7 +262,6 @@ Feature: sharing
       | permissions       | read, update, share |
       | mail_send         | 0                   |
       | uid_owner         | %username%          |
-      | file_parent       | A_STRING            |
       | displayname_owner | %displayname%       |
     Examples:
       | ocs_api_version | http_status_code |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -55,6 +55,8 @@ trait Sharing {
 	private $localLastShareTime = null;
 
 	/**
+	 * Defines the fields that can be provided in a share request.
+	 *
 	 * @var array
 	 */
 	private $shareFields = [
@@ -63,13 +65,19 @@ trait Sharing {
 	];
 
 	/**
-	 * @var array
+	 * Defines the fields that are known and can be tested in a share response.
+	 * Note that ownCloud10 also provides file_parent in responses.
+	 * file_parent is not provided by OCIS/reva.
+	 * There are no known clients that use file_parent.
+	 * The acceptance tests do not test for file_parent.
+	 *
+	 * @var array fields that are possible in a share response
 	 */
 	private $shareResponseFields = [
 		'id', 'share_type', 'uid_owner', 'displayname_owner', 'stime', 'parent',
 		'expiration', 'token', 'uid_file_owner', 'displayname_file_owner', 'path',
 		'item_type', 'mimetype', 'storage_id', 'storage', 'item_source',
-		'file_source', 'file_parent', 'file_target', 'name', 'url', 'mail_send',
+		'file_source', 'file_target', 'name', 'url', 'mail_send',
 		'attributes', 'permissions', 'share_with', 'share_with_displayname', 'share_with_additional_info'
 	];
 


### PR DESCRIPTION
## Description
See discussion in the linked issue.

`file_parent` is not provided in share responses by OCIS/reva. It is not being used by clients of ownCloud10. So remove it from the acceptance tests. This will make the test scenarios compatible with both ownCloud10 and OCIS/reva.

## Related Issue
- Fixes https://github.com/owncloud/ocis-reva/issues/326

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
