### PR TITLE
[Tests-Only] Remove skipOnOcis tag

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-26 @issue-ocis-reva-27
+@api @toImplementOnOCIS @issue-ocis-reva-26 @issue-ocis-reva-27
 Feature: CORS headers
 
   Background:

--- a/tests/acceptance/features/apiAuth/filesAppAuth.feature
+++ b/tests/acceptance/features/apiAuth/filesAppAuth.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-28
+@api @notToImplementOnOCIS @issue-ocis-reva-28
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuth/tokenAuth.feature
+++ b/tests/acceptance/features/apiAuth/tokenAuth.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-28 @issue-ocis-reva-37
+@api @notToImplementOnOCIS @issue-ocis-reva-28 @issue-ocis-reva-37
 Feature: tokenAuth
 
   Background:

--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -14,7 +14,7 @@ Feature: auth
     When user "Alice" requests "/remote.php/webdav" with "PROPFIND" using basic auth
     Then the HTTP status code should be "207"
 
-  @smokeTest @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-28
+  @smokeTest @notToImplementOnOCIS @issue-ocis-reva-28
   Scenario: using WebDAV with token auth
     Given a new client token for "Alice" has been generated
     When user "Alice" requests "/remote.php/webdav" with "PROPFIND" using basic token auth
@@ -25,7 +25,7 @@ Feature: auth
 	#	When requesting "/remote.php/webdav" with "PROPFIND" using a client token
 	#	Then the HTTP status code should be "207"
 
-  @smokeTest  @skipOnOcis @notToImplementOnOCIS
+  @smokeTest  @notToImplementOnOCIS
   Scenario: using WebDAV with browser session
     Given a new browser session for "Alice" has been started
     When the user requests "/remote.php/webdav" with "PROPFIND" using the browser session

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -4,7 +4,7 @@ Feature: auth
   Background:
     Given user "another-admin" has been created with default attributes and without skeleton files
 
-  @smokeTest @issue-32068 @skipOnOcis @issue-ocis-reva-30 @issue-ocis-reva-65
+  @smokeTest @issue-32068 @issue-ocis-reva-30 @issue-ocis-reva-65
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     Given user "another-admin" has been added to group "admin"

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -4,7 +4,7 @@ Feature: auth
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @issue-32068 @skipOnOcis
+  @issue-32068
   @issue-ocis-reva-30
   @smokeTest
   Scenario: using OCS anonymously
@@ -29,7 +29,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
 
-  @skipOnOcis @issue-ocis-reva-29
+  @issue-ocis-reva-29
   Scenario: ocs config end point accessible by unauthorized users
     When a user requests these endpoints with "GET" and no authentication
       | endpoint           |
@@ -42,7 +42,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @issue-32068 @skipOnOcis
+  @issue-32068
   @issue-ocis-reva-11
   @issue-ocis-reva-30
   @issue-ocis-reva-31
@@ -82,7 +82,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
 
-  @issue-32068 @skipOnOcis @issue-ocis-reva-29 @issue-ocis-reva-30
+  @issue-32068 @issue-ocis-reva-29 @issue-ocis-reva-30
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as normal user with wrong password
@@ -117,7 +117,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @skipOnOcis @issue-ocis-reva-65
+  @issue-ocis-reva-65
   Scenario:using OCS with admin basic auth
     When the administrator requests these endpoint with "GET"
       | endpoint                 |
@@ -134,7 +134,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @skipOnOcis @issue-ocis-reva-30 @issue-ocis-reva-65
+  @issue-ocis-reva-30 @issue-ocis-reva-65
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as admin user with wrong password
     Given user "another-admin" has been created with default attributes and without skeleton files
@@ -171,7 +171,7 @@ Feature: auth
     And the OCS status code of responses on all endpoints should be "200"
 
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-30 @issue-ocis-reva-28
+  @notToImplementOnOCIS @issue-ocis-reva-30 @issue-ocis-reva-28
   Scenario: using OCS with token auth of a normal user
     Given a new client token for "Alice" has been generated
     When user "Alice" requests these endpoints with "GET" using basic token auth
@@ -205,7 +205,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
 
-  @skipOnOcis @notToImplementOnOCIS
+  @notToImplementOnOCIS
   Scenario: using OCS with browser session of normal user
     Given a new browser session for "Alice" has been started
     When the user requests these endpoints with "GET" using a new browser session
@@ -239,7 +239,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-30 @issue-ocis-reva-60
+  @toImplementOnOCIS @issue-ocis-reva-30 @issue-ocis-reva-60
   Scenario: using OCS with an app password of a normal user
     Given a new browser session for "Alice" has been started
     And the user has generated a new app password named "my-client"

--- a/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
@@ -4,7 +4,7 @@ Feature: auth
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @skipOnOcis @issue-ocis-reva-30
+  @issue-ocis-reva-30
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to OCS endpoints as normal user with wrong password

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -4,7 +4,7 @@ Feature: auth
   Background:
     Given user "another-admin" has been created with default attributes and without skeleton files
 
-  @skipOnOcis @issue-ocis-reva-30
+  @issue-ocis-reva-30
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT request to OCS endpoints as admin with wrong password

--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
@@ -32,7 +32,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-13
+  @issue-ocis-reva-13
   Scenario: send DELETE requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "DELETE" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |
@@ -74,7 +74,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-60
+  @toImplementOnOCIS @issue-ocis-reva-60
   Scenario: send DELETE requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -88,7 +88,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-60
+  @toImplementOnOCIS @issue-ocis-reva-60
   Scenario: send DELETE requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -34,7 +34,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9
+  @issue-ocis-reva-9
   Scenario: send LOCK requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
       | endpoint                                           |
@@ -78,7 +78,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send LOCK requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -92,7 +92,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send LOCK requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -33,7 +33,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9 @issue-ocis-reva-197
+  @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send MKCOL requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
       | endpoint                                           |
@@ -78,7 +78,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send MKCOL requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -92,7 +92,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send MKCOL requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -33,7 +33,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-14
+  @issue-ocis-reva-14
   Scenario: send MOVE requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
       | endpoint                                           |
@@ -74,7 +74,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send MOVE requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -88,7 +88,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send MOVE requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -34,7 +34,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-179
+  @issue-ocis-reva-179
   Scenario: send POST requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" about user "Alice"
       | endpoint                                            |
@@ -75,7 +75,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send POST requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -89,7 +89,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send POST requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -33,7 +33,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9
+  @issue-ocis-reva-9
   Scenario: send PROPFIND requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PROPFIND" to get property "d:getetag" about user "Alice"
       | endpoint                                           |
@@ -74,7 +74,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send PROPFIND requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -88,7 +88,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send PROPFIND requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -34,7 +34,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9 @issue-ocis-reva-197
+  @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send PROPPATCH requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PROPPATCH" to set property "favorite" about user "Alice"
       | endpoint                                           |
@@ -75,7 +75,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send PROPPATCH requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -89,7 +89,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send PROPPATCH requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -34,7 +34,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @issue-ocis-reva-9 @issue-ocis-reva-197
+  @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send PUT requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" about user "Alice"
       | endpoint                                       |
@@ -78,7 +78,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send PUT requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -92,7 +92,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcis @notToImplementOnOCIS @issue-ocis-reva-37
+  @notToImplementOnOCIS @issue-ocis-reva-37
   Scenario: send PUT requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-41
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41
 Feature: capabilities
 
   Background:

--- a/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
@@ -7,7 +7,7 @@ Feature: default capabilities for normal user
 
   # adjust this scenario after fixing tagged issues as its just created to show difference
   # in the response items in different environment (core & ocis-reva)
-  @skipOnOcis @issue-ocis-reva-175 @issue-ocis-reva-176
+  @issue-ocis-reva-175 @issue-ocis-reva-176
   Scenario: getting default capabilities with normal user
     When user "Alice" retrieves the capabilities using the capabilities API
     Then the capabilities should contain

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -1,4 +1,4 @@
-@api @comments-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-38
+@api @comments-app-required @toImplementOnOCIS @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -1,4 +1,4 @@
-@api @comments-app-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-38
+@api @comments-app-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiComments/deleteComments.feature
+++ b/tests/acceptance/features/apiComments/deleteComments.feature
@@ -1,4 +1,4 @@
-@api @comments-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-38
+@api @comments-app-required @toImplementOnOCIS @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiComments/editComments.feature
+++ b/tests/acceptance/features/apiComments/editComments.feature
@@ -1,4 +1,4 @@
-@api @comments-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-38
+@api @comments-app-required @toImplementOnOCIS @issue-ocis-reva-38
 Feature: Comments
 
   Background:

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -76,7 +76,7 @@ Feature: favorite
       | new         |
 
   @smokeTest @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @issue-ocis-reva-39
   Scenario Outline: Get favorited elements of a folder
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/FOLDER" using the WebDAV API
@@ -93,7 +93,7 @@ Feature: favorite
       | new         |
 
   @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @issue-ocis-reva-39
   Scenario Outline: Get favorited elements of a subfolder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/subfolder"
@@ -116,7 +116,7 @@ Feature: favorite
       | new         |
 
   @files_sharing-app-required @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @issue-ocis-reva-39
   Scenario Outline: moving a favorite file out of a share keeps favorite state
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -133,7 +133,7 @@ Feature: favorite
       | new         |
 
   @issue-33840 @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @issue-ocis-reva-39
   Scenario Outline: Get favorited elements and limit count of entries
     Given using <dav_version> DAV path
     And user "Alice" has favorited element "/textfile0.txt"
@@ -155,7 +155,7 @@ Feature: favorite
       | new         |
 
   @issue-33840 @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @issue-ocis-reva-39
   Scenario Outline: Get favorited elements paginated in subfolder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/subfolder"
@@ -185,7 +185,7 @@ Feature: favorite
       | new         |
 
   @files_sharing-app-required @toImplementOnOCIS
-  @skipOnOcis @issue-ocis-reva-39
+  @issue-ocis-reva-39
   Scenario Outline: sharer file favorite state should not change the favorite state of sharee
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -200,7 +200,7 @@ Feature: favorite
       | new         |
 
   @files_sharing-app-required @toImplementOnOCIS
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -214,7 +214,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-39
+  @issue-ocis-reva-39
   Scenario Outline: favoriting a folder does not change the favorite state of elements inside the folder
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/PARENT/parent.txt" using the WebDAV API

--- a/tests/acceptance/features/apiFederation1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederation1/etagPropagation.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required @toImplementOnOCIS
 Feature: propagation of etags between federated and local server
 
   Background:

--- a/tests/acceptance/features/apiFederation1/federated.feature
+++ b/tests/acceptance/features/apiFederation1/federated.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required @toImplementOnOCIS
 Feature: federated
 
   Background:

--- a/tests/acceptance/features/apiFederation2/federated.feature
+++ b/tests/acceptance/features/apiFederation2/federated.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required @toImplementOnOCIS
 Feature: federated
 
   Background:

--- a/tests/acceptance/features/apiMain/appmanagement.feature
+++ b/tests/acceptance/features/apiMain/appmanagement.feature
@@ -1,4 +1,4 @@
-@api @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @skipOnLDAP @notToImplementOnOCIS
 Feature: AppManagement
 
   Scenario: Two apps_path exist by default. The first one is more recent

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @toImplementOnOCIS
+@api @toImplementOnOCIS
 Feature: caldav
 
   Background:

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @toImplementOnOCIS
+@api @toImplementOnOCIS
 Feature: carddav
 
   Background:

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -13,7 +13,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-196
+  @smokeTest @issue-ocis-reva-196
   Scenario Outline: Uploading a file with checksum should return the checksum in the propfind
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
@@ -24,7 +24,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-98
+  @smokeTest @issue-ocis-reva-98
   Scenario Outline: Uploading a file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
