### PR TITLE
Replace deprecated twitter link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Learn about the different ways you can get support for ownCloud: https://ownclou
 * :envelope: [Mailing list](https://mailman.owncloud.org/mailman/listinfo)
 * :hash: [IRC channel](https://webchat.freenode.net/?channels=owncloud)
 * :busts_in_silhouette: [Facebook](https://facebook.com/ownclouders)
-* :hatching_chick: [Twitter](https://twitter.com/ownClouders)
+* :hatching_chick: [Twitter](https://twitter.com/ownCloud)
 
 ## Important notice on translations
 Please submit translations via Transifex:


### PR DESCRIPTION
## Description
Fix twitter link in Readme.

## Motivation and Context
Twitter account deprecated.

## How Has This Been Tested?
Preview:
https://github.com/owncloud/core/blob/ce640318b9c2a70d59b680c868861db5e67d4f8f/README.md
