### PR TITLE
[tests-only] Fix tests for ocis with proxy

### DIFF
--- a/tests/acceptance/features/apiMain/main.feature
+++ b/tests/acceptance/features/apiMain/main.feature
@@ -11,4 +11,4 @@ Feature: Other tests related to api
   #after fixing all issues delete this Scenario and use the one above
   Scenario: robots.txt file should be accessible
     When a user requests "/robots.txt" with "GET" and no authentication
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be "401" or "404"

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -1,4 +1,4 @@
-@api
+@api @skipOnOcis @issue-ocis-187
 Feature: previews of files downloaded through the webdav API
 
   Background:


### PR DESCRIPTION
## Description
This should make ocis API tests work when using the proxy `:9200`
1. skip all preview tests (they are currently useless because they were written on the premises to use the webdav port `9140` that does not work at all, so the tests need to be rewritten) see https://github.com/owncloud/ocis-thumbnails/issues/29 & https://github.com/owncloud/ocis/issues/187
2. allow also `404` as return code when `robots.txt` is not found

## Related Issue
part of https://github.com/owncloud/ocis/pull/409

## How Has This Been Tested?
https://github.com/owncloud/ocis/pull/424

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
