### PR TITLE
[Tests-Only] Remove skipOnOcis tag for scenarios not to be skipped on ocis

### DIFF
--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis
+@api @files_sharing-app-required
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -3,11 +3,11 @@ Feature: auth
 
   Background:
     Given user "another-admin" has been created with default attributes and without skeleton files
-    And user "another-admin" has been added to group "admin"
 
   @smokeTest @issue-32068 @skipOnOcis @issue-ocis-reva-30 @issue-ocis-reva-65
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
+    Given user "another-admin" has been added to group "admin"
     When user "another-admin" requests these endpoints with "DELETE" using password "invalid" about user "Alice"
       | endpoint                                                        |
       | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/123 |
@@ -33,7 +33,7 @@ Feature: auth
   @smokeTest @skipOnOcV10 @issue-ocis-reva-30 @issue-ocis-reva-65
    #after fixing all issues delete this Scenario and use the one above
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
-    When user "another-admin" requests these endpoints with "DELETE" using password "invalid" about user "Alice"
+    When the administrator requests these endpoints with "DELETE" using password "invalid" about user "Alice"
       | endpoint                                                        |
       | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/123 |
       | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/123 |

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis
+@api @files_sharing-app-required
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -3,13 +3,13 @@ Feature: auth
 
   Background:
     Given user "another-admin" has been created with default attributes and without skeleton files
-    And user "another-admin" has been added to group "admin"
 
   @skipOnOcis
   @issue-ocis-reva-30
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT request to OCS endpoints as admin with wrong password
+    Given user "another-admin" has been added to group "admin"
     When user "another-admin" requests these endpoints with "PUT" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                         |
       | /ocs/v1.php/cloud/users/%username%               |
@@ -28,7 +28,7 @@ Feature: auth
   @smokeTest
   #after fixing all issues delete this Scenario and use the one above
   Scenario: send PUT request to OCS endpoints as admin with wrong password
-    When user "another-admin" requests these endpoints with "PUT" including body "doesnotmatter" using password "invalid" about user "Alice"
+    When the administrator requests these endpoints with "PUT" with body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                         |
       | /ocs/v1.php/cloud/users/%username%               |
       | /ocs/v2.php/cloud/users/%username%               |

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -397,32 +397,38 @@ class AuthContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminRequestsEndpoint($method, TableNode $table) {
-		$this->adminRequestsEndpointsWithPassword($method, null, $table);
+		$this->adminRequestsEndpointsWithBodyWithPassword($method, null, null, null, $table);
 	}
 
 	/**
-	 * @When the administrator requests these endpoints with :method using password :password
+	 * @When the administrator requests these endpoints with :method with body :body using password :password about user :ofUser
 	 *
 	 * @param string $method
+	 * @param string $body
 	 * @param string $password
+	 * @param string $ofUser
 	 * @param TableNode $table
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function adminRequestsEndpointsWithPassword(
+	public function adminRequestsEndpointsWithBodyWithPassword(
 		$method,
+		$body,
 		$password,
+		$ofUser,
 		TableNode $table
 	) {
+		$ofUser = $this->featureContext->getActualUsername($ofUser);
 		$this->featureContext->verifyTableNodeColumns($table, ['endpoint']);
 		$this->featureContext->emptyLastHTTPStatusCodesArray();
 		$this->featureContext->emptyLastOCSStatusCodesArray();
 		foreach ($table->getHash() as $row) {
-			$this->administratorRequestsURLWithUsingBasicAuth(
-				$row['endpoint'],
-				$method,
-				$password
+			$row['endpoint'] = $this->featureContext->substituteInLineCodes(
+				$row['endpoint'], $ofUser
+			);
+			$this->userRequestsURLWithUsingBasicAuth(
+				$this->featureContext->getAdminUsername(), $row['endpoint'], $method, $password, $body
 			);
 			$this->featureContext->pushToLastHttpStatusCodesArray(
 				$this->featureContext->getResponse()->getStatusCode()
@@ -438,6 +444,26 @@ class AuthContext implements Context {
 				$this->featureContext->pushToLastOcsCodesArray("notset");
 			}
 		}
+	}
+
+	/**
+	 * @When the administrator requests these endpoints with :method using password :password about user :ofUser
+	 *
+	 * @param string $method
+	 * @param string $password
+	 * @param string $ofUser
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminRequestsEndpointsWithPassword(
+		$method,
+		$password,
+		$ofUser,
+		TableNode $table
+	) {
+		$this->adminRequestsEndpointsWithBodyWithPassword($method, null, $password, $ofUser, $table);
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR removes skipOnOcis tag from the scenarios which are expected to run on ocis.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/37724

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/423
- https://github.com/owncloud/ocis-reva/pull/404

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
