### PR TITLE
[tests-only] export TESTING_REMOTE_SYSTEM variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 #
 #  curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
 #  sudo apt-get install -y nodejs build-essential
-#  
+#
 # (installation from distro packages is not recommended, often old versions)
 #
 #
@@ -60,10 +60,12 @@ TEST_PHP_SUITE=
 TEST_SERVER_URL?=
 TEST_SERVER_FED_URL?=
 TEST_EXTERNAL_USER_BACKENDS?=
-TESTING_REMOTE_SYSTEM?=true
 BEHAT_FEATURE?=
 NORERUN?=
 BEHAT_RERUN_TIMES?=
+
+# set TESTING_REMOTE_SYSTEM to default=true and make it a system env. variable
+export TESTING_REMOTE_SYSTEM?=true
 
 RELEASE_CHANNEL=git
 


### PR DESCRIPTION
## Description
make the variable from the Makefile a environment variable, so it will be passed to `run.sh`

## Motivation and Context
setting the variable to default `true` for `run.sh` never really worked (outside of CI) and the script hang at https://github.com/owncloud/core/blob/d2cc4ec5d88a82f94a5eaaeda78d273e2cd03a4c/tests/acceptance/run.sh#L878. No idea why it worked in CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
