### PR TITLE
Add capabilities for file locking

### DIFF
--- a/apps/files/lib/Capabilities.php
+++ b/apps/files/lib/Capabilities.php
@@ -61,7 +61,9 @@ class Capabilities implements ICapability {
 				'privateLinksDetailsParam' => true,
 				'bigfilechunking' => true,
 				'blacklisted_files' => $this->config->getSystemValue('blacklisted_files', ['.htaccess']),
-				'favorites' => true
+				'favorites' => true,
+				'file_locking_support' => true,
+				'file_locking_enable_file_action' => (boolean)($this->config->getAppValue('files', 'enable_lock_file_action', 'no') === 'yes'),
 			],
 		];
 	}

--- a/changelog/10.5.0_2020-06-23/37620
+++ b/changelog/10.5.0_2020-06-23/37620
@@ -1,0 +1,8 @@
+Change: Add capabilities for file locking
+
+- file_locking_support -> general capability
+- file_locking_enable_file_action - > depending on the setting
+
+
+https://github.com/owncloud/core/issues/37620
+https://github.com/owncloud/core/pull/37747


### PR DESCRIPTION
## Description

## Add two capabilities
- 1) `file_locking_support` -> general capability
- 2) `file_locking_enable_file_action` - > depending on the setting

## Related Issue
- Fixes #37620 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
