### PR TITLE
Exclude reshares from files:transfer-ownership as ownership cannot be transfered

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -4,6 +4,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
  * @license AGPL-3.0
@@ -325,6 +326,14 @@ class TransferOwnership extends Command {
 				} else {
 					$filteredShares = $sharePage;
 				}
+
+				// filter out the reshares as transfer ownership only transfers
+				// files owned by the user - in case of reshares source
+				// user is not file owner
+				$filteredShares = \array_filter($filteredShares, function (IShare $share) {
+					return $share->getShareOwner() === $this->sourceUser;
+				});
+
 				$progress->advance(\count($filteredShares));
 				$this->shares = \array_merge($this->shares, $filteredShares);
 				$offset += 50;

--- a/changelog/unreleased/37791
+++ b/changelog/unreleased/37791
@@ -1,0 +1,8 @@
+Bugfix: Reshares using files:transfer-ownership cannot be transferred
+
+Received shares that have been reshared further now will not be transferred
+using files:transfer-ownership. Fixes issue with mismatching ownership after
+executing transfer.
+
+https://github.com/owncloud/enterprise/issues/4121
+https://github.com/owncloud/core/pull/37791

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -96,6 +96,26 @@ Feature: transfer-ownership
     Then the command should have been successful
     And as "Brian" folder "/test" should not exist in the last received transfer folder
 
+  @skipOnEncryptionType:user-keys @files_sharing-app-required
+  Scenario: transferring ownership does not transfer reshares
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and skeleton files
+    And user "David" has been created with default attributes and skeleton files
+    And user "Alice" has created folder "/testByAlice"
+    And user "Alice" has shared folder "/testByAlice" with user "Brian" with permissions "all"
+    And user "Brian" has shared folder "/testByAlice" with user "Carol" with permissions "all"
+    And user "Brian" has created folder "/testByBrian"
+    And user "Brian" has shared folder "/testByBrian" with user "Carol" with permissions "all"
+    When the administrator transfers ownership from "Brian" to "David" using the occ command
+    Then the command should have been successful
+    And as "Brian" folder "/testByAlice" should exist
+    But as "Brian" folder "/testByBrian" should not exist
+    And as "David" folder "/testByBrian" should exist in the last received transfer folder
+    But as "David" folder "/testByAlice" should not exist in the last received transfer folder
+    And as "Carol" folder "/testByAlice" should exist
+    And as "Carol" folder "/testByBrian" should exist
+
   @local_storage @skipOnEncryptionType:user-keys
   Scenario: transferring ownership does not transfer external storage
     Given user "Alice" has been created with default attributes and skeleton files


### PR DESCRIPTION
## Description

- Lets have a share (test1) to (test2) and reshare to (test4) created. Both UI and oc_shares table looks ok. However, when transfering ownership from (test2) to (test3), reshares are partially transfered causing mismatching ownership to actual share.

Transfer ownership should:
- transfers files owner by user
- transfers outgoing shares (files shared by user) 
- does not transfer incoming shares (as not owned)
- does not transfer incoming shares that have been reshared (outgoing shares) -> fixed by this PR

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4121

## How Has This Been Tested?
- unit tests
- manual

## Changes
- [x] Bug fix (non-breaking change which fixes an issues
- [x] Unit tests added
- [x] Changelog item
