### PR TITLE
[Tests-Only] Correct the label reported in FileActionsMenu openDetails

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -150,7 +150,7 @@ class FileActionsMenu extends OwncloudPage {
 		$this->assertElementNotNull(
 			$detailsBtn,
 			__METHOD__ .
-			" could not find action button with label $this->deleteActionLabel"
+			" could not find action button with label $this->detailsActionLabel"
 		);
 		$detailsBtn->focus();
 		$detailsBtn->click();


### PR DESCRIPTION
## Description
The acceptance test error reported when the files actions menu details button could not be found reports the wrong label. Fix it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
