### PR TITLE
[Tests-Only] Support skipOnFedOcV tags in acceptance tests

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -697,10 +697,10 @@ then
 		OCC_FED_URL="${TESTING_APP_FED_URL}occ"
 		# test that fed server is up and running, and testing app is enabled.
 		assert_server_up ${TEST_SERVER_FED_URL}
-	if [ "${TEST_OCIS}" != "true" ]
-	then
+		if [ "${TEST_OCIS}" != "true" ]
+		then
 			assert_testing_app_enabled ${TEST_SERVER_URL}
-	fi
+		fi
 	fi
 
 	echo "Not using php inbuilt server for running scenario ..."
@@ -1052,6 +1052,17 @@ OWNCLOUD_VERSION=`echo ${OWNCLOUD_VERSION} | cut -d"." -f1-2`
 BEHAT_FILTER_TAGS='~@skipOnOcV'${OWNCLOUD_VERSION}'&&'${BEHAT_FILTER_TAGS}
 OWNCLOUD_VERSION=`echo ${OWNCLOUD_VERSION} | cut -d"." -f1`
 BEHAT_FILTER_TAGS='~@skipOnOcV'${OWNCLOUD_VERSION}'&&'${BEHAT_FILTER_TAGS}
+
+if [ -n "${TEST_SERVER_FED_URL}" ]
+then
+	remote_occ ${ADMIN_AUTH} ${OCC_FED_URL} "config:system:get version"
+	OWNCLOUD_FED_VERSION=`echo ${REMOTE_OCC_STDOUT} | cut -d"." -f1-3`
+	BEHAT_FILTER_TAGS='~@skipOnFedOcV'${OWNCLOUD_FED_VERSION}'&&'${BEHAT_FILTER_TAGS}
+	OWNCLOUD_FED_VERSION=`echo ${OWNCLOUD_FED_VERSION} | cut -d"." -f1-2`
+	BEHAT_FILTER_TAGS='~@skipOnFedOcV'${OWNCLOUD_FED_VERSION}'&&'${BEHAT_FILTER_TAGS}
+	OWNCLOUD_FED_VERSION=`echo ${OWNCLOUD_FED_VERSION} | cut -d"." -f1`
+	BEHAT_FILTER_TAGS='~@skipOnFedOcV'${OWNCLOUD_FED_VERSION}'&&'${BEHAT_FILTER_TAGS}
+fi
 
 # If we are running remote only tests add another skip '@skipWhenTestingRemoteSystems'
 if [ "${TESTING_REMOTE_SYSTEM}" = true ]


### PR DESCRIPTION
## Description
Sometimes a fix is known to be not compatible with older federated server versions. In that case we need to be able to skip a scenario when running against an older federated server.

When running tests with a federated server, tags are automatically added for the federated server under test, in the form:

`@skipOnFedOcV10.5`
`@skipOnFedOcV10.5.0`

So these tags can be added to scenarios as necessary.

This has been triggered by PR #37835 - we have had cases like this in the past, and it would be nice to have a flexible solution.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
