### PR TITLE
Bump version to 10.5.1alpha1

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 5, 0, 10];
+$OC_Version = [10, 5, 1, 0];
 
 // The human readable string
-$OC_VersionString = '10.5.0';
+$OC_VersionString = '10.5.1alpha1';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
using a similar format to what was done in PR #37270 

Changelog not needed. The changelogs are for individual real changes, not for each internal version bump.

Note: the next actual release version might be 10.5.1 or it might be 10.6.0 or... The bump here is just so that CI etc will realiZe that we are moving on past 10.5.0

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
