### PR TITLE
[10.5.0] Add admin settings checkbox to 'Enable manual file locking on the web UI'

### DIFF
--- a/settings/Panels/Admin/PersistentLocking.php
+++ b/settings/Panels/Admin/PersistentLocking.php
@@ -47,6 +47,7 @@ class PersistentLocking implements ISettings {
 		$tmpl = new Template('settings', 'panels/admin/persistentlocking');
 		$tmpl->assign('defaultTimeout', $this->config->getAppValue('core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT));
 		$tmpl->assign('maximumTimeout', $this->config->getAppValue('core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX));
+		$tmpl->assign('manualFileLockOnWebUIEnabled', $this->config->getAppValue('files', 'enable_lock_file_action', 'no'));
 
 		return $tmpl;
 	}

--- a/settings/js/panels/persistentlocking.js
+++ b/settings/js/panels/persistentlocking.js
@@ -3,22 +3,34 @@ $(document).ready(function() {
 	$('#persistentlocking input').change(function () {
 		var currentInput = $(this);
 		var name = currentInput.attr('name');
-		var value = currentInput.val();
-
-		var minRange = currentInput.attr('min');
-		var maxRange = currentInput.attr('max');
-
-		// range validation (mainly for firefox) to prevent saving wrong values
 		var isValid = true;
-		if (minRange !== undefined && value < minRange) {
-			isValid = false;
-		}
-		if (maxRange !== undefined && value > maxRange) {
-			isValid = false;
+		var app = '';
+		var value = '';
+
+		if (name === 'enable_lock_file_action') {
+			app = 'files';
+			if (this.checked) {
+				value = 'yes';
+			} else {
+				value = 'no';
+			}
+		} else {
+			app = 'core';
+			value = currentInput.val();
+			var minRange = currentInput.attr('min');
+			var maxRange = currentInput.attr('max');
+
+			// range validation (mainly for firefox) to prevent saving wrong values
+			if (minRange !== undefined && value < minRange) {
+				isValid = false;
+			}
+			if (maxRange !== undefined && value > maxRange) {
+				isValid = false;
+			}
 		}
 
 		if (isValid) {
-			OC.AppConfig.setValue('core', name, value);
+			OC.AppConfig.setValue(app, name, value);
 		}
 		// browser should take care of the visual indication if the value
 		// isn't in the range

--- a/settings/templates/panels/admin/persistentlocking.php
+++ b/settings/templates/panels/admin/persistentlocking.php
@@ -17,4 +17,10 @@ script('settings', 'panels/persistentlocking');
 		min="0"
 		value="<?php p($_['maximumTimeout'])?>" />
 	<br/>
+	<input type="checkbox" name="enable_lock_file_action" id="manualFileLockOnWebUIEnabled" class="checkbox"
+		   value="1" <?php if ($_['manualFileLockOnWebUIEnabled'] === 'yes') {
+	print_unescaped('checked="checked"');
+} ?> />
+	<label for="manualFileLockOnWebUIEnabled"><?php p($l->t('Enable manual file locking on the web UI'));?></label>
+	<br/>
 </div>


### PR DESCRIPTION
## Description
Adds a checkbox to admin settings "Manual File Locking" to "Enable manual file locking on the web UI"

Checking the checkbox does the same as:

`occ config:app:set files enable_lock_file_action --value yes`

Unchecking does the same as:

`occ config:app:set files enable_lock_file_action --value no`

## Related Issue
This is a follow-on enhancement from all the file locking additions.

## How Has This Been Tested?
Manually check the new checkbox, the browse to the Files page and confirm that the "Lock file" action is available for a file.

Manually uncheck the new checkbox, the browse to the Files page and confirm that the "Lock file" action is not  available for a file.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
