### PR TITLE
Change cache prefix only with server upgrades but not installing apps

### DIFF
--- a/changelog/unreleased/37715
+++ b/changelog/unreleased/37715
@@ -1,0 +1,16 @@
+Bugfix: Fix problem with the market app installing an app using OpenIDConnect
+
+The OpenIDConnect app uses an in-memory cache to store an OpenID session
+in order to avoid hitting the OpenID provider too much.
+After an app was installed, the prefix used to store information in the cache was
+changing. This was causing problems because the OpenIDConnect app thought the
+OpenID session was no longer valid and, as a consequence, it was logging out the
+user. In practice, installing an new app with the market app having logged in via
+OpenIDConnect would cause the user to logout.
+
+Now, the cache prefix only changes after an ownCloud upgrade. Installing an app
+won't cause the cache prefix to change, so this will fix the problem.
+The OpenIDConnect app will still find the stored session information after the
+new apps are installed.
+
+https://github.com/owncloud/core/pull/37715

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -185,6 +185,8 @@ if (OC::checkUpgrade(false)) {
 		$eventSource->send('success', (string)$l->t('Finished code integrity check'));
 	});
 
+	$cacheFactory = \OC::$server->getMemCacheFactory();  // create instance before the upgrade
+
 	try {
 		$updater->upgrade();
 	} catch (\Exception $e) {
@@ -192,6 +194,12 @@ if (OC::checkUpgrade(false)) {
 		$eventSource->close();
 		exit();
 	}
+
+	// Clear caches after successful upgrade.
+	// Caches were created before the upgrade, so the cache prefix will be the old one
+	// TODO: Note that only the "create" method is available in the interface. It isn't
+	// possible to create local or distributed caches explicitly
+	$cacheFactory->create()->clear();
 
 	$disabledApps = [];
 	foreach ($disabledThirdPartyApps as $app) {

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -139,7 +139,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Maintenance\SingleUser(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
 
-	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger()));
+	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger(), \OC::$server->getMemCacheFactory()));
 	$application->add(new OC\Core\Command\Maintenance\Repair(
 		new \OC\Repair(\OC\Repair::getRepairSteps(), \OC::$server->getEventDispatcher()),
 		\OC::$server->getConfig(),

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -441,9 +441,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			$config = $c->getConfig();
 
 			if ($config->getSystemValue('installed', false) && !(\defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
-				$v = \OC_App::getAppVersions();
-				$v['core'] = \md5(\file_get_contents(\OC::$SERVERROOT . '/version.php'));
-				$version = \implode(',', $v);
+				$version = $config->getSystemValue('version', '0.0.0');  // copied from Updater->upgrade
 				$instanceId = \OC_Util::getInstanceId();
 				$path = \OC::$SERVERROOT;
 				$prefix = \md5($instanceId . '-' . $version . '-' . $path);


### PR DESCRIPTION
Upgrading the OC server will clear all the caches and change the cache
prefix. This commit will add the "clear" step after a successful upgrade
to avoid leaving unused data. Changing the cache prefix was already
being done in this case.

Installing a new app won't make the cache prefix to change. This fixes a
problem installing an app using openID auth. The openID app uses a
distributed cache whose prefix was changing after installing a new app
through the market app, causing the user to logout due to wrong or
missing info (coming from the cache)

Apps are now responsible to clear their caches after the app is
upgraded, if applicable. The apps can also decide not to clean the cache

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/owncloud/appliance/issues/80
https://github.com/owncloud/enterprise/issues/4089

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Linked issue hasn't been tested yet. However, I've verified the expected behaviour:
* Installing an new app through the market won't change the cache prefix. This should fix the linked issue
* Upgrading core will clear all the caches. This is new behaviour, but anyway the old caches weren't used any longer due to the change in the prefix, so it shouldn't cause new problems. Cache prefix will still be changed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
