### PR TITLE
Add explicit favorite capability entry

### DIFF
--- a/apps/files/lib/Capabilities.php
+++ b/apps/files/lib/Capabilities.php
@@ -61,6 +61,7 @@ class Capabilities implements ICapability {
 				'privateLinksDetailsParam' => true,
 				'bigfilechunking' => true,
 				'blacklisted_files' => $this->config->getSystemValue('blacklisted_files', ['.htaccess']),
+				'favorites' => true
 			],
 		];
 	}

--- a/apps/files/tests/CapabilitiesTest.php
+++ b/apps/files/tests/CapabilitiesTest.php
@@ -47,5 +47,6 @@ class CapabilitiesTest extends TestCase {
 		$this->assertArrayHasKey('files', $result);
 		$this->assertArrayHasKey('privateLinksDetailsParam', $result['files']);
 		$this->assertTrue($result['files']['privateLinksDetailsParam']);
+		$this->assertTrue($result['files']['capabilities']);
 	}
 }

--- a/apps/files/tests/CapabilitiesTest.php
+++ b/apps/files/tests/CapabilitiesTest.php
@@ -47,6 +47,6 @@ class CapabilitiesTest extends TestCase {
 		$this->assertArrayHasKey('files', $result);
 		$this->assertArrayHasKey('privateLinksDetailsParam', $result['files']);
 		$this->assertTrue($result['files']['privateLinksDetailsParam']);
-		$this->assertTrue($result['files']['capabilities']);
+		$this->assertTrue($result['files']['favorites']);
 	}
 }

--- a/changelog/unreleased/37673
+++ b/changelog/unreleased/37673
@@ -1,0 +1,6 @@
+Enhancement: Add capability for the favorite files feature
+
+The server is now exposing a new capability to advertise that the server supports the favorite files feature.
+
+https://github.com/owncloud/core/pull/37673
+https://github.com/owncloud/ocis-reva/issues/354


### PR DESCRIPTION
## Description
Add explicit favorite capability entry
As it's already supported in OC 10, it's set to true.

## Related Issue
For https://github.com/owncloud/ocis/issues/354

## Motivation and Context
This will make it possible for ocis-web to decide whether to enable the feature in the UI or not.
As this is not implemented yet in OCIS, the feature/capability will be disabled there.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

@LukasHirt FYI