### PR TITLE
[Tests-Only] Remove old skipOnOcV10.* tags

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -220,16 +220,15 @@ Feature: capabilities
       | files_sharing | group@@@expire_date@@@days     | 14    |
       | files_sharing | group@@@expire_date@@@enforced | EMPTY |
 
-	#feature added in #31824 will be released in 10.0.10
-  @smokeTest @skipOnOcV10.0.9
+  #feature added in #31824 released in 10.0.10
+  @smokeTest
   Scenario: getting capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability    | path_to_element | value |
       | files_sharing | can_share       | 1     |
 
-	#feature added in #32414 will be released in 10.0.10
-  @skipOnOcV10.0.9
+  #feature added in #32414 released in 10.0.10
   Scenario: getting async capabilites when async operations are enabled
     Given the administrator has enabled async operations
     When the administrator retrieves the capabilities using the capabilities API
@@ -237,7 +236,6 @@ Feature: capabilities
       | capability | path_to_element | value |
       | async      |                 | 1.0   |
 
-  @skipOnOcV10.0.9
   Scenario: getting async capabilites when async operations are disabled
     Given the administrator has disabled async operations
     When the administrator retrieves the capabilities using the capabilities API

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.0 @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
 Feature: there can be only one exclusive lock on a resource
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.0 @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
 Feature: lock folders
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @skipOnOcV10.0 @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
 Feature: persistent-locking in case of a public link
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @skipOnOcV10.0 @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
 Feature: LOCKDISCOVERY for public links
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.0 @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
 Feature: actions on a locked item are possible if the token is sent with the request
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.0 @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172 @issue-ocis-reva-11
+@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172 @issue-ocis-reva-11
 Feature: lock should propagate correctly if a share is reshared
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @skipOnOcV10.0 @toImplementOnOCIS @skipOnOcis @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @toImplementOnOCIS @skipOnOcis @issue-ocis-reva-172
 Feature: set timeouts of LOCKS
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/unlock.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.0 @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
 Feature: UNLOCK locked items
 
   Background:

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -73,7 +73,7 @@ Feature: add users
       Access it:
       """
 
-  @smokeTest @skipOnLDAP @skipOnOcV10.0 @skipOnOcV10.1 @skipOnOcV10.2 @skipOnOcV10.3
+  @smokeTest @skipOnLDAP @skipOnOcV10.3
   Scenario Outline: user sets his own password after being created with an Email address only
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI

--- a/tests/acceptance/features/webUILogin/resetPassword.feature
+++ b/tests/acceptance/features/webUILogin/resetPassword.feature
@@ -23,7 +23,7 @@ Feature: reset the password
       Use the following link to reset your password: <a href=
       """
 
-  @skipOnEncryption @skipOnOcV10.0 @skipOnOcV10.1
+  @skipOnEncryption
   @smokeTest @skipOnLDAP
   Scenario: reset password for the ordinary (no encryption) case
     When the user requests the password reset link using the webUI

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -27,7 +27,6 @@ Feature: manage user quota
       | Unlimited   | 55kB         | 55 KB          |
       | Unlimited   | 45Kb         | 45 KB          |
 
-  @skipOnOcV10.0.3
   Scenario: change quota to a valid value that do not work on 10.0.3
     Given the administrator has set the quota of user "Alice" to "Unlimited"
     When the administrator changes the quota of user "Alice" to "0 Kb" using the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
@@ -8,7 +8,6 @@ Feature: manage groups
     Given the administrator has logged in using the webUI
     And the administrator has browsed to the users page
 
-  @skipOnOcV10.0.3
   Scenario: delete group called "0" and "false"
     Given these groups have been created:
       | groupname      |
@@ -47,7 +46,6 @@ Feature: manage groups
       | 0         |
       | false     |
 
-  @skipOnOcV10.0.3 @skipOnOcV10.0.4 @skipOnOcV10.0.5
   Scenario: delete groups with special characters that appear in URLs
     Given these groups have been created:
       | groupname      |

--- a/tests/acceptance/features/webUISharingPublic1/permissionsShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic1/permissionsShareByPublicLink.feature
@@ -7,7 +7,6 @@ Feature: Share by public link
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
   Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
     Given user "Brian" has been created with default attributes and skeleton files
     And user "Brian" has logged in using the webUI
@@ -23,7 +22,6 @@ Feature: Share by public link
     Then the deleted elements should not be listed on the webUI
     And the deleted elements should not be listed on the webUI after a page reload
 
-  @skipOnOcV10.0.3 @feature_was_changed_in_10.0.4
   Scenario: creating a public link with read permissions only makes it impossible to delete files via the link
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has uploaded file with content "test" to "/simple-folder/lorem.txt"

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @skipOnOcV10.0
+@webUI @insulated @disablePreviews
 Feature: Locks
   As a user
   I would like to be able to use locks control deletion of files and folders

--- a/tests/acceptance/features/webUIWebdavLockProtection/move.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/move.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @skipOnOcV10.0
+@webUI @insulated @disablePreviews
 Feature: Locks
   As a user
   I would like to be able to use locks control moving and renaming of files and folders

--- a/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @skipOnOcV10.0
+@webUI @insulated @disablePreviews
 Feature: Locks
   As a user
   I would like to be able to use locks control upload of files and folders

--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @skipOnOcV10.0
+@webUI @insulated @disablePreviews
 Feature: Locks
   As a user
   I would like to be able to see what lock are on files and folders


### PR DESCRIPTION
## Description
We only run some current acceptance test scenarios against old ownCloud 10.3.2 and 10.4.1 systems. Remove old skip tags ffor `skipOnOcV10.0` `skipOnOcV10.1` `skipOnOcV10.2`. They make "noise" when reviewing scenarios for other reasons.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
