### PR TITLE
Add enable lock file action checkbox

### DIFF
--- a/changelog/10.5.0_2020-06-23/37460
+++ b/changelog/10.5.0_2020-06-23/37460
@@ -2,3 +2,4 @@ Change: Add file action to lock a file
 
 https://github.com/owncloud/core/pull/37460
 https://github.com/owncloud/core/pull/37647
+https://github.com/owncloud/core/pull/37700

--- a/changelog/10.5.0_2020-06-23/37460
+++ b/changelog/10.5.0_2020-06-23/37460
@@ -2,4 +2,3 @@ Change: Add file action to lock a file
 
 https://github.com/owncloud/core/pull/37460
 https://github.com/owncloud/core/pull/37647
-https://github.com/owncloud/core/pull/37700

--- a/changelog/unreleased/37720
+++ b/changelog/unreleased/37720
@@ -1,0 +1,8 @@
+Change: Add settings checkbox to enable manual file locking
+
+A checkbox to enable manual file locking on the web UI has been added to
+admin settings, additional, manual file locking. This checkbox is an alternative
+way to enable manual file locking on the web UI. The occ command can also still
+be used - occ config:app:set files enable_lock_file_action --value yes
+
+https://github.com/owncloud/core/pull/37720

--- a/changelog/unreleased/37720
+++ b/changelog/unreleased/37720
@@ -1,8 +1,8 @@
 Change: Add settings checkbox to enable manual file locking
 
-A checkbox to enable manual file locking on the web UI has been added to
+A checkbox to enable manual file locking on clients has been added to
 admin settings, additional, manual file locking. This checkbox is an alternative
-way to enable manual file locking on the web UI. The occ command can also still
-be used - occ config:app:set files enable_lock_file_action --value yes
+way to enable manual file locking on clients that support it. The occ command
+can also still be used - occ config:app:set files enable_lock_file_action --value yes
 
 https://github.com/owncloud/core/pull/37720

