### PR TITLE
[Tests-Only] skip on old oC10 test fixed in PR 37625

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -47,7 +47,7 @@ Feature: upload to a public link share
       | old      |
       | new      |
 
-  @skipOnOcis @issue-ocis-reva-290
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcis @issue-ocis-reva-290
   Scenario Outline: Uploading file to a public upload-only share using new public API that was deleted does not work
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share with settings


### PR DESCRIPTION
## Description
PR #37625 fixed the return status for accessing a public link that has been deleted. The fixed code only applies to ownCloud 10.5.0 onwards. Skip the test scenario on older ownCloud server version.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
