### PR TITLE
[Tests-Only] Refactor listFolder acceptance tests

### DIFF
--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -325,18 +325,34 @@ class HttpRequestHelper {
 	}
 
 	/**
-	 * Parses the response as XML
+	 * Parses the response as XML and returns a SimpleXMLElement with these
+	 * registered namespaces:
+	 *  | prefix | namespace                                 |
+	 *  | d      | DAV:                                      |
+	 *  | oc     | http://owncloud.org/ns                    |
+	 *  | ocs    | http://open-collaboration-services.org/ns |
 	 *
 	 * @param ResponseInterface $response
 	 *
 	 * @return SimpleXMLElement
+	 * @throws \Exception
 	 */
 	public static function getResponseXml($response) {
 		// rewind just to make sure we can re-parse it in case it was parsed already...
 		$response->getBody()->rewind();
 		$contents = $response->getBody()->getContents();
 		try {
-			return new SimpleXMLElement($contents);
+			$responseXmlObject = new SimpleXMLElement($contents);
+			$responseXmlObject->registerXPathNamespace(
+				'ocs', 'http://open-collaboration-services.org/ns'
+			);
+			$responseXmlObject->registerXPathNamespace(
+				'oc', 'http://owncloud.org/ns'
+			);
+			$responseXmlObject->registerXPathNamespace(
+				'd', 'DAV:'
+			);
+			return $responseXmlObject;
 		} catch (\Exception $e) {
 			if ($contents === '') {
 				throw new \Exception("Received empty response where XML was expected");

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -318,35 +318,6 @@ class WebDavHelper {
 	}
 
 	/**
-	 * returns the response parsed into a SimpleXMLElement
-	 * with these registered namespaces:
-	 *  | prefix | namespace                                 |
-	 *  | d      | DAV:                                      |
-	 *  | oc     | http://owncloud.org/ns                    |
-	 *  | ocs    | http://open-collaboration-services.org/ns |
-	 *
-	 * @param ResponseInterface $response
-	 *
-	 * @return SimpleXMLElement
-	 * @throws Exception
-	 */
-	public static function getResponseXmlWithNamespace(
-		$response
-	) {
-		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
-		$responseXmlObject->registerXPathNamespace(
-			'ocs', 'http://open-collaboration-services.org/ns'
-		);
-		$responseXmlObject->registerXPathNamespace(
-			'oc', 'http://owncloud.org/ns'
-		);
-		$responseXmlObject->registerXPathNamespace(
-			'd', 'DAV:'
-		);
-		return $responseXmlObject;
-	}
-
-	/**
 	 *
 	 * @param string $baseUrl
 	 * URL of owncloud e.g. http://localhost:8080

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -282,12 +282,7 @@ class WebDavHelper {
 	}
 
 	/**
-	 * returns the result parsed into a SimpleXMLElement
-	 * with these registered namespaces:
-	 *  | prefix | namespace                                 |
-	 *  | d      | DAV:                                      |
-	 *  | oc     | http://owncloud.org/ns                    |
-	 *  | ocs    | http://open-collaboration-services.org/ns |
+	 * returns the response to listing a folder (collection)
 	 *
 	 * @param string $baseUrl
 	 * @param string $user
@@ -298,7 +293,7 @@ class WebDavHelper {
 	 * @param string $type
 	 * @param int $davPathVersionToUse
 	 *
-	 * @return SimpleXMLElement|ResponseInterface
+	 * @return ResponseInterface
 	 * @throws Exception
 	 */
 	public static function listFolder(
@@ -316,22 +311,38 @@ class WebDavHelper {
 				'getetag', 'resourcetype'
 			];
 		}
-		$response = self::propfind(
+		return self::propfind(
 			$baseUrl, $user, $password, $path, $properties,
 			$folderDepth, $type, $davPathVersionToUse
 		);
-		try {
-			$responseXmlObject = HttpRequestHelper::getResponseXml($response);
-			$responseXmlObject->registerXPathNamespace(
-				'ocs', 'http://open-collaboration-services.org/ns'
-			);
-		} catch (\Exception $e) {
-			if (OcisHelper::isTestingOnOcis()) {
-				return $response;
-			} else {
-				throw new \Exception($e);
-			}
-		}
+	}
+
+	/**
+	 * returns the response parsed into a SimpleXMLElement
+	 * with these registered namespaces:
+	 *  | prefix | namespace                                 |
+	 *  | d      | DAV:                                      |
+	 *  | oc     | http://owncloud.org/ns                    |
+	 *  | ocs    | http://open-collaboration-services.org/ns |
+	 *
+	 * @param ResponseInterface $response
+	 *
+	 * @return SimpleXMLElement
+	 * @throws Exception
+	 */
+	public static function getResponseXmlWithNamespace(
+		$response
+	) {
+		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
+		$responseXmlObject->registerXPathNamespace(
+			'ocs', 'http://open-collaboration-services.org/ns'
+		);
+		$responseXmlObject->registerXPathNamespace(
+			'oc', 'http://owncloud.org/ns'
+		);
+		$responseXmlObject->registerXPathNamespace(
+			'd', 'DAV:'
+		);
 		return $responseXmlObject;
 	}
 

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3460,10 +3460,13 @@ class FeatureContext extends BehatVariablesContext {
 	 * @param string $targetUser
 	 *
 	 * @return string|null
+	 * @throws Exception
 	 */
 	public function findLastTransferFolderForUser($sourceUser, $targetUser) {
 		$foundPaths = [];
-		$responseXmlObject = $this->listFolder($targetUser, '', 1);
+		$responseXmlObject = $this->listFolderAndReturnResponseXml(
+			$targetUser, '', 1
+		);
 		$transferredElements = $responseXmlObject->xpath(
 			"//d:response/d:href[contains(., '/transferred%20from%20$sourceUser%20on%')]"
 		);

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -146,7 +146,7 @@ class TrashbinContext implements Context {
 		$asUser = $asUser ?? $user;
 		$path = $path ?? '/';
 		$password = $password ?? $this->featureContext->getPasswordForUser($asUser);
-		$responseXml = WebDavHelper::listFolder(
+		$response = WebDavHelper::listFolder(
 			$this->featureContext->getBaseUrl(),
 			$asUser,
 			$password,
@@ -160,6 +160,7 @@ class TrashbinContext implements Context {
 			],
 			'trash-bin'
 		);
+		$responseXml = WebDavHelper::getResponseXmlWithNamespace($response);
 
 		$this->featureContext->setResponseXmlObject($responseXml);
 		$files = $this->getTrashbinContentFromResponseXml($responseXml);

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -160,7 +160,7 @@ class TrashbinContext implements Context {
 			],
 			'trash-bin'
 		);
-		$responseXml = WebDavHelper::getResponseXmlWithNamespace($response);
+		$responseXml = HttpRequestHelper::getResponseXml($response);
 
 		$this->featureContext->setResponseXmlObject($responseXml);
 		$files = $this->getTrashbinContentFromResponseXml($responseXml);

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1318,7 +1318,7 @@ trait WebDav {
 		$statusCode = $response->getStatusCode();
 		if ($statusCode < 401 || $statusCode > 404) {
 			try {
-				$this->responseXmlObject = WebDavHelper::getResponseXmlWithNamespace(
+				$this->responseXmlObject = HttpRequestHelper::getResponseXml(
 					$response
 				);
 			} catch (\Exception $e) {
@@ -1444,10 +1444,11 @@ trait WebDav {
 	public function listFolderAndReturnResponseXml(
 		$user, $path, $folderDepth, $properties = null, $type = "files"
 	) {
-		$response = $this->listFolder(
-			$user, $path, $folderDepth, $properties, $type
+		return HttpRequestHelper::getResponseXml(
+			$this->listFolder(
+				$user, $path, $folderDepth, $properties, $type
+			)
 		);
-		return WebDavHelper::getResponseXmlWithNamespace($response);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -59,7 +59,9 @@ class WebDavPropertiesContext implements Context {
 		$user, $path
 	) {
 		$this->featureContext->setResponseXmlObject(
-			$this->featureContext->listFolder($user, $path, 0)
+			$this->featureContext->listFolderAndReturnResponseXml(
+				$user, $path, 0
+			)
 		);
 	}
 
@@ -76,7 +78,9 @@ class WebDavPropertiesContext implements Context {
 		$user, $path, $depth
 	) {
 		$this->featureContext->setResponseXmlObject(
-			$this->featureContext->listFolder($user, $path, $depth)
+			$this->featureContext->listFolderAndReturnResponseXml(
+				$user, $path, $depth
+			)
 		);
 	}
 
@@ -108,7 +112,9 @@ class WebDavPropertiesContext implements Context {
 			$this->featureContext->usingNewDavPath();
 		}
 		$this->featureContext->setResponseXmlObject(
-			$this->featureContext->listFolder($user, $path, $depth, $properties)
+			$this->featureContext->listFolderAndReturnResponseXml(
+				$user, $path, $depth, $properties
+			)
 		);
 	}
 
@@ -139,7 +145,7 @@ class WebDavPropertiesContext implements Context {
 			$this->featureContext->usingNewDavPath();
 		}
 		$this->featureContext->setResponseXmlObject(
-			$this->featureContext->listFolder(
+			$this->featureContext->listFolderAndReturnResponseXml(
 				$user, $commentsPath, $depth, $properties, "comments"
 			)
 		);
@@ -271,7 +277,9 @@ class WebDavPropertiesContext implements Context {
 			}
 		}
 		$this->featureContext->setResponseXmlObject(
-			$this->featureContext->listFolder($user, $path, 0, $properties, "public-files")
+			$this->featureContext->listFolderAndReturnResponseXml(
+				$user, $path, 0, $properties, "public-files"
+			)
 		);
 	}
 
@@ -662,7 +670,9 @@ class WebDavPropertiesContext implements Context {
 		$user, $path, $property, $expectedValue, $altExpectedValue
 	) {
 		$this->featureContext->setResponseXmlObject(
-			$this->featureContext->listFolder($user, $path, 0, [$property])
+			$this->featureContext->listFolderAndReturnResponseXml(
+				$user, $path, 0, [$property]
+			)
 		);
 		$this->theSingleResponseShouldContainAPropertyWithValueAndAlternative(
 			$property, $expectedValue, $altExpectedValue


### PR DESCRIPTION
## Description
PR #37721 adjusted the code that tests if a resource (file or folder) exists (or not exists). 
https://github.com/owncloud/core/blob/master/tests/acceptance/features/bootstrap/WebDav.php `asFileOrFolderShouldNotExist` used to return `ResponseInterface` (it used to call `WebDavHelper::makeDavRequest` and that gave back `ResponseInterface`).

After the refactoring, `asFileOrFolderShouldNotExist` uses `listFolder` to do its "real work". But that returns only a `SimpleXmlObject` (the XML that was in the body of the response to the `listFolder` request. And so `asFileOrFolderShouldNotExist` no longer returns `ResponseInterface`. (It returns void)

But `files_lifecycle` `ArchiveContext` is expecting to get a proper `ResponseInterface` so that it can examine the response itself.

Refactor so that `asFileOrFolderShouldNotExist` returns `ResponseInterface` again (restoring its previous behavior). To do that, I had to sort out the return of `WebDavHelper::listFolder` and the chains of things that call it.

This will fix the test fails in `files_lifecycle` https://drone.owncloud.com/owncloud/files_lifecycle/1305/43/11
```
    Then as "Alice" file "/a-folder/testfile.txt" should not exist in the archive                                    # ArchiveContext::asFileOrFolderShouldNotExist()
      Fatal error: Call to a member function getStatusCode() on null (Behat\Testwork\Call\Exception\FatalThrowableError)
```

## How Has This Been Tested?
core CI
https://github.com/owncloud/ocis-reva/pull/411
https://github.com/cs3org/reva/pull/1027

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