@@ -35,7 +35,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-196
+  @issue-ocis-reva-196
   Scenario Outline: Moving a file with checksum should return the checksum in the propfind
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
@@ -46,7 +46,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-98
+  @issue-ocis-reva-98
   Scenario: Downloading a file with checksum should return the checksum in the download header
     Given using old DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
@@ -54,7 +54,7 @@ Feature: checksums
     And user "Alice" downloads file "/myMovedChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
-  @skipOnOcis @issue-ocis-reva-196
+  @issue-ocis-reva-196
   Scenario: Uploading a chunked file with checksum should return the checksum in the propfind
     Given using old DAV path
     And user "Alice" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
@@ -63,7 +63,7 @@ Feature: checksums
     When user "Alice" requests the checksum of "/myChecksumFile.txt" via propfind
     Then the webdav checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
 
-  @skipOnOcis @issue-ocis-reva-17
+  @issue-ocis-reva-17
   Scenario: Uploading a chunked file with checksum should return the checksum in the download header
     Given using old DAV path
     And user "Alice" has uploaded chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
@@ -72,7 +72,7 @@ Feature: checksums
     When user "Alice" downloads file "/myChecksumFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
 
-  @local_storage @skipOnOcis @notToImplementOnOCIS
+  @local_storage @notToImplementOnOCIS
   Scenario Outline: Downloading a file from local storage has correct checksum
     Given using <dav_version> DAV path
     # Create the file directly in local storage, bypassing ownCloud
@@ -87,7 +87,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-14
+  @issue-ocis-reva-14
   Scenario Outline: Moving file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
@@ -99,14 +99,14 @@ Feature: checksums
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-196
+  @issue-ocis-reva-196
   Scenario: Copying a file with checksum should return the checksum in the propfind using new DAV path
     Given using new DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the WebDAV API
     Then as user "Alice" the webdav checksum of "/myChecksumFileCopy.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
-  @skipOnOcis @issue-ocis-reva-98
+  @issue-ocis-reva-98
   Scenario: Copying file with checksum should return the checksum in the download header using new DAV path
     Given using new DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
@@ -115,7 +115,7 @@ Feature: checksums
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
   @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-196
+  @issue-ocis-reva-196
   Scenario: Sharing a file with checksum should return the checksum in the propfind using new DAV path
     Given using new DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -125,7 +125,7 @@ Feature: checksums
     Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
 
   @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-196
+  @issue-ocis-reva-196
   Scenario: Sharing and modifying a file should return correct checksum in the propfind using new DAV path
     Given using new DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -134,7 +134,7 @@ Feature: checksums
     And user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/myChecksumFile.txt" using the WebDAV API
     Then as user "Alice" the webdav checksum of "/myChecksumFile.txt" via propfind should match "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 MD5:56e57920c3c8c727bfe7a5288cdf61c4 ADLER32:1048035a"
 
-  @skipOnOcis @issue-ocis-reva-56
+  @issue-ocis-reva-56
   Scenario: Upload new dav chunked file where checksum matches
     Given using new DAV path
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
@@ -143,7 +143,7 @@ Feature: checksums
     And user "Alice" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
     Then the HTTP status code should be "201"
 
-  @skipOnOcis @issue-ocis-reva-56
+  @issue-ocis-reva-56
   Scenario: Upload new dav chunked file where checksum does not match
     Given using new DAV path
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
@@ -154,7 +154,7 @@ Feature: checksums
     And user "Alice" should not see the following elements
       | /myChunkedFile.txt |
 
-  @skipOnOcis @issue-ocis-reva-56
+  @issue-ocis-reva-56
   Scenario: Upload new dav chunked file using async MOVE where checksum matches
     Given using new DAV path
     And the administrator has enabled async operations
@@ -170,7 +170,7 @@ Feature: checksums
       | fileId | /^[0-9a-z]{20,}$/ |
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "BBBBBCCCCC"
 
-  @skipOnOcis @issue-ocis-reva-56
+  @issue-ocis-reva-56
   Scenario: Upload new dav chunked file using async MOVE where checksum does not matches
     Given using new DAV path
     And the administrator has enabled async operations
@@ -188,7 +188,7 @@ Feature: checksums
     And user "Alice" should not see the following elements
       | /myChunkedFile.txt |
 
-  @skipOnOcis @issue-ocis-reva-56
+  @issue-ocis-reva-56
   Scenario: Upload new dav chunked file using async MOVE where checksum does not matches - retry with correct checksum
     Given using new DAV path
     And the administrator has enabled async operations
@@ -205,7 +205,7 @@ Feature: checksums
       | fileId | /^[0-9a-z]{20,}$/ |
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "BBBBBCCCCC"
 
-  @skipOnOcis @issue-ocis-reva-99
+  @issue-ocis-reva-99
   Scenario Outline: Upload a file where checksum does not match
     Given using <dav_version> DAV path
     When user "Alice" uploads file with checksum "SHA1:f005ba11" and content "Some Text" to "/chksumtst.txt" using the WebDAV API
@@ -226,7 +226,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-99
+  @issue-ocis-reva-99
   Scenario Outline: Uploaded file should have the same checksum when downloaded
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt"
@@ -239,7 +239,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @local_storage @skipOnOcis @notToImplementOnOCIS @skipOnEncryptionType:user-keys @encryption-issue-42
+  @local_storage @notToImplementOnOCIS @skipOnEncryptionType:user-keys @encryption-issue-42
   Scenario Outline: Uploaded file to external storage should have the same checksum when downloaded
     Given using <dav_version> DAV path
     And file "/local_storage/chksumtst.txt" has been deleted for user "Alice"
@@ -254,7 +254,7 @@ Feature: checksums
       | new         |
 
   ## Validation Plugin or Old Endpoint Specific
-  @skipOnOcis @issue-ocis-reva-17
+  @issue-ocis-reva-17
   Scenario: Uploading an old method chunked file with checksum should fail using new DAV path
     Given using new DAV path
     When user "Alice" uploads chunk file "1" of "3" with "AAAAA" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e" using the WebDAV API
@@ -263,7 +263,7 @@ Feature: checksums
       | /myChecksumFile.txt |
 
   ## upload overwriting
-  @skipOnOcis @issue-ocis-reva-196
+  @issue-ocis-reva-196
   Scenario Outline: Uploading a file with MD5 checksum overwriting an existing file
     Given using <dav_version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
@@ -279,7 +279,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-196
+  @issue-ocis-reva-196
   Scenario Outline: Uploading a file with SHA1 checksum overwriting an existing file
     Given using <dav_version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f" using the WebDAV API
@@ -296,7 +296,7 @@ Feature: checksums
       | new         |
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
-  @skipOnOcis @issue-ocis-reva-196
+  @issue-ocis-reva-196
   Scenario Outline: Uploading a file with invalid SHA1 checksum overwriting an existing file
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -308,7 +308,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-56
+  @issue-ocis-reva-56
   Scenario: Upload overwriting a file with new chunking and correct checksum
     Given using new DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -320,7 +320,7 @@ Feature: checksums
     And the content of file "/textfile0.txt" for user "Brian" should be "BBBBBCCCCC"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
-  @skipOnOcis @issue-ocis-reva-56
+  @issue-ocis-reva-56
   Scenario: Upload overwriting a file with new chunking and invalid checksum
     Given using new DAV path
     And user "Brian" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -1,4 +1,4 @@
-@api @local_storage @skipOnOcis @notToImplementOnOCIS
+@api @local_storage @notToImplementOnOCIS
 Feature: external-storage
 
   Background:

--- a/tests/acceptance/features/apiMain/main.feature
+++ b/tests/acceptance/features/apiMain/main.feature
@@ -1,7 +1,7 @@
 @api
 Feature: Other tests related to api
 
-  @skipOnOcis @issue-ocis-reva-100
+  @issue-ocis-reva-100
   Scenario: robots.txt file should be accessible
     When a user requests "/robots.txt" with "GET" and no authentication
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-101
+@api @issue-ocis-reva-101
 Feature: quota
 
   Background:

--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-65 @issue-ocis-reva-97
+@api @issue-ocis-reva-65 @issue-ocis-reva-97
 Feature: Status
 
   @smokeTest

--- a/tests/acceptance/features/apiMain/userSync.feature
+++ b/tests/acceptance/features/apiMain/userSync.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.3 @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-401
+@api @skipOnOcV10.3 @toImplementOnOCIS @issue-ocis-reva-401
 Feature: Users sync
 
   Background:

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: add user
   As an admin
   I want to be able to add users

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: access user provisioning API using app password
   As an ownCloud user
   I want to be able to use the provisioning API with an app password

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: delete users
   As an admin
   I want to be able to delete users

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: disable user
   As an admin
   I want to be able to disable a user

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: edit users
   As an admin, subadmin or as myself
   I want to be able to edit user information

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: enable user
   As an admin
   I want to be able to enable a user

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get user
   As an admin, subadmin or as myself
   I want to be able to retrieve user information

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get users
   As an admin
   I want to be able to list the users that exist

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: remove subadmin
   As an admin
   I want to be able to remove subadmin rights to a user from a group

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: add user
   As an admin
   I want to be able to add users

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: access user provisioning API using app password
   As an ownCloud user
   I want to be able to use the provisioning API with an app password

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: delete users
   As an admin
   I want to be able to delete users

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: disable user
   As an admin
   I want to be able to disable a user

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: edit users
   As an admin, subadmin or as myself
   I want to be able to edit user information

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: enable user
   As an admin
   I want to be able to enable a user

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get user
   As an admin, subadmin or as myself
   I want to be able to retrieve user information

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get users
   As an admin
   I want to be able to list the users that exist

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: remove subadmin
   As an admin
   I want to be able to remove subadmin rights to a user from a group

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: add groups
   As an admin
   I want to be able to add groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: add users to group
   As a admin
   I want to be able to add users to a group

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: delete groups
   As an admin
   I want to be able to delete groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get group
   As an admin
   I want to be able to get group details

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get subadmin groups
   As an admin
   I want to be able to get the groups in which the user is subadmin

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get user groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: remove a user from a group
   As an admin
   I want to be able to remove a user from a group

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: add groups
   As an admin
   I want to be able to add groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: add users to group
   As a admin
   I want to be able to add users to a group

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: delete groups
   As an admin
   I want to be able to delete groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get group
   As an admin
   I want to be able to get group details

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get subadmin groups
   As an admin
   I want to be able to get the groups in which the user is subadmin

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get user groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: remove a user from a group
   As an admin
   I want to be able to remove a user from a group

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243 @issue-ocis-reva-333
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243 @issue-ocis-reva-333
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareReceivedInMultipleWays.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-34
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareUniqueReceivedNames.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: resources shared with the same name are received with unique names
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareWhenExcludedFromSharing.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-41
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41
 Feature: cannot share resources when in a group that is excluded from sharing
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareDefaultFolderForReceivedShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-42 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-42 @issue-ocis-reva-243
 Feature: shares are received in the default folder for received shares
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
 Feature: sharing works when a username and group name are the same
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareGroupCaseSensitive.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
 Feature: share with groups, group names are case-sensitive
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: cannot share resources outside the group when share with membership groups is enabled
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareWithDisabledUser.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-243
 Feature: share resources with a disabled user
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecial2/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial2/createShareWithInvalidPermissions.feature
@@ -28,7 +28,7 @@ Feature: cannot share resources with invalid permissions
       | 1               | 404             | 200              | PARENT        | 32          |
       | 2               | 404             | 404              | PARENT        | 32          |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-45 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-45 @issue-ocis-reva-243
   Scenario Outline: Cannot create a share of a file with a user with only create permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -45,7 +45,7 @@ Feature: cannot share resources with invalid permissions
       | 1               | 400             | 200              |
       | 2               | 400             | 400              |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-45 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-45 @issue-ocis-reva-243
   Scenario Outline: Cannot create a share of a file with a user with only (create,delete) permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -64,7 +64,7 @@ Feature: cannot share resources with invalid permissions
       | 1               | 400             | 200              | create,delete |
       | 2               | 400             | 400              | create,delete |
 
