### PR TITLE
[Tests-Only] enable more public link share tests for get share and edit share

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243 @issue-ocis-reva-249
+@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41 @issue-ocis-reva-243 @issue-ocis-reva-249 @issue-ocis-reva-333
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -302,7 +302,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-294
+  @smokeTest @issue-ocis-reva-294
   Scenario Outline: Getting the share information of public link share from the OCS API does not expose sensitive information
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings

--- a/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
@@ -1,4 +1,4 @@
-@api @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-49 @issue-ocis-reva-288 @issue-ocis-reva-252
+@api @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-49 @issue-ocis-reva-288 @issue-ocis-reva-252
 Feature: multilinksharing
 
   Background:
@@ -176,7 +176,8 @@ Feature: multilinksharing
       | path           | permissions | name        |
       | /textfile0.txt | 1           | sharedlink1 |
       | /textfile0.txt | 1           | sharedlink2 |
-
+	
+  @skipOnOcis @issue-ocis-reva-335
   Scenario: Renaming a folder doesn't remove its public shares
     Given using OCS API version "1"
     And user "Alice" has created a public link share with settings

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -1,11 +1,11 @@
-@api @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @issue-ocis-reva-252
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-252
 Feature: update a public link share
 
   Background:
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @smokeTest
+  @smokeTest @skipOnOcis @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -37,7 +37,8 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Creating a new public link share with password and adding an expiration date
+  @skipOnOcis
+  Scenario Outline: Creating a new public link share with password and adding an expiration date using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -48,12 +49,28 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "Random data"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Creating a new public link share with password and adding an expiration date using the new public API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path     | randomfile.txt |
+      | password | %public%       |
+    And user "Alice" updates the last share using the sharing API with
+      | expireDate | +3 days |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -85,6 +102,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its password and getting its info
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -115,6 +133,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its permissions and getting its info
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -145,36 +164,38 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its permissions to view download and upload and getting its info
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" updates the last share using the sharing API with
-      | permissions | read,update,create |
+      | permissions | read,update,create,delete |
     And user "Alice" gets the info of the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | id                | A_STRING             |
-      | item_type         | folder               |
-      | item_source       | A_STRING             |
-      | share_type        | public_link          |
-      | file_source       | A_STRING             |
-      | file_target       | /FOLDER              |
-      | permissions       | read,update,create   |
-      | stime             | A_NUMBER             |
-      | token             | A_TOKEN              |
-      | storage           | A_STRING             |
-      | mail_send         | 0                    |
-      | uid_owner         | Alice                |
-      | displayname_owner | %displayname%        |
-      | url               | AN_URL               |
-      | mimetype          | httpd/unix-directory |
+      | id                | A_STRING                  |
+      | item_type         | folder                    |
+      | item_source       | A_STRING                  |
+      | share_type        | public_link               |
+      | file_source       | A_STRING                  |
+      | file_target       | /FOLDER                   |
+      | permissions       | read,update,create,delete |
+      | stime             | A_NUMBER                  |
+      | token             | A_TOKEN                   |
+      | storage           | A_STRING                  |
+      | mail_send         | 0                         |
+      | uid_owner         | Alice                     |
+      | displayname_owner | %displayname%             |
+      | url               | AN_URL                    |
+      | mimetype          | httpd/unix-directory      |
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcis @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating publicUpload option and getting its info
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -205,7 +226,8 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
+  @skipOnOcis
+  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
@@ -218,13 +240,32 @@ Feature: update a public link share
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+  @skipOnOcis @issue-ocis-reva-11
+  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the new public API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/test"
+    And user "Alice" has shared folder "/test" with user "Brian" with permissions "share,read"
+    And user "Brian" has created a public link share with settings
+      | path         | /test |
+      | publicUpload | false |
+    When user "Brian" updates the last share using the sharing API with
+      | publicUpload | true |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
 
-  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
+  @skipOnOcis
+  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
@@ -237,13 +278,32 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And uploading a file should work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @skipOnOcis @issue-ocis-reva-11
+  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the new public API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/test"
+    And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
+    And user "Brian" has created a public link share with settings
+      | path         | /test |
+      | publicUpload | false |
+    When user "Brian" updates the last share using the sharing API with
+      | publicUpload | true |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
     And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed
