### PR TITLE
Support signed urls

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -39,6 +39,7 @@ $authBackend = new Auth(
 	\OC::$server->getRequest(),
 	\OC::$server->getTwoFactorAuthManager(),
 	\OC::$server->getAccountModuleManager(),
+	\OC::$server->getConfig(),
 	'principals/'
 );
 $principalBackend = new Principal(

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -39,6 +39,7 @@ $authBackend = new Auth(
 	\OC::$server->getRequest(),
 	\OC::$server->getTwoFactorAuthManager(),
 	\OC::$server->getAccountModuleManager(),
+	\OC::$server->getConfig(),
 	'principals/'
 );
 $principalBackend = new Principal(

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -48,6 +48,7 @@ $authBackend = new \OCA\DAV\Connector\Sabre\Auth(
 	\OC::$server->getRequest(),
 	\OC::$server->getTwoFactorAuthManager(),
 	\OC::$server->getAccountModuleManager(),
+	\OC::$server->getConfig(),
 	'principals/'
 );
 $requestUri = \OC::$server->getRequest()->getRequestUri();

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -119,7 +119,8 @@ class Server {
 			OC::$server->getUserSession(),
 			OC::$server->getRequest(),
 			OC::$server->getTwoFactorAuthManager(),
-			OC::$server->getAccountModuleManager()
+			OC::$server->getAccountModuleManager(),
+			\OC::$server->getConfig()
 		);
 
 		// Set URL explicitly due to reverse-proxy situations

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -33,6 +33,7 @@ use OC\Authentication\AccountModule\Manager as AccountModuleManager;
 use OC\User\LoginException;
 use OC\User\Session;
 use OCA\DAV\Connector\Sabre\Auth;
+use OCP\IConfig;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
@@ -61,6 +62,10 @@ class AuthTest extends TestCase {
 	private $twoFactorManager;
 	/** @var AccountModuleManager | MockObject */
 	private $accountModuleManager;
+	/**
+	 * @var IConfig|MockObject
+	 */
+	private $config;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -69,12 +74,14 @@ class AuthTest extends TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->twoFactorManager = $this->createMock(Manager::class);
 		$this->accountModuleManager = $this->createMock(AccountModuleManager::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->auth = new Auth(
 			$this->session,
 			$this->userSession,
 			$this->request,
 			$this->twoFactorManager,
-			$this->accountModuleManager
+			$this->accountModuleManager,
+			$this->config
 		);
 	}
 

--- a/core/Command/Security/CreateSignKey.php
+++ b/core/Command/Security/CreateSignKey.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Security;
+
+use OC\Core\Command\Base;
+use OCP\IConfig;
+use OCP\IUserManager;
+use OCP\Security\ISecureRandom;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class CreateSignKey extends Base {
+
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+	/**
+	 * @var ISecureRandom
+	 */
+	private $secureRandom;
+
+	public function __construct(IUserManager $userManager, IConfig $config, ISecureRandom $secureRandom) {
+		parent::__construct();
+		$this->userManager = $userManager;
+		$this->config = $config;
+		$this->secureRandom = $secureRandom;
+	}
+
+	protected function configure() {
+		$this
+			->setName('security:sign-key:create')
+			->setDescription('Create and recreate a users signing key for signed urls')
+			->addArgument(
+				'user',
+				InputArgument::REQUIRED,
+				'The is of the user'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$uid = $input->getArgument('user');
+		$user = $this->userManager->get($uid);
+		if ($user === null) {
+			$output->write('User unknown');
+			return 1;
+		}
+		$signingKey = $this->config->getUserValue($uid, 'core', 'signing-key', null);
+		if ($signingKey !== null) {
+			$output->writeln('This user already has a signing key. Recreating the key will invalidate all existing signed urls.');
+
+			$helper = $this->getHelper('question');
+			$question = new ConfirmationQuestion('Shall we re-create the signing key? (y/N)', false);
+
+			if (!$helper->ask($input, $output, $question)) {
+				return 0;
+			}
+		}
+		$newSigningKey = $this->secureRandom->generate(64);
+		$this->config->setUserValue($uid, 'core', 'signing-key', $newSigningKey, $signingKey);
+		return 1;
+	}
+}

--- a/core/Controller/CloudController.php
+++ b/core/Controller/CloudController.php
@@ -71,4 +71,25 @@ class CloudController extends OCSController {
 		];
 		return ['data' => $data];
 	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @CORS
+	 *
+	 * @return array
+	 * @throws \OCP\PreConditionNotMetException
+	 */
+	public function getSigningKey(): array {
+		$userId = \OC_User::getUser();
+		$signingKey = \OC::$server->getConfig()->getUserValue($userId, 'core', 'signing-key', null);
+		if ($signingKey === null) {
+			$signingKey = \OC::$server->getSecureRandom()->generate(64);
+			\OC::$server->getConfig()->setUserValue($userId, 'core', 'signing-key', $signingKey, null);
+		}
+		return ['data' => [
+			'user' => $userId,
+			'signing-key' => $signingKey
+		]];
+	}
 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -62,7 +62,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\App\Enable(\OC::$server->getAppManager()));
 	$application->add(new OC\Core\Command\App\GetPath());
 	$application->add(new OC\Core\Command\App\ListApps(\OC::$server->getAppManager()));
-	
+
 	$application->add(new OC\Core\Command\TwoFactorAuth\Enable(
 		\OC::$server->getTwoFactorAuthManager(), \OC::$server->getUserManager()
 	));
@@ -177,6 +177,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Security\ImportCertificate(\OC::$server->getCertificateManager(null)));
 	$application->add(new OC\Core\Command\Security\RemoveCertificate(\OC::$server->getCertificateManager(null)));
 	$application->add(new OC\Core\Command\Security\ListRoutes(\OC::$server->getRouter()));
+	$application->add(new OC\Core\Command\Security\CreateSignKey(\OC::$server->getUserManager(), \OC::$server->getConfig(), \OC::$server->getSecureRandom()));
 	$application->add(new OC\Core\Command\System\Cron(\OC::$server->getJobList(), \OC::$server->getConfig(), \OC::$server->getLogger(), \OC::$server->getTempManager()));
 } else {
 	$application->add(new OC\Core\Command\Maintenance\Install(\OC::$server->getConfig()));

--- a/core/routes.php
+++ b/core/routes.php
@@ -59,6 +59,7 @@ $application->registerRoutes($this, [
 	'ocs' => [
 		['root' => '/cloud', 'name' => 'Cloud#getCapabilities', 'url' => '/capabilities', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Cloud#getCurrentUser', 'url' => '/user', 'verb' => 'GET'],
+		['root' => '/cloud', 'name' => 'Cloud#getSigningKey', 'url' => '/user/signing-key', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Roles#getRoles', 'url' => '/roles', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'UserSync#syncUser', 'url' => '/user-sync/{userId}', 'verb' => 'POST'],
 	]

--- a/lib/private/OCS/CoreCapabilities.php
+++ b/lib/private/OCS/CoreCapabilities.php
@@ -54,6 +54,7 @@ class CoreCapabilities implements ICapability {
 				'pollinterval' => $this->config->getSystemValue('pollinterval', 60),
 				'webdav-root' => $this->config->getSystemValue('webdav-root', 'remote.php/webdav'),
 				'status' => Util::getStatusInfo(true),
+				'support-url-signing' => true,
 			]
 		];
 	}

--- a/lib/private/Security/SignedUrl/Verifier.php
+++ b/lib/private/Security/SignedUrl/Verifier.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Security\SignedUrl;
+
+use OCP\IConfig;
+use Sabre\HTTP\RequestInterface;
+
+class Verifier {
+
+	/**
+	 * @var RequestInterface
+	 */
+	private $request;
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+	/**
+	 * @var \DateTime|null
+	 */
+	private $now;
+
+	public function __construct(RequestInterface $request, IConfig $config, \DateTime $now = null) {
+		$this->request = $request;
+		$this->config = $config;
+		$this->now = $now ?? new \DateTime();
+	}
+
+	public function isSignedRequest(): bool {
+		$params = $this->getQueryParameters();
+		return isset($params['OC-Signature']);
+	}
+
+	public function signedRequestIsValid(): bool {
+		$params = $this->getQueryParameters();
+		if (!isset($params['OC-Signature'], $params['OC-Credential'], $params['OC-Date'], $params['OC-Expires'], $params['OC-Verb'])) {
+			return false;
+		}
+		$urlSignature = $params['OC-Signature'];
+		$urlCredential = $params['OC-Credential'];
+		$urlDate = $params['OC-Date'];
+		$urlExpires = $params['OC-Expires'];
+		$urlVerb = $params['OC-Verb'];
+
+		unset($params['OC-Signature']);
+
+		$qp = \http_build_query($params);
+		$url =  \Sabre\Uri\parse($this->getAbsoluteUrl());
+		$url['query'] = $qp;
+		$url = \Sabre\Uri\build($url);
+
+		$signingKey = $this->config->getUserValue($urlCredential, 'core', 'signing-key');
+
+		$hash = \hash_pbkdf2("sha512", $url, $signingKey, 10000, 64, false);
+		if ($hash !== $urlSignature) {
+			return false;
+		}
+		if (\strtoupper($this->getMethod()) !== \strtoupper($urlVerb)) {
+			return false;
+		}
+		$date = new \DateTime($urlDate);
+		$date->add(new \DateInterval("PT${urlExpires}S"));
+		return !($date < $this->now);
+	}
+
+	private function getQueryParameters(): array {
+		return $this->request->getQueryParameters();
+	}
+
+	public function getUrlCredential(): string {
+		$params = $this->getQueryParameters();
+		if (!isset($params['OC-Credential'])) {
+			throw new \LogicException('OC-Credential not set');
+		}
+
+		return $params['OC-Credential'];
+	}
+
+	private function getAbsoluteUrl(): string {
+		return $this->request->getAbsoluteUrl();
+	}
+
+	private function getMethod(): string {
+		return $this->request->getMethod();
+	}
+}

--- a/tests/lib/Security/SignedUrl/VerifierTest.php
+++ b/tests/lib/Security/SignedUrl/VerifierTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Security\SignedUrl;
+
+use OC\Security\SignedUrl\Verifier;
+use OCP\IConfig;
+use Sabre\HTTP\Request;
+use Test\TestCase;
+
+class VerifierTest extends TestCase {
+
+	/**
+	 * @dataProvider providesUrls
+	 * @param bool $isSignedUrl
+	 * @param bool $isUrlValid
+	 * @param string $method
+	 * @param string $url
+	 */
+	public function testSignedUrl(bool $isSignedUrl, bool $isUrlValid, string $method, string $url): void {
+		$r = new Request($method, $url);
+		$r->setAbsoluteUrl($url);
+		$config = $this->createMock(IConfig::class);
+		$config->method('getUserValue')->willReturn('1234567890');
+		$v = new Verifier($r, $config, new \DateTime('2019-05-14T11:01:58.135Z', null));
+		if ($isSignedUrl) {
+			$this->assertTrue($v->isSignedRequest());
+			$this->assertEquals('alice', $v->getUrlCredential());
+			$this->assertEquals($isUrlValid, $v->signedRequestIsValid());
+		} else {
+			$this->assertFalse($v->isSignedRequest());
+		}
+	}
+
+	public function providesUrls(): array {
+		return [
+			'valid url' => [true, true, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
+			'no signature' => [false, false, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET'],
+			'wrong method' => [true, false, 'post', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
+			'invalid signature' => [true, false, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b'],
+		];
+	}
+}


### PR DESCRIPTION
## Description
- OCS API /cloud/user/signing-key to get the user's key for url signing
- capability to state that signed urls are supported
- allow signed url access for webdav endpoints



## Related Issue
- Refs https://github.com/owncloud/enterprise/issues/3912

## How Has This Been Tested?
- https://github.com/owncloud/owncloud-sdk/pull/504

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
