### PR TITLE
[Tests-only] copy certificates to server storage during testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ vendor-bin/**/composer.lock
 /tests/.phpunit.result.cache
 /tests/coverage*
 /tests/karma-coverage
+/tests/acceptance/server_tmp
 /tests/autoconfig*
 /tests/autotest*
 /tests/data/lorem-copy.txt

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -130,8 +130,8 @@ class OccContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function importSecurityCertificateFromPath($path) {
-		$this->invokingTheCommand("security:certificates:import " . $path);
+	public function importSecurityCertificateFromFileInTemporaryStorage($path) {
+		$this->invokingTheCommand("security:certificates:import " . TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER . "/$path");
 		if ($this->featureContext->getExitStatusCodeOfOccCommand() === 0) {
 			$pathComponents = \explode("/", $path);
 			$certificate = \end($pathComponents);
@@ -575,27 +575,27 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator imports security certificate from the path :path
+	 * @When the administrator imports security certificate from file :filename in temporary storage on the system under test
 	 *
-	 * @param string $path
+	 * @param string $filename
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theAdministratorImportsSecurityCertificateFromThePath($path) {
-		$this->importSecurityCertificateFromPath($path);
+	public function theAdministratorImportsSecurityCertificateFromFile($filename) {
+		$this->importSecurityCertificateFromFileInTemporaryStorage($filename);
 	}
 
 	/**
-	 * @Given the administrator has imported security certificate from the path :path
+	 * @Given the administrator has imported security certificate from file :filename in temporary storage on the system under test
 	 *
-	 * @param string $path
+	 * @param string $filename
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theAdministratorHasImportedSecurityCertificateFromThePath($path) {
-		$this->importSecurityCertificateFromPath($path);
+	public function theAdministratorHasImportedSecurityCertificateFromFile($filename) {
+		$this->importSecurityCertificateFromFileInTemporaryStorage($filename);
 		$this->theCommandShouldHaveBeenSuccessful();
 	}
 
@@ -2086,7 +2086,9 @@ class OccContext implements Context {
 	 * @throws Exception
 	 */
 	public function theAdministratorImportsTheMountFromFileUsingTheOccCommand($file) {
-		$this->invokingTheCommand('files_external:import ' . $file);
+		$this->invokingTheCommand(
+			'files_external:import ' . TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER . "/$file"
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
@@ -14,10 +14,10 @@ Feature: import exported local storage mounts from the command line
     Given the administrator has created the local storage mount "local_storage2"
     And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
     And the administrator has exported the local storage mounts using the occ command
-    And the administrator has created a file "data/exportedMounts.json" with the last exported content using the testing API
+    And the administrator has created a file "exportedMounts.json" in temporary storage with the last exported content using the testing API
     And the administrator has deleted local storage "local_storage" using the occ command
     And the administrator has deleted local storage "local_storage2" using the occ command
-    When the administrator imports the local storage mount from file "data/exportedMounts.json" using the occ command
+    When the administrator imports the local storage mount from file "exportedMounts.json" using the occ command
     And the administrator lists the local storage using the occ command
     Then the following local storage should be listed:
       | MountPoint         | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |
@@ -45,11 +45,11 @@ Feature: import exported local storage mounts from the command line
     And the administrator has added group "grp2" as the applicable group for local storage mount "local_storage3"
     And the administrator has added group "grp3" as the applicable group for local storage mount "local_storage3"
     And the administrator has exported the local storage mounts using the occ command
-    And the administrator has created a file "data/exportedMounts.json" with the last exported content using the testing API
+    And the administrator has created a file "exportedMounts.json" in temporary storage with the last exported content using the testing API
     And the administrator has deleted local storage "local_storage" using the occ command
     And the administrator has deleted local storage "local_storage2" using the occ command
     And the administrator has deleted local storage "local_storage3" using the occ command
-    When the administrator imports the local storage mount from file "data/exportedMounts.json" using the occ command
+    When the administrator imports the local storage mount from file "exportedMounts.json" using the occ command
     And the administrator lists the local storage using the occ command
     Then the following local storage should be listed:
       | MountPoint      | Storage | AuthenticationType | Configuration | Options | ApplicableUsers | ApplicableGroups |

--- a/tests/acceptance/features/cliMain/securityCertificates.feature
+++ b/tests/acceptance/features/cliMain/securityCertificates.feature
@@ -1,11 +1,12 @@
-@cli @skipOnOcis @skipOnOcV10.3 @skipOnOcV10.4
+@cli @skipOnOcis @skipOnOcV10.3 @skipOnOcV10.4 @temporary_storage_on_server
 Feature: security certificates
   As an admin
   I want to be able to manage the ownCloud security certificates
   So that I can ensure the proper encrpytion mechanism
 
   Scenario: Import a security certificate
-    When the administrator imports security certificate from the path "tests/data/certificates/goodCertificate.crt"
+    Given the administrator has copied file "tests/data/certificates/goodCertificate.crt" to "goodCertificate.crt" in temporary storage on the system under test
+    When the administrator imports security certificate from file "goodCertificate.crt" in temporary storage on the system under test
     Then the command should have been successful
     When the administrator invokes occ command "security:certificates"
     Then the command should have been successful
@@ -14,13 +15,15 @@ Feature: security certificates
       | goodCertificate.crt |
 
   Scenario: Import a security certificate specifying a file that does not exist
-    When the administrator imports security certificate from the path "tests/data/certificates/aFileThatDoesNotExist.crt"
+    When the administrator imports security certificate from file "aFileThatDoesNotExist.crt" in temporary storage on the system under test
     Then the command should have failed with exit code 1
     And the command output should contain the text "certificate not found"
 
   Scenario: List security certificates when multiple certificates are imported
-    Given the administrator has imported security certificate from the path "tests/data/certificates/goodCertificate.crt"
-    And the administrator has imported security certificate from the path "tests/data/certificates/badCertificate.crt"
+    Given the administrator has copied file "tests/data/certificates/goodCertificate.crt" to "goodCertificate.crt" in temporary storage on the system under test
+    And the administrator has copied file "tests/data/certificates/badCertificate.crt" to "badCertificate.crt" in temporary storage on the system under test
+    And the administrator has imported security certificate from file "goodCertificate.crt" in temporary storage on the system under test
+    And the administrator has imported security certificate from file "badCertificate.crt" in temporary storage on the system under test
     When the administrator invokes occ command "security:certificates"
     And the command output table should contain the following text:
       | table_column        |
@@ -28,8 +31,10 @@ Feature: security certificates
       | badCertificate.crt  |
 
   Scenario: Remove a security certificate
-    Given the administrator has imported security certificate from the path "tests/data/certificates/goodCertificate.crt"
-    And the administrator has imported security certificate from the path "tests/data/certificates/badCertificate.crt"
+    Given the administrator has copied file "tests/data/certificates/goodCertificate.crt" to "goodCertificate.crt" in temporary storage on the system under test
+    And the administrator has copied file "tests/data/certificates/badCertificate.crt" to "badCertificate.crt" in temporary storage on the system under test
+    And the administrator has imported security certificate from file "goodCertificate.crt" in temporary storage on the system under test
+    And the administrator has imported security certificate from file "badCertificate.crt" in temporary storage on the system under test
     When the administrator removes the security certificate "goodCertificate.crt"
     Then the command should have been successful
     When the administrator invokes occ command "security:certificates"
@@ -43,5 +48,6 @@ Feature: security certificates
     And the command output should contain the text "certificate not found"
 
   Scenario: Import random file as certificate
-    When the administrator imports security certificate from the path "tests/data/lorem.txt"
+    Given the administrator has copied file "tests/data/lorem.txt" to "lorem.txt" in temporary storage on the system under test
+    When the administrator imports security certificate from file "lorem.txt" in temporary storage on the system under test
     Then the command error output should contain the text "Certificate could not get parsed."


### PR DESCRIPTION
## Description

In the acceptance tests for the `occ security:certificates` commands, use the testing app to copy the certificate files into a temporary directory on the system-under-test and import the certificates from the temporary directory. This avoids problems when the test-runner and the system-under-test are in different file-systems.

## Related Issue
- Fixes #37784 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
