### PR TITLE
[Tests-Only] Added tests for change in etag 

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -411,6 +411,7 @@ default:
         - LoggingContext:
         - OccContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
     apiWebdavUpload2:
       paths:

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -194,3 +194,35 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
+  @skipOnOcis @issue-product-127
+  Scenario Outline: uploading a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" uploads file with content "uploaded content" to "/upload/file.txt" using the WebDAV API
+    Then the content of file "/upload/file.txt" for user "Alice" should be "uploaded content"
+    And the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element |
+      | old         |         |
+      | old         | upload  |
+      | new         |         |
+      | new         | upload  |
+
+  @skipOnOcV10 @issue-product-127
+  #after fixing all issues delete this Scenario and use the one above
+  Scenario Outline: uploading a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" uploads file with content "uploaded content" to "/upload/file.txt" using the WebDAV API
+    Then the content of file "/upload/file.txt" for user "Alice" should be "uploaded content"
+#    And the etag of element "/<element>" of user "Alice" should have changed
+    And the etag of element "/<element>" of user "Alice" should not have changed
+    Examples:
+      | dav_version | element |
+      | old         |         |
+      | old         | upload  |
+      | new         |         |
+      | new         | upload  |


### PR DESCRIPTION
## Description
Added tests for change in `etag` after uploading a file inside a folder.

## Related Issue
https://github.com/owncloud/product/issues/127

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/438
- https://github.com/owncloud/ocis-reva/pull/431

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
