### PR TITLE
[tests-only] Delete users after test ocis ocs

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2365,9 +2365,8 @@ trait Provisioning {
 	public function deleteUser($user) {
 		if (OcisHelper::isTestingOnOcis()) {
 			OcisHelper::deleteRevaUserData($user);
-		} else {
-			$this->deleteTheUserUsingTheProvisioningApi($user);
 		}
+		$this->deleteTheUserUsingTheProvisioningApi($user);
 
 		$this->userShouldNotExist($user);
 	}
@@ -4115,12 +4114,10 @@ trait Provisioning {
 		if ($this->isTestingWithLdap()) {
 			$this->deleteLdapUsersAndGroups();
 		}
+		$this->cleanupDatabaseUsers();
+		$this->cleanupDatabaseGroups();
 
-		if (OcisHelper::isTestingOnOcis()) {
-			OcisHelper::deleteRevaUserData("");
-		} else {
-			$this->cleanupDatabaseUsers();
-			$this->cleanupDatabaseGroups();
+		if (!OcisHelper::isTestingOnOcis()) {
 			$this->resetAdminUserAttributes();
 		}
 	}


### PR DESCRIPTION
## Description
for owncloud/ocis#409 we need to create users using the provisioning API also when running tests with OCIS, so we better delete the users at the end of the scenario

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
