### PR TITLE
Fix exit codes of security:certificates commands

### DIFF
--- a/changelog/unreleased/35364
+++ b/changelog/unreleased/35364
@@ -1,0 +1,8 @@
+Bugfix: Fix exit codes of security:certificates commands
+
+If there is an error when doing occ security:certificates:import or
+occ security:certificates:remove then the command will exit with status 1.
+This allows the caller to reliably detect if there was a problem.
+
+https://github.com/owncloud/core/issues/35364
+https://github.com/owncloud/core/pull/37783

--- a/core/Command/Security/ImportCertificate.php
+++ b/core/Command/Security/ImportCertificate.php
@@ -53,7 +53,7 @@ class ImportCertificate extends Base {
 
 		if (!\file_exists($path)) {
 			$output->writeln('<error>certificate not found</error>');
-			return;
+			return 1;
 		}
 
 		$certData = \file_get_contents($path);

--- a/core/Command/Security/RemoveCertificate.php
+++ b/core/Command/Security/RemoveCertificate.php
@@ -52,6 +52,11 @@ class RemoveCertificate extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$name = $input->getArgument('name');
 
-		$this->certificateManager->removeCertificate($name);
+		if ($this->certificateManager->removeCertificate($name)) {
+			return 0;
+		}
+
+		$output->writeln('<error>certificate not found</error>');
+		return 1;
 	}
 }

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -172,6 +172,8 @@ class CertificateManager implements ICertificateManager {
 		if ($this->view->file_exists($path . $name)) {
 			$this->view->unlink($path . $name);
 			$this->createCertificateBundle();
+		} else {
+			return false;
 		}
 		return true;
 	}

--- a/tests/Core/Command/Security/ImportCertificateTest.php
+++ b/tests/Core/Command/Security/ImportCertificateTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\Security;
+
+use OC\Core\Command\Security\ImportCertificate;
+use OC\Files\View;
+use OC\Security\CertificateManager;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class ImportCertificateTest
+ *
+ * @group DB
+ */
+class ImportCertificateTest extends TestCase {
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	/** @var CertificateManager */
+	private $certificateManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->certificateManager = new CertificateManager(
+			$this->getUniqueID('', 20),
+			new View(),
+			$this->createMock('OCP\IConfig')
+		);
+		$command = new ImportCertificate(
+			$this->certificateManager
+		);
+		$command->setApplication(new Application());
+		$this->commandTester = new CommandTester($command);
+	}
+
+	/**
+	 * @dataProvider inputProvider
+	 * @param array $input
+	 * @param array $answers
+	 * @param int $expectedStatus
+	 * @param string $expectedOutput
+	 */
+	public function testCommandInput($input, $answers, $expectedStatus, $expectedOutput) {
+		$this->commandTester->setInputs($answers);
+		$actualStatus = $this->commandTester->execute($input);
+		$this->assertEquals($expectedStatus, $actualStatus);
+		$output = $this->commandTester->getDisplay();
+		$this->assertStringContainsString($expectedOutput, $output);
+	}
+
+	public function inputProvider() {
+		return [
+			[['path' => 'doesNotExist.crt'], [], 1, 'certificate not found'],
+			[['path' => 'data/certificates/goodCertificate.crt'], [], 0, ''],
+		];
+	}
+}

