### PR TITLE
Add ability to explicitly set an license implementation

### DIFF
--- a/changelog/unreleased/37827
+++ b/changelog/unreleased/37827
@@ -1,0 +1,5 @@
+Change: Add ILicenseManager::setLicense
+
+The default license implementation can now be replaced.
+
+https://github.com/owncloud/core/pull/37827

--- a/lib/base.php
+++ b/lib/base.php
@@ -582,10 +582,11 @@ class OC {
 		\stream_wrapper_register('quota', 'OC\Files\Stream\Quota');
 
 		\OC::$server->getEventLogger()->start('init_session', 'Initialize session');
-		OC_App::loadApps(['session', 'theme']);
+		OC_App::loadApps(['session']);
 		if (!self::$CLI) {
 			self::initSession();
 		}
+		OC_App::loadApps(['license', 'theme']);
 
 		\OC::$server->getEventLogger()->end('init_session');
 

--- a/lib/private/License/ILicense.php
+++ b/lib/private/License/ILicense.php
@@ -20,8 +20,8 @@
 namespace OC\License;
 
 interface ILicense {
-	const LICENSE_TYPE_NORMAL = 0;
-	const LICENSE_TYPE_DEMO = 1;
+	public const LICENSE_TYPE_NORMAL = 0;
+	public const LICENSE_TYPE_DEMO = 1;
 
 	/**
 	 * get the raw license string, such as "owncloud_28731_df987_234sf"

--- a/lib/public/License/ILicenseManager.php
+++ b/lib/public/License/ILicenseManager.php
@@ -19,6 +19,8 @@
  */
 namespace OCP\License;
 
+use OC\License\ILicense;
+
 /**
  * Interface ILicenseManager
  * Holds operations for managing the ownCloud license
@@ -89,6 +91,9 @@ interface ILicenseManager {
 	public function getLicenseStateFor(string $appid): int;
 
 	/**
+	 * @param string $appid the application to be checked
+	 * @param string|null $language the language to translate the messages to.
+	 * @return array containing the information as described above
 	 * @since 10.5.0
 	 * Get a message suitable to be displayed with the state of the license for the app
 	 * The message will be translated to the requested language if there is translation
@@ -104,9 +109,6 @@ interface ILicenseManager {
 	 * "contains_html" -> an array containing which lines of the translated message contains html code
 	 *   The lines start counting at 0
 	 *
-	 * @param string $appid the aplication to be checked
-	 * @param string $language the language to translate the messages to.
-	 * @return array containing the information as described above
 	 */
 	public function getLicenseMessageFor(string $appid, string $language = null): array;
 
@@ -133,4 +135,12 @@ interface ILicenseManager {
 	 * otherwise.
 	 */
 	public function checkLicenseFor(string $appid): bool;
+
+	/**
+	 * In some cases the default ownCloud license implementation shall be replaces
+	 * by a different mechanism. Use this method to do so.
+	 * @param ILicense $license
+	 * @since 10.6.0
+	 */
+	public function setLicense(ILicense $license): void;
 }


### PR DESCRIPTION
## Description
In some specific cases the default license implementation shall be replaced by a different implementation.

To make sure the license is replaced as early as possible (before any other app being loaded - with exception of session apps) a new app type 'license' has been introduced.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/3991

## How Has This Been Tested?
- :hand: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
