### PR TITLE
[Tests-Only] Include trailing slash when matching a suite name

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -391,7 +391,13 @@ function run_behat_tests() {
 
 	if [ -n "${EXPECTED_FAILURES_FILE}" ]
 	then
-		echo "Checking expected failures"
+		if [ -n "${BEHAT_SUITE_TO_RUN}" ]
+		then
+			echo "Checking expected failures for suite ${BEHAT_SUITE_TO_RUN}"
+		else
+			echo "Checking expected failures"
+		fi
+
 		PASSED=true
 		FAILED_SCENARIO_FOUND=false
 		FAILED_SCENARIO_PATHS_COLORED=`awk '/Failed scenarios:/',0 ${TEST_LOG_FILE} | grep feature`
@@ -430,7 +436,7 @@ function run_behat_tests() {
 				then
 					# If the expected failure is not in the suite that is currently being run,
 					# then do not try and check that it failed.
-					REGEX_TO_MATCH="^${BEHAT_SUITE_TO_RUN}"
+					REGEX_TO_MATCH="^${BEHAT_SUITE_TO_RUN}/"
 					if ! [[ "${SUITE_SCENARIO}" =~ ${REGEX_TO_MATCH} ]]
 					then
 						continue


### PR DESCRIPTION
## Description
1) when a pipeline is running acceptance tests for a single suite (or running multiple suites one after the other), report the suite name in the information message "Checking expected failures..." This helps us to be confident about what is being checked.

2) when deciding if a line in `EXPECTED_FAILURES_FILE` should be examined, the code was just checking that the line begins with the suite name, e.g. `apiAuthOcs/ocsDELETEAuth.feature:9` starts with suite name `apiAuthOcs`. But sometimes a suite name is a substring of another suite name. e.g. there is a suite `apiAuth` That was causing a problem because the code would run all the tests for `apiAuth` then check the expected failures. It would complain that `apiAuthOcs/ocsDELETEAuth.feature:9` was expected to fail.

Change the code so that it checks for the line starting with the suite name followed by `/`

## How Has This Been Tested?
CI - this code is currently in PR #37736 (which is WIP) and is being used by https://github.com/owncloud/ocis-reva/pull/410 to allow the acceptance tests to be split into parts (multiple drone pipelines) and for each pipeline to correctly check for expected failures in its part of the acceptance test run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
