### PR TITLE
extend share_external name column length to 255

### DIFF
--- a/apps/files_sharing/appinfo/Migrations/Version20200823121322.php
+++ b/apps/files_sharing/appinfo/Migrations/Version20200823121322.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Files_Sharing\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Extend name column length to 255
+ */
+class Version20200823121322 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+		if ($schema->hasTable("${prefix}share_external")) {
+			$table = $schema->getTable("{$prefix}share_external");
+			$nameColumn = $table->getColumn('name');
+			if ($nameColumn && $nameColumn->getLength() !== 255) {
+				$nameColumn->setOptions(['length' => 255]);
+			}
+		}
+	}
+}

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -10,7 +10,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	<licence>AGPL</licence>
 	<author>Michael Gapczynski, Bjoern Schiessle</author>
 	<default_enable/>
-	<version>0.13.0</version>
+	<version>0.14.0</version>
 	<types>
 		<filesystem/>
 	</types>

--- a/changelog/unreleased/37835
+++ b/changelog/unreleased/37835
@@ -1,0 +1,7 @@
+Bugfix: Allow federated share name up to 255 character
+
+Receiving a federated share of a file with name greater than 63 characters was not possible.
+This problem has been resolved by extending related column length of database to 255.
+
+https://github.com/owncloud/core/issues/36730
+https://github.com/owncloud/core/pull/37835

--- a/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
@@ -193,16 +193,13 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
-  @issue-36730
+  @skipOnOcV10.3 @skipOnFedOcV10.3 @skipOnOcV10.4 @skipOnFedOcV10.4 @skipOnOcV10.5.0 @skipOnFedOcV10.5.0
   Scenario: test sharing long file names with federation share
     When user "Alice" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
     And the user has reloaded the current page of the webUI
     And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
-    #  And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
-    And using server "REMOTE"
-    Then user "Alice" should not have any received shares
-    # Then as "Alice" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
-    Then as "Alice" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should not exist
+    And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
+    Then as "Alice" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
 
   Scenario: sharee should be able to access the files/folders inside other folder
     Given user "Alice" has created folder "simple-folder/simple-empty-folder"


### PR DESCRIPTION
## Description
Extend share_external name column length to 255

## Related Issue
- Fixes #36730
- Fixes https://github.com/owncloud/enterprise/issues/4151

## Motivation and Context
oc_filecache allows filename up to 250 character, federated share file name should support same limits.

## How Has This Been Tested?
- Manually executed federation and checked the column lenghth from db.
- There is an acceptance test covers this scenario.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