--- a/settings/Panels/Admin/PersistentLocking.php
+++ b/settings/Panels/Admin/PersistentLocking.php
@@ -47,6 +47,7 @@ class PersistentLocking implements ISettings {
 		$tmpl = new Template('settings', 'panels/admin/persistentlocking');
 		$tmpl->assign('defaultTimeout', $this->config->getAppValue('core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT));
 		$tmpl->assign('maximumTimeout', $this->config->getAppValue('core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX));
+		$tmpl->assign('manualFileLockOnWebUIEnabled', $this->config->getAppValue('files', 'enable_lock_file_action', 'no'));
 
 		return $tmpl;
 	}

--- a/settings/Panels/Admin/PersistentLocking.php
+++ b/settings/Panels/Admin/PersistentLocking.php
@@ -47,7 +47,7 @@ class PersistentLocking implements ISettings {
 		$tmpl = new Template('settings', 'panels/admin/persistentlocking');
 		$tmpl->assign('defaultTimeout', $this->config->getAppValue('core', 'lock_timeout_default', LockManager::LOCK_TIMEOUT_DEFAULT));
 		$tmpl->assign('maximumTimeout', $this->config->getAppValue('core', 'lock_timeout_max', LockManager::LOCK_TIMEOUT_MAX));
-		$tmpl->assign('manualFileLockOnWebUIEnabled', $this->config->getAppValue('files', 'enable_lock_file_action', 'no'));
+		$tmpl->assign('manualFileLockOnClientsEnabled', $this->config->getAppValue('files', 'enable_lock_file_action', 'no'));
 
 		return $tmpl;
 	}

--- a/settings/js/panels/persistentlocking.js
+++ b/settings/js/panels/persistentlocking.js
@@ -3,22 +3,34 @@ $(document).ready(function() {
 	$('#persistentlocking input').change(function () {
 		var currentInput = $(this);
 		var name = currentInput.attr('name');
-		var value = currentInput.val();
-
-		var minRange = currentInput.attr('min');
-		var maxRange = currentInput.attr('max');
-
-		// range validation (mainly for firefox) to prevent saving wrong values
 		var isValid = true;
-		if (minRange !== undefined && value < minRange) {
-			isValid = false;
-		}
-		if (maxRange !== undefined && value > maxRange) {
-			isValid = false;
+		var app = '';
+		var value = '';
+
+		if (name === 'enable_lock_file_action') {
+			app = 'files';
+			if (this.checked) {
+				value = 'yes';
+			} else {
+				value = 'no';
+			}
+		} else {
+			app = 'core';
+			value = currentInput.val();
+			var minRange = currentInput.attr('min');
+			var maxRange = currentInput.attr('max');
+
+			// range validation (mainly for firefox) to prevent saving wrong values
+			if (minRange !== undefined && value < minRange) {
+				isValid = false;
+			}
+			if (maxRange !== undefined && value > maxRange) {
+				isValid = false;
+			}
 		}
 
 		if (isValid) {
-			OC.AppConfig.setValue('core', name, value);
+			OC.AppConfig.setValue(app, name, value);
 		}
 		// browser should take care of the visual indication if the value
 		// isn't in the range

--- a/settings/templates/panels/admin/persistentlocking.php
+++ b/settings/templates/panels/admin/persistentlocking.php
@@ -17,4 +17,10 @@ script('settings', 'panels/persistentlocking');
 		min="0"
 		value="<?php p($_['maximumTimeout'])?>" />
 	<br/>
+	<input type="checkbox" name="enable_lock_file_action" id="manualFileLockOnWebUIEnabled" class="checkbox"
+		   value="1" <?php if ($_['manualFileLockOnWebUIEnabled'] === 'yes') {
+	print_unescaped('checked="checked"');
+} ?> />
+	<label for="manualFileLockOnWebUIEnabled"><?php p($l->t('Enable manual file locking on the web UI'));?></label>
+	<br/>
 </div>

--- a/settings/templates/panels/admin/persistentlocking.php
+++ b/settings/templates/panels/admin/persistentlocking.php
@@ -17,10 +17,10 @@ script('settings', 'panels/persistentlocking');
 		min="0"
 		value="<?php p($_['maximumTimeout'])?>" />
 	<br/>
-	<input type="checkbox" name="enable_lock_file_action" id="manualFileLockOnWebUIEnabled" class="checkbox"
-		   value="1" <?php if ($_['manualFileLockOnWebUIEnabled'] === 'yes') {
+	<input type="checkbox" name="enable_lock_file_action" id="manualFileLockOnClientsEnabled" class="checkbox"
+		   value="1" <?php if ($_['manualFileLockOnClientsEnabled'] === 'yes') {
 	print_unescaped('checked="checked"');
 } ?> />
-	<label for="manualFileLockOnWebUIEnabled"><?php p($l->t('Enable manual file locking on the web UI'));?></label>
+	<label for="manualFileLockOnClientsEnabled"><?php p($l->t('Enable manual file locking on clients'));?></label>
 	<br/>
 </div>


### PR DESCRIPTION
## Description
Adds a checkbox to admin settings "Manual File Locking" to "Enable manual file locking on clients"

Checking the checkbox does the same as:

`occ config:app:set files enable_lock_file_action --value yes`

Unchecking does the same as:

`occ config:app:set files enable_lock_file_action --value no`

![Screenshot_2020-07-22 Settings - ownCloud](https://user-images.githubusercontent.com/1535615/88136961-31796500-cc0a-11ea-9804-57086fe9d581.png)

Note: the 3rd commit adjusts the checkbox description so that it says "Enable manual file locking on clients".

## Related Issue
This is a follow-on enhancement from all the file locking additions.

Also related to the discussion in #37620 about the meaning/interpretation of this setting. Any client that wants to support manual file locking can check this when deciding whether to give the user options for locking files. (A separate PR proposes to expose this setting in the capabilities API endpoint)

## How Has This Been Tested?
Manually check the new checkbox, the browse to the Files page and confirm that the "Lock file" action is available for a file.

Manually uncheck the new checkbox, the browse to the Files page and confirm that the "Lock file" action is not  available for a file.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
