### PR TITLE
[Tests-Only] Fix replacement usernames

### DIFF
--- a/tests/acceptance/features/apiFederation1/federated.feature
+++ b/tests/acceptance/features/apiFederation1/federated.feature
@@ -65,14 +65,14 @@ Feature: federated
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
-    And the fields of the last response to user "Brian" should include
+    And the fields of the last response about user "Alice" sharing with user "Brian" should include
       | id          | A_STRING                                   |
       | remote      | REMOTE                                     |
       | remote_id   | A_STRING                                   |
       | share_token | A_TOKEN                                    |
       | name        | /textfile0.txt                             |
-      | owner       | Alice                                      |
-      | user        | Brian                                      |
+      | owner       | %username%                                 |
+      | user        | %username%                                 |
       | mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
       | accepted    | 0                                          |
     Examples:
@@ -87,14 +87,14 @@ Feature: federated
     When user "Brian" retrieves the information of the last federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
-    And the fields of the last response to user "Brian" should include
+    And the fields of the last response about user "Alice" sharing with user "Brian" should include
       | id          | A_STRING                 |
       | remote      | REMOTE                   |
       | remote_id   | A_STRING                 |
       | share_token | A_TOKEN                  |
       | name        | /textfile0.txt           |
-      | owner       | Alice                    |
-      | user        | Brian                    |
+      | owner       | %username%               |
+      | user        | %username%               |
       | mountpoint  | /textfile0 (2).txt       |
       | accepted    | 1                        |
       | type        | file                     |
@@ -111,14 +111,14 @@ Feature: federated
     When user "Brian" retrieves the information of the last pending federated cloud share using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs-status>"
-    And the fields of the last response to user "Brian" should include
+    And the fields of the last response about user "Alice" sharing with user "Brian" should include
       | id          | A_STRING                                   |
       | remote      | REMOTE                                     |
       | remote_id   | A_STRING                                   |
       | share_token | A_TOKEN                                    |
       | name        | /textfile0.txt                             |
-      | owner       | Alice                                      |
-      | user        | Brian                                      |
+      | owner       | %username%                                 |
+      | user        | %username%                                 |
       | mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
       | accepted    | 0                                          |
     Examples:
@@ -303,14 +303,14 @@ Feature: federated
     And user "Brian" should see the following elements
       | /textfile0%20(2).txt |
     When user "Brian" gets the list of federated cloud shares using the sharing API
-    Then the fields of the last response to user "Brian" should include
+    Then the fields of the last response about user "Alice" sharing with user "Brian" should include
       | id          | A_STRING                 |
       | remote      | REMOTE                   |
       | remote_id   | A_STRING                 |
       | share_token | A_TOKEN                  |
       | name        | /textfile0.txt           |
-      | owner       | Alice                    |
-      | user        | Brian                    |
+      | owner       | %username%               |
+      | user        | %username%               |
       | mountpoint  | /textfile0 (2).txt       |
       | accepted    | 1                        |
       | type        | file                     |
@@ -349,14 +349,14 @@ Feature: federated
     And user "Brian" should not see the following elements
       | /textfile0%20(2).txt |
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
-    Then the fields of the last response to user "Brian" should include
+    Then the fields of the last response about user "Alice" sharing with user "Brian" should include
       | id          | A_STRING                                   |
       | remote      | REMOTE                                     |
       | remote_id   | A_STRING                                   |
       | share_token | A_TOKEN                                    |
       | name        | /textfile0.txt                             |
-      | owner       | Alice                                      |
-      | user        | Brian                                      |
+      | owner       | %username%                                 |
+      | user        | %username%                                 |
       | mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
       | accepted    | 0                                          |
     When user "Brian" gets the list of federated cloud shares using the sharing API
@@ -419,12 +419,12 @@ Feature: federated
     When user "Brian" retrieves the information of the last federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
-    And the fields of the last response to user "Brian" should include
+    And the fields of the last response about user "Alice" sharing with user "Brian" should include
       | id          | A_STRING       |
       | remote      | REMOTE         |
       | name        | /zzzfolder     |
