### PR TITLE
Ignore exceptions while getting the extended share info

### DIFF
--- a/apps/files_sharing/lib/Controller/RemoteOcsController.php
+++ b/apps/files_sharing/lib/Controller/RemoteOcsController.php
@@ -27,6 +27,8 @@ use OCA\Files_Sharing\External\Manager;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 use OCP\Share;
+use OCP\Files\StorageNotAvailableException;
+use OCP\Files\StorageInvalidException;
 
 class RemoteOcsController extends OCSController {
 	/** @var IRequest */
@@ -123,10 +125,16 @@ class RemoteOcsController extends OCSController {
 	 * @return Result
 	 */
 	public function getShares($includingPending = false) {
-		$shares = \array_map(
-			[$this, 'extendShareInfo'],
-			$this->externalManager->getAcceptedShares()
-		);
+		$shares = [];
+		foreach ($this->externalManager->getAcceptedShares() as $shareInfo) {
+			try {
+				$shares[] = $this->extendShareInfo($shareInfo);
+			} catch (StorageNotAvailableException $e) {
+				//TODO: Log the exception here? There are several logs already below the stack
+			} catch (StorageInvalidException $e) {
+				//TODO: Log the exception here? There are several logs already below the stack
+			}
+		}
 
 		if ($includingPending === true) {
 			/**

--- a/changelog/unreleased/37786
+++ b/changelog/unreleased/37786
@@ -1,0 +1,11 @@
+Bugfix: Show all shares in the "shared with you" section
+
+Previously, when a user received some shares from multiple remote servers
+and one of them was removed, the "shared with you" section didn't show any
+share even though the user still had other shares that were accessible in
+other remote servers.
+
+This is now fixed by ignoring those non-accessible remote shares. The rest
+of the shares will be shown.
+
+https://github.com/owncloud/core/pull/37786


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Exceptions could be thrown while getting the extended share information of the accepted shares. If user1 in serverA shares remotely with user2 in serverB, and serverA is removed (no longer accessible), the exception would crash the request.
Now the exception is ignored and the request can be completed, showing the information of the rest of the shares.

## Related Issue
https://github.com/owncloud/enterprise/issues/4117

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Upload some files in serverA
2. Upload some files in serverB
3. admin in serverA shares a bunch of files with admin in serverC
4. admin in serverC accepts all the files
5. admin in serverB shares another bunch of files with admin in serverC
6. admin in serverC accepts all the files
7. admin in serverC goes to the "shared with you" section
8. serverA is taken down
9. admin in serverC refreshes the "shared with you" section

Admin in serverC sees only the shares coming from serverB. The ones from serverA are ignored.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