-  @skipOnOcis @issue-ocis-reva-34
+  @issue-ocis-reva-34
   Scenario Outline: Cannot create a share of a file with a group with only create permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -83,7 +83,7 @@ Feature: cannot share resources with invalid permissions
       | 1               | 400             | 200              |
       | 2               | 400             | 400              |
 
-  @skipOnOcis @issue-ocis-reva-34
+  @issue-ocis-reva-34
   Scenario Outline: Cannot create a share of a file with a group with only (create,delete) permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareManagement/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: accept/decline shares coming from internal users
   As a user
   I want to have control of which received shares I accept

--- a/tests/acceptance/features/apiShareManagement/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagement/disableSharing.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: sharing
   As an admin
   I want to be able to disable sharing functionality

--- a/tests/acceptance/features/apiShareManagement/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagement/mergeShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagement/moveReceivedShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -7,7 +7,7 @@ Feature: sharing
 
   @smokeTest
   @skipOnEncryptionType:user-keys @issue-32322
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
   Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -34,7 +34,7 @@ Feature: sharing
 
   @smokeTest
   @skipOnEncryptionType:user-keys @issue-32322
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
   Scenario Outline: Creating a share of a file containing commas in the filename, with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -145,7 +145,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-34
+  @issue-ocis-reva-34
   Scenario Outline: Creating a share of a file with a group, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -169,7 +169,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-34
+  @issue-ocis-reva-34
   Scenario Outline: Creating a share of a folder with a group, the default permissions are all permissions(31)
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -194,7 +194,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
+  @smokeTest @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
   Scenario Outline: Share of folder to a group
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -222,7 +222,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
   Scenario Outline: sharing again an own file while belonging to a group
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -239,7 +239,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-372 @issue-ocis-reva-243
+  @issue-ocis-reva-372 @issue-ocis-reva-243
   Scenario Outline: sharing subfolder of already shared folder, GET result is correct
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -269,7 +269,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243
   Scenario Outline: user shares a file with file name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -283,7 +283,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-243 @toImplementOnOCIS
+  @issue-ocis-reva-34 @issue-ocis-reva-243 @toImplementOnOCIS
   Scenario Outline: user shares a file with file name longer than 64 chars to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -299,7 +299,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243 @issue-ocis-reva-12
+  @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243 @issue-ocis-reva-12
   Scenario Outline: user shares a folder with folder name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -314,7 +314,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-243 @issue-ocis-reva-12 @toImplementOnOCIS
+  @issue-ocis-reva-34 @issue-ocis-reva-243 @issue-ocis-reva-12 @toImplementOnOCIS
   Scenario Outline: user shares a folder with folder name longer than 64 chars to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -332,7 +332,7 @@ Feature: sharing
       | 2               | 200             |
 
   @issue-35484
-  @skipOnOcis @skipOnOcis-OC-Storage @issue-ocis-reva-11
+  @skipOnOcis-OC-Storage @issue-ocis-reva-11
   Scenario: share with user when username contains capital letters
     Given these users have been created without skeleton files:
       | username |
@@ -353,7 +353,7 @@ Feature: sharing
     And user "brian" should not see the following elements if the upper and lower case username are different
       | /randomfile.txt |
 
-  @skipOnLDAP @skipOnOcis
+  @skipOnLDAP
   Scenario: creating a new share with user of a group when username contains capital letters
     Given these users have been created without skeleton files:
       | username |
@@ -368,7 +368,7 @@ Feature: sharing
       | /randomfile.txt |
     And the content of file "randomfile.txt" for user "Brian" should be "Random data"
 
-  @skipOnOcis @issue-ocis-reva-34 @toImplementOnOCIS
+  @issue-ocis-reva-34 @toImplementOnOCIS
   Scenario Outline: Share of folder to a group with emoji in the name
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -396,7 +396,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP @skipOnOcis
+  @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP
   Scenario Outline: share with a group and then add a user to that group
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -417,7 +417,7 @@ Feature: sharing
       | 1               |
       | 2               |
 
-  @skipOnLDAP @skipOnOcis @notToImplementOnOCIS
+  @skipOnLDAP @notToImplementOnOCIS
   # deleting an LDAP group is not relevant or possible using the provisioning API
   Scenario Outline: shares shared to deleted group should not be available
     Given using OCS API version "<ocs_api_version>"
@@ -451,7 +451,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-34 @skipOnFilesClassifier @issue-files-classifier-291 @issue-ocis-reva-243 @toImplementOnOCIS
+  @issue-ocis-reva-34 @skipOnFilesClassifier @issue-files-classifier-291 @issue-ocis-reva-243 @toImplementOnOCIS
   Scenario: Share a file by multiple channels and download from sub-folder and direct file share
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/deleteShare.feature
@@ -1,7 +1,7 @@
 @api @files_sharing-app-required @toFixOnOCIS @issue-ocis-reva-243
 Feature: sharing
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194
+  @toImplementOnOCIS @issue-ocis-reva-194
   Scenario Outline: Delete all group shares
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -21,7 +21,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @skipOnOcis @toFixOnOCIS @issue-ocis-reva-356
+  @smokeTest @toFixOnOCIS @issue-ocis-reva-356
   Scenario Outline: delete a share
     Given user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -49,7 +49,7 @@ Feature: sharing
     Then the HTTP status code should be "204"
     And as "Brian" folder "/sub" should not exist
 
-  @smokeTest @files_trashbin-app-required @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
+  @smokeTest @files_trashbin-app-required @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
@@ -64,7 +64,7 @@ Feature: sharing
     And as "Alice" file "/shared_file.txt" should exist in the trashbin
     And as "Brian" file "/shared_file.txt" should exist in the trashbin
 
-  @files_trashbin-app-required @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
+  @files_trashbin-app-required @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
@@ -82,7 +82,7 @@ Feature: sharing
     And as "Brian" folder "/sub" should exist in the trashbin
     And as "Brian" file "/sub/shared_file.txt" should exist in the trashbin
 
-  @smokeTest @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194
+  @smokeTest @toImplementOnOCIS @issue-ocis-reva-194
   Scenario: unshare from self
     And group "grp1" has been created
     And these users have been created with default attributes and without skeleton files:
@@ -100,7 +100,7 @@ Feature: sharing
     And the etag of element "/" of user "Brian" should have changed
     And the etag of element "/PARENT" of user "Carol" should not have changed
 
-  @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
   Scenario: sharee of a read-only share folder tries to delete the shared folder
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
@@ -112,7 +112,7 @@ Feature: sharing
     Then the HTTP status code should be "403"
     And as "Brian" file "/shared/shared_file.txt" should exist
 
-  @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
   Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
@@ -124,7 +124,7 @@ Feature: sharing
     Then the HTTP status code should be "403"
     And as "Alice" file "/shared/shared_file.txt" should exist
 
-  @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
   Scenario: sharee of an upload-only shared folder tries to delete their file in the folder
     Given using OCS API version "1"
     And these users have been created with default attributes and without skeleton files:
@@ -138,7 +138,7 @@ Feature: sharing
     Then the HTTP status code should be "403"
     And as "Alice" file "/shared/textfile.txt" should exist
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194
+  @toImplementOnOCIS @issue-ocis-reva-194
   Scenario Outline: A Group share recipient tries to delete the share
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -163,7 +163,7 @@ Feature: sharing
       | /PARENT            | 1               | 200              | PARENT         |
       | /PARENT            | 2               | 404              | PARENT         |
 
-  @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-364
+  @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-364
   Scenario Outline: An individual share recipient tries to delete the share
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiShareManagementBasic/excludeGroupFromReceivingShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/excludeGroupFromReceivingShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-41
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41
 Feature: Exclude groups from receiving shares
   As an admin
   I want to exclude groups from receiving shares

--- a/tests/acceptance/features/apiShareOperations/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/accessToShare.feature
@@ -34,7 +34,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-260
+  @smokeTest @issue-ocis-reva-260
   Scenario Outline: Sharee can't see the share that is filtered out
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
@@ -48,7 +48,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-194
+  @smokeTest @issue-ocis-reva-34 @issue-ocis-reva-194
   Scenario Outline: Sharee can see the group share
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperations/changingFilesShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature
@@ -8,7 +8,7 @@ Feature: sharing
       | Alice    |
       | Brian    |
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-47
+  @smokeTest @issue-ocis-reva-47
   Scenario Outline: Correct webdav share-permissions for owned file
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -21,7 +21,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received file with edit and reshare permissions
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -35,7 +35,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared file with edit and reshare permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -55,7 +55,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -68,7 +68,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared file with edit permissions but no reshare permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -88,7 +88,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -101,7 +101,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared file with reshare permissions but no edit permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -121,7 +121,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis
+
   Scenario Outline: Correct webdav share-permissions for owned folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -134,7 +134,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -148,7 +148,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -167,7 +167,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but edit
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -180,7 +180,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but edit
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -200,7 +200,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but create
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -213,7 +213,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but create
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -233,7 +233,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but delete
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -246,7 +246,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but delete
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -266,7 +266,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but share
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -279,7 +279,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but share
     Given using <dav-path> DAV path
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareOperations/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperations/gettingShares.feature
@@ -7,7 +7,7 @@ Feature: sharing
       | Alice    |
       | Brian    |
 
-  @skipOnOcis @smokeTest @issue-ocis-reva-262
+  @smokeTest @issue-ocis-reva-262
   Scenario Outline: getting all shares of a user using that user
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has moved file "/textfile0.txt" to "/file_to_share.txt"
@@ -21,7 +21,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-65
+  @issue-ocis-reva-65
   Scenario Outline: getting all shares of a user using another user
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
@@ -54,7 +54,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @smokeTest @toImplementOnOCIS @issue-ocis-reva-243
+  @smokeTest @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: getting all shares of a file with reshares
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and skeleton files:
@@ -74,7 +74,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @smokeTest @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-194
+  @smokeTest @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-194
   Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -93,7 +93,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @smokeTest @toFixOnOCIS @issue-ocis-reva-357 @issue-ocis-reva-301 @issue-ocis-reva-302
+  @smokeTest @toFixOnOCIS @issue-ocis-reva-357 @issue-ocis-reva-301 @issue-ocis-reva-302
   #after fixing all the issues merge this scenario with the one below
   Scenario Outline: getting share info of a share
     Given using OCS API version "<ocs_api_version>"
@@ -155,7 +155,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-374
+  @issue-ocis-reva-374
   Scenario Outline: Get a share with a user that didn't receive the share
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -168,7 +168,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnLDAP @skipOnOcis @issue-ocis-reva-194
+  @skipOnLDAP @issue-ocis-reva-194
   Scenario: Share of folder to a group, remove user from that group
     Given using OCS API version "1"
     And user "Carol" has been created with default attributes and skeleton files
@@ -191,7 +191,7 @@ Feature: sharing
       | /PARENT%20(2)/           |
       | /PARENT%20(2)/parent.txt |
 
-  @skipOnOcis @issue-ocis-reva-372
+  @issue-ocis-reva-372
   Scenario Outline: getting all the shares inside the folder
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"

--- a/tests/acceptance/features/apiShareOperations/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperations/uploadToShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
@@ -1,4 +1,4 @@
-@api @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @issue-ocis-reva-282
+@api @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-282
 Feature: accessing a public link share
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -7,7 +7,7 @@ Feature: changing a public link share
       | username |
       | Alice    |
 
-  @skipOnOcis
+
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -22,7 +22,7 @@ Feature: changing a public link share
       | read,update,create        | 403              | should        |
       | read,update,create,delete | 204              | should not    |
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -37,7 +37,7 @@ Feature: changing a public link share
       | read,update,create        | 403              | should        |
       | read,update,create,delete | 204              | should not    |
 
