### PR TITLE
Fix decoding of calendars uri

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarHome.php
+++ b/apps/dav/lib/CalDAV/CalendarHome.php
@@ -86,6 +86,7 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 		}
 
 		// Calendars
+		$name = \urldecode($name);
 		foreach ($this->caldavBackend->getCalendarsForUser($this->principalInfo['uri']) as $calendar) {
 			if ($calendar['uri'] === $name) {
 				return new Calendar($this->caldavBackend, $calendar, $this->l10n);

--- a/changelog/unreleased/37750
+++ b/changelog/unreleased/37750
@@ -1,0 +1,5 @@
+Bugfix: fix decoding of calendars uri
+
+In case an user had calendars uri containing special characters, for instance "persönlich", and this user was then invited to a calendar event, the event could not be created and a 404 was shown in the stack trace. Reason for this was the uri not being properly decoded. The behavior has now been fixed.
+
+https://github.com/owncloud/core/pull/37750


### PR DESCRIPTION
## Description

Fix decoding of calendars uri

## Motivation and Context

This PR fixes decoding of calendars uri in case they do contain special characters, for instance, `persönlich`.

## How Has This Been Tested?

Manually:

- create a new user, log in as this user, go into the DB and update his oc_calendars.uri like: `update oc_calendars set uri='persönlich' where id=$id`. So basically by adding an umlaut in his calendar uri

- as another user try to invite this user to an event --> without this fix, the event cannot be created and a 404 is shown in the stack trace. Reason for this is the uri not being properly decoded.

```
{"reqId":"2Dx37BA32uuaGHMNk4p8","level":0,"time":"2020-07-28T21:13:48+00:00","remoteAddr":"::1","user":"admin","app":"webdav","method":"PUT","url":"\/owncloud1050\/remote.php\/dav\/calendars\/admin\/personal\/ownCloud-QFB8XWSOMQ2AC7YKQTLV9.ics","message":"Exception: HTTP\/1.1 404 Node with name 'pers%c3%b6nlich' could not be found: {\"Exception\":\"Sabre\\\\DAV\\\\Exception\\\\NotFound\",\"Message\":\"Node with name 'pers%c3%b6nlich' could not be found\",\"Code\":0,\"Trace\":\"#0 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Tree.php(78): OCA\\\\DAV\\\\CalDAV\\\\CalendarHome->getChild('pers%c3%b6nlich')\\n#1 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/apps\\\/dav\\\/lib\\\/Tree.php(51): Sabre\\\\DAV\\\\Tree->getNodeForPath('calendars\\\/user2...')\\n#2 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/CalDAV\\\/Schedule\\\/Plugin.php(523): OCA\\\\DAV\\\\Tree->getNodeForPath('calendars\\\/user2...')\\n#3 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/event\\\/lib\\\/WildcardEmitterTrait.php(89): Sabre\\\\CalDAV\\\\Schedule\\\\Plugin->scheduleLocalDelivery(Object(Sabre\\\\VObject\\\\ITip\\\\Message))\\n#4 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/CalDAV\\\/Schedule\\\/Plugin.php(350): Sabre\\\\DAV\\\\Server->emit('schedule', Array)\\n#5 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/CalDAV\\\/Schedule\\\/Plugin.php(626): Sabre\\\\CalDAV\\\\Schedule\\\\Plugin->deliver(Object(Sabre\\\\VObject\\\\ITip\\\\Message))\\n#6 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/CalDAV\\\/Schedule\\\/Plugin.php(337): Sabre\\\\CalDAV\\\\Schedule\\\\Plugin->processICalendarChange(NULL, Object(Sabre\\\\VObject\\\\Component\\\\VCalendar), Array, Array, true)\\n#7 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/event\\\/lib\\\/WildcardEmitterTrait.php(89): Sabre\\\\CalDAV\\\\Schedule\\\\Plugin->calendarObjectChange(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response), Object(Sabre\\\\VObject\\\\Component\\\\VCalendar), 'calendars\\\/admin...', true, true)\\n#8 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/CalDAV\\\/Plugin.php(897): Sabre\\\\DAV\\\\Server->emit('calendarObjectC...', Array)\\n#9 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/CalDAV\\\/Plugin.php(766): Sabre\\\\CalDAV\\\\Plugin->validateICalendar('BEGIN:VCALENDAR...', 'calendars\\\/admin...', false, Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response), true)\\n#10 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/event\\\/lib\\\/WildcardEmitterTrait.php(89): Sabre\\\\CalDAV\\\\Plugin->beforeCreateFile('calendars\\\/admin...', 'BEGIN:VCALENDAR...', Object(OCA\\\\DAV\\\\CalDAV\\\\Calendar), false)\\n#11 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(1087): Sabre\\\\DAV\\\\Server->emit('beforeCreateFil...', Array)\\n#12 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/CorePlugin.php(504): Sabre\\\\DAV\\\\Server->createFile('calendars\\\/admin...', 'BEGIN:VCALENDAR...', NULL)\\n#13 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/event\\\/lib\\\/WildcardEmitterTrait.php(89): Sabre\\\\DAV\\\\CorePlugin->httpPut(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#14 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(470): Sabre\\\\DAV\\\\Server->emit('method:PUT', Array)\\n#15 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/lib\\\/composer\\\/sabre\\\/dav\\\/lib\\\/DAV\\\/Server.php(251): Sabre\\\\DAV\\\\Server->invokeMethod(Object(Sabre\\\\HTTP\\\\Request), Object(Sabre\\\\HTTP\\\\Response))\\n#16 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/apps\\\/dav\\\/lib\\\/Server.php(329): Sabre\\\\DAV\\\\Server->start()\\n#17 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/apps\\\/dav\\\/appinfo\\\/v2\\\/remote.php(31): OCA\\\\DAV\\\\Server->exec()\\n#18 \\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/remote.php(165): require_once('\\\/Users\\\/pasquale...')\\n#19 {main}\",\"File\":\"\\\/Users\\\/pasqualetripodi\\\/Sites\\\/owncloud1050\\\/apps\\\/dav\\\/lib\\\/CalDAV\\\/CalendarHome.php\",\"Line\":105}"}
```

With this fix, the event can be correctly created and 404 is not logged anymore.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised 
- [x] Changelog item