### PR TITLE
private/Files/Type/Detection: fix isWrapped cond

### DIFF
--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -231,7 +231,7 @@ class Detection implements IMimeTypeDetector {
 				return empty($mimeType) ? 'application/octet-stream' : $mimeType;
 			}
 		}
-		$isWrapped = (\strpos($path, '://') !== false) and (\substr($path, 0, 7) === 'file://');
+		$isWrapped = (\strpos($path, '://') !== false) && (\substr($path, 0, 7) === 'file://');
 		if (!$isWrapped and $mimeType === 'application/octet-stream' && \function_exists("mime_content_type")) {
 			// use mime magic extension if available
 			$mimeType = \mime_content_type($path);


### PR DESCRIPTION


## Description

This is a minor bug fix.

Due to the `and` and `=` precedence, instead of checking for both
`://` and `file://` we only check for `://`:
```php
$path = 'foo://';
$isWrapped = (\strpos($path, '://') !== false) and (\substr($path, 0, 7) === 'file://');
var_dump($isWrapped); // => true, but want false
```
If we change `and` to `&&` the result becomes `false` as it should.

## Related Issue

I don't know.

## Motivation and Context

The code behaves incorrectly and/or it's misleading.

## How Has This Been Tested?

If the current tests were passing, it probably was not tested before as well.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
