### PR TITLE
[Tests-Only] Add tests for new capabilities

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -89,6 +89,32 @@ Feature: capabilities
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[1]  | passwordProtected |
       | files_sharing | providers_capabilities@@@ocFederatedSharing@@@remote     | EMPTY             |
 
+  @smokeTest @skipOnOcV10.3 @skipOnOcV10.4
+  # These are new capabilities in 10.5
+  Scenario: getting new default capabilities in 10.5.0 with admin user
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability | path_to_element | value |
+      | files      | favorites       | 1     |
+
+  @smokeTest @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  # These are new capabilities after 10.5.0
+  Scenario: getting new default capabilities in versions after 10.5.0 with admin user
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability | path_to_element                 | value |
+      | files      | file_locking_support            | 1     |
+      | files      | file_locking_enable_file_action | EMPTY |
+
+  @smokeTest @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  Scenario: lock file action can be enabled
+    Given parameter "enable_lock_file_action" of app "files" has been set to "yes"
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability | path_to_element                 | value |
+      | files      | file_locking_support            | 1     |
+      | files      | file_locking_enable_file_action | 1     |
+
   @files_trashbin-app-required
   Scenario: getting trashbin app capability with admin user
     When the administrator retrieves the capabilities using the capabilities API


### PR DESCRIPTION
## Description
Add acceptance tests for the new capabilities that have been added recently. This will make sure that they do not accidentally disappear.

Note: there are scenarios with `skipOnOcV10.5.0` because they are not in the 10.5.0 release but are in `master`. `master` still currently thinks it is version `10.5.0`. So these scenarios will not run in CI until the version is bumped in `master`. I ran the scenarios locally and they pass.

## Related Issue
- #37620 

## How Has This Been Tested?
CI and local run of the scenarios.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
