### PR TITLE
[Tests-Only] Adjust skip tags expected failures

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-26 @issue-ocis-reva-27
+@api @wasSkipOnOcis @issue-ocis-reva-26 @issue-ocis-reva-27
 Feature: CORS headers
 
   Background:

--- a/tests/acceptance/features/apiAuth/filesAppAuth.feature
+++ b/tests/acceptance/features/apiAuth/filesAppAuth.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-28
+@api @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-28
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuth/tokenAuth.feature
+++ b/tests/acceptance/features/apiAuth/tokenAuth.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-28 @issue-ocis-reva-37
+@api @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-28 @issue-ocis-reva-37
 Feature: tokenAuth
 
   Background:

--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -14,7 +14,7 @@ Feature: auth
     When user "Alice" requests "/remote.php/webdav" with "PROPFIND" using basic auth
     Then the HTTP status code should be "207"
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-28
+  @smokeTest @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-28
   Scenario: using WebDAV with token auth
     Given a new client token for "Alice" has been generated
     When user "Alice" requests "/remote.php/webdav" with "PROPFIND" using basic token auth
@@ -25,7 +25,7 @@ Feature: auth
 	#	When requesting "/remote.php/webdav" with "PROPFIND" using a client token
 	#	Then the HTTP status code should be "207"
 
-  @smokeTest  @skipOnOcis
+  @smokeTest  @skipOnOcis @toImplementOnOCIS
   Scenario: using WebDAV with browser session
     Given a new browser session for "Alice" has been started
     When the user requests "/remote.php/webdav" with "PROPFIND" using the browser session

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -1,11 +1,11 @@
-@api @files_sharing-app-required @skipOnOcis
+@api @files_sharing-app-required @wasSkipOnOcis
 Feature: auth
 
   Background:
     Given user "another-admin" has been created with default attributes and without skeleton files
     And user "another-admin" has been added to group "admin"
 
-  @smokeTest @issue-32068 @skipOnOcis @issue-ocis-reva-30 @issue-ocis-reva-65
+  @smokeTest @issue-32068 @wasSkipOnOcis @issue-ocis-reva-30 @issue-ocis-reva-65
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     When user "another-admin" requests these endpoints with "DELETE" using password "invalid" about user "Alice"

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -4,7 +4,7 @@ Feature: auth
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @issue-32068 @skipOnOcis
+  @issue-32068 @wasSkipOnOcis
   @issue-ocis-reva-30
   @smokeTest
   Scenario: using OCS anonymously
@@ -29,7 +29,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
 
-  @skipOnOcis @issue-ocis-reva-29
+  @wasSkipOnOcis @issue-ocis-reva-29
   Scenario: ocs config end point accessible by unauthorized users
     When a user requests these endpoints with "GET" and no authentication
       | endpoint           |
@@ -71,7 +71,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "notset"
 
-  @issue-32068 @skipOnOcis
+  @issue-32068 @wasSkipOnOcis
   @issue-ocis-reva-11
   @issue-ocis-reva-30
   @issue-ocis-reva-31
@@ -165,7 +165,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @issue-32068 @skipOnOcis
+  @issue-32068 @wasSkipOnOcis
   @issue-ocis-reva-29
   @issue-ocis-reva-30
   @smokeTest
@@ -232,7 +232,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "notset"
 
-  @skipOnOcis
+  @wasSkipOnOcis
   @issue-ocis-reva-65
   Scenario:using OCS with admin basic auth
     When the administrator requests these endpoint with "GET"
@@ -250,7 +250,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @skipOnOcis
+  @wasSkipOnOcis
   @issue-ocis-reva-30
   @issue-ocis-reva-65
   @skipOnBruteForceProtection @issue-brute_force_protection-112
@@ -289,7 +289,7 @@ Feature: auth
     And the OCS status code of responses on all endpoints should be "200"
 
 
-  @skipOnOcis
+  @wasSkipOnOcis
   @issue-ocis-reva-30
   @issue-ocis-reva-28
   Scenario: using OCS with token auth of a normal user
@@ -325,7 +325,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
 
-  @skipOnOcis
+  @skipOnOcis @toImplementOnOCIS
   Scenario: using OCS with browser session of normal user
     Given a new browser session for "Alice" has been started
     When the user requests these endpoints with "GET" using a new browser session
@@ -360,7 +360,7 @@ Feature: auth
     And the OCS status code of responses on all endpoints should be "997"
 
 
-  @skipOnOcis
+  @skipOnOcis @notToImplementOnOCIS
   @issue-ocis-reva-30
   @issue-ocis-reva-60
   Scenario: using OCS with an app password of a normal user

--- a/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
@@ -4,7 +4,7 @@ Feature: auth
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @skipOnOcis
+  @wasSkipOnOcis
   @issue-ocis-reva-30
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -1,11 +1,11 @@
-@api @files_sharing-app-required @skipOnOcis
+@api @files_sharing-app-required @wasSkipOnOcis
 Feature: auth
 
   Background:
     Given user "another-admin" has been created with default attributes and without skeleton files
     And user "another-admin" has been added to group "admin"
 
-  @skipOnOcis
+  @wasSkipOnOcis
   @issue-ocis-reva-30
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112

--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
@@ -32,7 +32,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-13
+  @wasSkipOnOcis @issue-ocis-reva-13
   Scenario: send DELETE requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "DELETE" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |
@@ -74,7 +74,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-60
+  @wasSkipOnOcis @issue-ocis-reva-60
   Scenario: send DELETE requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -88,7 +88,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-60
+  @wasSkipOnOcis @issue-ocis-reva-60
   Scenario: send DELETE requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -34,7 +34,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9
+  @wasSkipOnOcis @issue-ocis-reva-9
   Scenario: send LOCK requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
       | endpoint                                           |
