### PR TITLE
[Tests-Only] Bump phpunit version in autotest scripts

### DIFF
--- a/build/autotest-external.sh
+++ b/build/autotest-external.sh
@@ -33,7 +33,7 @@ function print_syntax {
 }
 
 if ! [ -x "$PHPUNIT" ]; then
-	echo "phpunit executable not found, please install phpunit version >= 3.7" >&2
+	echo "phpunit executable not found, please install phpunit version >= 8.5" >&2
 	exit 3
 fi
 
@@ -41,8 +41,8 @@ PHPUNIT_VERSION=$("$PHPUNIT" --version | cut -d" " -f2)
 PHPUNIT_MAJOR_VERSION=$(echo $PHPUNIT_VERSION | cut -d"." -f1)
 PHPUNIT_MINOR_VERSION=$(echo $PHPUNIT_VERSION | cut -d"." -f2)
 
-if ! [ $PHPUNIT_MAJOR_VERSION -gt 4 -o \( $PHPUNIT_MAJOR_VERSION -eq 4 -a $PHPUNIT_MINOR_VERSION -ge 4 \) ]; then
-	echo "phpunit version >= 4.4 required. Version found: $PHPUNIT_VERSION" >&2
+if ! [ $PHPUNIT_MAJOR_VERSION -gt 8 -o \( $PHPUNIT_MAJOR_VERSION -eq 8 -a $PHPUNIT_MINOR_VERSION -ge 5 \) ]; then
+	echo "phpunit version >= 8.5 required. Version found: $PHPUNIT_VERSION" >&2
 	exit 4
 fi
 

--- a/build/autotest.sh
+++ b/build/autotest.sh
@@ -61,7 +61,7 @@ else
 fi
 
 if ! [ -x "$PHPUNIT" ]; then
-	echo "phpunit executable not found, please install phpunit version >= 4.4" >&2
+	echo "phpunit executable not found, please install phpunit version >= 8.5" >&2
 	exit 3
 fi
 
@@ -76,8 +76,8 @@ PHPUNIT_VERSION=$($PHPUNIT --version | cut -d" " -f2)
 PHPUNIT_MAJOR_VERSION=$(echo "$PHPUNIT_VERSION" | cut -d"." -f1)
 PHPUNIT_MINOR_VERSION=$(echo "$PHPUNIT_VERSION" | cut -d"." -f2)
 
-if ! [ "$PHPUNIT_MAJOR_VERSION" -gt 4 -o \( "$PHPUNIT_MAJOR_VERSION" -eq 4 -a "$PHPUNIT_MINOR_VERSION" -ge 4 \) ]; then
-	echo "phpunit version >= 4.4 required. Version found: $PHPUNIT_VERSION" >&2
+if ! [ "$PHPUNIT_MAJOR_VERSION" -gt 8 -o \( "$PHPUNIT_MAJOR_VERSION" -eq 8 -a "$PHPUNIT_MINOR_VERSION" -ge 5 \) ]; then
+	echo "phpunit version >= 8.5 required. Version found: $PHPUNIT_VERSION" >&2
 	exit 4
 fi
 


### PR DESCRIPTION
## Description
The minimum version of `phpunit` has got out-of-date in some unit test scripts. Update it while I notice it.

Note: there is no real problem here, because actually for most developers they will get `phpunit` >= 8.5 automagically anyway from `composer.json`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
