### PR TITLE
[Tests-Only] Skip favorites capability scenario on 10.5.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -131,7 +131,7 @@ config = {
 				'apiFederation2',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['daily-master-qa', 'latest', '10.3.2']
+			'federatedServerVersions': ['daily-master-qa', 'latest', '10.4.1']
 		},
 		'cli': {
 			'suites': [
@@ -154,7 +154,7 @@ config = {
 				'cliExternalStorage',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['daily-master-qa', 'latest', '10.3.2']
+			'federatedServerVersions': ['daily-master-qa', 'latest', '10.4.1']
 		},
 		'webUI': {
 			'suites': {

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -89,20 +89,13 @@ Feature: capabilities
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[1]  | passwordProtected |
       | files_sharing | providers_capabilities@@@ocFederatedSharing@@@remote     | EMPTY             |
 
-  @smokeTest @skipOnOcV10.3 @skipOnOcV10.4
-  # These are new capabilities in 10.5
-  Scenario: getting new default capabilities in 10.5.0 with admin user
-    When the administrator retrieves the capabilities using the capabilities API
-    Then the capabilities should contain
-      | capability | path_to_element | value |
-      | files      | favorites       | 1     |
-
   @smokeTest @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   # These are new capabilities after 10.5.0
   Scenario: getting new default capabilities in versions after 10.5.0 with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain
       | capability | path_to_element                 | value |
+      | files      | favorites                       | 1     |
       | files      | file_locking_support            | 1     |
       | files      | file_locking_enable_file_action | EMPTY |
 


### PR DESCRIPTION
## Description
1) The `favorites` capability was added in PR #37673 but unfortunately that did not get into 10.5.0 release.

Adjust the test scenarios so that this new capability is not checked on a 10.5.0 system.

2) Run federation tests with a federated server running 10.4.1 (rather than 10.3.2).

Note: federation tests also run against `daily-master-qa` and `latest`. `latest` is now 10.5.0.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