-  @skipOnOcis
+
   Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -48,7 +48,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -59,7 +59,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-  @skipOnRansomwareProtection @issue-ransomware-208 @skipOnOcis
+  @skipOnRansomwareProtection @issue-ransomware-208
   Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -81,7 +81,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
 
-  @skipOnOcis
+
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -92,7 +92,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -103,7 +103,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-  @skipOnOcis
+
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -124,7 +124,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "201"
     And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
 
-  @skipOnOcis
+
   Scenario: Public cannot delete file through publicly shared link with password using an invalid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -147,7 +147,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "401"
     And as "Alice" file "PARENT/welcome.txt" should exist
 
-  @skipOnOcis
+
   Scenario: Public can delete file through publicly shared link with password using the valid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -170,7 +170,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/welcome.txt" should not exist
 
-  @skipOnOcis
+
   Scenario: Public tries to rename a file in a password protected share using an invalid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -193,7 +193,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/newparent.txt" should not exist
     And as "Alice" file "/PARENT/parent.txt" should exist
 
-  @skipOnRansomwareProtection @issue-ransomware-208 @skipOnOcis
+  @skipOnRansomwareProtection @issue-ransomware-208
   Scenario: Public tries to rename a file in a password protected share using the valid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -217,7 +217,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/newparent.txt" should exist
     And as "Alice" file "/PARENT/parent.txt" should not exist
 
-  @skipOnOcis
+
   Scenario: Public tries to upload to a password protected public share using an invalid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -240,7 +240,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-  @skipOnOcis
+
   Scenario: Public tries to upload to a password protected public share using the valid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -263,7 +263,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/lorem.txt" should exist
 
-  @skipOnOcis
+
   Scenario: Public cannot rename a file in uploadwriteonly public link share with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -274,7 +274,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario: Public cannot rename a file in uploadwriteonly public link share with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -285,7 +285,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-  @skipOnOcis
+
   Scenario: Public cannot delete a file in uploadwriteonly public link share with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
@@ -296,7 +296,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/welcome.txt" should exist
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario: Public cannot delete a file in uploadwriteonly public link share with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -5,7 +5,7 @@ Feature: create a public link share
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1) using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And the administrator has enabled DAV tech_preview
@@ -34,7 +34,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-12
+  @issue-ocis-reva-12
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1) using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And the administrator has enabled DAV tech_preview
@@ -63,7 +63,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario Outline: Creating a new public link share of a file with password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
@@ -95,7 +95,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-199
+  @smokeTest @issue-ocis-reva-199
   Scenario Outline: Creating a new public link share of a file with password using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
@@ -127,7 +127,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
@@ -155,7 +155,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario Outline: Trying to create a new public link share of a file with edit permissions results in a read-only share using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
@@ -183,7 +183,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And the administrator has enabled DAV tech_preview
@@ -214,7 +214,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-12
+  @issue-ocis-reva-12
   Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And the administrator has enabled DAV tech_preview
@@ -245,7 +245,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Creating a new public link share of a folder, with a password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
@@ -276,7 +276,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario Outline: Creating a new public link share of a folder, with a password using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
@@ -351,7 +351,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -370,7 +370,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-41
+  @issue-ocis-reva-41
   Scenario Outline: Creating a link share with no specified permissions defaults to read permissions when public upload disabled globally using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -389,7 +389,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-36442 @skipOnOcis @issue-ocis-reva-41
+  @issue-36442 @issue-ocis-reva-41
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -413,7 +413,7 @@ Feature: create a public link share
       | 2               | 403             | 403              |
       #| 2               | 200             | 200              |
 
-  @issue-36442 @skipOnOcis @issue-ocis-reva-41
+  @issue-36442 @issue-ocis-reva-41
   Scenario Outline: Creating a public link share with create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -437,7 +437,7 @@ Feature: create a public link share
       | 2               | 403             | 403              |
       #| 2               | 200             | 200              |
 
-  @issue-36442 @skipOnOcis @issue-ocis-reva-41
+  @issue-36442 @issue-ocis-reva-41
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -463,7 +463,7 @@ Feature: create a public link share
       | 2               | 400             | 400              |
       #| 2               | 200             | 200              |
 
-  @issue-36442 @skipOnOcis @issue-ocis-reva-41
+  @issue-36442 @issue-ocis-reva-41
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -497,7 +497,7 @@ Feature: create a public link share
       | 2               | 403             | 403              | read,create,update,delete |
       #| 2               | 200             | 200              | read,create,update,delete  |
 
-  @skipOnOcis @issue-ocis-reva-41
+  @issue-ocis-reva-41
   Scenario Outline: Creating a link share with read+update+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -518,7 +518,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-41
+  @issue-ocis-reva-41
   Scenario Outline: Creating a link share with update permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -534,7 +534,7 @@ Feature: create a public link share
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
-  @skipOnOcis
+
   Scenario Outline: Creating a link share with edit permissions keeps it using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -571,7 +571,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Creating a link share with upload permissions keeps it using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -608,7 +608,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-283
+  @issue-ocis-reva-283
   Scenario Outline: Do not allow public sharing of the root
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -620,7 +620,7 @@ Feature: create a public link share
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
-  @skipOnOcis
+
   Scenario Outline: user creates a public link share of a file with file name longer than 64 chars using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "long file" to "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
@@ -647,7 +647,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
@@ -678,7 +678,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-41
+  @issue-ocis-reva-41
   Scenario Outline: Create a public link with default expiration date set and max expiration date enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
@@ -714,7 +714,7 @@ Feature: create a public link share
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
-  @skipOnOcis @issue-ocis-reva-199
+  @issue-ocis-reva-199
   Scenario: Deleting a folder that has been publicly shared
     Given user "Alice" has created a public link share with settings
       | path        | PARENT |
@@ -723,7 +723,7 @@ Feature: create a public link share
     Then the public download of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API should fail with HTTP status code "404"
     And the public download of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API should fail with HTTP status code "404"
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario: try to download from a public share that has upload only permissions
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -774,7 +774,7 @@ Feature: create a public link share
       | old         |
       | new         |
 
-  @skipOnOcis @issue-37605
+  @issue-37605
   #after fixing all issues make this scenario like the one in OCIS, and delete the one in OCIS
   Scenario: Get the mtime of a file inside a folder shared by public link using new webDAV version
     Given user "Alice" has created folder "testFolder"
@@ -788,7 +788,7 @@ Feature: create a public link share
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should not be "Thu, 08 Aug 2019 04:18:13 GMT"
 #    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
 
-  @skipOnOcis @issue-37605
+  @issue-37605
   #after fixing all issues make this scenario like the one in OCIS, and delete the one in OCIS
   Scenario: overwriting a file changes its mtime (new public webDAV API)
     Given user "Alice" has created folder "testFolder"

--- a/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/deletePublicLinkShare.feature
@@ -20,7 +20,7 @@ Feature: delete a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-product-60 @skipOnOcis @issue-ocis-reva-311
+  @issue-product-60 @issue-ocis-reva-311
   Scenario Outline: Deleting a public link after renaming a file
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"

--- a/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature
@@ -56,7 +56,7 @@ Feature: copying from public link share
     And as "Alice" file "/PARENT/copy1.txt" should exist
     And the content of file "/PARENT/copy1.txt" for user "Alice" should be "some data 0"
 
-  @skipOnOcis @issue-ocis-reva-373 @issue-core-37683
+  @issue-ocis-reva-373 @issue-core-37683
   Scenario: Copy folder within a public link folder to the same folder name as an already existing file
     Given user "Alice" has created folder "/PARENT/testFolder"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/testFolder/testfile.txt"
@@ -82,7 +82,7 @@ Feature: copying from public link share
     Then the HTTP status code should be "204"
     And as "Alice" file "/PARENT/copy1.txt" should not exist
 
-  @skipOnOcis @issue-ocis-reva-373 @issue-core-37683
+  @issue-ocis-reva-373 @issue-core-37683
   Scenario: Copy file within a public link folder to a file with name same as an existing folder
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"
     And user "Alice" has created folder "/PARENT/new-folder"
@@ -152,7 +152,7 @@ Feature: copying from public link share
       | C++ file.cpp            |
       | sample,1.txt            |
 
-  @skipOnOcis @issue-ocis-reva-368
+  @issue-ocis-reva-368
   Scenario Outline: Copy file within a public link folder to a file with unusual destination names
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"
     And user "Alice" has created a public link share with settings
@@ -167,7 +167,7 @@ Feature: copying from public link share
       | testfile.txt          |
       |                       |
 
-  @skipOnOcis @issue-ocis-reva-368
+  @issue-ocis-reva-368
   Scenario Outline: Copy folder within a public link folder to a folder with unusual destination names
     Given user "Alice" has created folder "/PARENT/testFolder"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/testFolder/testfile.txt"

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLink.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-282
+@api @files_sharing-app-required @public_link_share-feature-required @toImplementOnOCIS @issue-ocis-reva-282
 @issue-ocis-reva-233 @issue-ocis-reva-243 @issue-ocis-reva-289
 Feature: reshare as public link
   As a user

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -5,7 +5,7 @@ Feature: update a public link share
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-37653
+  @toImplementOnOCIS @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-37653
   #after fixing all the issues merge this scenario with the one below
   Scenario Outline: API responds with a full set of parameters when owner changes the expireDate of a public share
     Given using OCS API version "<ocs_api_version>"
@@ -77,7 +77,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Creating a new public link share with password and adding an expiration date using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
@@ -266,7 +266,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -285,7 +285,7 @@ Feature: update a public link share
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the new public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -304,7 +304,7 @@ Feature: update a public link share
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcis
+
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -323,7 +323,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the new public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -342,7 +342,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -361,7 +361,7 @@ Feature: update a public link share
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the new public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -380,7 +380,7 @@ Feature: update a public link share
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcis
+
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the old public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -399,7 +399,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the new public API
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -418,7 +418,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the old public API
     Given the administrator has enabled DAV tech_preview
     And using OCS API version "<ocs_api_version>"
@@ -440,7 +440,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the new public API
     Given the administrator has enabled DAV tech_preview
     And using OCS API version "<ocs_api_version>"
@@ -462,7 +462,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis
+
   Scenario Outline: Updating share permissions from read to change allows public to delete files using the old public API
     Given the administrator has enabled DAV tech_preview
     And using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -5,7 +5,7 @@ Feature: upload to a public link share
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: Uploading same file to a public upload-only share multiple times via old API
     # The old API needs to have the header OC-Autorename: 1 set to do the autorename
     Given user "Alice" has created a public link share with settings
@@ -19,7 +19,7 @@ Feature: upload to a public link share
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-286
+  @smokeTest @issue-ocis-reva-286
   Scenario: Uploading same file to a public upload-only share multiple times via new API
     # The new API does the autorename automatically in upload-only folders
     Given the administrator has enabled DAV tech_preview
@@ -34,7 +34,7 @@ Feature: upload to a public link share
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
 
-  @skipOnOcis
+
   Scenario Outline: Uploading file to a public upload-only share using old public API that was deleted does not work
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share with settings
@@ -48,7 +48,7 @@ Feature: upload to a public link share
       | old      |
       | new      |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcis @issue-ocis-reva-290
+  @skipOnOcV10.3 @skipOnOcV10.4 @issue-ocis-reva-290
   Scenario Outline: Uploading file to a public upload-only share using new public API that was deleted does not work
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share with settings
@@ -62,7 +62,7 @@ Feature: upload to a public link share
       | old      |
       | new      |
 
-  @skipOnOcis
+
   Scenario: Uploading file to a public read-only share folder with old public API does not work
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
@@ -70,7 +70,7 @@ Feature: upload to a public link share
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "403"
 
-  @skipOnOcis @issue-ocis-reva-292
+  @issue-ocis-reva-292
   Scenario: Uploading file to a public read-only share folder with new public API does not work
     Given the administrator has enabled DAV tech_preview
     When user "Alice" creates a public link share using the sharing API with settings
