### PR TITLE
[Tests-Only] Do not be so specific about storage_id

### DIFF
--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -269,7 +269,7 @@ Feature: sharing
       | item_source                | A_STRING             |
       | path                       | /Alice-folder        |
       | mimetype                   | httpd/unix-directory |
-      | storage_id                 | home::Alice          |
+      | storage_id                 | A_STRING             |
       | storage                    | A_STRING             |
       | file_source                | A_STRING             |
       | file_target                | /Alice-folder        |


### PR DESCRIPTION
## Description
On files_primary_s3 the scenario fails:
https://drone.owncloud.com/owncloud/files_primary_s3/1790/61/17
```
  Scenario Outline: API responds with a full set of parameters when owner changes the permission of a share # /var/www/owncloud/testrunner/tests/acceptance/features/apiShareUpdate/updateShare.feature:244
    Given using OCS API version "<ocs_api_version>"                                                         # FeatureContext::usingOcsApiVersion()
    And user "Brian" has been created with default attributes and without skeleton files                    # FeatureContext::userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles()
    And user "Alice" has created folder "/Alice-folder"                                                     # FeatureContext::userHasCreatedFolder()
    And user "Alice" has shared folder "/Alice-folder" with user "Brian" with permissions "read"            # FeatureContext::userHasSharedFileWithUserUsingTheSharingApi()
    When user "Alice" updates the last share using the sharing API with                                     # FeatureContext::userUpdatesTheLastShareWith()
      | permissions | all |
    Then the OCS status code should be "<ocs_status_code>"                                                  # OCSContext::theOCSStatusCodeShouldBe()
    And the OCS status message should be ""                                                                 # OCSContext::theOCSStatusMessageShouldBe()
    And the HTTP status code should be "200"                                                                # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    Then the fields of the last response to user "Alice" sharing with user "Brian" should include           # FeatureContext::checkFieldsOfLastResponseToUser()
      | id                         | A_STRING             |
      | share_type                 | user                 |
      | uid_owner                  | %username%           |
      | displayname_owner          | %displayname%        |
      | permissions                | all                  |
      | stime                      | A_NUMBER             |
      | parent                     |                      |
      | expiration                 |                      |
      | token                      |                      |
      | uid_file_owner             | %username%           |
      | displayname_file_owner     | %displayname%        |
      | additional_info_owner      |                      |
      | additional_info_file_owner |                      |
      | item_type                  | folder               |
      | item_source                | A_STRING             |
      | path                       | /Alice-folder        |
      | mimetype                   | httpd/unix-directory |
      | storage_id                 | home::Alice          |
      | storage                    | A_STRING             |
      | file_source                | A_STRING             |
      | file_target                | /Alice-folder        |
      | share_with                 | %username%           |
      | share_with_displayname     | %displayname%        |
      | share_with_additional_info |                      |
      | mail_send                  | 0                    |
      | attributes                 |                      |
    And the fields of the last response should not include                                                  # FeatureContext::checkFieldsNotInResponse()
      | name |  |

    Examples:
      | ocs_api_version | ocs_status_code |
      | 1               | 100             |
        │ storage_id has unexpected value 'object::user:Alice'
        │ 
        storage_id doesn't have value 'home::Alice'
        Failed asserting that false is true.
      | 2               | 200             |
        │ storage_id has unexpected value 'object::user:Alice'
        │ 
        storage_id doesn't have value 'home::Alice'
        Failed asserting that false is true.
```

IMO the objective of this scenario was just to make sure that something is returned in all the expected share response fields. We could make the scenario "smarter" to know what exactly should be returned for different storages. But actually that could be done in separate specific scenarios here in core, and in files_primary_s3, that run just for the relevant storage.

For this scenario, just expect `A_STRING`.

Also note, expecting `home::Alice`  would not work when we substitute username `Alice` with some other username in the tests. It should have expected something like `home::%username%` 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