@@ -88,7 +88,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send LOCK requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -102,7 +102,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send LOCK requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -33,7 +33,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9 @issue-ocis-reva-197
+  @wasSkipOnOcis @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send MKCOL requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
       | endpoint                                           |
@@ -78,7 +78,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send MKCOL requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -92,7 +92,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send MKCOL requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -33,7 +33,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-14
+  @wasSkipOnOcis @issue-ocis-reva-14
   Scenario: send MOVE requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |
@@ -84,7 +84,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send MOVE requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -98,7 +98,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send MOVE requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -34,7 +34,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-179
+  @wasSkipOnOcis @issue-ocis-reva-179
   Scenario: send POST requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" about user "Alice"
       | endpoint                                            |
@@ -75,7 +75,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send POST requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -89,7 +89,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send POST requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -33,7 +33,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9
+  @wasSkipOnOcis @issue-ocis-reva-9
   Scenario: send PROPFIND requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PROPFIND" to get property "d:getetag" about user "Alice"
       | endpoint                                           |
@@ -84,7 +84,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send PROPFIND requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -98,7 +98,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send PROPFIND requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -34,7 +34,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9 @issue-ocis-reva-197
+  @wasSkipOnOcis @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send PROPPATCH requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PROPPATCH" to set property "favorite" about user "Alice"
       | endpoint                                           |
@@ -75,7 +75,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send PROPPATCH requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -89,7 +89,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send PROPPATCH requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -34,7 +34,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9 @issue-ocis-reva-197
+  @wasSkipOnOcis @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send PUT requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" about user "Alice"
       | endpoint                                       |
@@ -78,7 +78,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send PUT requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -92,7 +92,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-37
+  @wasSkipOnOcis @issue-ocis-reva-37
   Scenario: send PUT requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-41
+@api @files_sharing-app-required @wasSkipOnOcis @issue-ocis-reva-41
 Feature: capabilities
 
   Background:

--- a/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
@@ -48,7 +48,7 @@ Feature: default capabilities for normal user
 
   # remove this scenario after fixing tagged issue as its just created to show difference
   # in the response items in different environment (core & ocis-reva)
-  @skipOnOcis @issue-ocis-reva-175 @issue-ocis-reva-176
+  @wasSkipOnOcis @issue-ocis-reva-175 @issue-ocis-reva-176
   Scenario: getting default capabilities with normal user
     When user "Alice" retrieves the capabilities using the capabilities API
     Then the capabilities should contain

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -1,4 +1,4 @@
-@api @comments-app-required @skipOnOcis @issue-ocis-reva-38
+@api @comments-app-required @wasSkipOnOcis @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -1,4 +1,4 @@
-@api @comments-app-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-38
+@api @comments-app-required @files_sharing-app-required @wasSkipOnOcis @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiComments/deleteComments.feature
+++ b/tests/acceptance/features/apiComments/deleteComments.feature
@@ -1,4 +1,4 @@
-@api @comments-app-required @skipOnOcis @issue-ocis-reva-38
+@api @comments-app-required @wasSkipOnOcis @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiComments/editComments.feature
+++ b/tests/acceptance/features/apiComments/editComments.feature
@@ -1,4 +1,4 @@
-@api @comments-app-required @skipOnOcis @issue-ocis-reva-38
+@api @comments-app-required @wasSkipOnOcis @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -87,7 +87,7 @@ Feature: favorite
       | new         |
 
   @smokeTest @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @wasSkipOnOcis @issue-ocis-reva-39
   Scenario Outline: Get favorited elements of a folder
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/FOLDER" using the WebDAV API
@@ -104,7 +104,7 @@ Feature: favorite
       | new         |
 
   @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @wasSkipOnOcis @issue-ocis-reva-39
   Scenario Outline: Get favorited elements of a subfolder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/subfolder"
@@ -127,7 +127,7 @@ Feature: favorite
       | new         |
 
   @files_sharing-app-required @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @wasSkipOnOcis @issue-ocis-reva-39
   Scenario Outline: moving a favorite file out of a share keeps favorite state
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -144,7 +144,7 @@ Feature: favorite
       | new         |
 
   @issue-33840 @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @wasSkipOnOcis @issue-ocis-reva-39
   Scenario Outline: Get favorited elements and limit count of entries
     Given using <dav_version> DAV path
     And user "Alice" has favorited element "/textfile0.txt"
@@ -166,7 +166,7 @@ Feature: favorite
       | new         |
 
   @issue-33840 @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @wasSkipOnOcis @issue-ocis-reva-39
   Scenario Outline: Get favorited elements paginated in subfolder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/subfolder"
@@ -196,7 +196,7 @@ Feature: favorite
       | new         |
 
   @files_sharing-app-required @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @wasSkipOnOcis @issue-ocis-reva-39
   Scenario Outline: sharer file favorite state should not change the favorite state of sharee
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -211,7 +211,7 @@ Feature: favorite
       | new         |
 
   @files_sharing-app-required @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-243
+  @wasSkipOnOcis @issue-ocis-reva-243
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -225,7 +225,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-39
+  @wasSkipOnOcis @issue-ocis-reva-39
   Scenario Outline: favoriting a folder does not change the favorite state of elements inside the folder
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/PARENT/parent.txt" using the WebDAV API


### PR DESCRIPTION
Uses `EXPECTED_FAILURES_FILE` test runner ability from PR #37717 which is now in core master.
This is a helper demonstrator for https://github.com/owncloud/ocis-reva/pull/394
It changes some `skipOnOcis` tags to `wasSkipOnOcis` - that means that the scenarios will be run by OCIS CI (and are scenarios that will currently fail on OCIS).

That enables demonstration of using `EXPECTED_FAILURES_FILE` to handle a list of known failures in the ocis-reva repo.
