### PR TITLE
Command to troubleshoot invalid shares generated by transfer ownership

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -29,6 +29,7 @@
 		<command>OCA\Files\Command\Scan</command>
 		<command>OCA\Files\Command\DeleteOrphanedFiles</command>
 		<command>OCA\Files\Command\TransferOwnership</command>
+		<command>OCA\Files\Command\TroubleshootTransferOwnership</command>
 		<command>OCA\Files\Command\VerifyChecksums</command>
 	</commands>
 

--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -319,7 +319,7 @@ class TransferOwnership extends Command {
 							}
 						} catch (NotFoundException | NoUserException $e) {
 							$skipped++;
-							$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
+							$output->writeln('<error>Share with id ' . $share->getId() . ' and type ' . $share->getShareType() . ' points at deleted file or share that is no longer accessible, skipping</error>');
 							$progress->advance(1);
 						}
 					}
@@ -409,7 +409,7 @@ class TransferOwnership extends Command {
 				}
 				$this->shareManager->transferShare($share, $this->sourceUser, $this->destinationUser, $this->finalTarget);
 			} catch (NotFoundException | NoUserException $e) {
-				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
+				$output->writeln('<error>Share with id ' . $share->getId() . ' and type ' . $share->getShareType() . ' points at deleted file or share that is no longer accessible, skipping</error>');
 			} catch (\Exception $e) {
 				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getTraceAsString() . '</error>');
 				$status = 1;

