### PR TITLE
The response of LOCK shall hold the updated owner set by the LockManager

### DIFF
--- a/apps/dav/lib/Files/FileLocksBackend.php
+++ b/apps/dav/lib/Files/FileLocksBackend.php
@@ -192,6 +192,7 @@ class FileLocksBackend implements BackendInterface {
 
 		// in case the timeout has not been accepted, adjust in lock info
 		$lockInfo->timeout = $lock->getTimeout();
+		$lockInfo->owner = $lock->getOwner();
 
 		return !empty($lock);
 	}

--- a/changelog/unreleased/37460
+++ b/changelog/unreleased/37460
@@ -1,3 +1,4 @@
 Change: Add file action to lock a file
 
 https://github.com/owncloud/core/pull/37460
+https://github.com/owncloud/core/pull/37647

--- a/tests/lib/Lock/Persistent/LockManagerTest.php
+++ b/tests/lib/Lock/Persistent/LockManagerTest.php
@@ -76,10 +76,10 @@ class LockManagerTest extends TestCase {
 		$this->expectExceptionMessage('No token provided in $lockInfo');
 
 		$this->config->method('getAppValue')
-			->will($this->returnValueMap([
+			->willReturnMap([
 				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, 120],
 				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, 150],
-			]));
+			]);
 
 		$this->manager->lock(6, '/foo/bar', 123, []);
 	}
@@ -91,20 +91,20 @@ class LockManagerTest extends TestCase {
 		$this->expectExceptionMessage('Invalid file id');
 
 		$this->config->method('getAppValue')
-			->will($this->returnValueMap([
+			->willReturnMap([
 				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, 120],
 				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, 150],
-			]));
+			]);
 
 		$this->manager->lock(6, '/foo/bar', -1, []);
 	}
 
 	public function testLockInsert() {
 		$this->config->method('getAppValue')
-			->will($this->returnValueMap([
+			->willReturnMap([
 				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_DEFAULT],
 				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, LockManager::LOCK_TIMEOUT_MAX],
-			]));
+			]);
 
 		$this->lockMapper->method('getLocksByPath')->willReturn([]);
 		$this->lockMapper->expects($this->once())
@@ -129,14 +129,15 @@ class LockManagerTest extends TestCase {
 		]);
 
 		$this->assertNotNull($lock);
+		$this->assertEquals('Alice (alice@example.net)', $lock->getOwner());
 	}
 
 	public function testLockUpdate() {
 		$this->config->method('getAppValue')
-			->will($this->returnValueMap([
+			->willReturnMap([
 				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, LockManager::LOCK_TIMEOUT_DEFAULT],
 				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, LockManager::LOCK_TIMEOUT_MAX],
-			]));
+			]);
 
 		$this->lockMapper->expects($this->once())
 			->method('getLocksByPath')
@@ -232,10 +233,10 @@ class LockManagerTest extends TestCase {
 	 */
 	public function testLockTimeout($givenTimeout, $default, $max, $expectedTimeout) {
 		$this->config->method('getAppValue')
-			->will($this->returnValueMap([
+			->willReturnMap([
 				['core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT, $default],
 				['core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX, $max],
-			]));
+			]);
 
 		$this->lockMapper->method('getLocksByPath')->willReturn([]);
 		$lockInfo = [


### PR DESCRIPTION
##  Description
In case the owner is updated by the server within the  LOCK operation the updated owner value needs to be sent back to the client

## How Has This Been Tested?
- :hand: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
