### PR TITLE
[Tests-Only] Skip new lock tests on old ownCloud

### DIFF
--- a/tests/acceptance/features/webUIFiles/lockFile.feature
+++ b/tests/acceptance/features/webUIFiles/lockFile.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews
+@webUI @insulated @disablePreviews @skipOnOcV10.3 @skipOnOcV10.4
 Feature: Manually lock a file
   As a user
   I want to be able to manually lock a file


### PR DESCRIPTION
## Description
PR #37699 was merged to `master` yesterday. (That is code that is also already in `release-10.5.0`) The new scenarios for the lock icon on the webUI fail against older ownCloud. This caused fails, for example, in nightly encryption CI https://drone.owncloud.com/owncloud/encryption/1366/169/17

Skip this feature on old ownCloud.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
