### PR TITLE
[Tests-Only] Add u to username

### DIFF
--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -144,7 +144,7 @@ class HttpRequestHelper {
 	) {
 		$options = [];
 		if ($user !== null) {
-			$options['auth'] = [$user, $password];
+			$options['auth'] = ["u" . $user, $password];
 		}
 		if ($config !== null) {
 			$options['config'] = $config;

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -755,7 +755,7 @@ class AuthContext implements Context {
 	 * @throws Exception
 	 */
 	public function userRequestsURLWithUsingBasicAuth($user, $url, $method, $password = null, $body = null) {
-		$userRenamed = $this->featureContext->getActualUsername($user);
+		$userRenamed = "u" . $this->featureContext->getActualUsername($user);
 		$url = $this->featureContext->substituteInLineCodes(
 			$url, $userRenamed
 		);

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -850,7 +850,9 @@ trait Provisioning {
 				$attributesToCreateUser['userid'] = $userAttributes['userid'];
 				$attributesToCreateUser['password'] = $userAttributes['password'];
 				if (OcisHelper::isTestingOnOcis()) {
-					$attributesToCreateUser['username'] = $userAttributes['userid'];
+					// Temporarily put a "u" at the start of the username.
+					// OCIS is currently expecting the username to start with an alpha or underscore.
+					$attributesToCreateUser['username'] = "u" . $userAttributes['userid'];
 					if ($userAttributes['email'] === null) {
 						$attributesToCreateUser['email'] = $userAttributes['username'] . '@owncloud.org';
 					} else {
@@ -880,7 +882,7 @@ trait Provisioning {
 					$httpStatusCode = $e->getResponse()->getStatusCode();
 					$reasonPhrase = $e->getResponse()->getReasonPhrase();
 					throw new Exception(
-						__METHOD__ . "Unexpected failure when creating a user: HTTP status $httpStatusCode HTTP reason $reasonPhrase OCS status $ocsStatusCode OCS message $messageText"
+						__METHOD__ . " Unexpected failure when creating a user: HTTP status $httpStatusCode HTTP reason $reasonPhrase OCS status $ocsStatusCode OCS message $messageText"
 					);
 				}
 			}


### PR DESCRIPTION
This is just a demonstrator for https://github.com/owncloud/product/issues/187 to show that it is possible to have `userid` and `username` different in `owncloud/ocis`

OCIS PR https://github.com/owncloud/ocis/pull/498 demonstrates that this passes.

If we actually do this some day, the code will be different - this is just a quick change to show that it works.