### PR TITLE
[tests-only] use usersHaveBeenCreated & delete UserHelper::createUser

### DIFF
--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -32,52 +32,6 @@ use Psr\Http\Message\ResponseInterface;
  */
 class UserHelper {
 	/**
-	 * @param string $baseUrl
-	 * @param string $user
-	 * @param string $password
-	 * @param string $adminUser
-	 * @param string $adminPassword
-	 * @param string $displayName
-	 * @param string $email
-	 *
-	 * @return ResponseInterface[]
-	 *          we need multiple requests to set $displayName and $email
-	 *          this array will contain the responses from all requests
-	 */
-	public static function createUser(
-		$baseUrl, $user, $password, $adminUser, $adminPassword,
-		$displayName = null, $email = null
-	) {
-		$body = [
-			'userid' => $user,
-			'password' => $password
-		];
-		$return = [];
-		$return[] = OcsApiHelper::sendRequest(
-			$baseUrl, $adminUser, $adminPassword, "POST", "/cloud/users", $body
-		);
-		//if we couldn't successfully create the user, no need to keep on going
-		if ($return[0]->getStatusCode() !== 200) {
-			return $return;
-		}
-		if ($displayName !== null) {
-			$editResponse = self::editUser(
-				$baseUrl, $user, "display", $displayName, $adminUser, $adminPassword
-			);
-			$return[] = $editResponse;
-			if ($editResponse->getStatusCode() !== 200) {
-				return $return;
-			}
-		}
-		if ($email !== null) {
-			$return[] = self::editUser(
-				$baseUrl, $user, "email", $email, $adminUser, $adminPassword
-			);
-		}
-		return $return;
-	}
-
-	/**
 	 *
 	 * @param string $baseUrl
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2303,31 +2303,6 @@ trait Provisioning {
 		$user = \trim($user);
 		$method = \trim(\strtolower($method));
 		switch ($method) {
-			case "api":
-				$results = UserHelper::createUser(
-					$this->getBaseUrl(),
-					$user,
-					$password,
-					$this->getAdminUsername(),
-					$this->getAdminPassword(),
-					$displayName, $email
-				);
-				foreach ($results as $result) {
-					if ($result->getStatusCode() !== 200) {
-						$message = $this->getResponseXml($result)->xpath("/ocs/meta/message");
-						if ($message && (string) $message[0] === "User already exists") {
-							Assert::fail(
-								'Could not create user as it already exists. ' .
-								'Please delete the user to run tests again.'
-							);
-						}
-						throw new Exception(
-							__METHOD__ . " could not create user. "
-							. $result->getStatusCode() . " " . $result->getBody()
-						);
-					}
-				}
-				break;
 			case "occ":
 				$result = SetupHelper::createUser(
 					$user, $password, $displayName, $email
@@ -2338,6 +2313,7 @@ trait Provisioning {
 					);
 				}
 				break;
+			case "api":
 			case "ldap":
 				$settings = [];
 				$setting["userid"] = $user;


### PR DESCRIPTION
## Description
`usersHaveBeenCreated()` is also able to create users through the provisioning API, so let's use it everywhere and delete `UserHelper::createUser()`

## Motivation and Context
deleted code, is debugged code
for https://github.com/owncloud/ocis/pull/409 I also need to upload the skeleton files when not using the LDAP server, that would result in code duplication currently

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
