### PR TITLE
[Tests-Only] Check for http status code 204

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -913,11 +913,16 @@ trait Sharing {
 			$this->ocsApiVersion,
 			$this->sharingApiVersion
 		);
-		$this->lastShareData = $this->getResponseXml();
-		if ($shareType === 'public_link' && isset($this->lastShareData->data)) {
-			$linkName = (string) $this->lastShareData->data[0]->name;
-			$linkUrl = (string) $this->lastShareData->data[0]->url;
-			$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+		// In case of HTTP status code 204, there is no content in response payload body.
+		if ($this->response->getStatusCode() === 204) {
+			$this->lastShareData = null;
+		} else {
+			$this->lastShareData = $this->getResponseXml();
+			if ($shareType === 'public_link' && isset($this->lastShareData->data)) {
+				$linkName = (string) $this->lastShareData->data[0]->name;
+				$linkUrl = (string) $this->lastShareData->data[0]->url;
+				$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+			}
 		}
 		$this->localLastShareTime = \microtime(true);
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR adds check for http status code = 204. This PR is needed because of PR https://github.com/owncloud/password_policy/pull/314 . Here, `admin expires password of a user and then the user tries to share a file` scenario fails as there is no response when the user tries to create a share.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 Is needed for PR https://github.com/owncloud/password_policy/pull/314

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
