### PR TITLE
[Tests-Only] Use latest osixia/openldap in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1630,14 +1630,13 @@ def ldapService(ldapNeeded):
 	if ldapNeeded:
 		return [{
 			'name': 'ldap',
-			'image': 'osixia/openldap:1.3.0',
+			'image': 'osixia/openldap',
 			'pull': 'always',
 			'environment': {
 				'LDAP_DOMAIN': 'owncloud.com',
 				'LDAP_ORGANISATION': 'owncloud',
 				'LDAP_ADMIN_PASSWORD': 'admin',
 				'LDAP_TLS_VERIFY_CLIENT': 'never',
-				'HOSTNAME': 'ldap',
 			}
 		}]
 


### PR DESCRIPTION
## Description
Remove the offending `HOSTNAME`env var in CI. Use the latest osixia/openldap

See similar fix in https://github.com/owncloud/phoenix/pull/3738

## Related Issue
Part of issue https://github.com/owncloud/user_ldap/issues/578

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
