### PR TITLE
[Tests-Only] Expected failures demo

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -248,6 +248,9 @@ config = {
 			'filterTags': '@smokeTest&&~@notifications-app-required',
 			'runAllSuites': True,
 			'numberOfParts': 5,
+			'extraEnvironment': {
+				'EXPECTED_FAILURES_FILE': 'tests/acceptance/expected-failures.txt'
+			}
 		},
 	}
 }

--- a/.drone.star
+++ b/.drone.star
@@ -116,6 +116,9 @@ config = {
 				'apiWebdavUpload1',
 				'apiWebdavUpload2',
 			],
+			'extraEnvironment': {
+				'EXPECTED_FAILURES_FILE': 'tests/acceptance/expected-failures.txt'
+			}
 		},
 		'apiNotifications': {
 			'suites': [

--- a/.drone.star
+++ b/.drone.star
@@ -249,7 +249,7 @@ config = {
 			'runAllSuites': True,
 			'numberOfParts': 5,
 			'extraEnvironment': {
-				'EXPECTED_FAILURES_FILE': 'tests/acceptance/expected-failures.txt'
+				'EXPECTED_FAILURES_FILE': 'tests/acceptance/expected-smoke-test-failures.txt'
 			}
 		},
 	}

--- a/tests/acceptance/expected-failures.txt
+++ b/tests/acceptance/expected-failures.txt
@@ -1,0 +1,5 @@
+apiComments/comments.feature:9
+# write a comment
+apiComments/comments.feature:38
+apiFavorites/favorites.feature:28
+apiFavorites/favorites.feature:29

--- a/tests/acceptance/expected-smoke-test-failures.txt
+++ b/tests/acceptance/expected-smoke-test-failures.txt
@@ -1,0 +1,1 @@
+apiComments/comments.feature:9

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -11,7 +11,7 @@ Feature: Comments
     And user "Alice" has commented with content "My first comment" on file "/myFileToComment.txt"
     And user "Alice" should have the following comments on file "/myFileToComment.txt"
       | user  | comment          |
-      | Alice | My first comment |
+      | Alice | My first commenz |
     When user "Alice" gets the following properties of folder "/myFileToComment.txt" using the WebDAV API
       | propertyName       |
       | oc:comments-href   |
@@ -47,7 +47,7 @@ Feature: Comments
       | objectType       | files            |
       | isUnread         | false            |
       | actorDisplayName | %displayname%    |
-      | message          | My first comment |
+      | message          | My first commenz |
 
   Scenario: Getting more info about comments using PROPFIND method
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "myFileToComment.txt"

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -22,7 +22,7 @@ Feature: favorite
     When user "Alice" gets the following properties of folder "/FOLDER" using the WebDAV API
       | propertyName |
       | oc:favorite  |
-    Then the single response should contain a property "oc:favorite" with value "1"
+    Then the single response should contain a property "oc:favorite" with value "2"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -34,6 +34,19 @@ BEHAT_TAGS_OPTION_FOUND=false
 # RUN_PART and DIVIDE_INTO_NUM_PARTS - see "--part" description
 # SHOW_OC_LOGS - see "--show-oc-logs" description
 # TESTING_REMOTE_SYSTEM - see "--remote" description
+# EXPECTED_FAILURES_FILE - a file that contains a list of the scenarios that are expected to fail
+
+if [ -n "${EXPECTED_FAILURES_FILE}" ]
+then
+	if [ -f "${EXPECTED_FAILURES_FILE}" ]
+	then
+		echo "Checking expected failures in ${EXPECTED_FAILURES_FILE}"
+	else
+		echo "Expected failures file ${EXPECTED_FAILURES_FILE} not found"
+		echo "Check the setting of EXPECTED_FAILURES_FILE environment variable"
+		exit 1
+	fi
+fi
 
 # Default to testing a local system
 if [ -z "${TESTING_REMOTE_SYSTEM}" ]
@@ -376,14 +389,84 @@ function run_behat_tests() {
 		fi
 	fi
 
+	if [ -n "${EXPECTED_FAILURES_FILE}" ]
+	then
+		echo "Checking expected failures"
+		PASSED=true
+		SOME_SCENARIO_RERUN=false
+		FAILED_SCENARIO_PATHS_COLORED=`awk '/Failed scenarios:/',0 ${TEST_LOG_FILE} | grep feature`
+		# There will be some ANSI escape codes for color in the FEATURE_COLORED var.
+		# Strip them out so we can pass just the ordinary feature details to Behat.
+		# Thanks to https://en.wikipedia.org/wiki/Tee_(command) and
+		# https://stackoverflow.com/questions/23416278/how-to-strip-ansi-escape-sequences-from-a-variable
+		# for ideas.
+		FAILED_SCENARIO_PATHS=$(echo "${FAILED_SCENARIO_PATHS_COLORED}" | sed "s/\x1b[^m]*m//g")
+
+		# Check that every failed scenario is in the list of expected failures
+		for FAILED_SCENARIO_PATH in ${FAILED_SCENARIO_PATHS}
+			do
+				SUITE_PATH=`dirname ${FAILED_SCENARIO_PATH}`
+				SUITE=`basename ${SUITE_PATH}`
+				SCENARIO=`basename ${FAILED_SCENARIO_PATH}`
+				SUITE_SCENARIO="${SUITE}/${SCENARIO}"
+				grep -x ${SUITE_SCENARIO} ${EXPECTED_FAILURES_FILE} > /dev/null
+				if [ $? -ne 0 ]
+				then
+					echo "Error: Scenario ${SUITE_SCENARIO} failed but was not expected to fail."
+					PASSED=false
+				fi
+			done
+
+		# Check that every scenario in the list of expected failures did fail
+		while read SUITE_SCENARIO
+			do
+				# Ignore comment lines (starting with hash)
+				if [[ "${SUITE_SCENARIO}" =~ ^# ]]
+				then
+					continue
+				fi
+
+				if [ -n "${BEHAT_SUITE_TO_RUN}" ]
+				then
+					# If the expected failure is not in the suite that is currently being run,
+					# then do not try and check that it failed.
+					REGEX_TO_MATCH="^${BEHAT_SUITE_TO_RUN}"
+					if ! [[ "${SUITE_SCENARIO}" =~ ${REGEX_TO_MATCH} ]]
+					then
+						continue
+					fi
+				fi
+
+				# look for the expected suite-scenario at the end of a line in the
+				# FAILED_SCENARIO_PATHS - for example looking for apiComments/comments.feature:9
+				# we want to match lines like:
+				# tests/acceptance/features/apiComments/comments.feature:9
+				# but not lines like::
+				# tests/acceptance/features/apiComments/comments.feature:902
+				echo "${FAILED_SCENARIO_PATHS}" | grep ${SUITE_SCENARIO}$ > /dev/null
+				if [ $? -ne 0 ]
+				then
+					echo "Error: Scenario ${SUITE_SCENARIO} was expected to fail but did not fail."
+					PASSED=false
+				fi
+			done < ${EXPECTED_FAILURES_FILE}
+
+		if [ "${PASSED}" = true ]
+		then
+			echo "Success - all failures were expected"
+		else
+			echo "Failure - actual and expected failures did not match"
+		fi
+	fi
+
 	# With webUI tests, we try running failed tests again.
 	if [ "${PASSED}" = false ] && [ "${RUNNING_WEBUI_TESTS}" = true ] && [ "${RERUN_FAILED_WEBUI_SCENARIOS}" = true ]
 	then
 		echo "webUI test run failed with exit status: ${BEHAT_EXIT_STATUS}"
 		PASSED=true
 		SOME_SCENARIO_RERUN=false
-		FAILED_SCENARIOS=`awk '/Failed scenarios:/',0 ${TEST_LOG_FILE} | grep feature`
-		for FEATURE_COLORED in ${FAILED_SCENARIOS}
+		FAILED_SCENARIO_PATHS=`awk '/Failed scenarios:/',0 ${TEST_LOG_FILE} | grep feature`
+		for FEATURE_COLORED in ${FAILED_SCENARIO_PATHS}
 			do
 				SOME_SCENARIO_RERUN=true
 				# There will be some ANSI escape codes for color in the FEATURE_COLORED var.
@@ -391,9 +474,9 @@ function run_behat_tests() {
 				# Thanks to https://en.wikipedia.org/wiki/Tee_(command) and
 				# https://stackoverflow.com/questions/23416278/how-to-strip-ansi-escape-sequences-from-a-variable
 				# for ideas.
-				FEATURE=$(echo "${FEATURE_COLORED}" | sed "s/\x1b[^m]*m//g")
-				echo "Rerun failed scenario: ${FEATURE}"
-				${BEHAT} --colors --strict -c ${BEHAT_YML} -f junit -f pretty ${BEHAT_SUITE_OPTION} --tags ${BEHAT_FILTER_TAGS} ${FEATURE} -v  2>&1 | tee -a ${TEST_LOG_FILE}
+				FAILED_SCENARIO_PATH=$(echo "${FEATURE_COLORED}" | sed "s/\x1b[^m]*m//g")
+				echo "Rerun failed scenario: ${FAILED_SCENARIO_PATH}"
+				${BEHAT} --colors --strict -c ${BEHAT_YML} -f junit -f pretty ${BEHAT_SUITE_OPTION} --tags ${BEHAT_FILTER_TAGS} ${FAILED_SCENARIO_PATH} -v  2>&1 | tee -a ${TEST_LOG_FILE}
 				BEHAT_EXIT_STATUS=${PIPESTATUS[0]}
 				if [ ${BEHAT_EXIT_STATUS} -ne 0 ]
 				then
@@ -602,8 +685,8 @@ fi
 # If a feature file has been specified but no suite, then deduce the suite
 if [ -n "${BEHAT_FEATURE}" ] && [ -z "${BEHAT_SUITE}" ]
 then
-	FEATURE_PATH=`dirname ${BEHAT_FEATURE}`
-	BEHAT_SUITE=`basename ${FEATURE_PATH}`
+	SUITE_PATH=`dirname ${BEHAT_FEATURE}`
+	BEHAT_SUITE=`basename ${SUITE_PATH}`
 fi
 
 if [ -z "${BEHAT_YML}" ]
@@ -1025,21 +1108,21 @@ TEST_LOG_FILE=$(mktemp)
 
 for i in "${!BEHAT_SUITES[@]}"
 	do
-	BEHAT_SUITE_OPTION="--suite=${BEHAT_SUITES[$i]}"
-	SUITE_FEATURE_TEXT="${BEHAT_SUITES[$i]}"
-	for rerun_number in $(seq 1 ${BEHAT_RERUN_TIMES})
-		do
-		if ((${BEHAT_RERUN_TIMES} > 1))
-		then
-			echo -e "\nTest repeat $rerun_number of ${BEHAT_RERUN_TIMES}"
-		fi
-		run_behat_tests
-	done
+		BEHAT_SUITE_TO_RUN="${BEHAT_SUITES[$i]}"
+		BEHAT_SUITE_OPTION="--suite=${BEHAT_SUITE_TO_RUN}"
+		SUITE_FEATURE_TEXT="${BEHAT_SUITES[$i]}"
+		for rerun_number in $(seq 1 ${BEHAT_RERUN_TIMES})
+			do
+				if ((${BEHAT_RERUN_TIMES} > 1))
+				then
+					echo -e "\nTest repeat $rerun_number of ${BEHAT_RERUN_TIMES}"
+				fi
+				run_behat_tests
+			done
 
 	if [ "${PASSED}" = false ]
 	then
-		teardown
-		exit 1
+		break
 	fi
 done
 
@@ -1047,7 +1130,13 @@ teardown
 
 if [ "${PASSED}" = true ]
 then
-	exit 0
+	FINAL_EXIT_STATUS=0
 else
-	exit 1
+	FINAL_EXIT_STATUS=1
 fi
+
+if [ -n "${EXPECTED_FAILURES_FILE}" ]
+then
+	echo "runsh: Exit code after checking expected failures: ${FINAL_EXIT_STATUS}"
+fi
+exit ${FINAL_EXIT_STATUS}


### PR DESCRIPTION
## Description
This is a demonstrator for defining a list of scenarios that are expected to fail.

- 1st commit purposely breaks some scenarios in `apiComments` and `apiFavorites` suites, and lists those in ` tests/acceptance/expected-failures.txt`
- 2nd commit defines `EXPECTED_FAILURES_FILE` in drone so that the failures will be checked to make sure exactly the expected failures have - no more and no less
- 3rd commit provides the code in ` tests/acceptance/run.sh` to do the checking

The file that lists the expected failures should list just the suite name followed by the feature and line number of each scenario (or scenario outline example) that is expected to fail.

Lines starting with `#` are comments and are ignored.

For example:
```
apiComments/comments.feature:9
# write a comment
apiComments/comments.feature:38
apiFavorites/favorites.feature:28
apiFavorites/favorites.feature:29
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