-      | owner       | Alice          |
-      | user        | Brian          |
+      | owner       | %username%     |
+      | user        | %username%     |
       | mountpoint  | /zzzfolder (2) |
       | type        | dir            |
       | permissions | all            |
@@ -446,14 +446,14 @@ Feature: federated
     When user "Brian" retrieves the information of the last federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
-    And the fields of the last response to user "Brian" should include
+    And the fields of the last response about user "Alice" sharing with user "Brian" should include
       | id          | A_STRING                 |
       | remote      | REMOTE                   |
       | remote_id   | A_STRING                 |
       | share_token | A_TOKEN                  |
       | name        | /randomfile.txt          |
-      | owner       | Alice                    |
-      | user        | Brian                    |
+      | owner       | %username%               |
+      | user        | %username%               |
       | mountpoint  | /randomfile (2).txt      |
       | accepted    | 1                        |
       | type        | file                     |

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
@@ -34,12 +34,12 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +15 days   |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" should include
-      | share_type  | user     |
-      | file_target | /FOLDER  |
-      | uid_owner   | Alice    |
-      | expiration  | +15 days |
-      | share_with  | Brian    |
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_type  | user       |
+      | file_target | /FOLDER    |
+      | uid_owner   | %username% |
+      | expiration  | +15 days   |
+      | share_with  | %username% |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
@@ -59,12 +59,12 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +15 days   |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" should include
-      | share_type  | user     |
-      | file_target | /FOLDER  |
-      | uid_owner   | Alice    |
-      | share_with  | Brian    |
-      | expiration  | +15 days |
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_type  | user       |
+      | file_target | /FOLDER    |
+      | uid_owner   | %username% |
+      | expiration  | +15 days   |
+      | share_with  | %username% |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
@@ -85,12 +85,12 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +15 days   |
     And the administrator sets parameter "shareapi_default_expire_date_user_share" of app "core" to "no"
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | share_type  | user     |
-      | file_target | /FOLDER  |
-      | uid_owner   | Alice    |
-      | share_with  | Brian    |
-      | expiration  | +15 days |
+    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_type  | user       |
+      | file_target | /FOLDER    |
+      | uid_owner   | %username% |
+      | expiration  | +15 days   |
+      | share_with  | %username% |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
@@ -111,12 +111,12 @@ Feature: a default expiration date can be specified for shares with users or gro
       | permissions | read,share |
     And the administrator sets parameter "shareapi_default_expire_date_user_share" of app "core" to "no"
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | share_type  | user    |
-      | file_target | /FOLDER |
-      | uid_owner   | Alice   |
-      | share_with  | Brian   |
-      | expiration  | +7 days |
+    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_type  | user       |
+      | file_target | /FOLDER    |
+      | uid_owner   | %username% |
+      | share_with  | %username% |
+      | expiration  | +7 days    |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +7 days |
     Examples:
@@ -158,12 +158,12 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +15 days   |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" should include
-      | share_type  | group    |
-      | file_target | /FOLDER  |
-      | uid_owner   | Alice    |
-      | expiration  | +15 days |
-      | share_with  | grp1     |
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_type  | group      |
+      | file_target | /FOLDER    |
+      | uid_owner   | %username% |
+      | expiration  | +15 days   |
+      | share_with  | grp1       |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
@@ -185,12 +185,12 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +15 days   |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" should include
-      | share_type  | group    |
-      | file_target | /FOLDER  |
-      | uid_owner   | Alice    |
-      | expiration  | +15 days |
-      | share_with  | grp1     |
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_type  | group      |
+      | file_target | /FOLDER    |
+      | uid_owner   | %username% |
+      | expiration  | +15 days   |
+      | share_with  | grp1       |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
@@ -213,12 +213,12 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +15 days   |
     And the administrator sets parameter "shareapi_default_expire_date_group_share" of app "core" to "no"
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | share_type  | group    |
-      | file_target | /FOLDER  |
-      | uid_owner   | Alice    |
-      | share_with  | grp1     |
-      | expiration  | +15 days |
+    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_type  | group      |
+      | file_target | /FOLDER    |
+      | uid_owner   | %username% |
+      | share_with  | grp1       |
+      | expiration  | +15 days   |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
@@ -242,12 +242,12 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +3 days    |
     And the administrator sets parameter "shareapi_default_expire_date_group_share" of app "core" to "no"
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | share_type  | group   |
-      | file_target | /FOLDER |
-      | uid_owner   | Alice   |
-      | share_with  | grp1    |
-      | expiration  | +3 days |
+    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_type  | group      |
+      | file_target | /FOLDER    |
+      | uid_owner   | %username% |
+      | share_with  | grp1       |
+      | expiration  | +3 days    |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +3 days |
     Examples:
