### PR TITLE
Adjust enable lock file action

### DIFF
--- a/apps/files/lib/App.php
+++ b/apps/files/lib/App.php
@@ -48,7 +48,7 @@ class App {
 		$maxChunkSize = (int)($config->getAppValue('files', 'max_chunk_size', (10 * 1024 * 1024)));
 		$uploadStallTimeout = (int)($config->getAppValue('files', 'upload_stall_timeout', 60)); // in seconds
 		$uploadStallRetries = (int)($config->getAppValue('files', 'upload_stall_retries', 100));
-		$enableLockFileAction = (boolean)($config->getAppValue('files', 'enable_lock_file_action', false));
+		$enableLockFileAction = (boolean)($config->getAppValue('files', 'enable_lock_file_action', 'no') === 'yes');
 
 		$array['array']['oc_appconfig']['files'] = [
 			'max_chunk_size' => $maxChunkSize,

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -2740,6 +2740,52 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @Given /^the administrator has (enabled|disabled) the webUI lock file action$/
+	 *
+	 * @param string $enabledOrDisabled
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorHasEnabledTheWebUILockFileAction($enabledOrDisabled) {
+		$switch = ($enabledOrDisabled !== "disabled");
+		if ($switch) {
+			$value = 'yes';
+		} else {
+			$value = 'no';
+		}
+		SetupHelper::runOcc(
+			[
+				"config:app:set",
+				"files",
+				"enable_lock_file_action",
+				"--value=$value"
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$response = SetupHelper::runOcc(
+			[
+				"config:app:get",
+				"files",
+				"enable_lock_file_action"
+			],
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
+		);
+		$status = \trim($response['stdOut']);
+		Assert::assertEquals(
+			$value,
+			$status,
+			"enable_lock_file_action was expected to be '$value'($enabledOrDisabled) but got '$status'"
+		);
+	}
+
+	/**
 	 * @When the administrator creates an external mount point with the following configuration about user :user using the occ command
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1755,7 +1755,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the option to (delete|rename|download)\s?(?:file|folder) "([^"]*)" should (not|)\s?be available on the webUI$/
+	 * @Then /^the option to (delete|rename|download|lock)\s?(?:file|folder) "([^"]*)" should (not|)\s?be available on the webUI$/
 	 *
 	 * @param string $action
 	 * @param string $name
@@ -1770,7 +1770,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$session = $this->getSession();
 		$pageObject->waitTillPageIsLoaded($session);
 		$fileRow = $pageObject->findFileRowByName($name, $session);
-		$action = \ucfirst($action);
+		if ($action !== 'lock') {
+			$action = \ucfirst($action);
+		}
 		if ($visible) {
 			Assert::assertTrue(
 				$fileRow->isActionLabelAvailable($action, $session),

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -41,6 +41,7 @@ class FileActionsMenu extends OwncloudPage {
 	protected $renameActionLabel = "Rename";
 	protected $deleteActionLabel = "Delete";
 	protected $detailsActionLabel = "Details";
+	protected $lockFileActionLabel = "Lock file";
 	protected $declineShareDataAction = "Reject";
 	protected $fileRowDownloadBtnXpath = "//td[@class='filename']//a[@class='name']";
 
@@ -157,6 +158,22 @@ class FileActionsMenu extends OwncloudPage {
 	}
 
 	/**
+	 * clicks the lock file button
+	 *
+	 * @return void
+	 */
+	public function lockFile() {
+		$detailsBtn = $this->findButton($this->lockFileActionLabel);
+		$this->assertElementNotNull(
+			$detailsBtn,
+			__METHOD__ .
+			" could not find action button with label $this->lockFileActionLabel"
+		);
+		$detailsBtn->focus();
+		$detailsBtn->click();
+	}
+
+	/**
 	 * clicks the decline share button
 	 *
 	 * @return void
@@ -216,6 +233,16 @@ class FileActionsMenu extends OwncloudPage {
 	 */
 	public function getDetailsActionLabel() {
 		return $this->detailsActionLabel;
+	}
+
+	/**
+	 * just so the label can be reused in other places
+	 * and does not need to be redefined
+	 *
+	 * @return string
+	 */
+	public function getLockFileActionLabel() {
+		return $this->lockFileActionLabel;
 	}
 
 	/**

--- a/tests/acceptance/features/webUIFiles/lockFile.feature
+++ b/tests/acceptance/features/webUIFiles/lockFile.feature
@@ -1,0 +1,31 @@
+@webUI @insulated @disablePreviews
+Feature: Manually lock a file
+  As a user
+  I want to be able to manually lock a file
+  So that other users cannot edit the file while I work with it
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+    And user "Alice" has uploaded file with content "some content" to "/can-lock-a-file.txt"
+    And user "Alice" has created folder "cannot-lock-a-folder"
+
+  Scenario: Lock File option is not shown when the admin has disabled it
+    Given the administrator has disabled the webUI lock file action
+    When user "Alice" logs in using the webUI
+    Then the option to lock file "can-lock-a-file.txt" should not be available on the webUI
+    And the option to lock folder "cannot-lock-a-folder" should not be available on the webUI
+
+  Scenario: Lock File option is shown only for a file when the admin has enabled it
+    Given the administrator has enabled the webUI lock file action
+    When user "Alice" logs in using the webUI
+    Then the option to lock file "can-lock-a-file.txt" should be available on the webUI
+    But the option to lock folder "cannot-lock-a-folder" should not be available on the webUI
+
+  Scenario: Lock File option is shown for a file in a folder when the admin has enabled it
+    Given the administrator has enabled the webUI lock file action
+    And user "Alice" has uploaded file with content "some content" to "/cannot-lock-a-folder/can-lock-a-file.txt"
+    And user "Alice" has logged in using the webUI
+    When the user opens folder "cannot-lock-a-folder" using the webUI
+    Then the option to lock file "can-lock-a-file.txt" should be available on the webUI


### PR DESCRIPTION
## Description
- change `enable_lock_file_action` so that it enables with the string `yes` instead of expecting a boolean `true`
- add some basic UI  acceptance tests that verify that the "Lock file" option appears (or not) in the file action menu on the UI

## Related Issue
Related to #37697 

## How Has This Been Tested?
CI and manually doing:
```
php occ config:app:set files enable_lock_file_action --value 'yes'
php occ config:app:set files enable_lock_file_action --value 'no'
php occ config:app:delete files enable_lock_file_action
```
and observing that the "Lock file" option in the UI comes and goes appropriately.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
