### PR TITLE
[Tests-Only] Wait for choose as profile picture button

### DIFF
--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -60,6 +60,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	protected $profilePicPreviewXpath = "//*[@id='displayavatar']/div[@class='avatardiv']/img";
 	protected $profilePicDeleteBtnXpath = "//*[@id='removeavatar']";
 	protected $profilePicUploadInputId = "uploadavatar";
+	protected $profilePicUploadedXpath = "//div[@class='jcrop-holder']";
 	protected $invalidImageErrorMsgXpath = "//*[@id='displayavatar']/div[@class='warning hidden' and contains(.,'Invalid image')]";
 
 	/**
@@ -300,6 +301,9 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	 */
 	public function selectDefaultCropForProfilePicture(Session $session) {
 		$setBtn = $this->find('xpath', $this->setProfilePicBtnXpath);
+		$this->waitTillXpathIsVisible(
+			$this->profilePicUploadedXpath
+		);
 		$this->assertElementNotNull(
 			$setBtn,
 			__METHOD__ . " The button to set profile picture was not found"


### PR DESCRIPTION

## Description
Test for uploading a new profile picture can fail intermittently. This PR fixes this by waiting for `Choose as profile picture button`, so that user can upload new profile picture successfully. 

## Related Issue
- https://github.com/owncloud/core/issues/37818

## How Has This Been Tested?
- https://github.com/owncloud/encryption/pull/209

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