@@ -262,11 +262,11 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
       | share_type  | user           |
       | file_target | /textfile0.txt |
-      | uid_owner   | Alice          |
-      | share_with  | Brian          |
+      | uid_owner   | %username%     |
+      | share_with  | %username%     |
       | expiration  | +7 days        |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +7 days |
@@ -304,11 +304,11 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
       | share_type  | user           |
       | file_target | /textfile0.txt |
-      | uid_owner   | Alice          |
-      | share_with  | Brian          |
+      | uid_owner   | %username%     |
+      | share_with  | %username%     |
       | expiration  | +30 days       |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +30 days |
@@ -382,10 +382,10 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
       | share_type  | group          |
       | file_target | /textfile0.txt |
-      | uid_owner   | Alice          |
+      | uid_owner   | %username%     |
       | share_with  | grp1           |
       | expiration  | +7 days        |
     And the response when user "Brian" gets the info of the last share should include
@@ -428,10 +428,10 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
       | share_type  | group          |
       | file_target | /textfile0.txt |
-      | uid_owner   | Alice          |
+      | uid_owner   | %username%     |
       | share_with  | grp1           |
       | expiration  | +30 days       |
     And the response when user "Brian" gets the info of the last share should include

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareReceivedInMultipleWays.feature
@@ -99,17 +99,17 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Carol" has uploaded file with content "Second data" to "/randomfile.txt"
     When user "Brian" shares file "randomfile.txt" with user "Alice" with permissions "read" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | uid_owner   | Brian           |
-      | share_with  | Alice           |
+    Then the fields of the last response about user "Brian" sharing with user "Alice" should include
+      | uid_owner   | %username%      |
+      | share_with  | %username%      |
       | file_target | /randomfile.txt |
       | item_type   | file            |
       | permissions | read            |
     When user "Carol" shares file "randomfile.txt" with user "Alice" with permissions "read,update" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | uid_owner   | Carol               |
-      | share_with  | Alice               |
+    Then the fields of the last response about user "Carol" sharing with user "Alice" should include
+      | uid_owner   | %username%          |
+      | share_with  | %username%          |
       | file_target | /randomfile (2).txt |
       | item_type   | file                |
       | permissions | read,update         |
@@ -133,17 +133,17 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Carol" has created folder "zzzfolder/Carol"
     When user "Brian" shares folder "zzzfolder" with user "Alice" with permissions "read,delete" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | uid_owner   | Brian       |
-      | share_with  | Alice       |
+    Then the fields of the last response about user "Brian" sharing with user "Alice" should include
+      | uid_owner   | %username%  |
+      | share_with  | %username%  |
       | file_target | /zzzfolder  |
       | item_type   | folder      |
       | permissions | read,delete |
     When user "Carol" shares folder "zzzfolder" with user "Alice" with permissions "read,share" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | uid_owner   | Carol          |
-      | share_with  | Alice          |
+    Then the fields of the last response about user "Carol" sharing with user "Alice" should include
+      | uid_owner   | %username%     |
+      | share_with  | %username%     |
       | file_target | /zzzfolder (2) |
       | item_type   | folder         |
       | permissions | read,share     |

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupCaseSensitive.feature
@@ -55,7 +55,7 @@ Feature: share with groups, group names are case-sensitive
       | file_target | /textfile1.txt    |
       | path        | /textfile1.txt    |
       | permissions | share,read,update |
