### PR TITLE
Delete the correct expired share and handle user/group shares on ExpiredSharesJob

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -878,7 +878,7 @@ class FederatedShareProvider implements IShareProvider {
 	 */
 	private function createShareObject($data) {
 		$share = new Share($this->rootFolder, $this->userManager);
-		$share->setId((int)$data['id'])
+		$share->setId($data['id'])
 			->setShareType((int)$data['share_type'])
 			->setPermissions((int)$data['permissions'])
 			->setTarget($data['file_target'])

--- a/apps/files_sharing/lib/ExpireSharesJob.php
+++ b/apps/files_sharing/lib/ExpireSharesJob.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Roeland Jago Douma <rullzer@owncloud.com>
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
@@ -22,6 +23,10 @@
 namespace OCA\Files_Sharing;
 
 use OC\BackgroundJob\TimedJob;
+use OC\Share20\DefaultShareProvider;
+use OCP\IDBConnection;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
 
 /**
  * Delete all shares that are expired
@@ -29,11 +34,37 @@ use OC\BackgroundJob\TimedJob;
 class ExpireSharesJob extends TimedJob {
 
 	/**
-	 * sets the correct interval for this timed job
+	 * @var IManager $shareManager
 	 */
-	public function __construct() {
+	private $shareManager;
+
+	/**
+	 * @var IDBConnection $connection
+	 */
+	private $connection;
+
+	/**
+	 * @var DefaultShareProvider $defaultShareProvider
+	 */
+	private $defaultShareProvider;
+
+	/**
+	 * sets the correct interval for this timed job
+	 *
+	 * @param IManager $shareManager
+	 * @param IDBConnection $connection
+	 * @param DefaultShareProvider $defaultShareProvider
+	 */
+	public function __construct(
+		IManager $shareManager,
+		IDBConnection $connection,
+		DefaultShareProvider $defaultShareProvider
+	) {
 		// Run once a day
 		$this->setInterval(24 * 60 * 60);
+		$this->shareManager = $shareManager;
+		$this->connection = $connection;
+		$this->defaultShareProvider = $defaultShareProvider;
 	}
 
 	/**
@@ -42,22 +73,18 @@ class ExpireSharesJob extends TimedJob {
 	 * @param array $argument unused argument
 	 */
 	public function run($argument) {
-		$connection = \OC::$server->getDatabaseConnection();
-		$logger = \OC::$server->getLogger();
-
 		//Current time
 		$now = new \DateTime();
 		$now = $now->format('Y-m-d H:i:s');
 
 		/*
-		 * Expire file link shares only (for now)
+		 * Expire file shares only (for now)
 		 */
-		$qb = $connection->getQueryBuilder();
-		$qb->select('id', 'file_source', 'uid_owner', 'item_type')
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('id')
 			->from('share')
 			->where(
 				$qb->expr()->andX(
-					$qb->expr()->eq('share_type', $qb->expr()->literal(\OCP\Share::SHARE_TYPE_LINK)),
 					$qb->expr()->lte('expiration', $qb->expr()->literal($now)),
 					$qb->expr()->orX(
 						$qb->expr()->eq('item_type', $qb->expr()->literal('file')),
@@ -68,7 +95,12 @@ class ExpireSharesJob extends TimedJob {
 
 		$shares = $qb->execute();
 		while ($share = $shares->fetch()) {
-			\OCP\Share::unshare($share['item_type'], $share['file_source'], \OCP\Share::SHARE_TYPE_LINK, null, $share['uid_owner']);
+			try {
+				$shareObject = $this->defaultShareProvider->getShareById($share['id']);
+				$this->shareManager->deleteShare($shareObject);
+			} catch (ShareNotFound $ex) {
+				//already deleted
+			}
 		}
 		$shares->closeCursor();
 	}

--- a/apps/files_sharing/lib/ExpireSharesJob.php
+++ b/apps/files_sharing/lib/ExpireSharesJob.php
@@ -96,7 +96,12 @@ class ExpireSharesJob extends TimedJob {
 		$shares = $qb->execute();
 		while ($share = $shares->fetch()) {
 			try {
-				$shareObject = $this->defaultShareProvider->getShareById($share['id']);
+				/*
+				 * The type of $share['id'] changes depends on the db type. (int for pgsql, string for others)
+				 * This situation led to problem when stubbing method in tests.
+				 * $share['id'] has been casted to string to ensure consistency.
+				 */
+				$shareObject = $this->defaultShareProvider->getShareById((string)$share['id']);
 				$this->shareManager->deleteShare($shareObject);
 			} catch (ShareNotFound $ex) {
 				//already deleted

--- a/changelog/unreleased/37729
+++ b/changelog/unreleased/37729
@@ -1,0 +1,7 @@
+Bugfix: Fix expiring a wrong share entry problem
+
+If multiple links exist for the same node and, non-expired share created before expired share,
+expiredSharesJob was deleting non-expired share.
+This problem has been resolved. Also, ExpireSharesJob now handles user and group shares.
+
+https://github.com/owncloud/core/pull/37729

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -493,7 +493,7 @@ class DefaultShareProvider implements IShareProvider {
 			}
 			$cursor->closeCursor();
 		}
-		
+
 		return $shares;
 	}
 
@@ -569,7 +569,7 @@ class DefaultShareProvider implements IShareProvider {
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 			));
-		
+
 		$cursor = $qb->execute();
 		$data = $cursor->fetch();
 		$cursor->closeCursor();
@@ -945,7 +945,7 @@ class DefaultShareProvider implements IShareProvider {
 
 		return $share;
 	}
-	
+
 	/**
 	 * Create a share object from an database row
 	 *
@@ -955,7 +955,7 @@ class DefaultShareProvider implements IShareProvider {
 	 */
 	private function createShare($data) {
 		$share = new Share($this->rootFolder, $this->userManager);
-		$share->setId((int)$data['id'])
+		$share->setId($data['id'])
 			->setShareType((int)$data['share_type'])
 			->setPermissions((int)$data['permissions'])
 			->setTarget($data['file_target'])
@@ -1086,7 +1086,7 @@ class DefaultShareProvider implements IShareProvider {
 			}
 			$stmt->closeCursor();
 		}
-		
+
 		$resolvedShares = \array_values($shareIdToShareMap);
 		return $resolvedShares;
 	}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1397,7 +1397,7 @@ class Manager implements IManager {
 
 		$share = $provider->getShareById($id, $recipient);
 
-		// Validate link shares expiration date
+		// Validate shares expiration date
 		if ($this->shareHasExpired($share)) {
 			$this->deleteShare($share);
 			throw new ShareNotFound();

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -135,11 +135,11 @@ interface IShareProvider {
 	 * @since 10.0.0
 	 */
 	public function getAllSharesBy($userId, $shareTypes, $nodeIDs, $reshares);
-	
+
 	/**
 	 * Get share by id
 	 *
-	 * @param int $id
+	 * @param string $id
 	 * @param string|null $recipientId
 	 * @return \OCP\Share\IShare
 	 * @throws ShareNotFound
@@ -168,7 +168,7 @@ interface IShareProvider {
 	 * @since 10.0.0
 	 */
 	public function getAllSharedWith($userId, $node);
-	
+
 	/**
 	 * Get shared with the given user specifying share type predicate for this specific share provider
 	 *


### PR DESCRIPTION
## Description
Delete the correct expired share by using share id on `ExpireSharesJob`. `ExpireSharesJob` now also handles user and group shares. 

I created the pr based on @pako81 in https://github.com/owncloud/enterprise/issues/4112#issuecomment-662842454.



## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4112

## Motivation and Context
`ExpiredSharesJobs` currently uses `\OCP\Share::unshare` method for deleting expired shares.
If multiple links exist for the same node and, non-expired share created before expired share, expiredSharesJob currently deletes non-expired share.

This problem resolved with deleting correct expired shares by using share id.

Also, `ExpireSharesJob` now handles user and group shares. If we prefer, I can separate this part of the change to another pr.

## How Has This Been Tested?
The class has an integration test. Also, tried manually.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
