### PR TITLE
[Tests-Only] Fix phpstan.neon after phpstan 0.12.33 release

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,24 +2,20 @@ parameters:
   bootstrapFiles:
     - %currentWorkingDirectory%/lib/base.php
   excludes_analyse:
-    - %currentWorkingDirectory%/core/templates/*
-    - %currentWorkingDirectory%/core/routes.php
     - %currentWorkingDirectory%/core/ajax/update.php
     - %currentWorkingDirectory%/apps/*/tests*
-    - %currentWorkingDirectory%/apps/*/appinfo/routes.php
     - %currentWorkingDirectory%/apps/*/composer/*
     - %currentWorkingDirectory%/apps/*/3rdparty/*
     - %currentWorkingDirectory%/apps/files_external/ajax/oauth2.php
     - %currentWorkingDirectory%/apps/files_external/lib/Lib/Storage/Google.php
     - %currentWorkingDirectory%/apps/files_external/lib/Lib/Storage/SMB.php
     - %currentWorkingDirectory%/settings/templates/*
-    - %currentWorkingDirectory%/settings/routes.php
   ignoreErrors:
     - '#Undefined variable: \$OC_[a-zA-Z0-9\\_]+#'
     - '#Undefined variable: \$vendor#'
     - '#Instantiated class Test\\Util\\User\\Dummy not found.#'
     # errors below are to be addressed by own pull requests - non trivial changes required
-    - '#Unsafe usage of new static().#'
+    - '#Unsafe usage of new static\(\).#'
     - '#Cannot instantiate interface OCP\\Files\\ObjectStore\\IObjectStore.#'
     - '#Instantiated class OCA\\Encryption\\Crypto\\Crypt not found.#'
     - '#Instantiated class OCA\\Encryption\\Util not found.#'


### PR DESCRIPTION
## Description
CI is failing, e.g. https://drone.owncloud.com/owncloud/core/25992/4/7
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=2G --configuration=./phpstan.neon --level=0 apps core settings lib/private lib/public ocs ocs-provider
 -- --------------------------------------------------------------------------- 
     Error                                                                      
 -- --------------------------------------------------------------------------- 
     Ignored error #Unsafe usage of new static().# has an unescaped '()' which  
     leads to ignoring all errors. Use '\(\)' instead.                          
 -- --------------------------------------------------------------------------- 

 [ERROR] Found 1 error                 
```

phpstan https://github.com/phpstan/phpstan/releases/tag/0.12.33 now reports what is actually a problem in `phpstan.neon`

Fix it and also remove items from `excludes_analyse` that can now be analysed by phpstan.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