@@ -79,7 +79,7 @@ Feature: upload to a public link share
     Then uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "403"
 
-  @skipOnOcis
+
   Scenario: Uploading to a public upload-only share with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
@@ -99,7 +99,7 @@ Feature: upload to a public link share
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
 
-  @skipOnOcis
+
   Scenario: Uploading to a public upload-only share with password with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER   |
@@ -117,7 +117,7 @@ Feature: upload to a public link share
     When the public uploads file "test-new.txt" with password "%public%" and content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
 
-  @skipOnOcis
+
   Scenario: Uploading to a public read/write share with password with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER   |
@@ -135,7 +135,7 @@ Feature: upload to a public link share
     When the public uploads file "test-new.txt" with password "%public%" and content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
 
-  @skipOnOcis
+
   Scenario: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with old public API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
@@ -144,7 +144,7 @@ Feature: upload to a public link share
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "507"
 
-  @skipOnOcis @issue-ocis-reva-195
+  @issue-ocis-reva-195
   Scenario: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with new public API
     Given the administrator has enabled DAV tech_preview
     When user "Alice" creates a public link share using the sharing API with settings
@@ -154,7 +154,7 @@ Feature: upload to a public link share
     And uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "507"
 
-  @skipOnOcis
+
   Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with old public API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
@@ -163,7 +163,7 @@ Feature: upload to a public link share
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "507"
 
-  @skipOnOcis @issue-ocis-reva-195
+  @issue-ocis-reva-195
   Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with new public API
     Given the administrator has enabled DAV tech_preview
     When user "Alice" creates a public link share using the sharing API with settings
@@ -173,7 +173,7 @@ Feature: upload to a public link share
     And uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "507"
 
-  @skipOnOcis
+
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
@@ -182,7 +182,7 @@ Feature: upload to a public link share
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "403"
 
-  @skipOnOcis @issue-ocis-reva-41
+  @issue-ocis-reva-41
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -192,7 +192,7 @@ Feature: upload to a public link share
     And uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "403"
 
-  @skipOnOcis
+
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder with old public API
     Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "Alice" has created a public link share with settings
@@ -202,7 +202,7 @@ Feature: upload to a public link share
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "403"
 
-  @skipOnOcis @issue-ocis-reva-41
+  @issue-ocis-reva-41
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder with new public API
     Given the administrator has enabled DAV tech_preview
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -213,7 +213,7 @@ Feature: upload to a public link share
     And uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "403"
 
-  @skipOnOcis
+
   Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
@@ -223,7 +223,7 @@ Feature: upload to a public link share
     When the public uploads file "test-old.txt" with content "test-old" using the old public WebDAV API
     Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
 
-  @skipOnOcis @issue-ocis-reva-41
+  @issue-ocis-reva-41
   Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -234,7 +234,7 @@ Feature: upload to a public link share
     When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: Uploading to a public upload-write and no edit and no overwrite share with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
@@ -251,7 +251,7 @@ Feature: upload to a public link share
     When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
     Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with old public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings
@@ -269,7 +269,7 @@ Feature: upload to a public link share
     Then the HTTP status code should be "403"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
 
-  @smokeTest @skipOnOcis @issue-ocis-reva-286
+  @smokeTest @issue-ocis-reva-286
   Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with new public API
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share with settings

--- a/tests/acceptance/features/apiShareReshare1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshare1/reShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareChain.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-243
 Feature: resharing can be done on a reshared resource
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareDisabled.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-243
 Feature: resharing can be disabled
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareSubfolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-243
 Feature: a subfolder of a received share can be reshared
 
   Background:

--- a/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshare2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-233 @issue-ocis-reva-194 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-233 @issue-ocis-reva-194 @issue-ocis-reva-243
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareReshare3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshare3/reShareUpdate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareReshare3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshare3/reShareWithExpiryDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-333
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-333
 Feature: resharing a resource with an expiration date
 
   Background:
@@ -27,7 +27,7 @@ Feature: resharing a resource with an expiration date
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
+  @skipOnOcV10.3 @issue-ocis-reva-194
   Scenario Outline: User should be able to set expiration while resharing a file with group
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -77,7 +77,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
+  @skipOnOcV10.3 @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API with expire days set and combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -130,7 +130,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
+  @skipOnOcV10.3 @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API without expire days set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -184,7 +184,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 | 100             |
       | 2               | no                  | yes                 | 200             |
 
-  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
+  @skipOnOcV10.3 @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API with expire days set and with combinations of default/enforce expire date enabled and specify expire date in share
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -236,7 +236,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 | 100             |
       | 2               | no                  | yes                 | 200             |
 
-  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
+  @skipOnOcV10.3 @issue-ocis-reva-194
   Scenario Outline: resharing group share with user using the sharing API with default expire date set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -264,7 +264,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3 @skipOnOcis @issue-ocis-reva-194
+  @skipOnOcV10.3 @issue-ocis-reva-194
   Scenario Outline: resharing group share with user using the sharing API with default expire date set and specifying expiration on share and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"

--- a/tests/acceptance/features/apiShareUpdate/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @smokeTest @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @smokeTest @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Allow modification of reshare
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -25,7 +25,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: keep group permissions in sync
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and skeleton files
@@ -56,7 +56,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: Cannot set permissions to zero
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -70,7 +70,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 400              |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario Outline: Cannot update a share of a file with a user to have only create and/or delete permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -90,7 +90,7 @@ Feature: sharing
       | 1               | 200              | create,delete |
       | 2               | 400              | create,delete |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: Cannot update a share of a file with a group to have only create and/or delete permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -112,7 +112,7 @@ Feature: sharing
       | 1               | 200              | create,delete |
       | 2               | 400              | create,delete |
 
-  @skipOnFilesClassifier @issue-files-classifier-291 @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
+  @skipOnFilesClassifier @issue-files-classifier-291 @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
   Scenario: Share ownership change after moving a shared file outside of an outer share
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -142,7 +142,7 @@ Feature: sharing
     And as "Alice" folder "/folder1/folder2" should not exist
     And as "Carol" folder "/folder2" should exist
 
-  @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
   Scenario: Share ownership change after moving a shared file to another share
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -172,7 +172,7 @@ Feature: sharing
     And as "Alice" folder "/Alice-folder/folder2" should not exist
     And as "Carol" folder "/Carol-folder/folder2" should exist
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcis @toImplementOnOCIS @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
+  @skipOnOcV10.3 @skipOnOcV10.4 @toImplementOnOCIS @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
   #after fixing all the issues merge this scenario with the one below
   Scenario Outline: API responds with a full set of parameters when owner changes the permission of a share
     Given using OCS API version "<ocs_api_version>"
@@ -219,7 +219,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -240,7 +240,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: Forbid sharing with groups
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -253,7 +253,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: Editing share permission of existing share is forbidden when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -278,7 +278,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 400              |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: Deleting group share is allowed when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -294,7 +294,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: user can update the role in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -322,7 +322,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-37217 @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @issue-37217 @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareUpdate/updateShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
 Feature: updating shares to users and groups that have the same name
 
   Background:

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @issue-ocis-reva-34
+@api @files_sharing-app-required @issue-ocis-reva-34
 Feature: sharees
 
   Background:

--- a/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotifications/sharingNotifications.feature
@@ -1,4 +1,4 @@
-@api @app-required @notifications-app-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @app-required @notifications-app-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: Display notifications when receiving a share
   As a user
   I want to see notifications about shares that have been offered to me

--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-51
+@api @systemtags-app-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-51
 Feature: Assign tags to file/folder
   I want to assign tags to the file/folder
   So that I can organize the files/folders easily

--- a/tests/acceptance/features/apiTags/assignTagsGroup.feature
+++ b/tests/acceptance/features/apiTags/assignTagsGroup.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-51
+@api @systemtags-app-required @toImplementOnOCIS @issue-ocis-reva-51
 Feature: Title of your feature
   I want to use this template for my feature file
 

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-51
+@api @systemtags-app-required @toImplementOnOCIS @issue-ocis-reva-51
 Feature: Creation of tags
   As a user
   I should be able to create tags

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-51
+@api @systemtags-app-required @toImplementOnOCIS @issue-ocis-reva-51
 Feature: Deletion of tags
   As a user
   I want to delete the tags that are already created

--- a/tests/acceptance/features/apiTags/editTags.feature
+++ b/tests/acceptance/features/apiTags/editTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-51
+@api @systemtags-app-required @toImplementOnOCIS @issue-ocis-reva-51
 Feature: Editing the tags
   As a user
   I want to be able to change the tags I have created

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-51
+@api @systemtags-app-required @toImplementOnOCIS @issue-ocis-reva-51
 Feature: tags
 
   Background:

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -1,4 +1,4 @@
-@api @systemtags-app-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-51
+@api @systemtags-app-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-51
 Feature: Unassigning tags from file/folder
   As a user
   I want to be able to remove tags from file/folder

--- a/tests/acceptance/features/apiTranslation/translation.feature
+++ b/tests/acceptance/features/apiTranslation/translation.feature
@@ -1,4 +1,4 @@
-@api @skipOnLDAP @skipOnOcis @toImplementOnOCIS
+@api @skipOnLDAP @toImplementOnOCIS
 Feature: translate messages in api response to preferred language
   As a user
   I want response messages to be translated in preferred language

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-52
+@api @files_trashbin-app-required @toImplementOnOCIS @issue-ocis-reva-52
 Feature: files and folders can be deleted from the trashbin
   As a user
   I want to delete files and folders from the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-52
+@api @files_trashbin-app-required @toImplementOnOCIS @issue-ocis-reva-52
 Feature: files and folders exist in the trashbin after being deleted
   As a user
   I want deleted files and folders to be available in the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-52
+@api @files_trashbin-app-required @toImplementOnOCIS @issue-ocis-reva-52
 Feature: Restore deleted files/folders
   As a user
   I would like to restore files/folders

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -11,7 +11,7 @@ Feature: dav-versions
     When user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" using the WebDAV API
     Then the version folder of file "/davtest.txt" for user "Alice" should contain "0" elements
 
-  @skipOnOcis @issue-ocis-reva-17 @issue-ocis-reva-56
+  @issue-ocis-reva-17 @issue-ocis-reva-56
   Scenario: Upload file and no version is available using various chunking methods
     When user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms using the WebDAV API
     Then the version folder of file "/davtest.txt-olddav-regular" for user "Alice" should contain "0" elements
@@ -19,7 +19,7 @@ Feature: dav-versions
     Then the version folder of file "/davtest.txt-olddav-oldchunking" for user "Alice" should contain "0" elements
     Then the version folder of file "/davtest.txt-newdav-newchunking" for user "Alice" should contain "0" elements
 
-  @skipOnOcis @issue-ocis-reva-56
+  @issue-ocis-reva-56
   Scenario: Upload file and no version is available using async upload
     Given the administrator has enabled async operations
     When user "Alice" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 3 chunks with new chunking and using the WebDAV API
@@ -32,7 +32,7 @@ Feature: dav-versions
     Then the version folder of file "/davtest.txt" for user "Alice" should contain "1" element
     And the content length of file "/davtest.txt" with version index "1" for user "Alice" in versions folder should be "8"
 
-  @skipOnOcis @issue-ocis-reva-17 @issue-ocis-reva-56
+  @issue-ocis-reva-17 @issue-ocis-reva-56
   Scenario: Upload a file twice and versions are available using various chunking methods
     When user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms using the WebDAV API
     And user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms using the WebDAV API
@@ -41,7 +41,7 @@ Feature: dav-versions
     Then the version folder of file "/davtest.txt-olddav-oldchunking" for user "Alice" should contain "1" element
     Then the version folder of file "/davtest.txt-newdav-newchunking" for user "Alice" should contain "1" element
 
-  @skipOnOcis @issue-ocis-reva-17 @issue-ocis-reva-56
+  @issue-ocis-reva-17 @issue-ocis-reva-56
   Scenario: Upload a file twice and versions are available using async upload
     Given the administrator has enabled async operations
     When user "Alice" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
