### PR TITLE
Adjustment of the maximum width of the appmenu

### DIFF
--- a/core/css/header.css
+++ b/core/css/header.css
@@ -180,7 +180,7 @@
 	top: 45px;
 	left: 10px;
 	width: auto;
-	max-width: 265px;
+	max-width: 260px;
 	max-height: 85%;
 	margin-top: 0;
 	padding: 6px;


### PR DESCRIPTION
## Description
After testing https://github.com/owncloud/core/pull/37490 in RC7 I mentioned that the width of the menu becomes 5px too wide after adding more than 3 apps. 

## Motivation and Context
Prevent the menu from becoming wider than it needs to be with more than 3 entries.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested in Chrome
1. Add more then 3 apps into the menu. 
   (F.ex. Activity, Market, External Sites)

## Screenshots:

Before:
![image](https://user-images.githubusercontent.com/33026403/89029720-4f904500-d32f-11ea-805b-e330fb5dca5f.png)

After:
![image](https://user-images.githubusercontent.com/33026403/89029804-7babc600-d32f-11ea-95f9-79aba8fe75a9.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
