### PR TITLE
[Tests-Only] find data file relative to test-runner root

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2126,9 +2126,14 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * Copy a file from the test-runner to the temporary storage directory on
+	 * the system-under-test. This uses the testing app to push the file into
+	 * the backend of the server, where it can be seen by occ commands done in
+	 * the server-under-test.
+	 *
 	 * @Given the administrator has copied file :localPath to :destination in temporary storage on the system under test
 	 *
-	 * @param string $localPath
+	 * @param string $localPath relative to the core "root" folder
 	 * @param string $destination
 	 *
 	 * @return void
@@ -2136,7 +2141,11 @@ class FeatureContext extends BehatVariablesContext {
 	public function theAdministratorHasCopiedFileToTemporaryStorageOnTheSystemUnderTest(
 		$localPath, $destination
 	) {
-		$content = \file_get_contents($localPath);
+		// FeatureContext is in tests/acceptance/features/bootstrap so go up 4
+		// levels to the test-runner root
+		$testRunnerRoot = \dirname(__DIR__, 4);
+		// The local path is specified down from the root - e.g. tests/data/file.txt
+		$content = \file_get_contents("$testRunnerRoot/$localPath");
 		Assert::assertNotFalse(
 			$content,
 			"Local file $localPath cannot be read"


### PR DESCRIPTION
## Description
PR #37787 introduced the step:
```
    Given the administrator has copied file "tests/data/certificates/goodCertificate.crt" to "goodCertificate.crt" in temporary storage on the system under test
```
The code looked for the file relative to the current directory of the process running the test. That is a problem in app testing - the drone process is running with a current directory down in, for example, `apps/user_ldap`

This PR changes the code to find the "core root" of the ownCloud test-runner (4 levels up from `tests/acceptance/features/bootstrap`) and look for the file from there.

## How Has This Been Tested?
CI and local test run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