-      | uid_owner   | Alice             |
+      | uid_owner   | %username%        |
     And the content of file "textfile1.txt" for user "Brian" should be "ownCloud test text file 1" plus end-of-line
     When user "Alice" shares file "textfile2.txt" with group "<group_id2>" using the sharing API
     Then the OCS status code should be "404"

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -23,8 +23,8 @@ Feature: create a public link share
       | share_type             | public_link     |
       | displayname_file_owner | %displayname%   |
       | displayname_owner      | %displayname%   |
-      | uid_file_owner         | Alice           |
-      | uid_owner              | Alice           |
+      | uid_file_owner         | %username%      |
+      | uid_owner              | %username%      |
       | name                   |                 |
     When the public downloads the last public shared file with range "bytes=0-9" using the old public WebDAV API
     Then the downloaded content should be "Random dat"
@@ -52,8 +52,8 @@ Feature: create a public link share
       | share_type             | public_link     |
       | displayname_file_owner | %displayname%   |
       | displayname_owner      | %displayname%   |
-      | uid_file_owner         | Alice           |
-      | uid_owner              | Alice           |
+      | uid_file_owner         | %username%      |
+      | uid_owner              | %username%      |
       | name                   |                 |
     When the public downloads the last public shared file with range "bytes=0-9" using the new public WebDAV API
     Then the downloaded content should be "Random dat"
@@ -81,8 +81,8 @@ Feature: create a public link share
       | share_type             | public_link     |
       | displayname_file_owner | %displayname%   |
       | displayname_owner      | %displayname%   |
-      | uid_file_owner         | Alice           |
-      | uid_owner              | Alice           |
+      | uid_file_owner         | %username%      |
+      | uid_owner              | %username%      |
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "Random data"
     And the HTTP status code should be "200"
@@ -113,8 +113,8 @@ Feature: create a public link share
       | share_type             | public_link     |
       | displayname_file_owner | %displayname%   |
       | displayname_owner      | %displayname%   |
-      | uid_file_owner         | Alice           |
-      | uid_owner              | Alice           |
+      | uid_file_owner         | %username%      |
+      | uid_owner              | %username%      |
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
     And the HTTP status code should be "200"
@@ -145,8 +145,8 @@ Feature: create a public link share
       | share_type             | public_link     |
       | displayname_file_owner | %displayname%   |
       | displayname_owner      | %displayname%   |
-      | uid_file_owner         | Alice           |
-      | uid_owner              | Alice           |
+      | uid_file_owner         | %username%      |
+      | uid_owner              | %username%      |
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
     And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
@@ -173,8 +173,8 @@ Feature: create a public link share
       | share_type             | public_link     |
       | displayname_file_owner | %displayname%   |
       | displayname_owner      | %displayname%   |
-      | uid_file_owner         | Alice           |
-      | uid_owner              | Alice           |
+      | uid_file_owner         | %username%      |
+      | uid_owner              | %username%      |
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
     And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "403"
@@ -201,8 +201,8 @@ Feature: create a public link share
       | share_type             | public_link          |
       | displayname_file_owner | %displayname%        |
       | displayname_owner      | %displayname%        |
-      | uid_file_owner         | Alice                |
-      | uid_owner              | Alice                |
+      | uid_file_owner         | %username%           |
+      | uid_owner              | %username%           |
       | name                   |                      |
     When the public downloads file "/randomfile.txt" from inside the last public shared folder with range "bytes=1-7" using the old public WebDAV API
     Then the downloaded content should be "andom d"
@@ -232,8 +232,8 @@ Feature: create a public link share
       | share_type             | public_link          |
       | displayname_file_owner | %displayname%        |
       | displayname_owner      | %displayname%        |
