### PR TITLE
allow storages to explicitly opt-out of uploading .part files

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -60,7 +60,7 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 	public function __construct($params) {
 		if (isset($params['configured']) && $params['configured'] === 'true'
 			&& isset($params['client_id'], $params['client_secret'], $params['token'])
-			 
+
 		) {
 			$this->client = new \Google_Client([
 				'retry' => [
@@ -80,6 +80,13 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 		} else {
 			throw new \Exception('Creating Google storage failed');
 		}
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function usePartFile() {
+		return false;
 	}
 
 	public function getId() {

--- a/apps/files_external/lib/Lib/Storage/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Storage/OwnCloud.php
@@ -72,4 +72,11 @@ class OwnCloud extends \OC\Files\Storage\DAV {
 
 		parent::__construct($params);
 	}
+
+	/**
+	 * @return boolean
+	 */
+	public function usePartFile() {
+		return false;
+	}
 }

--- a/apps/files_external/tests/OwnCloudFunctionsTest.php
+++ b/apps/files_external/tests/OwnCloudFunctionsTest.php
@@ -111,4 +111,16 @@ class OwnCloudFunctionsTest extends \Test\TestCase {
 		$instance = new \OCA\Files_External\Lib\Storage\OwnCloud($config);
 		$this->assertEquals($expectedUri, $instance->createBaseUri());
 	}
+
+	public function testUsePartFile() {
+		$config = [
+			'host' => 'http://testhost/testroot',
+			'root' => 'subdir',
+			'secure' => true,
+			'user' => 'someuser',
+			'password' => 'somepassword'
+		];
+		$instance = new \OCA\Files_External\Lib\Storage\OwnCloud($config);
+		$this->assertFalse($instance->usePartFile());
+	}
 }

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -88,6 +88,13 @@ class Storage extends DAV implements ISharedStorage {
 		]);
 	}
 
+	/**
+	 * @return boolean
+	 */
+	public function usePartFile() {
+		return false;
+	}
+
 	protected function init() {
 		if ($this->ready) {
 			return;
@@ -299,7 +306,7 @@ class Storage extends DAV implements ISharedStorage {
 		}
 		return ($this->getPermissions($path) & \OCP\Constants::PERMISSION_SHARE);
 	}
-	
+
 	public function getPermissions($path) {
 		$response = $this->propfind($path);
 		if (isset($response['{http://open-collaboration-services.org/ns}share-permissions'])) {

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -92,6 +92,10 @@ class ExternalStorageTest extends \Test\TestCase {
 		$result = $this->getTestStorage('https://remoteserver')->test();
 		$this->assertTrue($result);
 	}
+
+	public function testUsePartFile() {
+		$this->assertFalse($this->getTestStorage('https://remoteserver/')->usePartFile());
+	}
 }
 
 /**

--- a/changelog/unreleased/25826
+++ b/changelog/unreleased/25826
@@ -1,0 +1,7 @@
+Bugfix: Google Drive file modifications should not create duplicate files
+Change: Allow Storage backends to explicitly opt-in/opt-out of marking file as partial while uploading
+
+Existing files in Google Drive that were modified and saved (uploaded) would result in duplicate files of the same name. The root cause was appending .part to filenames for upload. This update first allows Storage to opt-out of .part filenames during upload and second opts out of .part filenames for Google Storage backend specifically.
+
+https://github.com/owncloud/core/issues/25826
+https://github.com/owncloud/core/pull/37062

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -75,6 +75,13 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	}
 
 	/**
+	 * @return boolean
+	 */
+	public function usePartFile() {
+		return false;
+	}
+
+	/**
 	 * This is intended to be used during the moveFromStorage call. While moving, this is needed
 	 * for the sourceStorage to know we're moving stuff and it shouldn't change the cache
 	 * until it's finished.

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -154,6 +154,14 @@ abstract class Common implements Storage, ILockingStorage, IVersionedStorage, IP
 		return $this->isReadable($path);
 	}
 
+	/**
+	 * needsPartFile - allows a storage to opt-out of .part upload and rename
+	 * @return boolean
+	 */
+	public function usePartFile() {
+		return true;
+	}
+
 	public function getPermissions($path) {
 		$permissions = 0;
 		if ($this->isCreatable($path)) {

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -52,6 +52,13 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IPersistent
 	}
 
 	/**
+	 * @return boolean
+	 */
+	public function usePartFile() {
+		return $this->getWrapperStorage()->usePartFile();
+	}
+
+	/**
 	 * @return \OC\Files\Storage\Storage
 	 */
 	public function getWrapperStorage() {

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -47,6 +47,13 @@ use OCP\Files\StorageNotAvailableException;
 interface IStorage {
 
 	/**
+	 * usePartFile - allows a storage to opt-out of .part upload and rename
+	 * @return boolean
+	 * @since 10.5.1
+	 */
+	public function usePartFile();
+
+	/**
 	 * Get the identifier for the storage,
 	 * the returned id should be the same for every storage object that is created with the same parameters
 	 * and two storage objects with the same id should refer to two storages that display the same files.

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -636,8 +636,12 @@ abstract class Storage extends \Test\TestCase {
 	}
 
 	public function testPartFile() {
-		$this->instance->file_put_contents('bar.txt.part', 'bar');
-		$this->instance->rename('bar.txt.part', 'bar.txt');
+		if ($this->instance->usePartFile()) {
+			$this->instance->file_put_contents('bar.txt.part', 'bar');
+			$this->instance->rename('bar.txt.part', 'bar.txt');
+		} else {
+			$this->instance->file_put_contents('bar.txt', 'bar');
+		}
 		$this->assertEquals('bar', $this->instance->file_get_contents('bar.txt'));
 	}
 }

--- a/tests/lib/Files/Storage/Wrapper/WrapperTest.php
+++ b/tests/lib/Files/Storage/Wrapper/WrapperTest.php
@@ -8,6 +8,7 @@
 
 namespace Test\Files\Storage\Wrapper;
 
+use OCP\Files\Storage\IStorage;
 use Test\Files\Storage\Storage;
 use OC\Files\Storage\Wrapper\Wrapper;
 use OC\Files\Storage\Local;
@@ -19,16 +20,21 @@ use OC\Files\Storage\Local;
  */
 class WrapperTest extends Storage {
 	/**
-	 * @var string tmpDir
+	 * @var string $tmpDir
 	 */
 	private $tmpDir;
+
+	/**
+	 * @var IStorage $storage
+	 */
+	private $storage;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->tmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
-		$storage = new Local(['datadir' => $this->tmpDir]);
-		$this->instance = new Wrapper(['storage' => $storage]);
+		$this->storage = new Local(['datadir' => $this->tmpDir]);
+		$this->instance = new Wrapper(['storage' => $this->storage]);
 	}
 
 	protected function tearDown(): void {
@@ -39,5 +45,9 @@ class WrapperTest extends Storage {
 	public function testInstanceOfStorageWrapper() {
 		$this->assertTrue($this->instance->instanceOfStorage(Local::class));
 		$this->assertTrue($this->instance->instanceOfStorage(Wrapper::class));
+	}
+
+	public function testUsePartFile() {
+		$this->assertEquals($this->storage->usePartFile(), $this->instance->usePartFile());
 	}
 }


### PR DESCRIPTION
Continuation of https://github.com/owncloud/core/pull/37062
- Commits have been rebased and squashed
- Some unit tests have been added (Hard to write meaningful tests, I just asserted the boolean value according to related Storage class.)

## Description
Allow for storage classes to decide whether to use .part files. Default to using part files to preserve previous behavior.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/25826

## Motivation and Context
Google Drive external storage (and others?) should not create a duplicate file with the same name every time a file is changed.

## How Has This Been Tested?
- no serious testing, just UAT that ownCloud is no longer generating duplicate Google Drive files

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
