### PR TITLE
[10.5.0] Ignore enterprise_key app when checking for apps to default_enable

### DIFF
--- a/changelog/10.5.0_2020-07-09/36814
+++ b/changelog/10.5.0_2020-07-09/36814
@@ -12,3 +12,4 @@ key from there, and it will take into account whether the config.php is read-onl
 You can also enter a license key from the grace period popup.
 
 https://github.com/owncloud/core/pull/36814
+https://github.com/owncloud/core/pull/37711

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -447,6 +447,12 @@ class Installer {
 			if ($dir = \opendir($app_dir['path'])) {
 				$nodes = \scandir($app_dir['path']);
 				foreach ($nodes as $filename) {
+					// Since core 10.5.0, enterprise_key app is no longer used
+					// Be sure not to accidentally enable it if it has been
+					// left behind in an apps dir.
+					if ($filename === 'enterprise_key') {
+						continue;
+					}
 					if (\substr($filename, 0, 1) != '.' and \is_dir($app_dir['path']."/$filename")) {
 						if (\file_exists($app_dir['path']."/$filename/appinfo/info.xml")) {
 							if (!Installer::isInstalled($filename)) {

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -383,6 +383,15 @@ class OC_App {
 	 * This function set an app as enabled in appconfig.
 	 */
 	public static function enable($app, $groups = null) {
+		// Since core 10.5.0, enterprise_key app is no longer used
+		// Be sure not to accidentally enable it if it has been
+		// left behind in an apps dir.
+		if ($app === 'enterprise_key') {
+			throw new \Exception(
+				"App $app can't be enabled. It is not used from core 10.5.0 onwards."
+			);
+		}
+
 		self::$enabledAppsCache = []; // flush
 
 		// check for required dependencies


### PR DESCRIPTION
## Description
If someone upgrades to 10.5.0 and then, after putting the 10.5.0 code in place, they copy back their non-core apps from the previous installation, and that includes an recent but old version of the `enterprise_key` app, then the `enterprise_key` app will not have any core `max_version` set, and it will have `default_enable` in its `info.xml`. So the `enterprise_key` app will get auto-enabled.

That is unfortunate in 10.5.0!

This PR teaches the server code about the special-case of the `enterprise_key` app.

1) it will now be ignored when calculating the "shipped apps" (which include apps that have `default_enable`)
2) the `occ app:enable` command will also refuse to enable it (e.g. if someone puts an old version in their `apps` dir and then manually tries to `occ app:enable enterprise_key`)

## How Has This Been Tested?
```
$ php occ a:e enterprise_key

In app.php line 390:
                                                                                 
  App enterprise_key can't be enabled. It is not used from core 10.5.0 onwards.  
                                                                                 

app:enable [-g|--groups GROUPS] [--] <app-id>
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
