### PR TITLE
[Tests-Only] Added tests for public upload a file with mtime

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -27,6 +27,7 @@ use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use SimpleXMLElement;
+use DateTime;
 
 /**
  * Helper to make WebDav Requests
@@ -548,6 +549,7 @@ class WebDavHelper {
 		);
 		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
 		$xmlpart = $responseXmlObject->xpath("//d:getlastmodified");
-		return $xmlpart[0]->__toString();
+		$mtime = new DateTime($xmlpart[0]->__toString());
+		return $mtime->format('U');
 	}
 }

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -769,7 +769,19 @@ Feature: create a public link share
       | old         |
       | new         |
 
-@issue-ocis-reva-49 @issue-37605
+  @skipOnOcV10 @issue-ocis-reva-49 @issue-37605
+  Scenario: Get the mtime of a file inside a folder shared by public link using new webDAV version (run on OCIS)
+    Given user "Alice" has created folder "testFolder"
+    And user "Alice" has created a public link share with settings
+      | path        | /testFolder               |
+      | permissions | read,update,create,delete |
+    When the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+    Then as "Alice" file "testFolder/file.txt" should exist
+    And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
+
+  @skipOnOcis @issue-ocis-reva-49 @issue-37605
+  #after fixing all issues delete this Scenario and use the one above
   Scenario: Get the mtime of a file inside a folder shared by public link using new webDAV version
     Given user "Alice" has created folder "testFolder"
     And user "Alice" has created a public link share with settings
@@ -780,9 +792,22 @@ Feature: create a public link share
     And as "Alice" the mtime of the file "testFolder/file.txt" should not be "Thu, 08 Aug 2019 04:18:13 GMT"
 #    And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should not be "Thu, 08 Aug 2019 04:18:13 GMT"
-#    And the mtime of file "file.txt" in the the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
+#    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
 
-  @issue-ocis-reva-49 @issue-37605
+  @skipOnOcV10 @issue-ocis-reva-49 @issue-37605
+  Scenario: overwriting a file changes its mtime (new public webDAV API) (run on OCIS)
+    Given user "Alice" has created folder "testFolder"
+    When user "Alice" uploads file with content "uploaded content for file name ending with a dot" to "testFolder/file.txt" using the WebDAV API
+    And user "Alice" has created a public link share with settings
+      | path        | /testFolder |
+      | permissions | read,update,create,delete |
+    And the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+    Then as "Alice" file "/testFolder/file.txt" should exist
+    And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
+
+  @skipOnOcis @issue-ocis-reva-49 @issue-37605
+  #after fixing all issues delete this Scenario and use the one above
   Scenario: overwriting a file changes its mtime (new public webDAV API)
     Given user "Alice" has created folder "testFolder"
     When user "Alice" uploads file with content "uploaded content for file name ending with a dot" to "testFolder/file.txt" using the WebDAV API

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2108,6 +2108,8 @@ trait WebDav {
 		$user = $this->getActualUsername($user);
 		$password = $this->getPasswordForUser($user);
 		$baseUrl = $this->getBaseUrl();
+		$mtime = new DateTime($mtime);
+		$mtime = $mtime->format('U');
 		Assert::assertEquals(
 			$mtime,
 			\TestHelpers\WebDavHelper::getMtimeOfResource($user, $password, $baseUrl, $resource)
@@ -2129,6 +2131,8 @@ trait WebDav {
 		$user = $this->getActualUsername($user);
 		$password = $this->getPasswordForUser($user);
 		$baseUrl = $this->getBaseUrl();
+		$mtime = new DateTime($mtime);
+		$mtime = $mtime->format('U');
 		Assert::assertNotEquals(
 			$mtime,
 			\TestHelpers\WebDavHelper::getMtimeOfResource($user, $password, $baseUrl, $resource)


### PR DESCRIPTION
## Description
- The public can upload a file as well as set `mtime` in ocis. But in OC10 backend, it is still not possible for the public to reset `mtime` for a file.
- Mtime for public link upload is matched in format 'U'

## Related Issue
- Part of https://github.com/owncloud/ocis-reva/issues/273

## How Has This Been Tested?
- ocis : https://github.com/owncloud/ocis/pull/360
- ocis-reva : https://github.com/owncloud/ocis-reva/pull/342

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
