### PR TITLE
[Tests-Only] Fix theseUsersHaveBeenCreatedUsingTheOccCommand so it works with mixed-case usernames

### DIFF
--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -50,11 +50,15 @@ class OccUsersGroupsContext implements Context {
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"
 	 * displayname & email are optional
+	 * @param bool $checkOccCommandStatus
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function createUsersUsingOccCommand(TableNode $table) {
+	public function createUsersUsingOccCommand(
+		TableNode $table,
+		$checkOccCommandStatus = false
+	) {
 		foreach ($table as $row) {
 			$username = $row['username'];
 			$user = $this->featureContext->getActualUsername($username);
@@ -90,6 +94,10 @@ class OccUsersGroupsContext implements Context {
 				'OC_PASS',
 				$password
 			);
+
+			if ($checkOccCommandStatus) {
+				$this->occContext->theCommandShouldHaveBeenSuccessful();
+			}
 
 			$username = $this->featureContext->getActualUsername($username);
 			$this->featureContext->addUserToCreatedUsersList(
@@ -128,30 +136,10 @@ class OccUsersGroupsContext implements Context {
 	 * @throws \Exception
 	 */
 	public function theseUsersHaveBeenCreatedUsingTheOccCommand(TableNode $table) {
-		$this->createUsersUsingOccCommand($table);
-		$this->occContext->theCommandShouldHaveBeenSuccessful();
-		$createdUsersList = $this->featureContext->getCreatedUsers();
-		$usernameArray = \array_keys($createdUsersList);
+		$this->createUsersUsingOccCommand($table, true);
 
-		$url = "/cloud/users/%s";
-		foreach ($table as $users) {
-			$user = $this->featureContext->getActualUsername($users['username']);
-			$response = OcsApiHelper::sendRequest(
-				$this->featureContext->getBaseUrl(),
-				$user,
-				$this->featureContext->getPasswordForUser($user),
-				'GET',
-				\sprintf($url, $user)
-			);
-			$this->featureContext->setResponse($response);
-			$home = (string)$this->featureContext->getResponseXml()->data[0]->home;
-			$homeArray = \explode("data/", $home);
-			$username = $homeArray[1];
-			$username = $this->featureContext->normalizeUsername($username);
-			Assert::assertTrue(
-				\in_array($username, $usernameArray, true),
-				"User: " . $username . " was not created"
-			);
+		foreach ($table as $row) {
+			$this->featureContext->userShouldExist($row['username']);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -144,10 +144,13 @@ class OccUsersGroupsContext implements Context {
 				\sprintf($url, $user)
 			);
 			$this->featureContext->setResponse($response);
-			$username = \explode("data/", (string)$this->featureContext->getResponseXml()->data[0]->home);
+			$home = (string)$this->featureContext->getResponseXml()->data[0]->home;
+			$homeArray = \explode("data/", $home);
+			$username = $homeArray[1];
+			$username = $this->featureContext->normalizeUsername($username);
 			Assert::assertTrue(
-				\in_array($username[1], $usernameArray, true),
-				"User: " . \implode($username) . " was not created"
+				\in_array($username, $usernameArray, true),
+				"User: " . $username . " was not created"
 			);
 		}
 	}


### PR DESCRIPTION
## Description
1) fixup the code that checks that the user exists, so that it works for mixed-case usernames.
2) use a simpler test that the user exists.

## Related Issue
- Fixes #37850 

## How Has This Been Tested?
Locally trying with modified versions of tests/acceptance/features/cliProvisioning/getUsers.feature:7 with a mixed-case username.

CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
