### PR TITLE
[Tests-only] adjust tests for EOS storage

### DIFF
--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -13,7 +13,7 @@ Feature: favorite
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
+  @issue-ocis-reva-276
   Scenario Outline: Favorite a folder
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/FOLDER" using the WebDAV API
@@ -28,7 +28,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
+  @issue-ocis-reva-276
   Scenario Outline: Favorite and unfavorite a folder
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/FOLDER" using the WebDAV API
@@ -44,7 +44,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @smokeTest @skipOnOcis-EOS-Storage @issue-ocis-reva-276
+  @smokeTest @issue-ocis-reva-276
   Scenario Outline: Favorite a file
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/textfile0.txt" using the WebDAV API
@@ -59,7 +59,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @smokeTest @skipOnOcis-EOS-Storage @issue-ocis-reva-276
+  @smokeTest @issue-ocis-reva-276
   Scenario Outline: Favorite and unfavorite a file
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/textfile0.txt" using the WebDAV API

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -331,7 +331,7 @@ Feature: checksums
     Then the HTTP status code should be "400"
     And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
 
-  @issue-ocis-reva-214 @skipOnOcis-EOS-Storage
+  @issue-ocis-reva-214
   Scenario Outline: Uploading a file with checksum should work for file with special characters
     When user "Alice" uploads file "filesForUpload/textfile.txt" to <renamed_file> with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
     Then the HTTP status code should be "201"

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -66,7 +66,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-301 @issue-ocis-reva-302
+  @issue-ocis-reva-301 @issue-ocis-reva-302
   Scenario Outline: Creating a share of a file with a user and asking for various permission combinations
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -130,7 +130,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 400              |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-301
+  @issue-ocis-reva-301
   Scenario Outline: Creating a share of a folder with a user, the default permissions are all permissions(31)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @skipOnOcis-EOS-Storage @issue-ocis-reva-315 @issue-ocis-reva-316
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-315 @issue-ocis-reva-316
 
 Feature: changing a public link share
 

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @skipOnOcis-EOS-Storage @issue-ocis-reva-315 @issue-ocis-reva-316
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-315 @issue-ocis-reva-316
 
 Feature: create a public link share
 

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @skipOnOcis-EOS-Storage @issue-ocis-reva-315 @issue-ocis-reva-316
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-315 @issue-ocis-reva-316
 
 Feature: upload to a public link share
 

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -1,4 +1,4 @@
-@api @files_versions-app-required @skipOnOcis-EOS-Storage @issue-ocis-reva-275
+@api @files_versions-app-required @issue-ocis-reva-275
 
 Feature: dav-versions
 

--- a/tests/acceptance/features/apiVersions/fileVersionsOc10Issue37026.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsOc10Issue37026.feature
@@ -1,4 +1,4 @@
-@api @files_versions-app-required @skipOnOcis-EOS-Storage @issue-ocis-reva-275 @notToImplementOnOCIS
+@api @files_versions-app-required @issue-ocis-reva-275 @notToImplementOnOCIS
 
 Feature: dav-versions
 

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -281,7 +281,7 @@ Feature: move (rename) file
       | *a@b#c$e%f&g* |
       | 1 2 3##.##    |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-265
+  @issue-ocis-reva-265
   #after fixing the issues merge this Scenario into the one above
   Scenario Outline: renaming to a file with special characters
     When user "Alice" moves file "/textfile0.txt" to "/<renamed_file>" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
@@ -19,7 +19,7 @@ Feature: delete folder
       | old         |
       | new         |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-269
+  @issue-ocis-reva-269
   Scenario Outline: delete a folder when 2 folder exist with different case
     Given using <dav_version> DAV path
     And user "Alice" creates folder "/parent" using the WebDAV API
@@ -32,7 +32,7 @@ Feature: delete folder
       | old         |
       | new         |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-269
+  @issue-ocis-reva-269
   Scenario Outline: delete a sub-folder
     Given using <dav_version> DAV path
     And user "Alice" creates folder "/PARENT/CHILD" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -90,7 +90,7 @@ Feature: download file
     Then the HTTP status code should be "207"
     And the size of the file should be "19"
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-98
+  @issue-ocis-reva-98
   Scenario Outline: Get the content-length response header of a pdf file
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/simple.pdf" to "/simple.pdf"
@@ -103,7 +103,7 @@ Feature: download file
       | old         |
       | new         |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-98
