### PR TITLE
setupFS for share user before accepting a federated share

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -191,6 +191,7 @@ class Manager {
 		$share = $this->getShare($id);
 
 		if ($share) {
+			\OC_Util::setupFS($share['user']);
 			$shareFolder = Helper::getShareFolder();
 			$mountPoint = Files::buildNotExistingFileName($shareFolder, $share['name']);
 			$mountPoint = Filesystem::normalizePath($mountPoint);

--- a/changelog/unreleased/37834
+++ b/changelog/unreleased/37834
@@ -1,0 +1,8 @@
+Bugfix: Fix federated share accepting problem which occurs with some apps enabled
+
+Filesystem may not set already for shared user in some cases when accepting a federated share.
+This situation broke accept federated share api. This problem has been resolved.
+
+https://github.com/owncloud/core/issues/37719
+https://github.com/owncloud/music/issues/778
+https://github.com/owncloud/core/pull/37834


### PR DESCRIPTION
## Description
Filesystem may not set already for shared user in some cases when accepting a federated share. This PR resolves this problem. Since `setupFS` function does not allows second initialization, this pr change will not affect performance. 

## Related Issue
- Fixes https://github.com/owncloud/core/issues/37719
- Fixes https://github.com/owncloud/music/issues/778
- Fixes https://github.com/owncloud/enterprise/issues/4136

## Motivation and Context
Resolving bugs.

## How Has This Been Tested?
Manually with the sconario describe in related issues.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
