### PR TITLE
Add openid client secret to the sensitive values list

### DIFF
--- a/changelog/unreleased/37782
+++ b/changelog/unreleased/37782
@@ -1,0 +1,5 @@
+Bugfix: Add openid client secret to the sensitive values list
+
+Openid client secret was printed as is in the config report. Now it is masked.
+
+https://github.com/owncloud/core/pull/37782

--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -74,6 +74,9 @@ class SystemConfig {
 				],
 			],
 		],
+		'openid-connect' => [
+			'client-secret' => true
+		]
 	];
 	/** @var Config */
 	private $config;


### PR DESCRIPTION
## Description
Add openid client secret to the sensitive values list

## How Has This Been Tested?
1. configure openid connect app
2. `php occ config:list | grep client-secret`

### Expected
```
            "client-secret": "***REMOVED SENSITIVE VALUE***",
```

### Actual
```
            "client-secret": "ownCloud",
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
