### PR TITLE
Fix application id used for sharing settings translation

### DIFF
--- a/changelog/unreleased/37846
+++ b/changelog/unreleased/37846
@@ -1,0 +1,6 @@
+Bugfix: Fix application id used for sharing settings translation
+
+"Owner language" and permission titles "Create", "Change", "Delete", "Share" were not being translated.
+Now it is translated.
+
+https://github.com/owncloud/core/pull/37846

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -293,7 +293,7 @@ class SettingsManager implements ISettingsManager {
 				$this->urlGenerator,
 				$this->certificateManager),
 			Encryption::class => new Encryption(),
-			FileSharing::class => new FileSharing($this->config, $this->helper, $this->l),
+			FileSharing::class => new FileSharing($this->config, $this->helper, $this->lfactory),
 			Logging::class => new Logging($this->config, $this->urlGenerator, $this->helper),
 			Mail::class => new Mail($this->config, $this->helper),
 			PersistentLocking::class => new PersistentLocking($this->config),

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -27,7 +27,6 @@ use OCP\IConfig;
 use OCP\L10N\IFactory;
 use OCP\Settings\ISettings;
 use OCP\Template;
-use OCP\IL10N;
 
 class FileSharing implements ISettings {
 
@@ -35,17 +34,15 @@ class FileSharing implements ISettings {
 	protected $config;
 	/** @var Helper */
 	protected $helper;
-	/** @var IL10N */
-	protected $l;
 	/** @var IFactory */
 	private $lfactory;
 	/** @var LocaleHelper */
 	private $localeHelper;
 
-	public function __construct(IConfig $config, Helper $helper, IL10N $l) {
+	public function __construct(IConfig $config, Helper $helper, IFactory $lfactory) {
 		$this->config = $config;
 		$this->helper = $helper;
-		$this->l = $l;
+		$this->lfactory = $lfactory;
 	}
 
 	public function getPriority() {
@@ -53,7 +50,7 @@ class FileSharing implements ISettings {
 	}
 
 	public function getPanel() {
-		$this->lfactory = \OC::$server->getL10NFactory();
+		$l = $this->lfactory->get('settings');
 		$activeLangCode = $this->config->getAppValue(
 			'core',
 			'shareapi_public_notification_lang',
@@ -67,13 +64,13 @@ class FileSharing implements ISettings {
 
 		// Allow reset to the defaults when mail notification is sent in the lang of owner
 		if ($userLang['code']  === "owner") {
-			$userLang['name'] = $this->l->t("Owner language");
+			$userLang['name'] = $l->t("Owner language");
 		} else {
 			\array_push(
 				$commonLanguages,
 				[
 					'code' => 'owner',
-					'name' => $this->l->t("Owner language")
+					'name' => $l->t("Owner language")
 				]
 			);
 		}
@@ -125,22 +122,22 @@ class FileSharing implements ISettings {
 		$permList = [
 			[
 				'id' => 'cancreate',
-				'label' => $this->l->t('Create'),
+				'label' => $l->t('Create'),
 				'value' => \OCP\Constants::PERMISSION_CREATE
 			],
 			[
 				'id' => 'canupdate',
-				'label' => $this->l->t('Change'),
+				'label' => $l->t('Change'),
 				'value' => \OCP\Constants::PERMISSION_UPDATE
 			],
 			[
 				'id' => 'candelete',
-				'label' => $this->l->t('Delete'),
+				'label' => $l->t('Delete'),
 				'value' => \OCP\Constants::PERMISSION_DELETE
 			],
 			[
 				'id' => 'canshare',
-				'label' => $this->l->t('Share'),
+				'label' => $l->t('Share'),
 				'value' => \OCP\Constants::PERMISSION_SHARE
 			],
 		];

--- a/tests/Settings/Panels/Admin/FileSharingTest.php
+++ b/tests/Settings/Panels/Admin/FileSharingTest.php
@@ -14,6 +14,7 @@ use OC\Settings\Panels\Admin\FileSharing;
 use OC\Settings\Panels\Helper;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\L10N\IFactory;
 
 /**
  * @package Tests\Settings\Panels\Admin
@@ -31,8 +32,12 @@ class FileSharingTest extends \Test\TestCase {
 		parent::setUp();
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->helper = $this->getMockBuilder(Helper::class)->getMock();
-		$l10n = $this->getMockBuilder(IL10N::class)->getMock();
-		$this->panel = new FileSharing($this->config, $this->helper, $l10n);
+
+		$l = $this->createMock(IL10N::class);
+		$lfactory = $this->getMockBuilder(IFactory::class)->getMock();
+		$lfactory->method('findAvailableLanguages')->willReturn([]);
+		$lfactory->method('get')->willReturn($l);
+		$this->panel = new FileSharing($this->config, $this->helper, $lfactory);
 	}
 
 	public function testGetSection() {


### PR DESCRIPTION
## Description
'lib' was passed as the app name into the sharing settings panel instead of 'settings'

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4168

## Screenshots (if appropriate):
![section](https://user-images.githubusercontent.com/991300/91162645-097f9480-e6d5-11ea-9364-05eebaa0e547.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