-      | uid_file_owner         | Alice                |
-      | uid_owner              | Alice                |
+      | uid_file_owner         | %username%           |
+      | uid_owner              | %username%           |
       | name                   |                      |
     When the public downloads file "/randomfile.txt" from inside the last public shared folder with range "bytes=2-7" using the new public WebDAV API
     Then the downloaded content should be "ndom d"
@@ -264,8 +264,8 @@ Feature: create a public link share
       | share_type             | public_link          |
       | displayname_file_owner | %displayname%        |
       | displayname_owner      | %displayname%        |
-      | uid_file_owner         | Alice                |
-      | uid_owner              | Alice                |
+      | uid_file_owner         | %username%           |
+      | uid_owner              | %username%           |
       | name                   |                      |
     And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the old public WebDAV API with password "%public%"
     And the downloaded content should be "Random data"
@@ -295,8 +295,8 @@ Feature: create a public link share
       | share_type             | public_link          |
       | displayname_file_owner | %displayname%        |
       | displayname_owner      | %displayname%        |
-      | uid_file_owner         | Alice                |
-      | uid_owner              | Alice                |
+      | uid_file_owner         | %username%           |
+      | uid_owner              | %username%           |
       | name                   |                      |
     And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "%public%"
     And the downloaded content should be "Random data"
@@ -341,7 +341,7 @@ Feature: create a public link share
       | item_type   | file         |
       | share_type  | public_link  |
       | permissions | read         |
-      | uid_owner   | Alice        |
+      | uid_owner   | %username%   |
     And the fields of the last response should not include
       | share_with             | ANY_VALUE |
       | share_with_displayname | ANY_VALUE |
@@ -694,7 +694,7 @@ Feature: create a public link share
       | item_type   | file            |
       | share_type  | public_link     |
       | permissions | read            |
-      | uid_owner   | Alice           |
+      | uid_owner   | %username%      |
       | expiration  | +7 days         |
     When user "Alice" gets the info of the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -705,7 +705,7 @@ Feature: create a public link share
       | item_type   | file            |
       | share_type  | public_link     |
       | permissions | read            |
-      | uid_owner   | Alice           |
+      | uid_owner   | %username%      |
       | expiration  | +7 days         |
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -109,7 +109,7 @@ Feature: update a public link share
       | token             | A_TOKEN              |
       | storage           | A_STRING             |
       | mail_send         | 0                    |
-      | uid_owner         | Alice                |
+      | uid_owner         | %username%           |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -174,7 +174,7 @@ Feature: update a public link share
       | token             | A_TOKEN              |
       | storage           | A_STRING             |
       | mail_send         | 0                    |
-      | uid_owner         | Alice                |
+      | uid_owner         | %username%           |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -205,7 +205,7 @@ Feature: update a public link share
       | token             | A_TOKEN              |
       | storage           | A_STRING             |
       | mail_send         | 0                    |
-      | uid_owner         | Alice                |
+      | uid_owner         | %username%           |
       | displayname_owner | %displayname%        |
       | url               | AN_URL               |
       | mimetype          | httpd/unix-directory |
@@ -236,7 +236,7 @@ Feature: update a public link share
       | token             | A_TOKEN                   |
       | storage           | A_STRING                  |
       | mail_send         | 0                         |
-      | uid_owner         | Alice                     |
+      | uid_owner         | %username%                |
       | displayname_owner | %displayname%             |
       | url               | AN_URL                    |
       | mimetype          | httpd/unix-directory      |
@@ -267,7 +267,7 @@ Feature: update a public link share
       | token             | A_TOKEN                   |
       | storage           | A_STRING                  |
       | mail_send         | 0                         |
-      | uid_owner         | Alice                     |
+      | uid_owner         | %username%                |
       | displayname_owner | %displayname%             |
       | url               | AN_URL                    |
       | mimetype          | httpd/unix-directory      |
@@ -298,7 +298,7 @@ Feature: update a public link share
       | token             | A_TOKEN                   |
       | storage           | A_STRING                  |
       | mail_send         | 0                         |
