### PR TITLE
[Tests-Only] Wait for ajax call

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -373,7 +373,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 */
 	public function theAdministratorDeletesTheUser($username) {
 		$username = $this->featureContext->getActualUsername($username);
-		$this->usersPage->deleteUser($username, true);
+		$this->usersPage->deleteUser($username, true, $this->getSession());
 		$this->featureContext->rememberThatUserIsNotExpectedToExist($username);
 	}
 
@@ -386,7 +386,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 */
 	public function theAdministratorDoesNotDeleteTheUser($username) {
 		$username = $this->featureContext->getActualUsername($username);
-		$this->usersPage->deleteUser($username, false);
+		$this->usersPage->deleteUser($username, false, $this->getSession());
 	}
 
 	/**

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -641,10 +641,11 @@ class UsersPage extends OwncloudPage {
 	 *
 	 * @param string $username
 	 * @param bool $confirm
+	 * @param Session $session
 	 *
 	 * @return void
 	 */
-	public function deleteUser($username, $confirm) {
+	public function deleteUser($username, $confirm, Session $session) {
 		$userTr = $this->findUserInTable($username);
 		$deleteBtn = $userTr->find("xpath", $this->deleteUserBtnXpath);
 		if ($deleteBtn === null) {
@@ -655,6 +656,7 @@ class UsersPage extends OwncloudPage {
 			);
 		}
 		$deleteBtn->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
 
 		if ($confirm) {
 			$confirmBtn = $this->find('xpath', $this->deleteConfirmBtnXpath);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

User deletion using webUI fails intermittently. This PR fixes this failure by waiting for ajax call to finish, so that "user deletion confirmation dialog" can appear in the webUI

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/guests/issues/419

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- https://github.com/owncloud/guests/pull/420
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
