### PR TITLE
[Tests-Only] Skip new share response test on old oC10

### DIFF
--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -239,7 +239,7 @@ Feature: sharing
     And as "Alice" folder "/Alice-folder/folder2" should exist
     And as "Carol" folder "/Carol-folder/folder2" should not exist
 
-  @skipOnOcis @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcis @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
   #after fixing all the issues merge this scenario with the one below
   Scenario Outline: API responds with a full set of parameters when owner changes the permission of a share
     Given using OCS API version "<ocs_api_version>"


### PR DESCRIPTION
## Description
The new scenario does not pass on old versions of ownCloud10 - skip it there.
https://drone.owncloud.com/owncloud/files_primary_s3/1789/84/17
```
  Scenario Outline: API responds with a full set of parameters when owner changes the permission of a share # /var/www/owncloud/testrunner/tests/acceptance/features/apiShareUpdate/updateShare.feature:244
    Given using OCS API version "<ocs_api_version>"                                                         # FeatureContext::usingOcsApiVersion()
    And user "Brian" has been created with default attributes and without skeleton files                    # FeatureContext::userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles()
    And user "Alice" has created folder "/Alice-folder"                                                     # FeatureContext::userHasCreatedFolder()
    And user "Alice" has shared folder "/Alice-folder" with user "Brian" with permissions "read"            # FeatureContext::userHasSharedFileWithUserUsingTheSharingApi()
    When user "Alice" updates the last share using the sharing API with                                     # FeatureContext::userUpdatesTheLastShareWith()
      | permissions | all |
    Then the OCS status code should be "<ocs_status_code>"                                                  # OCSContext::theOCSStatusCodeShouldBe()
    And the OCS status message should be ""                                                                 # OCSContext::theOCSStatusMessageShouldBe()
    And the HTTP status code should be "200"                                                                # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    Then the fields of the last response to user "Alice" sharing with user "Brian" should include           # FeatureContext::checkFieldsOfLastResponseToUser()
      | id                         | A_STRING             |
      | share_type                 | user                 |
      | uid_owner                  | %username%           |
      | displayname_owner          | %displayname%        |
      | permissions                | all                  |
      | stime                      | A_NUMBER             |
      | parent                     |                      |
      | expiration                 |                      |
      | token                      |                      |
      | uid_file_owner             | %username%           |
      | displayname_file_owner     | %displayname%        |
      | additional_info_owner      |                      |
      | additional_info_file_owner |                      |
      | item_type                  | folder               |
      | item_source                | A_STRING             |
      | path                       | /Alice-folder        |
      | mimetype                   | httpd/unix-directory |
      | storage_id                 | home::Alice          |
      | storage                    | A_STRING             |
      | file_source                | A_STRING             |
      | file_target                | /Alice-folder        |
      | share_with                 | %username%           |
      | share_with_displayname     | %displayname%        |
      | share_with_additional_info |                      |
      | mail_send                  | 0                    |
      | attributes                 |                      |
    And the fields of the last response should not include                                                  # FeatureContext::checkFieldsNotInResponse()
      | name |  |

    Examples:
      | ocs_api_version | ocs_status_code |
      | 1               | 100             |
        │ storage_id has unexpected value 'object::user:Alice'
        │ 
        storage_id doesn't have value 'home::Alice'
        Failed asserting that false is true.
      | 2               | 200             |
        │ storage_id has unexpected value 'object::user:Alice'
        │ 
        storage_id doesn't have value 'home::Alice'
        Failed asserting that false is true.
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