--- a/tests/Core/Command/Security/RemoveCertificateTest.php
+++ b/tests/Core/Command/Security/RemoveCertificateTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\Security;
+
+use OC\Core\Command\Security\RemoveCertificate;
+use OC\Files\View;
+use OC\Security\CertificateManager;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class RemoveCertificateTest
+ *
+ * @group DB
+ */
+class RemoveCertificateTest extends TestCase {
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	/** @var CertificateManager */
+	private $certificateManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->certificateManager = new CertificateManager(
+			$this->getUniqueID('', 20),
+			new View(),
+			$this->createMock('OCP\IConfig')
+		);
+		$command = new RemoveCertificate(
+			$this->certificateManager
+		);
+		$command->setApplication(new Application());
+		$this->commandTester = new CommandTester($command);
+	}
+
+	/**
+	 * @dataProvider inputProvider
+	 * @param array $input
+	 * @param array $answers
+	 * @param int $expectedStatus
+	 * @param string $expectedOutput
+	 */
+	public function testCommandInput($input, $answers, $expectedStatus, $expectedOutput) {
+		$this->commandTester->setInputs($answers);
+		$actualStatus = $this->commandTester->execute($input);
+		$this->assertEquals($expectedStatus, $actualStatus);
+		$output = $this->commandTester->getDisplay();
+		$this->assertStringContainsString($expectedOutput, $output);
+	}
+
+	public function inputProvider() {
+		return [
+			[['name' => 'doesNotExist.crt'], [], 1, 'certificate not found'],
+		];
+	}
+
+	public function testRemoveCertificate() {
+		$this->certificateManager->addCertificate(
+			\file_get_contents('data/certificates/goodCertificate.crt'),
+			'goodCertificate.crt');
+		$this->commandTester->setInputs([]);
+		$actualStatus = $this->commandTester->execute(['name' => 'goodCertificate.crt']);
+		$this->assertEquals(0, $actualStatus);
+		$output = $this->commandTester->getDisplay();
+		$this->assertEquals('', $output);
+	}
+}

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -132,9 +132,11 @@ class OccContext implements Context {
 	 */
 	public function importSecurityCertificateFromPath($path) {
 		$this->invokingTheCommand("security:certificates:import " . $path);
-		$pathComponents = \explode("/", $path);
-		$certificate = \end($pathComponents);
-		\array_push($this->importedCertificates, $certificate);
+		if ($this->featureContext->getExitStatusCodeOfOccCommand() === 0) {
+			$pathComponents = \explode("/", $path);
+			$certificate = \end($pathComponents);
+			\array_push($this->importedCertificates, $certificate);
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/cliMain/securityCertificates.feature
+++ b/tests/acceptance/features/cliMain/securityCertificates.feature
@@ -13,6 +13,11 @@ Feature: security certificates
       | table_column        |
       | goodCertificate.crt |
 
+  Scenario: Import a security certificate specifying a file that does not exist
+    When the administrator imports security certificate from the path "tests/data/certificates/aFileThatDoesNotExist.crt"
+    Then the command should have failed with exit code 1
+    And the command output should contain the text "certificate not found"
+
   Scenario: List security certificates when multiple certificates are imported
     Given the administrator has imported security certificate from the path "tests/data/certificates/goodCertificate.crt"
     And the administrator has imported security certificate from the path "tests/data/certificates/badCertificate.crt"
@@ -32,11 +37,10 @@ Feature: security certificates
       | table_column       |
       | badCertificate.crt |
 
-  @issue-35364
   Scenario: Remove a security certificate that is not installed
     When the administrator removes the security certificate "someCertificate.crt"
-    Then the command should have been successful
-    # Then the command should not have been successful
+    Then the command should have failed with exit code 1
+    And the command output should contain the text "certificate not found"
 
   Scenario: Import random file as certificate
     When the administrator imports security certificate from the path "tests/data/lorem.txt"

--- a/tests/lib/Security/CertificateManagerTest.php
+++ b/tests/lib/Security/CertificateManagerTest.php
@@ -103,9 +103,13 @@ class CertificateManagerTest extends \Test\TestCase {
 		$this->assertFalse($this->certificateManager->removeCertificate('../../foo.txt'));
 	}
 
-	public function testRemoveExistingFile() {
+	public function testRemoveCertificate() {
 		$this->certificateManager->addCertificate(\file_get_contents(__DIR__ . '/../../data/certificates/goodCertificate.crt'), 'GoodCertificate');
 		$this->assertTrue($this->certificateManager->removeCertificate('GoodCertificate'));
+	}
+
+	public function testRemoveNonExistentCertificate() {
+		$this->assertFalse($this->certificateManager->removeCertificate('NonExistentCertificate'));
 	}
 
 	public function testGetCertificateBundle() {


### PR DESCRIPTION
## Description
I was getting acceptance test fails when running `cliMain/securityCertificates.feature` against ownCloud10 `latest` (currently 10.5.0 tarball). The `security:certificates:remove` and `security:certificates:import` commands are not exiting with proper error codes when something is wrong, so that makes it impossible for the acceptance test scenarios to react appropriately in steps like `Then the command should have been successful` - that step never fails because the command status is always 0 = success.

The easiest thing to do is first to fix the bug that was already reported in the related issue.

1) When importing a certificate and the certificate file is not found, exit with status 1.

2) When removing a certificate and the certificate does not exist, exit with status 1.

3) Adjust the acceptance tests to have cases for these.

4) Adjust `.drone.star` - it has `security:certificates:import` commands for when tests are using HTTPS and certificates. Those commands were also being done in pipelines where the certificates did not exist and were not needed. The commands were never successful. Now that the commands exit with an error status, the pipelines were failing during the setup. The starlark code has been adjusted so that it only does `security:certificates:import` in the correct cases.

Note 1: I did not find any existing unit tests for commands in ` core/Command/Security`. The commands seem to have been introduced in PR #21370 but that PR had no automated tests.

Note 2: I added some simple unit tests

## Related Issue
- Fixes #35364

## How Has This Been Tested?
Locally running commands:
```
$ php occ security:certificates:remove xyz.crt
certificate not found
$ echo $?
1
$ php occ security:certificates:import xyz.crt
certificate not found
$ echo $?
1
```

and scenarios in acceptance tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
