### PR TITLE
When locking a resource and no owner is given via the http request th…

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -122,8 +122,8 @@ class ServerFactory {
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
 
-		$fileLocksBackend = new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess);
-		$server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, function ($uri) use ($isPublicAccess) {
+		$fileLocksBackend = new FileLocksBackend($server->tree, true, $this->timeFactory, $this->userSession, $isPublicAccess);
+		$server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, static function ($uri) use ($isPublicAccess) {
 			return $isPublicAccess;
 		}));
 

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -158,8 +158,8 @@ class Server {
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 		$this->server->addPlugin(new LockPlugin());
 
-		$fileLocksBackend = new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory());
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, function ($uri) {
+		$fileLocksBackend = new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory(), OC::$server->getUserSession());
+		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, static function ($uri) {
 			if (\strpos($uri, "public-files/") === 0) {
 				return true;
 			}

--- a/changelog/unreleased/37460
+++ b/changelog/unreleased/37460
@@ -1,3 +1,4 @@
 Change: Add file action to lock a file
 
 https://github.com/owncloud/core/pull/37460
+https://github.com/owncloud/core/pull/37643


### PR DESCRIPTION

## Description
When locking a resource and no owner is given via the http request the current users displayname is set as lock owner

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):
![Screenshot from 2020-07-03 10-02-05](https://user-images.githubusercontent.com/1005065/86446448-44d49700-bd14-11ea-901a-d84e6c535fd2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
