### PR TITLE
add DI registration for licence manager

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -47,6 +47,7 @@ use OCP\AppFramework\IApi;
 use OCP\AppFramework\IAppContainer;
 use OCP\Files\Mount\IMountManager;
 use OCP\IDateTimeFormatter;
+use OCP\License\ILicenseManager;
 
 class DIContainer extends SimpleContainer implements IAppContainer {
 
@@ -83,6 +84,10 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		$this->registerService('OCP\\App\\IAppManager', function ($c) {
 			return $this->getServer()->getAppManager();
+		});
+
+		$this->registerService('OCP\\License\\ILicenseManager', function ($c) {
+			return $this->getServer()->getLicenseManager();
 		});
 
 		$this->registerService('OCP\\AppFramework\\Http\\IOutput', function ($c) {

--- a/lib/public/License/ILicenseManager.php
+++ b/lib/public/License/ILicenseManager.php
@@ -20,7 +20,7 @@
 namespace OCP\License;
 
 /**
- * @since 10.5.0
+ * Interface ILicenseManager
  * Holds operations for managing the ownCloud license
  *
  * License states are expected to go through the following states:
@@ -28,6 +28,9 @@ namespace OCP\License;
  * This means that "valid" and "about to expire" states must be considered
  * as "good" states. Error states are "expired", "invalid" (if the license string
  * can't be parsed or contains errors) and "missing" (if no license is found)
+ *
+ * @package OCP\License
+ * @since 10.5.0
  */
 interface ILicenseManager {
 	/** The license is valid and hasn't expired yet */


### PR DESCRIPTION
Without this, apps will get 
- `Could not resolve OCP\\\\License\\\\ILicenseManager! Class can not be instantiated\`
- `Exception: {\"Exception\":\"OCP\\\\AppFramework\\\\QueryException\",\"Message\":\"Could not resolve uid! Class uid does not exist or error resolving constructor arguments: Could not resolve LicenseManager! Class LicenseManager does not exist\`

@pmaier1 @micbar 