+  @skipOnOcis
+  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
@@ -256,13 +316,32 @@ Feature: update a public link share
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+  @skipOnOcis @issue-ocis-reva-11
+  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the new public API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/test"
+    And user "Alice" has shared folder "/test" with user "Brian" with permissions "share,read"
+    And user "Brian" has created a public link share with settings
+      | path        | /test |
+      | permissions | read  |
+    When user "Brian" updates the last share using the sharing API with
+      | permissions | read,update,create,delete |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
 
-  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions
+  @skipOnOcis
+  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
@@ -275,27 +354,66 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And uploading a file should work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @skipOnOcis @issue-ocis-reva-11
+  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the new public API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/test"
+    And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
+    And user "Brian" has created a public link share with settings
+      | path        | /test |
+      | permissions | read  |
+    When user "Brian" updates the last share using the sharing API with
+      | permissions | read,update,create,delete |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
     And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Updating share permissions from change to read/update/create restricts public from deleting files
+  @skipOnOcis
+  Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the old public API
     Given the administrator has enabled DAV tech_preview
     And using OCS API version "<ocs_api_version>"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     When user "Alice" updates the last share using the sharing API with
-      | permissions | read,update,create |
+      | permissions | read |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     When user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Alice" should include
-      | permissions | read,update,create |
+      | permissions | read |
     When the public deletes file "CHILD/child.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
+    And as "Alice" file "PARENT/CHILD/child.txt" should exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @skipOnOcis @issue-ocis-reva-292
+  Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the new public API
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When user "Alice" updates the last share using the sharing API with
+      | permissions | read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    When user "Alice" gets the info of the last share using the sharing API
+    Then the fields of the last response to user "Alice" should include
+      | permissions | read |
     When the public deletes file "CHILD/child.txt" from the last public share using the new public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/CHILD/child.txt" should exist
@@ -304,12 +422,13 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Updating share permissions from read/update/create to change allows public to delete files
+  @skipOnOcis
+  Scenario Outline: Updating share permissions from read to change allows public to delete files using the old public API
     Given the administrator has enabled DAV tech_preview
     And using OCS API version "<ocs_api_version>"
     And user "Alice" has created a public link share with settings
-      | path        | /PARENT            |
-      | permissions | read,update,create |
+      | path        | /PARENT |
+      | permissions | read    |
     When user "Alice" updates the last share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "<ocs_status_code>"
@@ -320,6 +439,30 @@ Feature: update a public link share
     When the public deletes file "CHILD/child.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/CHILD/child.txt" should not exist
+    When the public deletes file "parent.txt" from the last public share using the old public WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "PARENT/parent.txt" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: Updating share permissions from read to change allows public to delete files using the new public API
+    Given the administrator has enabled DAV tech_preview
+    And using OCS API version "<ocs_api_version>"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    When user "Alice" updates the last share using the sharing API with
+      | permissions | read,update,create,delete |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    When user "Alice" gets the info of the last share using the sharing API
+    Then the fields of the last response to user "Alice" should include
+      | permissions | read,update,create,delete |
+    When the public deletes file "CHILD/child.txt" from the last public share using the new public WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "PARENT/CHILD/child.txt" should not exist
     When the public deletes file "parent.txt" from the last public share using the new public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
@@ -327,3 +470,4 @@ Feature: update a public link share
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+


### PR DESCRIPTION
Enable more sharing tests

- [x] REQUIRES https://github.com/cs3org/reva/pull/930 for most to pass

### Enabled tests

- [x] expiration date https://github.com/owncloud/ocis-reva/issues/288
- [x] password value https://github.com/owncloud/ocis-reva/issues/294
- [x] edit public link https://github.com/owncloud/ocis-reva/issues/252, but most tests blocked by owncloud/ocis-reva#336
- [x] get share by id https://github.com/owncloud/ocis-reva/issues/249 => all existing tests **fail** but because of other tags in place for user shares, there are no public link share tests tagged with this
- [x] another get share ?? https://github.com/owncloud/ocis-reva/issues/21 => all tests **fail**, maybe another time

### Issues found
- raised https://github.com/owncloud/ocis-reva/issues/335 related to moving a resource that has shares attached
- legacy permission 7 inconsistently handled in OC 10: https://github.com/owncloud/core/issues/37635
- URL field in response is truncated: https://github.com/owncloud/ocis-reva/issues/336