### PR TITLE
[Tests-Only] Remove skip/toImplementOnOcis tags for passing sharing tests

### DIFF
--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-34 @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: accept/decline shares coming from internal users
   As a user
   I want to have control of which received shares I accept
@@ -16,7 +16,7 @@ Feature: accept/decline shares coming from internal users
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
 
-  @smokeTest
+  @smokeTest @toImplementOnOCIS
   Scenario Outline: share a file & folder with another internal user with different permissions when auto accept is enabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     When user "Alice" creates a share using the sharing API with settings
@@ -46,6 +46,7 @@ Feature: accept/decline shares coming from internal users
       | change      |
       | all         |
 
+  @toImplementOnOCIS
   Scenario Outline: share a file & folder with another internal user when auto accept is enabled and there is a default folder for received shares
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And the administrator has set the default folder for received shares to "<share_folder>"
@@ -72,6 +73,7 @@ Feature: accept/decline shares coming from internal users
       | ReceivedShares      | /ReceivedShares     |        | PARENT               | textfile0.txt          |
       | /My/Received/Shares | /My/Received/Shares |        | PARENT               | textfile0.txt          |
 
+  @toImplementOnOCIS
   Scenario Outline: share a file & folder with internal group with different permissions when auto accept is enabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     When user "Alice" creates a share using the sharing API with settings
@@ -112,7 +114,7 @@ Feature: accept/decline shares coming from internal users
       | change      |
       | all         |
 
-  @smokeTest
+  @smokeTest @toImplementOnOCIS
   Scenario: decline a share that has been auto-accepted
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -130,6 +132,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT/       |
       | /textfile0.txt |
 
+  @toImplementOnOCIS
   Scenario: accept a share that has been declined before
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -164,6 +167,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT/       |
       | /textfile0.txt |
 
+  @toImplementOnOCIS
   Scenario: unshare a share that was shared with a group and auto-accepted
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Alice" has shared folder "/PARENT" with group "grp1"
@@ -187,6 +191,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT (2)/       |
       | /textfile0 (2).txt |
 
+  @toImplementOnOCIS
   Scenario: rename accepted share, decline it
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -201,6 +206,7 @@ Feature: accept/decline shares coming from internal users
       | path     |
       | /PARENT/ |
 
+  @toImplementOnOCIS
   Scenario: rename accepted share, decline it then accept again, name stays
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -216,6 +222,7 @@ Feature: accept/decline shares coming from internal users
       | path             |
       | /PARENT-renamed/ |
 
+  @toImplementOnOCIS
   Scenario: move accepted share, decline it, accept again
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Alice" has created folder "/shared"
@@ -233,6 +240,7 @@ Feature: accept/decline shares coming from internal users
       | path            |
       | /PARENT/shared/ |
 
+  @toImplementOnOCIS
   Scenario: move accepted share, decline it, delete parent folder, accept again
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Alice" has created folder "/shared"
@@ -251,6 +259,7 @@ Feature: accept/decline shares coming from internal users
       | path     |
       | /shared/ |
 
+  @toImplementOnOCIS
   Scenario: receive two shares with identical names from different users
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And user "Alice" has created folder "/shared"
@@ -269,7 +278,7 @@ Feature: accept/decline shares coming from internal users
       | /shared/     |
       | /shared (2)/ |
 
-  @smokeTest
+  @smokeTest @toImplementOnOCIS
   Scenario: share a file & folder with another internal group when auto accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -473,6 +482,7 @@ Feature: accept/decline shares coming from internal users
     And user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the sharing API should report that no shares are shared with user "Brian"
 
+  @toImplementOnOCIS
   Scenario: only one user in a group accepts a share
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "Alice" has shared folder "/PARENT" with group "grp1"
@@ -518,6 +528,7 @@ Feature: accept/decline shares coming from internal users
       | /shared/     |
       | /shared (2)/ |
 
+  @toImplementOnOCIS
   Scenario: share with a group that you are part of yourself
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -588,6 +599,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/PARENT (2)/abc.txt" for user "Brian" should be "uploaded content"
     And the content of file "/FOLDER (2)/abc.txt" for user "Brian" should be "uploaded content"
 
+  @toImplementOnOCIS
   Scenario: user shares folder in a group with matching folder-name for every users involved
     Given user "Alice" uploads file with content "uploaded content" to "/PARENT/abc.txt" using the WebDAV API
     And user "Alice" uploads file with content "uploaded content" to "/FOLDER/abc.txt" using the WebDAV API
@@ -620,6 +632,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/PARENT (2)/abc.txt" for user "Carol" should be "uploaded content"
     And the content of file "/FOLDER (2)/abc.txt" for user "Carol" should be "uploaded content"
 
+  @toImplementOnOCIS
   Scenario: user shares files in a group with matching file-names for every users involved in sharing
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     And user "Alice" shares file "/textfile1.txt" with group "grp1" using the sharing API
@@ -656,6 +669,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT%20(2)/       |
       | /textfile0%20(2).txt |
 
+  @toImplementOnOCIS
   Scenario: user shares file in a group with matching filename when auto accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API

--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -48,7 +48,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @issue-ocis-reva-34 @issue-ocis-reva-194
+  @smokeTest @issue-ocis-reva-34 @issue-ocis-reva-194 @toImplementOnOCIS
   Scenario Outline: Sharee can see the group share
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -168,7 +168,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnLDAP @issue-ocis-reva-194
+  @skipOnLDAP @issue-ocis-reva-194 @toImplementOnOCIS
   Scenario: Share of folder to a group, remove user from that group
     Given using OCS API version "1"
     And user "Carol" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -66,6 +66,9 @@ class AppConfigurationContext implements Context {
 	public function serverParameterHasBeenSetTo($parameter, $app, $value) {
 		// The capturing group of the regex always includes the quotes at each
 		// end of the captured string, so trim them.
+		if (\TestHelpers\OcisHelper::isTestingOnOcis()) {
+			return;
+		}
 		$value = \trim($value, $value[0]);
 		$this->adminSetsServerParameterToUsingAPI($parameter, $app, $value);
 	}


### PR DESCRIPTION
## Description
This PR removes `skip` tags and `toImplementOnOCIS` tags for the tests that have been already implemented or pass on ocis. Also, `toImplementOnOCIS` tag is added for the scenarios with group sharing steps..

## Related Issue
- https://github.com/owncloud/ocis-reva/issues/415

## How Has This Been Tested?
- 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
