### PR TITLE
[Tests-Only] Added toImplementOnOCIS tag in tests for change in etag

### DIFF
--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -184,7 +184,7 @@ Feature: upload file
       | old         |
       | new         |
 
-  @toImplementOnOCIS @issue-product-127
+  @skipOnOcis @toImplementOnOCIS @issue-product-127
   Scenario Outline: uploading a file inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"


### PR DESCRIPTION
## Description
Added `toImplementOnOCIS` tag in tests for change in etag and removed parallel tests.

## Related Issue
https://github.com/owncloud/product/issues/127

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
