### PR TITLE
[Tests-Only] Add env var TEST_REVA

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -43,6 +43,13 @@ class OcisHelper {
 	/**
 	 * @return bool
 	 */
+	public static function isTestingOnReva() {
+		return (\getenv("TEST_REVA") === "true");
+	}
+
+	/**
+	 * @return bool
+	 */
 	public static function getDeleteUserDataCommand() {
 		return (\getenv("DELETE_USER_DATA_CMD"));
 	}

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -299,33 +299,33 @@ Feature: sharing
     And the OCS status message should be "OK"
     And the HTTP status code should be "200"
     Then the fields of the last response to user "Alice" sharing with user "Brian" should include
-      | id                         | A_STRING      |
-      | share_type                 | user          |
-      | uid_owner                  | %username%    |
-      | displayname_owner          | %displayname% |
-      | permissions                | all           |
-      | stime                      | A_NUMBER      |
-      | parent                     |               |
-      | expiration                 |               |
-      | token                      |               |
-      | uid_file_owner             | %username%    |
-      | displayname_file_owner     | %displayname% |
-      | additional_info_owner      |               |
-      | additional_info_file_owner |               |
-      | state                      | 0             |
-      | item_source                |               |
-      | path                       |               |
-      | item_type                  |               |
-      | mimetype                   |               |
-      | storage_id                 |               |
-      | storage                    | 0             |
-      | file_source                |               |
-      | file_target                |               |
-      | share_with                 | %username%    |
-      | share_with_displayname     | %displayname% |
-      | share_with_additional_info |               |
-      | mail_send                  | 0             |
-      | name                       |               |
+      | id                         | A_STRING             |
+      | share_type                 | user                 |
+      | uid_owner                  | %username%           |
+      | displayname_owner          | %displayname%        |
+      | permissions                | all                  |
+      | stime                      | A_NUMBER             |
+      | parent                     |                      |
+      | expiration                 |                      |
+      | token                      |                      |
+      | uid_file_owner             | %username%           |
+      | displayname_file_owner     | %displayname%        |
+      | additional_info_owner      |                      |
+      | additional_info_file_owner |                      |
+      | state                      | 0                    |
+      | item_type                  | folder               |
+      | item_source                | A_STRING             |
+      | path                       | /Alice-folder        |
+      | mimetype                   | httpd/unix-directory |
+      | storage_id                 | A_STRING             |
+      | storage                    | 0                    |
+      | file_source                | A_STRING             |
+      | file_target                | /Alice-folder        |
+      | share_with                 | %username%           |
+      | share_with_displayname     | %displayname%        |
+      | share_with_additional_info |                      |
+      | mail_send                  | 0                    |
+      | name                       |                      |
     And the fields of the last response should not include
       | attributes |  |
 #      | token      |  |

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1263,10 +1263,15 @@ class FeatureContext extends BehatVariablesContext {
 	 * @return bool
 	 */
 	public function isAPublicLinkUrl($url) {
-		if (\substr($url, 0, 4) !== "http") {
-			return false;
+		if (OcisHelper::isTestingOnReva()) {
+			$urlEnding = \ltrim($url, '/');
+		} else {
+			if (\substr($url, 0, 4) !== "http") {
+				return false;
+			}
+			$urlEnding = \substr($url, \strlen($this->getBaseUrl() . '/'));
 		}
-		$urlEnding = \substr($url, \strlen($this->getBaseUrl() . '/'));
+
 		if (OcisHelper::isTestingOnOcis()) {
 			return \preg_match("%^(#/)?s/([a-zA-Z0-9]{15})$%", $urlEnding);
 		} else {


### PR DESCRIPTION
## Description
PR #37662 added extra checks in FeatureContext `isAPublicLinkUrl`. Those pass in `ocis-reva` (see PR https://github.com/owncloud/ocis-reva/pull/367 ) which is good.

But in `cs3org/reva` they fail. See PR https://github.com/cs3org/reva/pull/960 https://cloud.drone.io/cs3org/reva/1822/4/6
```
  Scenario Outline: Creating a new public link share, updating its expiration date and getting its info # /drone/src/tmp/testrunner/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature:90
    Given using OCS API version "<ocs_api_version>"                                                     # FeatureContext::usingOcsApiVersion()
    When user "Alice" creates a public link share using the sharing API with settings                   # FeatureContext::userCreatesAPublicLinkShareWithSettings()
      | path | FOLDER |
    And user "Alice" updates the last share using the sharing API with                                  # FeatureContext::userUpdatesTheLastShareWith()
      | expireDate | +3 days |
    And user "Alice" gets the info of the last share using the sharing API                              # FeatureContext::userGetsInfoOfLastShareUsingTheSharingApi()
    Then the OCS status code should be "<ocs_status_code>"                                              # OCSContext::theOCSStatusCodeShouldBe()
    And the HTTP status code should be "200"                                                            # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And the fields of the last response to user "Alice" should include                                  # FeatureContext::checkFields()
      | id                | A_STRING             |
      | item_type         | folder               |
      | item_source       | A_STRING             |
      | share_type        | public_link          |
      | file_source       | A_STRING             |
      | file_target       | /FOLDER              |
      | permissions       | read                 |
      | stime             | A_NUMBER             |
      | expiration        | +3 days              |
      | token             | A_TOKEN              |
      | storage           | A_STRING             |
      | mail_send         | 0                    |
      | uid_owner         | Alice                |
      | displayname_owner | %displayname%        |
      | url               | AN_URL               |
      | mimetype          | httpd/unix-directory |

    Examples:
      | ocs_api_version | ocs_status_code |
      | 1               | 100             |
        │ url has unexpected value '/#/s/HrvagFONkTYrISn'
        │ 
        url doesn't have value 'AN_URL'
        Failed asserting that false is true.
      | 2               | 200             |
        │ url has unexpected value '/#/s/PDCPtrzaJgfvAcP'
        │ 
        url doesn't have value 'AN_URL'
        Failed asserting that false is true.
```

The URL does not have the base URL part on the front. In particular the test code expects `AN_URL` to start with `http`. In `cs3org/reva` there is only the end part of the URL.

Add an environment variable `TEST_REVA` so that we can easily detect when we are testing against a "base" REVA system (rather than an "OCIS REVA"...). Adjust the test expectation so it knows not to expect the `http` in this case.

The `TEST_REVA` environment variable can be used in future in other situations where the "base"  REVA system behavior is expected to be different to ocis-reva and ocis.

2) cs3org/reva PR https://github.com/cs3org/reva/pull/958 fixed up share response so that they now contain more data in the fields. Adjust the failing test so that it now expects the response items that do come back.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