--- a/apps/files/lib/Command/TroubleshootTransferOwnership.php
+++ b/apps/files/lib/Command/TroubleshootTransferOwnership.php
@@ -1,0 +1,373 @@
+<?php
+/**
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Command;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OC\Share20\ProviderFactory;
+use OCP\IDBConnection;
+use OCP\Share\IManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableCell;
+
+/**
+ */
+class TroubleshootTransferOwnership extends Command {
+
+	/**
+	 * @var ProviderFactory
+	 */
+	protected $shareProviderFactory;
+
+	/**
+	 * @var IDBConnection
+	 */
+	protected $connection;
+
+	private $allowedOps = "all|invalid-owner|invalid-initiator";
+
+	public function __construct(IDBConnection $connection, ProviderFactory $shareProviderFactory) {
+		$this->connection = $connection;
+		$this->shareProviderFactory = $shareProviderFactory;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('files:troubleshoot-transfer-ownership')
+			->setDescription('Scan for problems that might have occurred while running ownership transfer')
+			->addArgument(
+				'type',
+				InputArgument::OPTIONAL,
+				$this->allowedOps,
+				''
+			)
+			->addOption(
+				'fix',
+				'f',
+				InputOption::VALUE_NONE,
+				'perform auto-fix for found problems'
+			);
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output) {
+		$type = $input->getArgument('type');
+		$fix = $input->getOption('fix');
+
+		$allowedOps = \explode("|", $this->allowedOps);
+		if (!\in_array($type, $allowedOps)) {
+			$output->writeln([
+				"<error>type is not recognised, allowed: {$this->allowedOps}</>",
+			]);
+			return 1;
+		}
+
+		if ($type == 'all' || $type == 'invalid-initiator') {
+			$this->findInvalidReshareInitiator($input, $output, $fix);
+		}
+		if ($type == 'all' || $type == 'invalid-owner') {
+			$this->findInvalidShareOwner($input, $output, $fix);
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Search for shares with invalid storage ids. This could have happened due
+	 * to past bug or as a result of lack of transactions in IManager->transferShare
+	 * that could cause mismatching entries when a run has been terminated.
+	 *
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @param boolean $fix
+	 */
+	protected function findInvalidShareOwner(InputInterface $input, OutputInterface $output, $fix) {
+		$output->writeln([
+			"<info>==========================</>",
+			"<info>Searching for shares that have invalid uid_owner, meaning share uid_owner that does not match associated file storage id.</>",
+			"<info>==========================</>",
+			"",
+		]);
+
+		$invalidSharesCount = 0;
+
+		$shareStorages = \array_merge(
+			$this->getAllInvalidShareStorages('home::'),
+			$this->getAllInvalidShareStorages('object::user:')
+		);
+
+		$tableRows = [];
+		$table = new Table($output);
+		$table->setHeaders([
+			[new TableCell("Invalid share storages", ['colspan' => 8])],
+			['share_id', 'share_type', 'share_parent', 'file_source', 'storage', 'uid_owner', 'uid_initiator', 'share_with'],
+		]);
+
+		$sharesToFix = [];
+		foreach ($shareStorages as $shareStorage) {
+			$invalidSharesCount += 1;
+			\array_push($sharesToFix, $shareStorage);
+			\array_push($tableRows, [$shareStorage['share_id'], $shareStorage['share_type'], $shareStorage['share_parent'], $shareStorage['file_source'], $shareStorage['storage'], $shareStorage['uid_owner'], $shareStorage['uid_initiator'], $shareStorage['share_with']]);
+		}
+
+		if (\count($tableRows) > 0) {
+			$table->setRows($tableRows);
+			$table->render();
+			$output->writeln("");
+		}
+
+		$output->writeln("<info>Found $invalidSharesCount invalid share owners</>");
+
+		if ($fix) {
+			foreach ($sharesToFix as $shareToFix) {
+				// we need to adjust uid_owner to match user storage id
+				$userIdFromStorage = null;
+				if (\strpos($shareToFix['storage'], 'home::') === 0) {
+					$userIdFromStorage = \explode('home::', $shareToFix['storage'])[1];
+				} elseif (\strpos($shareToFix['storage'], 'object::user:') === 0) {
+					$userIdFromStorage = \explode('object::user:', $shareToFix['storage'])[1];
+				}
+
+				if (!$userIdFromStorage) {
+					continue;
+				}
+
+				if ($shareToFix['share_with'] !== null && $userIdFromStorage == $shareToFix['share_with']) {
+					$this->deleteCorruptedShare($shareToFix);
+				} else {
+					$this->adjustShareOwner($shareToFix['share_id'], $userIdFromStorage);
+				}
+			}
+
+			$output->writeln("<info>Repaired $invalidSharesCount invalid share owners</>");
+		}
+
+		$output->writeln("");
+	}
+
+	/**
+	 * Search for invalid initiator of the reshare that has been generated by
+	 * bug which has been fixed as of https://github.com/owncloud/core/pull/37791
+	 *
+	 * NOTE: this command can take long
+	 *
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @param boolean $fix
+	 */
+	protected function findInvalidReshareInitiator(InputInterface $input, OutputInterface $output, $fix) {
+		$output->writeln([
+			"<info>==========================</>",
+			"<info>Searching for reshares that have invalid uid_initiator(resharer), meaning resharer which does not have the received share mounted anymore (that he reshared with other user).</>",
+			"<info>==========================</>",
+			"",
+		]);
+
+		$runExceptions = 0;
+		$invalidReshareInitiatorCount = 0;
+		$resharers = $this->getAllResharers();
+
+		$resharesToFix = [];
+		foreach ($resharers as $resharer) {
+			$resharerUid = $resharer['uid_initiator'];
+
+			$table = new Table($output);
+			$table->setHeaders([
+				[new TableCell("Invalid uid_initiator found for $resharerUid", ['colspan' => 7])],
+				['share_id', 'share_type', 'share_parent', 'file_source', 'uid_owner', 'uid_initiator', 'share_with'],
+			]);
+			$tableRows = [];
+			try {
+				$userFolder = $this->getUserFolder($resharerUid);
+
+				// extract all reshares for this user and check if they have mount node
+				$reshares = $this->getResharesForUser($resharerUid);
+				foreach ($reshares as $reshare) {
+					$nodes = $userFolder->getById((int) $reshare['file_source'], true);
+					if (\count($nodes) == 0) {
+						$invalidReshareInitiatorCount += 1;
+						\array_push($resharesToFix, $reshare);
+						\array_push($tableRows, [$reshare['id'], $reshare['share_type'], $reshare['parent'], $reshare['file_source'], $reshare['uid_owner'], $reshare['uid_initiator'], $reshare['share_with']]);
+					}
+				}
+				if (\count($tableRows) > 0) {
+					$table->setRows($tableRows);
+					$table->render();
+					$output->writeln("");
+				}
+			} catch (\Exception $e) {
+				$runExceptions = $runExceptions + 1;
+				$table->setRows($tableRows);
+				$table->render();
+				$output->writeln("<info>Encountered error for user {$resharer['uid_initiator']}, command might need to be retried: </info>");
+				$output->writeln("<error>{$e->getMessage()}: </error>");
+				$output->writeln("<error>{$e->getTraceAsString()}: </error>");
+				$output->writeln("<info>Waiting 1 seconds after error before continuing with next user..</info>");
+				$output->writeln("");
+				\sleep(1);
+			}
+		}
+
+		$output->writeln([
+			"<info>Encountered $runExceptions exceptions while running command</>",
+			"<info>Found $invalidReshareInitiatorCount invalid initiator reshares</>"
+		]);
+
+		if ($fix) {
+			foreach ($resharesToFix as $reshareToFix) {
+				// as we do not know what uid_initiator might be, we need to use uid_owner (original share initiator)
+				$this->adjustShareInitiator($reshareToFix['id'], $reshareToFix['uid_owner']);
+			}
+
+			$output->writeln("<info>Repaired $invalidReshareInitiatorCount invalid initiator reshares</>");
+		}
+
+		$output->writeln("");
+	}
+
+	protected function getAllResharers() {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->selectDistinct('uid_initiator')
+			->from('share')
+			->andWhere($query->expr()->orX(
+				$query->expr()->eq('item_type', $query->createNamedParameter('file')),
+				$query->expr()->eq('item_type', $query->createNamedParameter('folder'))
+			));
+
+		$query->andWhere($query->expr()->neq('uid_initiator', 'uid_owner'));
+
+		$cursor = $query->execute();
+		$resharers = $cursor->fetchAll();
+		$cursor->closeCursor();
+
+		return $resharers;
+	}
+
+	protected function getResharesForUser($userId) {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select('*')
+			->from('share')
+			->andWhere($query->expr()->orX(
+				$query->expr()->eq('item_type', $query->createNamedParameter('file')),
+				$query->expr()->eq('item_type', $query->createNamedParameter('folder'))
+			));
+
+		$query->andWhere($query->expr()->neq('uid_initiator', 'uid_owner'));
+		$query->andWhere($query->expr()->eq('uid_initiator', $query->createNamedParameter($userId)));
+
+		$cursor = $query->execute();
+		$reshares = $cursor->fetchAll();
+		$cursor->closeCursor();
+
+		return $reshares;
+	}
+
+	protected function getAllInvalidShareStorages($storageType) {
+		$query = $this->connection->getQueryBuilder();
+
+		if ($this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+			$concatFunction = $query->createFunction("CONCAT('$storageType', s.uid_owner)");
+		} else {
+			$concatFunction = $query->createFunction("('$storageType' || s.`uid_owner`)");
+		}
+
+		$query->select('s.id', 's.file_source', 's.share_type', 's.parent', 'st.id', 's.uid_owner', 's.uid_initiator', 's.share_with')
+			->selectAlias('s.id', 'share_id')
+			->selectAlias('s.file_source', 'file_source')
+			->selectAlias('s.share_type', 'share_type')
+			->selectAlias('s.parent', 'share_parent')
+			->selectAlias('st.id', 'storage')
+			->selectAlias('s.uid_owner', 'uid_owner')
+			->selectAlias('s.uid_initiator', 'uid_initiator')
+			->selectAlias('s.share_with', 'share_with')
+			->from('share', 's')
+			->join('s', 'filecache', 'f', $query->expr()->eq('s.file_source', 'f.fileid'))
+			->join('f', 'storages', 'st', $query->expr()->eq('st.numeric_id', 'f.storage'))
+			->andWhere($query->expr()->orX(
+				$query->expr()->like('st.id', $query->createNamedParameter("$storageType%"))
+			))
+			->andWhere($query->expr()->orX(
+				$query->expr()->eq('s.item_type', $query->createNamedParameter('file')),
+				$query->expr()->eq('s.item_type', $query->createNamedParameter('folder'))
+			))
+			->andWhere($query->expr()->neq(
+				$concatFunction,
+				'st.id'
+			));
+
+		$cursor = $query->execute();
+		$shareStorages = $cursor->fetchAll();
+		$cursor->closeCursor();
+
+		return $shareStorages;
+	}
+
+	protected function adjustShareInitiator($shareId, $newUidInitiator) {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->update('share')
+			->set('uid_initiator', $query->createParameter('uid_initiator'))
+			->where($query->expr()->eq('id', $query->createParameter('shareid')))
+			->andWhere($query->expr()->orX(
+				$query->expr()->eq('item_type', $query->createNamedParameter('file')),
+				$query->expr()->eq('item_type', $query->createNamedParameter('folder'))
+			));
+
+		$query->setParameter('shareid', $shareId);
+		$query->setParameter('uid_initiator', $newUidInitiator);
+
+		return $query->execute();
+	}
+
+	protected function adjustShareOwner($shareId, $newUidOwner) {
+		$query = $this->connection->getQueryBuilder();
+
+		$query->update('share')
+			->set('uid_owner', $query->createParameter('uid_owner'))
+			->where($query->expr()->eq('id', $query->createParameter('shareid')))
+			->andWhere($query->expr()->orX(
+				$query->expr()->eq('item_type', $query->createNamedParameter('file')),
+				$query->expr()->eq('item_type', $query->createNamedParameter('folder'))
+			));
+
+		$query->setParameter('shareid', $shareId);
+		$query->setParameter('uid_owner', $newUidOwner);
+
+		return $query->execute();
+	}
+
+	protected function deleteCorruptedShare($shareData) {
+		$shareProvider = $this->shareProviderFactory->getProviderForType((int) $shareData["share_type"]);
+		$share = $shareProvider->getShareById($shareData["id"]);
+		$shareProvider->delete($share);
+	}
+
+	protected function getUserFolder($uid) {
+		return \OC::$server->getUserFolder($uid);
+	}
+}

--- a/apps/files/tests/Command/TransferOwnershipTest.php
+++ b/apps/files/tests/Command/TransferOwnershipTest.php
@@ -391,6 +391,7 @@ class TransferOwnershipTest extends TestCase {
 		$shareNode->method('getPath')->willReturn('/source-user/files/transfer');
 		$share = $this->createMock(IShare::class);
 		$share->method('getId')->willReturn(1);
+		$share->method('getShareType')->willReturn(1);
 		$share->method('getNode')->willThrowException($exception);
 
 		$shareManager = $this->createMock(IManager::class);
@@ -417,7 +418,7 @@ class TransferOwnershipTest extends TestCase {
 		$commandTester->execute($input);
 		$output = $commandTester->getDisplay();
 
-		$this->assertStringContainsString('Share with id 1 points at deleted file, skipping', $output);
+		$this->assertStringContainsString('Share with id 1 and type 1 points at deleted file or share that is no longer accessible, skipping', $output);
 		foreach ($expectedOutputs as $expectedOutput) {
 			$this->assertStringContainsString($expectedOutput, $output);
 		}

--- a/apps/files/tests/Command/TroubleshootTransferOwnershipTest.php
+++ b/apps/files/tests/Command/TroubleshootTransferOwnershipTest.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Tests\Command;
+
+use OC\Share20\ProviderFactory;
+use OCA\Files\Command\TroubleshootTransferOwnership;
+use OCP\Files\Folder;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class TroubleshootTransferOwnershipTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files\Tests\Command
+ */
+class TroubleshootTransferOwnershipTest extends TestCase {
+
+	/**
+	 * @var CommandTester
+	 */
+	private $commandTester;
+
+	protected function setup(): void {
+		parent::setUp();
+
+		// setup all db entries created if any
+
+		// setup command
+		$command = new TroubleshootTransferOwnership(
+			\OC::$server->getDatabaseConnection(),
+			$this->createMock(ProviderFactory::class)
+		);
+		$this->commandTester = new CommandTester($command);
+	}
+
+	protected function tearDown(): void {
+		// cleanup all db entries created if any
+		parent::tearDown();
+	}
+
+	private function getMockedCommand(): CommandTester {
+		$command = $this->getMockBuilder(TroubleshootTransferOwnership::class)
+			->setConstructorArgs([
+				$this->createMock(IDBConnection::class),
+				$this->createMock(ProviderFactory::class)
+			])
+			->setMethods([
+				'getAllResharers',
+				'getUserFolder',
+				'getResharesForUser',
+				'adjustShareInitiator',
+				'getAllInvalidShareStorages',
+				'deleteCorruptedShare',
+				'adjustShareOwner',
+			])
+			->getMock();
+
+		$command->expects($this->any())->method('getAllResharers')->willReturn(null);
+		$command->expects($this->any())->method('getUserFolder')->willReturn(null);
+		$command->expects($this->any())->method('getResharesForUser')->willReturn(null);
+		$command->expects($this->any())->method('adjustShareInitiator')->willReturn(null);
+		$command->expects($this->any())->method('getAllInvalidShareStorages')->willReturn(null);
+		$command->expects($this->any())->method('deleteCorruptedShare')->willReturn(null);
+		$command->expects($this->any())->method('adjustShareOwner')->willReturn(null);
+
+		return new CommandTester($command);
+	}
+
+	public function testTypeIsNotRecognised() {
+		$input = [
+			'type' => 'not-existing'
+		];
+
+		$this->commandTester->execute($input);
+		$output = $this->commandTester->getDisplay();
+
+		$this->assertStringContainsString('type is not recognised, allowed: all|invalid-owner|invalid-initiator', $output);
+	}
+
+	public function testFindInvalidShareOwner() {
+		$command = $this->getMockBuilder(TroubleshootTransferOwnership::class)
+			->setConstructorArgs([
+				$this->createMock(IDBConnection::class),
+				$this->createMock(ProviderFactory::class)
+			])
+			->setMethods([
+				'getAllInvalidShareStorages',
+				'deleteCorruptedShare',
+				'adjustShareOwner',
+			])
+			->getMock();
+
+		$invalidUidOwnerCorrectable = [
+			'share_id' => '1',
+			'share_type' => '0',
+			'share_parent' => '',
+			'file_source' => '1',
+			'storage' => 'home::user1',
+			'uid_owner' => 'user2',
+			'uid_initiator' => 'user2',
+			'share_with' => 'user3',
+		];
+		$invalidUidOwnerShareWithPointingToStorage = [
+			'share_id' => '1',
+			'share_type' => '0',
+			'share_parent' => '',
+			'file_source' => '1',
+			'storage' => 'home::user1',
+			'uid_owner' => 'user2',
+			'uid_initiator' => 'user2',
+			'share_with' => 'user1',
+		];
+		$invalidShareStorages = [
+			$invalidUidOwnerCorrectable,
+			$invalidUidOwnerShareWithPointingToStorage
+		];
+
+		$command->expects($this->at(0))->method('getAllInvalidShareStorages')->with('home::')->willReturn($invalidShareStorages);
+		$command->expects($this->at(1))->method('getAllInvalidShareStorages')->with('object::user:')->willReturn([]);
+		$command->expects($this->exactly(1))->method('deleteCorruptedShare')->with($invalidUidOwnerShareWithPointingToStorage)->willReturn(null);
+		$command->expects($this->exactly(1))->method('adjustShareOwner')->with('1', 'user1')->willReturn(null);
+
+		$commandTester = new CommandTester($command);
+
+		$input = [
+			'type' => 'invalid-owner',
+			'--fix' => null
+		];
+
+		$commandTester->execute($input);
+		$output = $commandTester->getDisplay();
+
+		$this->assertStringContainsString('Found 2 invalid share owners', $output);
+		$this->assertStringContainsString('Repaired 2 invalid share owners', $output);
+	}
+
+	public function testFindInvalidReshareInitiator() {
+		$command = $this->getMockBuilder(TroubleshootTransferOwnership::class)
+			->setConstructorArgs([
+				$this->createMock(IDBConnection::class),
+				$this->createMock(ProviderFactory::class)
+			])
+			->setMethods([
+				'getAllResharers',
+				'getUserFolder',
+				'getResharesForUser',
+				'adjustShareInitiator',
+			])
+			->getMock();
+
+		$reshares = [
+			// add reshare
+			[
+				'id' => '1',
+				'share_type' => '0',
+				'parent' => '',
+				'file_source' => '1',
+				'uid_owner' => 'user1',
+				'uid_initiator' => 'user2',
+				'share_with' => 'user3',
+			]
+		];
+
+		// reshare with (file_source = 1) does not have any nodes attached
+		// (invalid uid_initiator -> resharer that does not have a node anymore)
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->expects($this->at(0))->method('getById')->with(1, true)->willReturn([]);
+
+		$command->expects($this->exactly(1))->method('getAllResharers')->willReturn([
+			[ 'uid_initiator' => 'user2']
+		]);
+		$command->expects($this->exactly(1))->method('getUserFolder')->with('user2')->willReturn($userFolder);
+		$command->expects($this->exactly(1))->method('getResharesForUser')->with('user2')->willReturn($reshares);
+		$command->expects($this->exactly(1))->method('adjustShareInitiator')->with('1', 'user1')->willReturn(null);
+
+		$commandTester = new CommandTester($command);
+
+		$input = [
+			'type' => 'invalid-initiator',
+			'--fix' => null
+		];
+
+		$commandTester->execute($input);
+		$output = $commandTester->getDisplay();
+
+		$this->assertStringContainsString('Found 1 invalid initiator reshares', $output);
+		$this->assertStringContainsString('Repaired 1 invalid initiator reshares', $output);
+	}
+}

--- a/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
+++ b/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
@@ -78,6 +78,16 @@ class TransferOwnershipContext implements Context {
 	}
 
 	/**
+	 * @param string $type
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function troubleshootingTransferOwnership($type) {
+		$this->featureContext->runOcc(['files:troubleshoot-transfer-ownership', $type, '--fix']);
+	}
+
+	/**
 	 * @When /^the administrator transfers ownership from "([^"]+)" to "([^"]+)" using the occ command$/
 	 *
 	 * @param string $user1
@@ -90,6 +100,19 @@ class TransferOwnershipContext implements Context {
 		$user1 = $this->featureContext->getActualUsername($user1);
 		$user2 = $this->featureContext->getActualUsername($user2);
 		$this->transferringOwnership($user1, $user2);
+	}
+
+	/**
+	 * @When /^the administrator troubleshoots transfer of ownerships for "([^"]+)" using the occ command$/
+	 *
+	 * @param string $type
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorTroubleshootsTransferOwnershipUsingTheOccCommand($type) {
+		$this->troubleshootingTransferOwnership($type);
+		$this->occContext->theCommandShouldHaveBeenSuccessful();
 	}
 
 	/**

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -308,3 +308,55 @@ Feature: transfer-ownership
     When the administrator transfers ownership from "Alice" to "Brian" using the occ command
     Then the command output should contain the text "No files/folders to transfer"
     And the command should have failed with exit code 1
+
+  @skipOnEncryptionType:user-keys
+  Scenario: troubleshoot transfer ownerships for all with share and reshare
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and skeleton files
+    And user "David" has been created with default attributes and skeleton files
+    And user "Alice" has created folder "/testByAlice"
+    And user "Alice" has shared folder "/testByAlice" with user "Brian" with permissions "all"
+    And user "Brian" has shared folder "/testByAlice" with user "Carol" with permissions "all"
+    And user "Brian" has created folder "/testByBrian"
+    And user "Brian" has shared folder "/testByBrian" with user "Carol" with permissions "all"
+    And the administrator transfers ownership from "Brian" to "David" using the occ command
+    When the administrator troubleshoots transfer of ownerships for "all" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text "Searching for reshares that have invalid uid_initiator"
+    And the command output should contain the text "Found 0 invalid initiator reshares"
+    And the command output should contain the text "Repaired 0 invalid initiator reshares"
+    And the command output should contain the text "Searching for shares that have invalid uid_owner"
+    And the command output should contain the text "Found 0 invalid share owners"
+    And the command output should contain the text "Repaired 0 invalid share owners"
+
+  @skipOnEncryptionType:user-keys
+  Scenario: troubleshoot transfer ownerships for invalid-initiator with reshare
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and skeleton files
+    And user "David" has been created with default attributes and skeleton files
+    And user "Alice" has created folder "/testByAlice"
+    And user "Alice" has shared folder "/testByAlice" with user "Brian" with permissions "all"
+    And user "Brian" has shared folder "/testByAlice" with user "Carol" with permissions "all"
+    And the administrator transfers ownership from "Brian" to "David" using the occ command
+    When the administrator troubleshoots transfer of ownerships for "invalid-initiator" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text "Searching for reshares that have invalid uid_initiator"
+    And the command output should contain the text "Found 0 invalid initiator reshares"
+    And the command output should contain the text "Repaired 0 invalid initiator reshares"
+
+  @skipOnEncryptionType:user-keys
+  Scenario: troubleshoot transfer ownerships for invalid-owner with share
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and skeleton files
+    And user "Alice" has created folder "/test"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
+    And user "Alice" has shared folder "/test" with user "Carol" with permissions "all"
+    And the administrator transfers ownership of path "test" from "Alice" to "Brian" using the occ command
+    When the administrator troubleshoots transfer of ownerships for "invalid-owner" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text "Searching for shares that have invalid uid_owner"
+    And the command output should contain the text "Found 0 invalid share owners"
+    And the command output should contain the text "Repaired 0 invalid share owners"


### PR DESCRIPTION
Adds new commands that detect and fix invalid shares generated by transfer ownership. 

- [x] add logging of invalid shares
- [x] add option to fix invalid shares
- [x] decide whether we want to release this as command (as is), or as update repair steps, or just as patch for specific customers -> and add unit tests if first 2 options (@micbar @pmaier1 )
- [ ] add docs - see issue https://github.com/owncloud/docs/issues/2794
- [x] add unit and integration tests

**1. Invalid initiator**

This has been triggered by past bug, that has been fixed in https://github.com/owncloud/core/pull/37791

```
$ occ files:troubleshoot-transfer-ownership invalid-initiator

SEARCHING FOR RESHARES THAT HAVE INVALID UID_INITIATOR(RESHARER) - RESHARER WHICH DOES NOT HAVE HIS SHARE MOUNTED ANY MORE AND THUS SHARE IS CORRUPTED
Invalid reshare initiator found for user test4 in shares: 
id=2,file_source=8,uid_owner=test1,uid_initiator=test4,share_with=test3
FOUND 1 INVALID INITIATOR RESHARES
```
  

**2. Invalid owner_uid (detached shares from their file storages, these would not show in UI to the user unless adjusted)**

This could have been created for three reasons I can think of:
- mismatching initiator (above case 1) somehow lead to this
- fact that `Share\IManager->transferShares` is not wrapped with transaction, and thus any termination in the middle could have resulted in mismatch between `share. uid_owner` and `storages.id` 
- past bug that is yet not identified or has been already fixed

```
$ occ files:troubleshoot-transfer-ownership invalid-owner

SEARCHING FOR SHARES THAT HAVE INVALID UID_OWNER - UID_OWNER VALUES THAT HAVE NOT BEEN UPDATED TO MATCH REQUIRED TRANSFERRED STORAGE
Invalid shares:
id=1,file_source=8,storage=home::test1,uid_owner=test4,uid_initiator=test4,share_with=test2
FOUND 1 INVALID SHARE OWNERS
```

Related: https://github.com/owncloud/enterprise/issues/4121
