### PR TITLE
If the client disconnects while downloading, use debug level instead

### DIFF
--- a/changelog/unreleased/37856
+++ b/changelog/unreleased/37856
@@ -1,0 +1,9 @@
+Change: Use a debug log level if a share download is aborted
+
+If a client was downloading a file through a public link share
+and he decided to disconnect and abort the download, ownCloud was
+logging that exception.
+Now ownCloud will log a message with a debug level instead of logging
+the exception in order to reduce the noise.
+
+https://github.com/owncloud/core/pull/37856

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -191,11 +191,16 @@ class OC_Files {
 			\OC_Template::printErrorPage('Access denied', $ex->getMessage(), 403);
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
-			OC::$server->getLogger()->logException($ex);
-			$l = \OC::$server->getL10N('lib');
-			/* @phan-suppress-next-line PhanUndeclaredMethod */
-			$hint = \method_exists($ex, 'getHint') ? $ex->getHint() : '';
-			\OC_Template::printErrorPage($l->t('File cannot be downloaded'), $hint);
+			if (\connection_status() !== 0) {
+				// assume the client closed the connection
+				OC::$server->getLogger()->debug($ex->getMessage());
+			} else {
+				OC::$server->getLogger()->logException($ex);
+				$l = \OC::$server->getL10N('lib');
+				/* @phan-suppress-next-line PhanUndeclaredMethod */
+				$hint = \method_exists($ex, 'getHint') ? $ex->getHint() : '';
+				\OC_Template::printErrorPage($l->t('File cannot be downloaded'), $hint);
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
If a client disconnects while downloading a shared file or folder, use a debug log instead of logging the whole exception.

## Related Issue
https://github.com/owncloud/enterprise/issues/4162

## Motivation and Context
There seems to be frequent client disconnections in some environment which cause these exceptions to be logged. This could be normal if the client decide to cancel downloads (especially for big files)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Share a file via public link
2. Using a slow network connection, download the file via the public link, and cancel it while the file is still downloading.

Instead of an exception to be logged, a debug log level should appear in the logs

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