@@ -74,7 +74,7 @@ Feature: dav-versions
     Then the content of file "/davtest.txt" for user "Alice" should be "Back To The Future."
 
   @smokeTest @skipOnStorage:ceph @files_primary_s3-issue-161
-  @skipOnOcis @issue-ocis-reva-17 @issue-ocis-reva-56
+  @issue-ocis-reva-17 @issue-ocis-reva-56
   Scenario Outline: Uploading a chunked file does create the correct version that can be restored
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"
@@ -89,7 +89,7 @@ Feature: dav-versions
       | old      |
 
   @skipOnStorage:ceph @files_primary_s3-issue-161
-  @skipOnOcis @issue-ocis-reva-17 @issue-ocis-reva-56
+  @issue-ocis-reva-17 @issue-ocis-reva-56
   Scenario: Uploading a file asynchronously does create the correct version that can be restored
     Given the administrator has enabled async operations
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"
@@ -100,7 +100,7 @@ Feature: dav-versions
     Then the content of file "/textfile0.txt" for user "Alice" should be "Dav-Test"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-156
-  @skipOnOcis @issue-ocis-reva-196 @skipOnOracle
+  @issue-ocis-reva-196 @skipOnOracle
   Scenario: Restore a file and check, if the content and correct checksum is now in the current file
     Given user "Alice" has uploaded file with content "AAAAABBBBBCCCCC" and checksum "MD5:45a72715acdd5019c5be30bdbb75233e" to "/davtest.txt"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/davtest.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
@@ -110,7 +110,7 @@ Feature: dav-versions
     And as user "Alice" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-156
-  @skipOnOcis @issue-ocis-reva-196 @skip @issue-37026
+  @issue-ocis-reva-196 @skip @issue-37026
   Scenario: Restore a file and check, if the content and correct checksum is now in the current file
     Given user "Alice" has uploaded file with content "AAAAABBBBBCCCCC" and checksum "MD5:45a72715acdd5019c5be30bdbb75233e" to "/davtest.txt"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/davtest.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
@@ -140,7 +140,7 @@ Feature: dav-versions
     Then the version folder of fileId "<<FILEID>>" for user "Brian" should contain "1" element
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharer of a file can see the old version information when the sharee changes the content of the file
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "First content" to "sharefile.txt"
@@ -150,7 +150,7 @@ Feature: dav-versions
     And the version folder of file "/sharefile.txt" for user "Alice" should contain "1" element
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "First content" to "sharefile.txt"
@@ -162,7 +162,7 @@ Feature: dav-versions
     And the content of file "/sharefile.txt" for user "Brian" should be "First content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharer can restore a file inside a shared folder modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -175,7 +175,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharee can restore a file inside a shared folder modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -188,7 +188,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -201,7 +201,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharee can restore a file inside a shared folder created by sharee and modified by sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -214,7 +214,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -227,7 +227,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -240,7 +240,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -255,7 +255,7 @@ Feature: dav-versions
     And the content of file "/received/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "old content" to "/sharefile.txt"
@@ -269,7 +269,7 @@ Feature: dav-versions
     And the content of file "/received/sharefile.txt" for user "Brian" should be "old content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243
+  @toImplementOnOCIS @issue-ocis-reva-243
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -284,7 +284,7 @@ Feature: dav-versions
     And the content of file "/received/sharefile.txt" for user "Brian" should be "old content"
 
   @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-34
+  @issue-ocis-reva-34
   Scenario: sharer can restore a file inside a group shared folder modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
@@ -303,7 +303,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Carol" should be "First content"
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-386
+  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-386
   Scenario Outline: Moving a file (with versions) into a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -331,7 +331,7 @@ Feature: dav-versions
       | new         | Brian |
 
   @files_sharing-app-required
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-386
+  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-386
   Scenario Outline: Moving a file (with versions) out of a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -358,7 +358,7 @@ Feature: dav-versions
       | new         | Brian |
 
   @skipOnOcV10.3.0 @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-382
+  @issue-ocis-reva-382
   Scenario: Receiver tries to get file versions of unshared file from the sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"
@@ -369,7 +369,7 @@ Feature: dav-versions
     Then the value of the item "//s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
   @skipOnStorage:ceph @files_primary_s3-issue-161 @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-376
+  @issue-ocis-reva-376
   Scenario: Receiver tries get file versions of shared file from the sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @toImplementOnOCIS @issue-ocis-reva-172
 Feature: there can be only one exclusive lock on a resource
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @toImplementOnOCIS @issue-ocis-reva-172
 Feature: lock folders
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172
 Feature: persistent-locking in case of a public link
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172
 Feature: LOCKDISCOVERY for public links
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @toImplementOnOCIS @issue-ocis-reva-172
 Feature: actions on a locked item are possible if the token is sent with the request
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172 @issue-ocis-reva-11
+@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172 @issue-ocis-reva-11
 Feature: lock should propagate correctly if a share is reshared
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @toImplementOnOCIS @skipOnOcis @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @toImplementOnOCIS @issue-ocis-reva-172
 Feature: set timeouts of LOCKS
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/unlock.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-172
+@api @toImplementOnOCIS @issue-ocis-reva-172
 Feature: UNLOCK locked items
 
   Background:

--- a/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-14
+@api @issue-ocis-reva-14
 Feature: move (rename) file
   As a user
   I want to be able to move and rename files asynchronously

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-14
+@api @issue-ocis-reva-14
 Feature: users cannot move (rename) a file to a blacklisted name
   As an administrator
   I want to be able to prevent users from moving (renaming) files to specified file names

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-14
+@api @issue-ocis-reva-14
 Feature: users cannot move (rename) a file to or into an excluded directory
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to rename an existing file or folder to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
@@ -8,7 +8,7 @@ Feature: move (rename) folder
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-211 @skipOnOcis
+  @issue-ocis-reva-211
   Scenario Outline: Renaming a folder to a backslash should return an error
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/testshare"
@@ -21,7 +21,7 @@ Feature: move (rename) folder
       | old         |
       | new         |
 
-  @issue-ocis-reva-211 @skipOnOcis
+  @issue-ocis-reva-211
   Scenario Outline: Renaming a folder beginning with a backslash should return an error
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/testshare"
@@ -34,7 +34,7 @@ Feature: move (rename) folder
       | old         |
       | new         |
 
-  @issue-ocis-reva-211 @skipOnOcis
+  @issue-ocis-reva-211
   Scenario Outline: Renaming a folder including a backslash encoded should return an error
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/testshare"

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
@@ -8,7 +8,7 @@ Feature: users cannot move (rename) a folder to a blacklisted name
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-211 @skipOnOcis
+  @issue-ocis-reva-211
   Scenario Outline: Rename a folder to a name that is banned by default
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/testshare"
@@ -21,7 +21,7 @@ Feature: users cannot move (rename) a folder to a blacklisted name
       | old         |
       | new         |
 
-  @skipOnOcis
+
   Scenario Outline: Rename a folder to a banned name
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/testshare"
@@ -35,7 +35,7 @@ Feature: users cannot move (rename) a folder to a blacklisted name
       | old         |
       | new         |
 
-  @skipOnOcV10.3 @skipOnOcis
+  @skipOnOcV10.3
   Scenario Outline: rename a folder to a folder name that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-14
+@api @issue-ocis-reva-14
 Feature: users cannot move (rename) a folder to or into an excluded directory
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to rename an existing folder to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -68,7 +68,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a file into a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -91,7 +91,7 @@ Feature: move (rename) file
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a file out of a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -114,7 +114,7 @@ Feature: move (rename) file
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a folder into a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -138,7 +138,7 @@ Feature: move (rename) file
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a folder out of a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -162,7 +162,7 @@ Feature: move (rename) file
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a file to a shared folder with no permissions
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -181,7 +181,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a file to overwrite a file in a shared folder with no permissions
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -209,7 +209,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @issue-ocis-reva-211 @skipOnOcis
+  @issue-ocis-reva-211
   Scenario Outline: rename a file into an invalid filename
     Given using <dav_version> DAV path
     When user "Alice" moves file "/welcome.txt" to "/a\\a" using the WebDAV API
@@ -231,7 +231,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Checking file id after a move between received shares
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -255,7 +255,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @issue-ocis-reva-211 @skipOnOcis
+  @issue-ocis-reva-211
   Scenario Outline: Renaming a file to a path with extension .part should not be possible
     Given using <dav_version> DAV path
     When user "Alice" moves file "/welcome.txt" to "/welcome.part" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
@@ -8,7 +8,7 @@ Feature: users cannot move (rename) a file to a blacklisted name
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @issue-ocis-reva-211 @skipOnOcis
+  @issue-ocis-reva-211
   Scenario Outline: rename a file to a filename that is banned by default
     Given using <dav_version> DAV path
     When user "Alice" moves file "/welcome.txt" to "/.htaccess" using the WebDAV API
@@ -18,7 +18,7 @@ Feature: users cannot move (rename) a file to a blacklisted name
       | old         |
       | new         |
 
-  @skipOnOcis
+
   Scenario Outline: rename a file to a banned filename
     Given using <dav_version> DAV path
     When the administrator updates system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json" using the occ command
@@ -29,7 +29,7 @@ Feature: users cannot move (rename) a file to a blacklisted name
       | old         |
       | new         |
 
-  @skipOnOcV10.3 @skipOnOcis
+  @skipOnOcV10.3
   Scenario Outline: rename a file to a filename that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-14
+@api @issue-ocis-reva-14
 Feature: users cannot move (rename) a file to or into an excluded directory
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to rename an existing file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature
@@ -47,7 +47,7 @@ Feature: delete folder
       | old         |
       | new         |
 
-  @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11
+  @files_sharing-app-required @issue-ocis-reva-11
   Scenario Outline: delete a folder when there is a default folder for received shares
     Given using <dav_version> DAV path
     And the administrator has set the default folder for received shares to "<share_folder>"
@@ -69,7 +69,7 @@ Feature: delete folder
       | old         | ReceivedShares  |
       | new         | ReceivedShares  |
 
-  @files_sharing-app-required @skipOnOcis @issue-ocis-reva-11
+  @files_sharing-app-required @issue-ocis-reva-11
   Scenario Outline: delete a folder when there is a default folder for received shares that is a multi-level path
     Given using <dav_version> DAV path
     And the administrator has set the default folder for received shares to "/My/Received/Shares"

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -19,7 +19,7 @@ Feature: download file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-12
+  @issue-ocis-reva-12
   Scenario Outline: download a file with range
     Given using <dav_version> DAV path
     When user "Alice" downloads file "/welcome.txt" with range "bytes=24-50" using the WebDAV API
@@ -60,7 +60,7 @@ Feature: download file
       | old         |
       | new         |
 
-  @skipOnOcis
+
   Scenario Outline: Doing a GET with a web login should work without CSRF token on the new backend
     Given using <dav_version> DAV path
     And user "Alice" has logged in to a web-style session
@@ -72,7 +72,7 @@ Feature: download file
       | old         |
       | new         |
 
-  @skipOnOcis
+
   Scenario Outline: Doing a GET with a web login should work with CSRF token on the new backend
     Given using <dav_version> DAV path
     And user "Alice" has logged in to a web-style session

--- a/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
+++ b/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
@@ -7,7 +7,7 @@ Feature: refuse access
   Background:
     Given using OCS API version "1"
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario Outline: Unauthenticated call
     Given using <dav_version> DAV path
     When an unauthenticated client connects to the dav endpoint using the WebDAV API
@@ -21,7 +21,7 @@ Feature: refuse access
       | old         |
       | new         |
 
-  @skipOnOcis
+
   Scenario Outline: A disabled user cannot use webdav
     Given using <dav_version> DAV path
     And user "Alice" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-39
