### PR TITLE
[Tests-Only] Run unit tests with mariadb 10.5

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1110,7 +1110,7 @@ def phptests(testType):
 	default = {
 		'phpVersions': ['7.2', '7.3', '7.4'],
 		'databases': [
-			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mariadb:10.4', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'postgres:10.3', 'oracle'
+			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mariadb:10.4', 'mariadb:10.5', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'postgres:10.3', 'oracle'
 		],
 		'coverage': True,
 		'includeKeyInMatrixName': False,

--- a/.drone.star
+++ b/.drone.star
@@ -1110,7 +1110,17 @@ def phptests(testType):
 	default = {
 		'phpVersions': ['7.2', '7.3', '7.4'],
 		'databases': [
-			'sqlite', 'mariadb:10.2', 'mariadb:10.3', 'mariadb:10.4', 'mariadb:10.5', 'mysql:5.5', 'mysql:5.7', 'mysql:8.0', 'postgres:9.4', 'postgres:10.3', 'oracle'
+			'sqlite',
+			'mariadb:10.2',
+			'mariadb:10.3',
+			'mariadb:10.4',
+			'mariadb:10.5',
+			'mysql:5.5',
+			'mysql:5.7',
+			'mysql:8.0',
+			'postgres:9.4',
+			'postgres:10.3',
+			'oracle'
 		],
 		'coverage': True,
 		'includeKeyInMatrixName': False,


### PR DESCRIPTION
## Description
Run PHP unit tests with mariadb 10.5.

https://mariadb.com/kb/en/changes-improvements-in-mariadb-105/
https://mariadb.com/kb/en/mariadb-1054-release-notes/

Issue #37677 mentioned mariadb 10.5. We can easily test against it.

PR #37678 demonstrates that the acceptance tests pass against mariadb 10.5. That is good. We do not routinely/automaticallly run all the acceptance tests against all the databases.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