+  @issue-ocis-reva-98
   Scenario Outline: Get the content-length response header of an image file
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/testavatar.png" to "/testavatar.png"

--- a/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
@@ -8,7 +8,7 @@ Feature: create folder
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-269
+  @issue-ocis-reva-269
   Scenario Outline: create a folder
     Given using <dav_version> DAV path
     When user "Alice" creates folder "<folder_name>" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
@@ -8,7 +8,7 @@ Feature: set file properties
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
+  @smokeTest @issue-ocis-reva-276
   Scenario Outline: Setting custom DAV property and reading it
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustomprop.txt"
@@ -32,7 +32,7 @@ Feature: set file properties
       | old         |
       | new         |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
+  @issue-ocis-reva-276
   Scenario Outline: Setting custom DAV property and reading it after the file is renamed
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustompropwithmove.txt"
@@ -63,7 +63,7 @@ Feature: set file properties
       | old         |
       | new         |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
+  @issue-ocis-reva-276
   Scenario Outline: Setting custom DAV property using one endpoint and reading it with other endpoint
     Given using <action_dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testnewold.txt"
@@ -76,7 +76,7 @@ Feature: set file properties
       | old                | new               |
       | new                | old               |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-276
+  @issue-ocis-reva-276
   Scenario: Setting custom DAV property using an old endpoint and reading it using a new endpoint
     Given using old DAV path
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testoldnew.txt"

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -89,7 +89,7 @@ Feature: get file properties
       | new         | /नेपाली                          | नेपाली                        |
       | new         | /folder #2.txt                   | file #2.txt                   |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-265
+  @issue-ocis-reva-265
   #after fixing all issues delete this Scenario and merge with the one above
   Scenario Outline: Do a PROPFIND of various files inside various folders
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -37,7 +37,7 @@ Feature: upload file
       | new         | "C++ file.cpp"      |
       | new         | "file #2.txt"       |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-265
+  @issue-ocis-reva-265
   #after fixing all issues delete this Scenario and merge with the one above
   Scenario Outline: upload a file and check download content
     Given using <dav_version> DAV path
@@ -83,7 +83,7 @@ Feature: upload file
       | new         | /नेपाली                          | नेपाली                        |
       | new         | /folder #2.txt                   | file #2.txt                   |
 
-  @skipOnOcis-EOS-Storage @issue-ocis-reva-265
+  @issue-ocis-reva-265
     #after fixing all issues delete this Scenario and merge with the one above
   Scenario Outline: upload a file into a folder and check download content
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2758,6 +2758,41 @@ trait Sharing {
 	}
 
 	/**
+	 * @param $user
+	 *
+	 * @throws Exception
+	 *
+	 * @return void
+	 */
+	public function deleteAllSharesForUser($user) {
+		$user = $this->getActualUsername($user);
+		$url = $this->getSharesEndpointPath("?format=json");
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user, "GET", $url, null
+		);
+		if ($this->response->getStatusCode() !== 200) {
+			return;
+		}
+		$result = $this->response->getBody()->getContents();
+		$usersShares = \json_decode($result, true);
+		if (!\is_array($usersShares)) {
+			throw new Exception(
+				__METHOD__ . " API result about shares is not valid JSON"
+			);
+		}
+		if (!isset($usersShares['ocs']['data'])) {
+			return;
+		}
+		foreach ($usersShares['ocs']['data'] as $share) {
+			$share_id = $share['id'];
+			$url = $this->getSharesEndpointPath("/$share_id");
+			$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+				$user, "DELETE", $url, null
+			);
+		}
+	}
+
+	/**
 	 * replace values from table
 	 *
 	 * @param string $field


### PR DESCRIPTION
## Description
1. delete `@skipOnOcis-EOS-Storage` tags because we have now the expected failures list
2. introduce `STORAGE_DRIVER` setting, this setting is used to generate the correct delete command to delete user data
3. hack to create user storage on EOS storage `createEOSStorageHome()` after deleting the user and recreating it we need an extra request to create the user home storage on EOS
4. when creating a user use guid and uid numbers (needed for EOS)
5. when testing on OCIS delete all shares of all users before deleting the user - this is needed because shares are not deleted automatically when user is deleted

## How Has This Been Tested?
https://github.com/owncloud/ocis/pull/704

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