+@api @issue-ocis-reva-39
 Feature: Search
   As a user
   I would like to be able to search for files

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-187 @preview-extension-required
+@api @issue-ocis-187 @preview-extension-required
 Feature: previews of files downloaded through the webdav API
 
   Background:

--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -46,7 +46,7 @@ Feature: copy file
       | new         |
 
   @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: Copying a file to a folder with no permissions
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -66,7 +66,7 @@ Feature: copy file
       | new         |
 
   @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -85,7 +85,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-15
+  @issue-ocis-reva-15
   Scenario Outline: Copying file to a path with extension .part should not be possible
     Given using <dav_version> DAV path
     When user "Alice" copies file "/textfile1.txt" to "/textfile1.part" using the WebDAV API
@@ -102,7 +102,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-387
+  @issue-ocis-reva-387
   Scenario Outline: copy a file over the top of an existing folder
       Given using <dav_version> DAV path
       And user "Alice" has created folder "FOLDER/sample-folder"
@@ -116,7 +116,7 @@ Feature: copy file
         | old         |
         | new         |
 
-  @skipOnOcis @issue-ocis-reva-387
+  @issue-ocis-reva-387
   Scenario Outline: copy a folder over the top of an existing file
     Given using <dav_version> DAV path
     And user "Alice" has created folder "FOLDER/sample-folder"
@@ -129,7 +129,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-387
+  @issue-ocis-reva-387
   Scenario Outline: copy a folder into another folder at different level
     Given using <dav_version> DAV path
     And user "Alice" has created folder "FOLDER/second-level-folder"
@@ -146,7 +146,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-387
+  @issue-ocis-reva-387
   Scenario Outline: copy a file into a folder at different level
     Given using <dav_version> DAV path
     And user "Alice" has created folder "FOLDER/second-level-folder"
@@ -165,7 +165,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-387
+  @issue-ocis-reva-387
   Scenario Outline: copy a file into a file at different level
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "file at second level" to "FOLDER/second-level-file.txt"
@@ -183,7 +183,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-387
+  @issue-ocis-reva-387
   Scenario Outline: copy a folder into a file at different level
     Given using <dav_version> DAV path
     And user "Alice" has created folder "FOLDER/second-level-folder"
@@ -202,7 +202,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a file over the top of an existing folder received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -220,7 +220,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a folder over the top of an existing file received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -237,7 +237,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a folder into another folder at different level which is received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -259,7 +259,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a file into a folder at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -283,7 +283,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a file into a file at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -306,7 +306,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a folder into a file at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -329,7 +329,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-387
+  @issue-ocis-reva-34 @issue-ocis-reva-387
   Scenario Outline: copy a file over the top of an existing folder received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -350,7 +350,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-387
+  @issue-ocis-reva-34 @issue-ocis-reva-387
   Scenario Outline: copy a folder over the top of an existing file received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -370,7 +370,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-387
+  @issue-ocis-reva-34 @issue-ocis-reva-387
   Scenario Outline: copy a folder into another folder at different level which is received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -395,7 +395,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-387
+  @issue-ocis-reva-34 @issue-ocis-reva-387
   Scenario Outline: copy a file into a folder at different level received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -422,7 +422,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-387
+  @issue-ocis-reva-34 @issue-ocis-reva-387
   Scenario Outline: copy a file into a file at different level received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -448,7 +448,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-34 @issue-ocis-reva-387
+  @issue-ocis-reva-34 @issue-ocis-reva-387
   Scenario Outline: copy a folder into a file at different level received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
@@ -56,7 +56,7 @@ Feature: create folder
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-15
+  @issue-ocis-reva-15
   Scenario Outline: Creating a directory which contains .part should not be possible
     Given using <dav_version> DAV path
     When user "Alice" creates folder "/folder.with.ext.part" using the WebDAV API
@@ -71,7 +71,7 @@ Feature: create folder
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-168
+  @issue-ocis-reva-168
   Scenario Outline: try to create a folder that already exists
     Given using <dav_version> DAV path
     And user "Alice" has created folder "my-data"
@@ -85,7 +85,7 @@ Feature: create folder
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-168
+  @issue-ocis-reva-168
   Scenario Outline: try to create a folder with a name of an existing file
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded data" to "/my-data.txt"

--- a/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-101
+@api @issue-ocis-reva-101
 Feature: get quota
   As a user
   I want to be able to find out my available storage quota

--- a/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
@@ -20,7 +20,7 @@ Feature: set file properties
       | old         |
       | new         |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcis @issue-ocis-reva-217
+  @skipOnOcV10.3 @skipOnOcV10.4 @issue-ocis-reva-217
   Scenario Outline: Setting custom complex DAV property and reading it
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustomprop.txt"
@@ -45,7 +45,7 @@ Feature: set file properties
       | old         |
       | new         |
 
-  @files_sharing-app-required @skipOnOcis  @issue-ocis-reva-217
+  @files_sharing-app-required @issue-ocis-reva-217
   Scenario Outline: Setting custom DAV property on a shared file as an owner and reading as a recipient
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -25,7 +25,7 @@ Feature: get file properties
       | old         | s,a,m,p,l,e.txt   |
       | new         | s,a,m,p,l,e.txt   |
 
-  @skipOnOcis @issue-ocis-reva-214
+  @issue-ocis-reva-214
   Scenario Outline: Do a PROPFIND of various file names
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "<file_name>"
@@ -43,7 +43,7 @@ Feature: get file properties
       | new         | /file ?2.txt  | dav\/files\/%username%\/file%20%3f2\.txt    |
       | new         | /file &2.txt  | dav\/files\/%username%\/file%20%262\.txt    |
 
-  @skipOnOcis @issue-ocis-reva-214
+  @issue-ocis-reva-214
   Scenario Outline: Do a PROPFIND of various folder names
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<folder_name>"
@@ -115,7 +115,7 @@ Feature: get file properties
       | new         |
 
   @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: A file that is shared to a user has a share-types property
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -136,7 +136,7 @@ Feature: get file properties
       | new         |
 
   @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: A file that is shared to a group has a share-types property
     Given using <dav_version> DAV path
     And group "grp1" has been created
@@ -157,7 +157,7 @@ Feature: get file properties
       | new         |
 
   @public_link_share-feature-required @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: A file that is shared by link has a share-types property
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -175,7 +175,7 @@ Feature: get file properties
       | new         |
 
   @skipOnLDAP @user_ldap-issue-268 @public_link_share-feature-required @files_sharing-app-required
-  @skipOnOcis @issue-ocis-reva-11
+  @issue-ocis-reva-11
   Scenario Outline: A file that is shared by user,group and link has a share-types property
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -206,7 +206,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis
+
   Scenario Outline: Doing a PROPFIND with a web login should work with CSRF token on the new backend
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
@@ -219,7 +219,7 @@ Feature: get file properties
       | new         |
 
   @smokeTest
-  @skipOnOcis @issue-ocis-reva-216
+  @issue-ocis-reva-216
   Scenario Outline: Retrieving private link
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
@@ -232,7 +232,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-163
+  @issue-ocis-reva-163
   Scenario Outline: Do a PROPFIND to a non-existing URL
     And user "Alice" requests "<url>" with "PROPFIND" using basic auth
     Then the value of the item "/d:error/s:message" in the response about user "Alice" should be "<message>"
@@ -242,7 +242,7 @@ Feature: get file properties
       | /remote.php/dav/files/does-not-exist | Principal with name does-not-exist not found |
       | /remote.php/dav/does-not-exist       | File not found: does-not-exist in 'root'     |
 
-  @skipOnOcis @issue-ocis-reva-57 @issue-ocis-reva-217
+  @issue-ocis-reva-57 @issue-ocis-reva-217
   Scenario: add, receive multiple custom meta properties to a file
     Given user "Alice" has created folder "/TestFolder"
     And user "Alice" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
@@ -262,7 +262,7 @@ Feature: get file properties
       | /TestFolder/test1.txt | status       | HTTP/1.1 200 OK |
 
   @issue-36920
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcis @issue-ocis-reva-57 @issue-ocis-reva-217
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-reva-57 @issue-ocis-reva-217
   Scenario: add multiple properties to files inside a folder and do a propfind of the parent folder
     Given user "Alice" has created folder "/TestFolder"
     And user "Alice" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
@@ -288,7 +288,7 @@ Feature: get file properties
       | /TestFolder/test2.txt | testprop2    | DDDDD                  |
       | /TestFolder/          | status       | HTTP/1.1 404 Not Found |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the last modified date of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -301,7 +301,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the content type of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -314,7 +314,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the content type of a file using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
@@ -363,7 +363,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the size of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -376,7 +376,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the file id of a file using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
@@ -389,7 +389,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the file id of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -402,7 +402,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the owner display name of a file using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
@@ -415,7 +415,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the owner display name of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -428,7 +428,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the permissions on a file using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
@@ -441,7 +441,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-57
+  @issue-ocis-reva-57
   Scenario Outline: Propfind the permissions on a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -97,7 +97,7 @@ Feature: upload file
       | new         | /folder ?2.txt                   | file ?2.txt                   |
       | new         | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
 
-  @skipOnOcis @issue-ocis-reva-15
+  @issue-ocis-reva-15
   Scenario Outline: Uploading file to path with extension .part should not be possible
     Given using <dav_version> DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile.part" using the WebDAV API
@@ -132,7 +132,7 @@ Feature: upload file
       | new         | /upload...1.. | abc...txt.. |
       | new         | /...          | ...         |
 
-  @skipOnOcis @issue-ocis-reva-174
+  @issue-ocis-reva-174
   Scenario Outline: upload file with mtime
     Given using <dav_version> DAV path
     When user "Alice" uploads file to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
@@ -144,7 +144,7 @@ Feature: upload file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-174
+  @issue-ocis-reva-174
   Scenario Outline: upload a file with mtime in a folder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "testFolder"
@@ -157,7 +157,7 @@ Feature: upload file
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-174
+  @issue-ocis-reva-174
   Scenario Outline: moving a file does not changes its mtime
     Given using <dav_version> DAV path
     And user "Alice" has created folder "testFolder"
@@ -184,7 +184,7 @@ Feature: upload file
       | old         |
       | new         |
 
-  @skipOnOcis @toImplementOnOCIS @issue-product-127
+  @toImplementOnOCIS @issue-product-127
   Scenario Outline: uploading a file inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-56
+@api @issue-ocis-reva-56
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks asynchronously

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
@@ -8,7 +8,7 @@ Feature: users cannot upload a file to a blacklisted name
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @skipOnOcis @issue-ocis-reva-15
+  @issue-ocis-reva-15
   Scenario Outline: upload a file to a filename that is banned by default
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to ".htaccess" using the WebDAV API
@@ -19,7 +19,7 @@ Feature: users cannot upload a file to a blacklisted name
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-54
+  @issue-ocis-reva-54
   Scenario Outline: upload a file to a banned filename
     Given using <dav_version> DAV path
     When the administrator updates system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json" using the occ command
@@ -32,7 +32,7 @@ Feature: users cannot upload a file to a blacklisted name
       | new         |
 
   @skipOnOcV10.3
-  @skipOnOcis @issue-ocis-reva-54
+  @issue-ocis-reva-54
   Scenario Outline: upload a file to a filename that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-56
+@api @issue-ocis-reva-56
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
@@ -8,7 +8,7 @@ Feature: users cannot upload a file to or into an excluded directory
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @skipOnOcis @issue-ocis-reva-54
+  @issue-ocis-reva-54
   Scenario Outline: upload a file to an excluded directory name
     Given using <dav_version> DAV path
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
@@ -20,7 +20,7 @@ Feature: users cannot upload a file to or into an excluded directory
       | old         |
       | new         |
 
-  @skipOnOcis @issue-ocis-reva-54
+  @issue-ocis-reva-54
   Scenario Outline: upload a file to an excluded directory name inside a parent directory
     Given using <dav_version> DAV path
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
@@ -34,7 +34,7 @@ Feature: users cannot upload a file to or into an excluded directory
       | new         |
 
   @skipOnOcV10.3
