### PR TITLE
[tests-only] only send userid and password on user creation

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -616,6 +616,7 @@ trait Provisioning {
 		$usersAttributes = [];
 		foreach ($table as $row) {
 			$userAttribute['userid'] = $this->getActualUsername($row['username']);
+
 			if (isset($row['displayname'])) {
 				$userAttribute['displayName'] = $row['displayname'];
 			} elseif ($setDefaultAttributes) {
@@ -837,12 +838,22 @@ trait Provisioning {
 			if ($this->isTestingWithLdap()) {
 				$this->createLdapUser($userAttributes);
 			} else {
+				$attributesToCreateUser['userid'] = $userAttributes['userid'];
+				$attributesToCreateUser['password'] = $userAttributes['password'];
+				if (OcisHelper::isTestingOnOcis()) {
+					$attributesToCreateUser['username'] = $userAttributes['userid'];
+					if ($userAttributes['email'] === null) {
+						$attributesToCreateUser['email'] = $userAttributes['username'] . '@owncloud.org';
+					} else {
+						$attributesToCreateUser['email'] = $userAttributes['email'];
+					}
+				}
 				// Create a OCS request for creating the user. The request is not sent to the server yet.
 				$request = OcsApiHelper::createOcsRequest(
 					$this->getBaseUrl(),
 					'POST',
 					"/cloud/users",
-					$userAttributes
+					$attributesToCreateUser
 				);
 				// Add the request to the $requests array so that they can be sent in parallel.
 				\array_push($requests, $request);


### PR DESCRIPTION
## Description
`$userAttributes` contains all attributes of the user e.g. also displayname, but the provisioning API in oc10 does not do anything with values other that userid and password, so don't send them

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
