### PR TITLE
Include new options for the license manager

### DIFF
--- a/lib/public/License/ILicenseManager.php
+++ b/lib/public/License/ILicenseManager.php
@@ -126,11 +126,18 @@ interface ILicenseManager {
 	 * If there no valid license and the grace period has finished, this method
 	 * will disable the app.
 	 *
+	 * Implementations can provide additional options to customize this behaviour. Check
+	 * the implementations for details.
+	 * Some known options are:
+	 * - startGracePeriod => true/false (default true): in order to start the grace period or not
+	 * - disableApp => true/false (default true): to disable the app under the above conditions or not
+	 *
 	 * This method will return true if there is a license valid for the app (usually
 	 * the ownCloud's license) or if the grace period is active
 	 * @param string $appid the id of the app we want to check
+	 * @param array $options an array with the options to be applied.
 	 * @return bool true if there is a valid license or the grace period is active, false
 	 * otherwise.
 	 */
-	public function checkLicenseFor(string $appid): bool;
+	public function checkLicenseFor(string $appid, array $options = []): bool;
 }

--- a/tests/lib/License/LicenseManagerTest.php
+++ b/tests/lib/License/LicenseManagerTest.php
@@ -361,32 +361,194 @@ class LicenseManagerTest extends TestCase {
 		$ocLicenseAboutExpire->method('isValid')->willReturn(true);
 		$ocLicenseAboutExpire->method('getExpirationTime')->willReturn(1581945782 + 60);
 		$ocLicenseAboutExpire->method('getLicenseString')->willReturn('dummy-license-string');
+
+		$options0 = [];
+		$options1 = ['startGracePeriod' => false];
+		$options2 = ['startGracePeriod' => true];
+		$options3 = ['disableApp' => false];
+		$options4 = ['disableApp' => true];
+		$options5 = ['startGracePeriod' => false, 'disableApp' => false];
+		$options6 = ['startGracePeriod' => false, 'disableApp' => true];
+		$options7 = ['startGracePeriod' => true, 'disableApp' => false];
+		$options8 = ['startGracePeriod' => true, 'disableApp' => true];
 		return [
-			[null, 1581945782, null, true],
-			[1581945782, 1581945782, null, true],  // no license set
-			[1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, false],
-			[null, 1581945782, $ocLicenseValid, true],
-			[1581945782, 1581945782, $ocLicenseValid, true],
-			[1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, true],
-			[null, 1581945782, $ocLicenseInvalid, true],
-			[1581945782, 1581945782, $ocLicenseInvalid, true],
-			[1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, false],
-			[null, 1581945782, $ocLicenseExpired, true],
-			[1581945782, 1581945782, $ocLicenseExpired, true],
-			[1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, false],
-			[null, 1581945782, $ocLicenseInvalidExpired, true],
-			[1581945782, 1581945782, $ocLicenseInvalidExpired, true],
-			[1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, false],
-			[null, 1581945782, $ocLicenseAboutExpire, true],
-			[1581945782, 1581945782, $ocLicenseAboutExpire, true],
-			[1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, false],
+			/*0*/ [null, 1581945782, null, $options0, true],
+			/*1*/ [1581945782, 1581945782, null, $options0, true],  // no license set
+			/*2*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, $options0, false],
+			/*3*/ [null, 1581945782, $ocLicenseValid, $options0, true],
+			/*4*/ [1581945782, 1581945782, $ocLicenseValid, $options0, true],
+			/*5*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, $options0, true],
+			/*6*/ [null, 1581945782, $ocLicenseInvalid, $options0, true],
+			/*7*/ [1581945782, 1581945782, $ocLicenseInvalid, $options0, true],
+			/*8*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, $options0, false],
+			/*9*/ [null, 1581945782, $ocLicenseExpired, $options0, true],
+			/*10*/ [1581945782, 1581945782, $ocLicenseExpired, $options0, true],
+			/*11*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, $options0, false],
+			/*12*/ [null, 1581945782, $ocLicenseInvalidExpired, $options0, true],
+			/*13*/ [1581945782, 1581945782, $ocLicenseInvalidExpired, $options0, true],
+			/*14*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, $options0, false],
+			/*15*/ [null, 1581945782, $ocLicenseAboutExpire, $options0, true],
+			/*16*/ [1581945782, 1581945782, $ocLicenseAboutExpire, $options0, true],
+			/*17*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, $options0, false],
+
+			/*18*/ [null, 1581945782, null, $options1, false],
+			/*19*/ [1581945782, 1581945782, null, $options1, true],  // no license set
+			/*20*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, $options1, false],
+			/*21*/ [null, 1581945782, $ocLicenseValid, $options1, true],
+			/*22*/ [1581945782, 1581945782, $ocLicenseValid, $options1, true],
+			/*23*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, $options1, true],
+			/*24*/ [null, 1581945782, $ocLicenseInvalid, $options1, false],
+			/*25*/ [1581945782, 1581945782, $ocLicenseInvalid, $options1, true],
+			/*26*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, $options1, false],
+			/*27*/ [null, 1581945782, $ocLicenseExpired, $options1, false],
+			/*28*/ [1581945782, 1581945782, $ocLicenseExpired, $options1, true],
+			/*29*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, $options1, false],
+			/*30*/ [null, 1581945782, $ocLicenseInvalidExpired, $options1, false],
+			/*31*/ [1581945782, 1581945782, $ocLicenseInvalidExpired, $options1, true],
+			/*32*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, $options1, false],
+			/*33*/ [null, 1581945782, $ocLicenseAboutExpire, $options1, true],
+			/*34*/ [1581945782, 1581945782, $ocLicenseAboutExpire, $options1, true],
+			/*35*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, $options1, false],
+
+			/*36*/ [null, 1581945782, null, $options2, true],
+			/*37*/ [1581945782, 1581945782, null, $options2, true],  // no license set
+			/*38*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, $options2, false],
+			/*39*/ [null, 1581945782, $ocLicenseValid, $options2, true],
+			/*40*/ [1581945782, 1581945782, $ocLicenseValid, $options2, true],
+			/*41*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, $options2, true],
+			/*42*/ [null, 1581945782, $ocLicenseInvalid, $options2, true],
+			/*43*/ [1581945782, 1581945782, $ocLicenseInvalid, $options2, true],
+			/*44*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, $options2, false],
+			/*45*/ [null, 1581945782, $ocLicenseExpired, $options2, true],
+			/*46*/ [1581945782, 1581945782, $ocLicenseExpired, $options2, true],
+			/*47*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, $options2, false],
+			/*48*/ [null, 1581945782, $ocLicenseInvalidExpired, $options2, true],
+			/*49*/ [1581945782, 1581945782, $ocLicenseInvalidExpired, $options2, true],
+			/*50*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, $options2, false],
+			/*51*/ [null, 1581945782, $ocLicenseAboutExpire, $options2, true],
+			/*52*/ [1581945782, 1581945782, $ocLicenseAboutExpire, $options2, true],
+			/*53*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, $options2, false],
+
+			/*54*/ [null, 1581945782, null, $options3, true],
+			/*55*/ [1581945782, 1581945782, null, $options3, true],  // no license set
+			/*56*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, $options3, false],
+			/*57*/ [null, 1581945782, $ocLicenseValid, $options3, true],
+			/*58*/ [1581945782, 1581945782, $ocLicenseValid, $options3, true],
+			/*59*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, $options3, true],
+			/*60*/ [null, 1581945782, $ocLicenseInvalid, $options3, true],
+			/*61*/ [1581945782, 1581945782, $ocLicenseInvalid, $options3, true],
+			/*62*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, $options3, false],
+			/*63*/ [null, 1581945782, $ocLicenseExpired, $options3, true],
+			/*64*/ [1581945782, 1581945782, $ocLicenseExpired, $options3, true],
+			/*65*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, $options3, false],
+			/*66*/ [null, 1581945782, $ocLicenseInvalidExpired, $options3, true],
+			/*67*/ [1581945782, 1581945782, $ocLicenseInvalidExpired, $options3, true],
+			/*68*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, $options3, false],
+			/*69*/ [null, 1581945782, $ocLicenseAboutExpire, $options3, true],
+			/*70*/ [1581945782, 1581945782, $ocLicenseAboutExpire, $options3, true],
+			/*71*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, $options3, false],
+
+			/*72*/ [null, 1581945782, null, $options4, true],
+			/*73*/ [1581945782, 1581945782, null, $options4, true],  // no license set
+			/*74*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, $options4, false],
+			/*75*/ [null, 1581945782, $ocLicenseValid, $options4, true],
+			/*76*/ [1581945782, 1581945782, $ocLicenseValid, $options4, true],
+			/*77*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, $options4, true],
+			/*78*/ [null, 1581945782, $ocLicenseInvalid, $options4, true],
+			/*79*/ [1581945782, 1581945782, $ocLicenseInvalid, $options4, true],
+			/*80*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, $options4, false],
+			/*81*/ [null, 1581945782, $ocLicenseExpired, $options4, true],
+			/*82*/ [1581945782, 1581945782, $ocLicenseExpired, $options4, true],
+			/*83*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, $options4, false],
+			/*84*/ [null, 1581945782, $ocLicenseInvalidExpired, $options4, true],
+			/*85*/ [1581945782, 1581945782, $ocLicenseInvalidExpired, $options4, true],
+			/*86*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, $options4, false],
+			/*87*/ [null, 1581945782, $ocLicenseAboutExpire, $options4, true],
+			/*88*/ [1581945782, 1581945782, $ocLicenseAboutExpire, $options4, true],
+			/*89*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, $options4, false],
+
+			/*90*/ [null, 1581945782, null, $options5, false],
+			/*91*/ [1581945782, 1581945782, null, $options5, true],  // no license set
+			/*92*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, $options5, false],
+			/*93*/ [null, 1581945782, $ocLicenseValid, $options5, true],
+			/*94*/ [1581945782, 1581945782, $ocLicenseValid, $options5, true],
+			/*95*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, $options5, true],
+			/*96*/ [null, 1581945782, $ocLicenseInvalid, $options5, false],
+			/*97*/ [1581945782, 1581945782, $ocLicenseInvalid, $options5, true],
+			/*98*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, $options5, false],
+			/*99*/ [null, 1581945782, $ocLicenseExpired, $options5, false],
+			/*100*/ [1581945782, 1581945782, $ocLicenseExpired, $options5, true],
+			/*101*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, $options5, false],
+			/*102*/ [null, 1581945782, $ocLicenseInvalidExpired, $options5, false],
+			/*103*/ [1581945782, 1581945782, $ocLicenseInvalidExpired, $options5, true],
+			/*104*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, $options5, false],
+			/*105*/ [null, 1581945782, $ocLicenseAboutExpire, $options5, true],
+			/*106*/ [1581945782, 1581945782, $ocLicenseAboutExpire, $options5, true],
+			/*107*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, $options5, false],
+
+			/*108*/ [null, 1581945782, null, $options6, false],
+			/*109*/ [1581945782, 1581945782, null, $options6, true],  // no license set
+			/*110*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, $options6, false],
+			/*111*/ [null, 1581945782, $ocLicenseValid, $options6, true],
+			/*112*/ [1581945782, 1581945782, $ocLicenseValid, $options6, true],
+			/*113*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, $options6, true],
+			/*114*/ [null, 1581945782, $ocLicenseInvalid, $options6, false],
+			/*115*/ [1581945782, 1581945782, $ocLicenseInvalid, $options6, true],
+			/*116*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, $options6, false],
+			/*117*/ [null, 1581945782, $ocLicenseExpired, $options6, false],
+			/*118*/ [1581945782, 1581945782, $ocLicenseExpired, $options6, true],
+			/*119*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, $options6, false],
+			/*120*/ [null, 1581945782, $ocLicenseInvalidExpired, $options6, false],
+			/*121*/ [1581945782, 1581945782, $ocLicenseInvalidExpired, $options6, true],
+			/*122*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, $options6, false],
+			/*123*/ [null, 1581945782, $ocLicenseAboutExpire, $options6, true],
+			/*124*/ [1581945782, 1581945782, $ocLicenseAboutExpire, $options6, true],
+			/*125*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, $options6, false],
+
+			/*126*/ [null, 1581945782, null, $options7, true],
+			/*127*/ [1581945782, 1581945782, null, $options7, true],  // no license set
+			/*128*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, $options7, false],
+			/*129*/ [null, 1581945782, $ocLicenseValid, $options7, true],
+			/*130*/ [1581945782, 1581945782, $ocLicenseValid, $options7, true],
+			/*131*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, $options7, true],
+			/*132*/ [null, 1581945782, $ocLicenseInvalid, $options7, true],
+			/*133*/ [1581945782, 1581945782, $ocLicenseInvalid, $options7, true],
+			/*134*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, $options7, false],
+			/*135*/ [null, 1581945782, $ocLicenseExpired, $options7, true],
+			/*136*/ [1581945782, 1581945782, $ocLicenseExpired, $options7, true],
+			/*137*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, $options7, false],
+			/*138*/ [null, 1581945782, $ocLicenseInvalidExpired, $options7, true],
+			/*139*/ [1581945782, 1581945782, $ocLicenseInvalidExpired, $options7, true],
+			/*140*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, $options7, false],
+			/*141*/ [null, 1581945782, $ocLicenseAboutExpire, $options7, true],
+			/*142*/ [1581945782, 1581945782, $ocLicenseAboutExpire, $options7, true],
+			/*143*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, $options7, false],
+
+			/*144*/ [null, 1581945782, null, $options8, true],
+			/*145*/ [1581945782, 1581945782, null, $options8, true],  // no license set
+			/*146*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), null, $options8, false],
+			/*147*/ [null, 1581945782, $ocLicenseValid, $options8, true],
+			/*148*/ [1581945782, 1581945782, $ocLicenseValid, $options8, true],
+			/*149*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseValid, $options8, true],
+			/*150*/ [null, 1581945782, $ocLicenseInvalid, $options8, true],
+			/*151*/ [1581945782, 1581945782, $ocLicenseInvalid, $options8, true],
+			/*152*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalid, $options8, false],
+			/*153*/ [null, 1581945782, $ocLicenseExpired, $options8, true],
+			/*154*/ [1581945782, 1581945782, $ocLicenseExpired, $options8, true],
+			/*155*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseExpired, $options8, false],
+			/*156*/ [null, 1581945782, $ocLicenseInvalidExpired, $options8, true],
+			/*157*/ [1581945782, 1581945782, $ocLicenseInvalidExpired, $options8, true],
+			/*158*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseInvalidExpired, $options8, false],
+			/*159*/ [null, 1581945782, $ocLicenseAboutExpire, $options8, true],
+			/*160*/ [1581945782, 1581945782, $ocLicenseAboutExpire, $options8, true],
+			/*161*/ [1581945782, 1581945782 + (LicenseManager::GRACE_PERIOD * 2), $ocLicenseAboutExpire, $options8, false],
 		];
 	}
 
 	/**
 	 * @dataProvider checkLicenseForProvider
 	 */
-	public function testCheckLicenseFor($gracePeriodStart, $currentTime, $ocLicense, $expectedResult) {
+	public function testCheckLicenseFor($gracePeriodStart, $currentTime, $ocLicense, $options, $expectedResult) {
 		$this->timeFactory->method('getTime')->willReturn($currentTime);
 
 		$this->config->method('getAppValue')
@@ -396,7 +558,7 @@ class LicenseManagerTest extends TestCase {
 
 		$this->licenseFetcher->method('getOwncloudLicense')->willReturn($ocLicense);
 
-		if ($expectedResult === false) {
+		if ($expectedResult === false && (!isset($options['disableApp']) || $options['disableApp'] === true)) {
 			// ensure the app will be disabled
 			$this->appManager->expects($this->once())
 				->method('disableApp')
@@ -407,7 +569,7 @@ class LicenseManagerTest extends TestCase {
 				->with('dummyApp');
 		}
 
-		$this->assertSame($expectedResult, $this->licenseManager->checkLicenseFor('dummyApp'));
+		$this->assertSame($expectedResult, $this->licenseManager->checkLicenseFor('dummyApp', $options));
 	}
 
 	public function checkLicenseForInvalidProvider() {


### PR DESCRIPTION
These options are intended to be used in one of the following cases:

If the application can be used freely but it has some parts that require
a license the app should check the license with "startGracePeriod =>
false" and "disableApp => false". This way the app will mostly work with
the open parts without starting the grace period nor having a valid
license.

If the app is intended to be used with a license but has some minor
parts that can be used without it, the app should check the license with
"startGracePeriod => true" and "disableApp => false". The grace period
will start (if possible) allowing the full usage of the app for a
limited time, but once the grace period ends the app won't be disabled,
leaving only the free parts running.

Note that it's the app's responsibility to handle the license state
switch by themselves. The grace period could end anytime, as well as a
new license could be used

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
New options aiming for apps with some parts under a license. These changes are aimed for the next OC release. Some apps will require adjustments in order to use these new changes.

## Related Issue
https://github.com/owncloud/enterprise/issues/4143

## Motivation and Context
Apps with parts under a license (such as richdocuments) aren't taken into account properly. Either they need to be fully licensed or not.
These options aims to fix this problem, so the app can have parts that can be used freely and other parts under a license.

## How Has This Been Tested?
Not tested yet

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