-      | uid_owner         | Alice                     |
+      | uid_owner         | %username%                |
       | displayname_owner | %displayname%             |
       | url               | AN_URL                    |
       | mimetype          | httpd/unix-directory      |

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -512,10 +512,10 @@ Feature: get file properties
   Scenario Outline: Propfind the owner display name of a file using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
-    When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
+    When user "Alice" gets the following properties of file "file.txt" using the WebDAV API
       | propertyName          |
       | oc:owner-display-name |
-    Then the single response should contain a property "oc:owner-display-name" with value "Alice Hansen"
+    Then the single response about the file owned by "Alice" should contain a property "oc:owner-display-name" with value "%displayname%"
     Examples:
       | dav_version |
       | old         |
@@ -528,7 +528,7 @@ Feature: get file properties
     When user "Alice" gets the following properties of folder "/test" using the WebDAV API
       | propertyName          |
       | oc:owner-display-name |
-    Then the single response should contain a property "oc:owner-display-name" with value "Alice Hansen"
+    Then the single response about the file owned by "Alice" should contain a property "oc:owner-display-name" with value "%displayname%"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2016,6 +2016,7 @@ trait Sharing {
 			if (\in_array($field, $userRelatedFieldNames)) {
 				$value = $this->substituteInLineCodes($value, $user);
 			}
+			$value = $this->getActualUsername($value);
 			$value = $this->replaceValuesFromTable($field, $value);
 			Assert::assertTrue(
 				$this->isFieldInResponse($field, $value),
@@ -2025,7 +2026,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^the fields of the last response to user "([^"]*)" sharing with (?:user|group) "([^"]*)" should include$/
+	 * @Then /^the fields of the last response (?:to|about) user "([^"]*)" sharing with (?:user|group) "([^"]*)" should include$/
 	 *
 	 * @param string $sharer
 	 * @param string $sharee
@@ -2037,9 +2038,9 @@ trait Sharing {
 		$this->verifyTableNodeColumnsCount($body, 2);
 		$bodyRows = $body->getRowsHash();
 		foreach ($bodyRows as $field => $value) {
-			if (\in_array($field, ["displayname_owner", "displayname_file_owner", "uid_owner", "uid_file_owner"])) {
+			if (\in_array($field, ["displayname_owner", "displayname_file_owner", "owner", "uid_owner", "uid_file_owner"])) {
 				$value = $this->substituteInLineCodes($value, $sharer);
-			} elseif (\in_array($field, ["share_with", "share_with_displayname"])) {
+			} elseif (\in_array($field, ["share_with", "share_with_displayname", "user"])) {
 				$value = $this->substituteInLineCodes($value, $sharee);
 			}
 			$value = $this->replaceValuesFromTable($field, $value);

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -459,8 +459,26 @@ class WebDavPropertiesContext implements Context {
 	public function theSingleResponseShouldContainAPropertyWithValue(
 		$key, $expectedValue
 	) {
-		$this->theSingleResponseShouldContainAPropertyWithValueAndAlternative(
+		$this->checkSingleResponseContainsAPropertyWithValueAndAlternative(
 			$key, $expectedValue, $expectedValue
+		);
+	}
+
+	/**
+	 * @Then the single response about the file owned by :user should contain a property :key with value :value
+	 *
+	 * @param string $user
+	 * @param string $key
+	 * @param string $expectedValue
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theSingleResponseAboutTheFileOwnedByShouldContainAPropertyWithValue(
+		$user, $key, $expectedValue
+	) {
+		$this->checkSingleResponseContainsAPropertyWithValueAndAlternative(
+			$key, $expectedValue, $expectedValue, $user
 		);
 	}
 
@@ -477,6 +495,23 @@ class WebDavPropertiesContext implements Context {
 	public function theSingleResponseShouldContainAPropertyWithValueAndAlternative(
 		$key, $expectedValue, $altExpectedValue
 	) {
+		$this->checkSingleResponseContainsAPropertyWithValueAndAlternative(
+			$key, $expectedValue, $altExpectedValue
+		);
+	}
+
+	/**
+	 * @param string $key
+	 * @param string $expectedValue
+	 * @param string $altExpectedValue
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function checkSingleResponseContainsAPropertyWithValueAndAlternative(
+		$key, $expectedValue, $altExpectedValue, $user = null
+	) {
 		$xmlPart = $this->featureContext->getResponseXmlObject()->xpath(
 			"//d:prop/$key"
 		);
@@ -485,7 +520,8 @@ class WebDavPropertiesContext implements Context {
 		);
 		$value = $xmlPart[0]->__toString();
 		$expectedValue = $this->featureContext->substituteInLineCodes(
-			$expectedValue
+			$expectedValue,
+			$user
 		);
 		$expectedValue = "#^$expectedValue$#";
 		$altExpectedValue = "#^$altExpectedValue$#";

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
@@ -31,7 +31,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  |            |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario: expiration date is disabled for sharing with groups but enabled for sharing with users, user shares with a group
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
@@ -45,7 +45,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  |            |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario: expiration date is enabled for sharing with groups, user shares a file with a group
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
@@ -60,7 +60,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario Outline: expiration date is enforced for group, user shares a file
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
@@ -75,7 +75,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | <days>     |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
     Examples:
       | num_days | days     |
       | 3        | +3 days  |
@@ -94,7 +94,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario: expiration date is enforced for group, user reshares received file with the group
     Given user "Carol" has shared file "lorem.txt" with user "Alice"
@@ -109,7 +109,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario: expiration date is enabled but not enforced for group, user reshares received file with group
     Given user "Carol" has shared file "lorem.txt" with user "Alice"
@@ -123,7 +123,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | +7 days    |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario: expiration date is enabled but not enforced for group, user reshares received file with group, but removes default expiration date
     Given user "Carol" has shared file "lorem.txt" with user "Alice"
@@ -136,7 +136,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
     And the information of the last share of user "Alice" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  |            |
 
   Scenario: expiration date is enabled but not enforced for group, user reshares received file with user, but changes expiration date
@@ -150,7 +150,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
     And the information of the last share of user "Alice" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +15 days   |
 
   Scenario: expiration date is enabled but not enforced for group, user shares to group through api and checks the expiration date on webUI
@@ -183,7 +183,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
     And the information of the last share of user "Alice" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +10 days   |
 
   Scenario: expiration date is enabled but not enforced for group, user receives a share with expiration date and reshares with expiration date in future than the original
@@ -203,7 +203,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
     And the information of the last share of user "Alice" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +20 days   |
 
   Scenario: expiration date is enabled and enforced for group, user receives a share with expiration date and tries to reshare with expiration date less than the original
@@ -224,7 +224,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
     And the information of the last share of user "Alice" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +20 days   |
 
   Scenario: expiration date is enabled and enforced for group, user receives a share with expiration date and tries to reshare with expiration date further in future than the original
@@ -245,7 +245,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
     And the information of the last share of user "Alice" should include
       | share_type  | group      |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +30 days   |
 
   Scenario: expiration date is enabled and enforced for group, user receives a folder from a group share with expiration date and shares sub-folder with group
@@ -268,7 +268,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
     And the information of the last share of user "Alice" should include
       | share_type  | group                |
       | file_target | /simple-empty-folder |
-      | uid_owner   | Alice                |
+      | uid_owner   | %username%           |
       | expiration  | +20 days             |
       | share_with  | grp1                 |
 
@@ -285,7 +285,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | share_type  | group      |
       | file_target | /lorem.txt |
       | expiration  | <days>     |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | share_with  | grp1       |
     Examples:
       | days     |

--- a/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
@@ -22,7 +22,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  |            |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario: expiration date is disabled for sharing with users but enabled for sharing with groups, user shares with another user
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
@@ -43,7 +43,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | +7 days    |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario Outline: expiration date is enforced for user, user shares file
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
@@ -58,7 +58,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | <days>     |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
     Examples:
       | num_days | days     |
       | 3        | +3 days  |
@@ -77,7 +77,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario: expiration date is enforced for user, user reshares received file with another user
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -92,7 +92,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | +3 days    |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario: expiration date is enabled but not enforced for user, user reshares received file with another user
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -106,7 +106,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | +7 days    |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
 
   Scenario: expiration date is enabled but not enforced for user, user reshares received file with another user, but removes default expiration date
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -119,7 +119,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
     And the information of the last share of user "Alice" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  |            |
 
   Scenario: expiration date is enabled but not enforced for user, user reshares received file with another user, but changes expiration date
@@ -133,7 +133,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
     And the information of the last share of user "Alice" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +15 days   |
 
   Scenario: expiration date is enabled but not enforced, user shares through api and checks the expiration date on webUI
@@ -166,7 +166,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
     And the information of the last share of user "Alice" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +10 days   |
 
   Scenario: expiration date is enabled but not enforced, user receives a share with expiration date and reshares it, setting a date further in future than the original
@@ -186,7 +186,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
     And the information of the last share of user "Alice" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +20 days   |
 
   Scenario: expiration date is enabled and enforced, user receives a share with expiration date and tries to reshare with expiration date less than the original
@@ -207,7 +207,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
     And the information of the last share of user "Alice" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +20 days   |
 
   Scenario: expiration date is enabled and enforced, user receives a share with expiration date and tries to reshare it with a date further in future than the original
@@ -228,7 +228,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
     And the information of the last share of user "Alice" should include
       | share_type  | user       |
       | file_target | /lorem.txt |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
       | expiration  | +30 days   |
 
   Scenario: expiration date is enabled and enforced, user receives a folder from a user share with expiration date and shares sub-folder with another user
@@ -249,7 +249,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
     And the information of the last share of user "Alice" should include
       | share_type  | user                 |
       | file_target | /simple-empty-folder |
-      | uid_owner   | Alice                |
+      | uid_owner   | %username%           |
       | expiration  | +20 days             |
       | share_with  | Brian                |
 
@@ -266,7 +266,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | share_type  | user       |
       | file_target | /lorem.txt |
       | expiration  | <days>     |
-      | uid_owner   | Alice      |
+      | uid_owner   | %username% |
     Examples:
       | days     |
       | +15 days |

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -344,6 +344,12 @@ function env_alt_home_clear {
 function run_behat_tests() {
 	echo "Running ${SUITE_FEATURE_TEXT} tests tagged ${BEHAT_FILTER_TAGS} ${BROWSER_TEXT}${BROWSER_VERSION_TEXT}${PLATFORM_TEXT}" | tee ${TEST_LOG_FILE}
 
+	if [ "${REPLACE_USERNAMES}" == "true" ]
+	then
+		echo "Usernames and attributes in tests are being replaced:"
+		cat ${SCRIPT_PATH}/usernames.json
+	fi
+
 	${BEHAT} --colors --strict -c ${BEHAT_YML} -f junit -f pretty ${BEHAT_SUITE_OPTION} --tags ${BEHAT_FILTER_TAGS} ${BEHAT_FEATURE} -v  2>&1 | tee -a ${TEST_LOG_FILE}
 
 	BEHAT_EXIT_STATUS=${PIPESTATUS[0]}


### PR DESCRIPTION
## Description
When I do an acceptance test run with replacement usernames I get various test fails because some recently-added scenarios are not abstracting the username in the required places. So, for example, "Alice" is replaced with username "000" in PR #37506 but some `Then` steps fail because they expect hard-coded "Alice" when they should be expecting `%username%` which will be substituted at run-time for the actual replaced username.

- Fix these so that they work properly when replacing the username.
- Add some log output at the beginning of a test run when `REPLACE_USERNAMES` is defined. Show the username and user attribute replacements so that we know what was happening when we later lok at the log output.

## How Has This Been Tested?
CI in PR #37506 passes

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
