### PR TITLE
[tests-only] delete reva data folder after tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2363,11 +2363,7 @@ trait Provisioning {
 	 * @throws \Exception
 	 */
 	public function deleteUser($user) {
-		if (OcisHelper::isTestingOnOcis()) {
-			OcisHelper::deleteRevaUserData($user);
-		}
 		$this->deleteTheUserUsingTheProvisioningApi($user);
-
 		$this->userShouldNotExist($user);
 	}
 
@@ -4117,7 +4113,9 @@ trait Provisioning {
 		$this->cleanupDatabaseUsers();
 		$this->cleanupDatabaseGroups();
 
-		if (!OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcis()) {
+			OcisHelper::deleteRevaUserData("");
+		} else {
 			$this->resetAdminUserAttributes();
 		}
 	}


### PR DESCRIPTION
## Description
after the test, don't delete the single user directory, but the whole reva data folder

## Motivation and Context
the folder name of the user data is case sensitive in reva, so we try to delete `data/alice` when we should have deleted `data/Alice`

## How Has This Been Tested?
https://github.com/owncloud/ocis-reva/pull/416

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
