### PR TITLE
[Tests-Only] Reporting expected failures when running a single feature

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1269,8 +1269,25 @@ else
 fi
 if [ "${UNEXPECTED_SUCCESS}" = true ]
 then
+  ACTUAL_UNEXPECTED_PASS=()
+  # if running a single feature or a single scenario
+  if [[ -n "${BEHAT_FEATURE}" ]]
+  then
+    for unexpected_passed_value in "${UNEXPECTED_PASSED_SCENARIOS[@]}"
+    do
+      # check only for the running feature
+      if [[ $BEHAT_FEATURE == *"${unexpected_passed_value}" ]]
+      then
+        ACTUAL_UNEXPECTED_PASS+="${unexpected_passed_value}"
+      fi
+    done
+  else
+    ACTUAL_UNEXPECTED_PASS="${UNEXPECTED_PASSED_SCENARIOS[@]}"
+  fi
+
   tput setaf 3; echo "runsh: Total unexpected passed scenarios throughout the test run:"
-  tput setaf 1; printf "%s\n" "${UNEXPECTED_PASSED_SCENARIOS[@]}"
+  tput setaf 1; printf "%s\n" "${ACTUAL_UNEXPECTED_PASS[@]}"
+
 else
   tput setaf 2; echo "runsh: There were no unexpected success."
 fi


### PR DESCRIPTION
## Description
Reporting log when running just a single feature or single scenario that are listed in `expected-failure.txt`. Previously we used to get the log about scenarios that were actually running and also for scenarios that were not running but were listed in `expected-failure`.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/37815


## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