-  @skipOnOcis @issue-ocis-reva-54
+  @issue-ocis-reva-54
   Scenario Outline: upload a file to a filename that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-56
+@api @issue-ocis-reva-56
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-56
+@api @issue-ocis-reva-56
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-15
+@api @issue-ocis-reva-15
 Feature: users cannot upload a file to a blacklisted name using old chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-56
+@api @issue-ocis-reva-56
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-15
+@api @issue-ocis-reva-15
 Feature: users cannot upload a file to or into an excluded directory using old chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-56
+@api @issue-ocis-reva-56
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis @issue-ocis-reva-17
+@api @issue-ocis-reva-17
 Feature: upload file using old chunking
   As a user
   I want to be able to upload "large" files in chunks

--- a/tests/acceptance/features/cliAppManagement/appUpgrade.feature
+++ b/tests/acceptance/features/cliAppManagement/appUpgrade.feature
@@ -1,4 +1,4 @@
-@cli @skipWhenTestingRemoteSystems @skipOnLDAP @skipOnOcis
+@cli @skipWhenTestingRemoteSystems @skipOnLDAP
 Feature: App upgrade
   As an admin
   I want to be able to upgrade my app version

--- a/tests/acceptance/features/cliAppManagement/listApps.feature
+++ b/tests/acceptance/features/cliAppManagement/listApps.feature
@@ -1,4 +1,4 @@
-@cli @skipWhenTestingRemoteSystems @skipOnLDAP @skipOnOcis
+@cli @skipWhenTestingRemoteSystems @skipOnLDAP
 Feature: list apps
   As an admin
   I want to be able to get a list of apps that are enabled and/or disabled

--- a/tests/acceptance/features/cliBackground/backgroundJobs.feature
+++ b/tests/acceptance/features/cliBackground/backgroundJobs.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: change background jobs mode
   As an admin
   I want to be able to change background jobs modes

--- a/tests/acceptance/features/cliBackground/backgroundQueue.feature
+++ b/tests/acceptance/features/cliBackground/backgroundQueue.feature
@@ -1,4 +1,4 @@
-@cli @files_trashbin-app-required @files_sharing-app-required @skipOnLDAP @skipOnOcis
+@cli @files_trashbin-app-required @files_sharing-app-required @skipOnLDAP
 Feature: get status, delete and execute jobs in background queue
   As an admin
   I want to be able to see, delete and execute the jobs in background queue

--- a/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
+++ b/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
@@ -1,4 +1,4 @@
-@cli @skipOnOcis
+@cli
 Feature: poll incoming shares
   As an administrator of a ownCloud Server
   I want to be able to poll incoming shares manually

--- a/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
+++ b/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
@@ -1,4 +1,4 @@
-@cli @external_storage @skipOnLDAP @skipOnOcis
+@cli @external_storage @skipOnLDAP
 Feature: using files external service with storage as webdav_owncloud
 
 As a user

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: create local storage from the command line
   As an admin
   I want to create local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: create local storage from the command line
   As an admin
   I want to create local storage available to a specific group(s) from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroupsAndUsers.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroupsAndUsers.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: create local storage from the command line
   As an admin
   I want to create local storage available to a specific user(s) group(s) from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: create local storage from the command line
   As an admin
   I want to create local storage available to a specific user(s) from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: create read-only local storage from the command line
   As an admin
   I want to create read-only local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnlyAndShare.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnlyAndShare.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: create local storage and enable read-only and sharing from the command line
   As an admin
   I want to create read-only local storage and enable sharing from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadWriteAndShare.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadWriteAndShare.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: create local storage and enable sharing from the command line
   As an admin
   I want to create read-write local storage and enable sharing from the command line

--- a/tests/acceptance/features/cliLocalStorage/deleteLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/deleteLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: delete local storage from the command line
   As an admin
   I want to delete local storage

--- a/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: export created local storage mounts from the command line
   As an admin
   I want to export all created local storage mounts from the command line

--- a/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: import exported local storage mounts from the command line
   As an admin
   I want to import exported local storage mounts from the command line

--- a/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: list created local storage from the command line
   As an admin
   I want to list all created local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/manageBackendConfig.feature
+++ b/tests/acceptance/features/cliLocalStorage/manageBackendConfig.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: manage backend configuration for a mount using occ command
   As an admin
   I want to configure a local storage mount

--- a/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: manage options for a mount using occ command
   As an admin
   I want to add options for a local storage mount

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnOcis
+@cli @local_storage
 Feature: Scanning files on local storage
   As an admin
   I want to be able to control the scanning of local storage for changes

--- a/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
+++ b/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: show available backends using occ command
   As an admin
   I want to list backends

--- a/tests/acceptance/features/cliLocalStorage/verifyMountConfiguration.feature
+++ b/tests/acceptance/features/cliLocalStorage/verifyMountConfiguration.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @skipOnOcis
+@cli @local_storage @skipOnLDAP
 Feature: verify mount configuration using occ command
   As an admin
   I want to verify mount configuration for created local storage

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -1,4 +1,4 @@
-@cli @skipOnOcis
+@cli
 Feature: add and delete app configs using occ command
 
   As an administrator

--- a/tests/acceptance/features/cliMain/fileVersions.feature
+++ b/tests/acceptance/features/cliMain/fileVersions.feature
@@ -1,4 +1,4 @@
-@cli @skipOnOcis
+@cli
 Feature: check file versions
 
   Scenario: user clears the versions of a file

--- a/tests/acceptance/features/cliMain/filesChecksum.feature
+++ b/tests/acceptance/features/cliMain/filesChecksum.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnOcis
+@cli @local_storage
 Feature: files checksum command
 
   @skipOnEncryptionType:user-keys @issue-encryption-182

--- a/tests/acceptance/features/cliMain/logManage.feature
+++ b/tests/acceptance/features/cliMain/logManage.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: manage logging configuration
   As an admin
   I want to be able to manage the logging configuration

--- a/tests/acceptance/features/cliMain/logOwnCloud.feature
+++ b/tests/acceptance/features/cliMain/logOwnCloud.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: manipulate the ownCloud logging backend
   As an admin
   I want to be able to manipulate the ownCloud logging backend

--- a/tests/acceptance/features/cliMain/maintenance.feature
+++ b/tests/acceptance/features/cliMain/maintenance.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnOcis
+@cli @local_storage
 Feature: Maintenance command
 
   As an admin

--- a/tests/acceptance/features/cliMain/securityCertificates.feature
+++ b/tests/acceptance/features/cliMain/securityCertificates.feature
@@ -1,4 +1,4 @@
-@cli @skipOnOcis @skipOnOcV10.3 @skipOnOcV10.4 @temporary_storage_on_server
+@cli @skipOnOcV10.3 @skipOnOcV10.4 @temporary_storage_on_server
 Feature: security certificates
   As an admin
   I want to be able to manage the ownCloud security certificates

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -1,4 +1,4 @@
-@cli @skipOnOcis
+@cli
 Feature: transfer-ownership
 
   @smokeTest

--- a/tests/acceptance/features/cliProvisioning/addGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addGroup.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: add group
   As an admin
   I want to be able to add groups

--- a/tests/acceptance/features/cliProvisioning/addToGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addToGroup.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: add users to group
   As a admin
   I want to be able to add users to a group

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: add a user using the using the occ command
 
   As an administrator

--- a/tests/acceptance/features/cliProvisioning/deleteGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteGroup.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: delete groups
   As an admin
   I want to be able to delete groups

--- a/tests/acceptance/features/cliProvisioning/deleteUser.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: delete users
   As an admin
   I want to be able to delete users

--- a/tests/acceptance/features/cliProvisioning/disableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/disableApp.feature
@@ -1,4 +1,4 @@
-@cli @comments-app-required @skipOnLDAP @skipOnOcis
+@cli @comments-app-required @skipOnLDAP
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/cliProvisioning/disableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/disableUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: disable user
   As an admin
   I want to be able to disable a user

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: edit users
   As an admin
   I want to be able to edit user information

--- a/tests/acceptance/features/cliProvisioning/enableApp.feature
+++ b/tests/acceptance/features/cliProvisioning/enableApp.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/cliProvisioning/enableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/enableUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: enable user
   As an admin
   I want to be able to enable a user

--- a/tests/acceptance/features/cliProvisioning/getAppInfo.feature
+++ b/tests/acceptance/features/cliProvisioning/getAppInfo.feature
@@ -1,4 +1,4 @@
-@cli @comments-app-required @skipOnLDAP @skipOnOcis
+@cli @comments-app-required @skipOnLDAP
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/cliProvisioning/getApps.feature
+++ b/tests/acceptance/features/cliProvisioning/getApps.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -1,4 +1,4 @@
-@cli @skipOnOcis
+@cli
 Feature: get group
   As an admin
   I want to be able to get group details

--- a/tests/acceptance/features/cliProvisioning/getGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroups.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: get groups
   As an admin
   I want to be able to get a list of groups

--- a/tests/acceptance/features/cliProvisioning/getUser.feature
+++ b/tests/acceptance/features/cliProvisioning/getUser.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: get user
   As an admin
   I want to be able to retrieve user information

--- a/tests/acceptance/features/cliProvisioning/getUserGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getUserGroups.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: get user groups
   As an admin
   I want to be able to get group membership information

--- a/tests/acceptance/features/cliProvisioning/getUsers.feature
+++ b/tests/acceptance/features/cliProvisioning/getUsers.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: get users
   As an admin
   I want to be able to list the users that exist

--- a/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: remove a user from a group
   As an admin
   I want to be able to remove a user from a group

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@cli @mailhog @skipOnLDAP @skipOnOcis
+@cli @mailhog @skipOnLDAP
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password

--- a/tests/acceptance/features/cliProvisioning/userLastSeen.feature
+++ b/tests/acceptance/features/cliProvisioning/userLastSeen.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: get user last seen
   As an admin
   I want to be able get user last seen

--- a/tests/acceptance/features/cliProvisioning/userReport.feature
+++ b/tests/acceptance/features/cliProvisioning/userReport.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: get user report
   As an admin
   I want to be able get user report

--- a/tests/acceptance/features/cliProvisioning/userSettings.feature
+++ b/tests/acceptance/features/cliProvisioning/userSettings.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @skipOnOcis
+@cli @skipOnLDAP
 Feature: user settings
   As an admin
   I want to be able set user settings

--- a/tests/acceptance/features/cliTrashbin/trashbin.feature
+++ b/tests/acceptance/features/cliTrashbin/trashbin.feature
@@ -1,4 +1,4 @@
-@cli @files_trashbin-app-required @skipOnOcis
+@cli @files_trashbin-app-required
 Feature: files and folders can be deleted from the trashbin
   As an admin
   I want to delete files and folders from the trashbin


### PR DESCRIPTION
## Description
The `skipOnOcis` tag is no longer used. It has been replaced by 3 "categories" of scenario:
1) `toImplementOnOCIS` - means that the test scenario is something that is intended to be implemented on OCIS, but is currently not being run in OCIS CI (implies that the related API endpoint is not exiting or about to exist or similar)
2) `notToImplementOnOCIS` - means that the test scenario is for something that is not intended to be implmented on OCIS
3) neither of these tags - the scenario will be run in OCIS CI. These are scenarios that should pass now in OCIS, or that currently fail but may be worked on "soon". The list of scenarios that fail are managed in `tests/acceptance/expected-failures.txt` in each OCIS-related repo.

Delete the `skipOnOcis` tag to avoid confusion. (If it is not removed, then people will think that it is used for something)

Note: if `skipOnOcis` was the only tag on a scenario, then it has been removed and an empty line is left. That avoids any line numbers of scenarios changing in feature files. So this should have no effect on the line numbers in each `tests/acceptance/expected-failures.txt` in OCIS-related repos.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
