### PR TITLE
Fix for centering the credential fields on IE11

### DIFF
--- a/changelog/unreleased/37692
+++ b/changelog/unreleased/37692
@@ -1,0 +1,5 @@
+Bugfix: Fix for centering the credential fields on IE11
+
+In IE11 the input fields for user and password were not always centered.
+
+https://github.com/owncloud/core/pull/37692

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -985,3 +985,10 @@ fieldset.warning legend + p, fieldset.update legend + p {
         padding-top: 35px;
     }
 }
+
+/* IE11 fix for centering the credential fields */
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+	#body-login .v-align {
+		margin-top: 30px;
+	}
+}


### PR DESCRIPTION
## Description
In IE11 the input fields for user and password were not centered.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/owncloud/core/issues/37690

## Motivation and Context
Even users of old browsers should experience centered input fields. 
However, this does not change the fact that IE11 should no longer be used, dear folks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested in IE11

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
