### PR TITLE
Translate 'Passwords do not match' messages

### DIFF
--- a/changelog/unreleased/37826
+++ b/changelog/unreleased/37826
@@ -1,0 +1,5 @@
+Bugfix: "Passwords do not match" message was not being translated
+
+This message is now able to be translated.
+
+https://github.com/owncloud/core/pull/37826

--- a/core/js/lostpassword.js
+++ b/core/js/lostpassword.js
@@ -92,7 +92,7 @@ OC.Lostpassword = {
 			$('#retypepassword').val('');
 			$('#password').parent().addClass('shake');
 			$('#message').addClass('warning');
-			$('#message').text('Passwords do not match');
+			$('#message').text(t('core', 'Passwords do not match'));
 			$('#message').show();
 			$('#password').focus();
 		}

--- a/settings/js/setpassword.js
+++ b/settings/js/setpassword.js
@@ -24,7 +24,7 @@
 				retypePasswordObj.val('');
 				passwordObj.parent().addClass('shake');
 				$('#message').addClass('warning');
-				$('#message').text('Passwords do not match');
+				$('#message').text(t('core', 'Passwords do not match'));
 				$('#message').show();
 				passwordObj.focus();
 			}


### PR DESCRIPTION
## Description
When setting an initial password or when the user forgot their password and is resetting by being sent an email, if the user enters the new password and confirmation differently then the message "Passwords do not match" is always displayed in English.

Adjust the code so that the message is translated.

Then this string will appear in Transifex, and the translators can translate it to whatever languages they like.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4157

## How Has This Been Tested?
- change the system language to "de"
- temporarily add a translation of "Passwords do not match" to `core/l10n/de.js`
- create a user with email address
- get the email to that user, use the link to reset the password
- enter different password and confirmation
- observer that "Passwords do not match" is actually displayed as the temporary translation that you put in.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
