### PR TITLE
[10.5.0] When locking a resource and no owner is given via the http request th…

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -122,8 +122,8 @@ class ServerFactory {
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
 
-		$fileLocksBackend = new FileLocksBackend($server->tree, true, $this->timeFactory, $isPublicAccess);
-		$server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, function ($uri) use ($isPublicAccess) {
+		$fileLocksBackend = new FileLocksBackend($server->tree, true, $this->timeFactory, $this->userSession, $isPublicAccess);
+		$server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, static function ($uri) use ($isPublicAccess) {
 			return $isPublicAccess;
 		}));
 

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -158,8 +158,8 @@ class Server {
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 		$this->server->addPlugin(new LockPlugin());
 
-		$fileLocksBackend = new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory());
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, function ($uri) {
+		$fileLocksBackend = new FileLocksBackend($this->server->tree, false, OC::$server->getTimeFactory(), OC::$server->getUserSession());
+		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\PublicDavLocksPlugin($fileLocksBackend, static function ($uri) {
 			if (\strpos($uri, "public-files/") === 0) {
 				return true;
 			}

--- a/changelog/10.5.0_2020-06-23/37460
+++ b/changelog/10.5.0_2020-06-23/37460
@@ -1,3 +1,4 @@
 Change: Add file action to lock a file
 
 https://github.com/owncloud/core/pull/37460
+https://github.com/owncloud/core/pull/37643


### PR DESCRIPTION
…e current users displayname is set as lock owner

Backport #37643 to `release-10.5.0`