### PR TITLE
[tests-only] test successfully move folder

### DIFF
--- a/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
@@ -83,6 +83,21 @@ Feature: move (rename) folder
       | old         |
       | new         |
 
+  Scenario Outline: Move a folder into an other one
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/testshare"
+    And user "Alice" has created folder "/an-other-folder"
+    When user "Alice" moves folder "/testshare" to "/an-other-folder/testshare" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "Alice" should not see the following elements
+      | /testshare/ |
+    And user "Alice" should see the following elements
+      | /an-other-folder/testshare/ |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   Scenario Outline: Move a folder into a not existing one
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/testshare"


### PR DESCRIPTION
## Description
Following up a problem that includes moving a folder I could not find a test that moves a folder inside on an other successfully, so I added it

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://github.com/owncloud/ocis/pull/359
https://github.com/owncloud/ocis-reva/pull/337


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
