### PR TITLE
[Tests-Only] skipOnOcV10.5.0 cliMain securityCertificates features

### DIFF
--- a/tests/acceptance/features/cliMain/securityCertificates.feature
+++ b/tests/acceptance/features/cliMain/securityCertificates.feature
@@ -14,6 +14,7 @@ Feature: security certificates
       | table_column        |
       | goodCertificate.crt |
 
+  @skipOnOcV10.5.0
   Scenario: Import a security certificate specifying a file that does not exist
     When the administrator imports security certificate from file "aFileThatDoesNotExist.crt" in temporary storage on the system under test
     Then the command should have failed with exit code 1
@@ -42,6 +43,7 @@ Feature: security certificates
       | table_column       |
       | badCertificate.crt |
 
+  @skipOnOcV10.5.0
   Scenario: Remove a security certificate that is not installed
     When the administrator removes the security certificate "someCertificate.crt"
     Then the command should have failed with exit code 1


### PR DESCRIPTION
## Description
https://drone.owncloud.com/owncloud/user_ldap/2703/142/12 fails:
```
--- Failed scenarios:

    /var/www/owncloud/testrunner/tests/acceptance/features/cliMain/securityCertificates.feature:17
    /var/www/owncloud/testrunner/tests/acceptance/features/cliMain/securityCertificates.feature:45

53 scenarios (51 passed, 2 failed)
311 steps (307 passed, 2 failed, 2 skipped)
```

Those tests were created/adjusted in PR #37783 which fixed the expected exit status of security:certificates commands.

The test scenarios will not pass on ownCloud 10.5.0, so skip them in that case. (note the whole of `securityCertificates.feature` is already skipped on 10.3 and 10.4)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
