### PR TITLE
[Tests-Only] Improve error reporting when getArrayOfShareesResponded response has missing data

### DIFF
--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -148,6 +148,12 @@ class ShareesContext implements Context {
 			$shareeType = \substr($shareeType, 6);
 		}
 
+		Assert::assertArrayHasKey(
+			$shareeType,
+			$elements,
+			__METHOD__ . " The sharees response does not have key '$shareeType'"
+		);
+
 		$sharees = [];
 		foreach ($elements[$shareeType] as $element) {
 			if (\is_int(\key($element))) {

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -435,7 +435,7 @@ class TrashbinContext implements Context {
 
 		Assert::assertNotNull(
 			$firstEntry,
-			"The first trash entry is found null unexpectedly"
+			"The first trash entry was not found while looking for trashbin entry '$path' of user '$user'"
 		);
 
 		if (\count($sections) !== 1) {


### PR DESCRIPTION
## Description
1) When testing against a system that does not do sharing status requests properly yet we get results like:
https://cloud.drone.io/owncloud/ocis-reva/948/4/7
```
  Scenario Outline: Search without exact match                               # /srv/app/testrunner/tests/acceptance/features/apiSharees/sharees.feature:14
    Given using OCS API version "<ocs-api-version>"                          # FeatureContext::usingOcsApiVersion()
    When user "Alice" gets the sharees using the sharing API with parameters # ShareesContext::userGetsTheShareesWithParameters()
      | search   | sharee |
      | itemType | file   |
    Then the OCS status code should be "<ocs-status>"                        # OCSContext::theOCSStatusCodeShouldBe()
    And the HTTP status code should be "<http-status>"                       # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And the "exact users" sharees returned should be empty                   # ShareesContext::theShareesReturnedShouldBeEmpty()
    And the "users" sharees returned should be                               # ShareesContext::theShareesReturnedShouldBe()
      | Sharee One | 0 | sharee1 |
    And the "exact groups" sharees returned should be empty                  # ShareesContext::theShareesReturnedShouldBeEmpty()
    And the "groups" sharees returned should be                              # ShareesContext::theShareesReturnedShouldBe()
      | ShareeGroup  | 1 | ShareeGroup  |
      | ShareeGroup2 | 1 | ShareeGroup2 |
    And the "exact remotes" sharees returned should be empty                 # ShareesContext::theShareesReturnedShouldBeEmpty()
    And the "remotes" sharees returned should be empty                       # ShareesContext::theShareesReturnedShouldBeEmpty()

    Examples:
      | ocs-api-version | ocs-status | http-status |
      | 1               | 100        | 200         |
        Notice: Undefined index: users in /srv/app/testrunner/tests/acceptance/features/bootstrap/ShareesContext.php line 152
      | 2               | 200        | 200         |
        Notice: Undefined index: users in /srv/app/testrunner/tests/acceptance/features/bootstrap/ShareesContext.php line 152
```

"Undefined index" is not very helpful. Adjust the code to check and fail earlier with a better message when the sharees response is missing expected data.

2) Improve a trashbin test error message so that we know what user and trashbin path had the problem.
```
  Scenario Outline: deleting a file moves it to trashbin                 # /srv/app/testrunner/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature:13
    Given using <dav-path> DAV path                                      # FeatureContext::usingOldOrNewDavPath()
    When user "Alice" deletes file "/textfile0.txt" using the WebDAV API # FeatureContext::userDeletesFile()
    Then as "Alice" file "/textfile0.txt" should exist in the trashbin   # TrashbinContext::asFileOrFolderExistsInTrash()
    But as "Alice" file "/textfile0.txt" should not exist                # FeatureContext::asFileOrFolderShouldNotExist()

    Examples:
      | dav-path |
      | old      |
      | new      |
        The first trash entry is found null unexpectedly
        Failed asserting that null is not null.
```

`The first trash entry is found null unexpectedly` is not really helpful, and, specially in scenario examples, it is not obvious which step caused the problem.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
