### PR TITLE
[Tests-Only] Purposely make scenarios fail to test PR 37785

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -9,7 +9,7 @@ Feature: capabilities
     Given parameter "shareapi_enabled" of app "core" has been set to "no"
     And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be ""
     When the administrator sets parameter "shareapi_enabled" of app "core" to "yes"
-    Then the capabilities setting of "files_sharing" path "api_enabled" should be "1"
+    Then the capabilities setting of "files_sharing" path "api_enabled" should be "0"
 
   @smokeTest
   Scenario: Check that the sharing API can be disabled

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -47,7 +47,7 @@ Feature: Comments
       | objectType       | files            |
       | isUnread         | false            |
       | actorDisplayName | %displayname%    |
-      | message          | My first comment |
+      | message          | My first failure |
 
   Scenario: Getting more info about comments using PROPFIND method
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "myFileToComment.txt"


### PR DESCRIPTION
do not merge - testing only

https://drone.owncloud.com/owncloud/core/26334/52/13
```
--- Failed scenarios:

    /drone/src/tests/acceptance/features/apiCapabilities/capabilities.feature:8

49 scenarios (48 passed, 1 failed)
222 steps (221 passed, 1 failed)
10m44.65s (15.51Mb)
runsh: Total 49 scenarios (48 passed, 1 failed)
runsh: Exit code of main run: 1
runsh: Total unexpected failed scenarios throughout the test run:
apiCapabilities/capabilities.feature:8
runsh: There were no unexpected success.
Makefile:207: recipe for target 'test-acceptance-api' failed
make: *** [test-acceptance-api] Error 1
```

https://drone.owncloud.com/owncloud/core/26334/53/13
```
--- Failed scenarios:

    /drone/src/tests/acceptance/features/apiComments/comments.feature:38

31 scenarios (30 passed, 1 failed)
233 steps (232 passed, 1 failed)
7m42.50s (16.60Mb)
runsh: Total 31 scenarios (30 passed, 1 failed)
runsh: Exit code of main run: 1
runsh: Total unexpected failed scenarios throughout the test run:
apiComments/comments.feature:38
runsh: There were no unexpected success.
Makefile:207: recipe for target 'test-acceptance-api' failed
make: *** [test-acceptance-api] Error 1
```

Good - the expected failures are correctly reported.