### PR TITLE
[Tests-Only] Run multiple tests for trashbinFilesFolders

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -104,7 +104,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  @issue-23151
+  @skipOnOcV10 @issue-23151
   # This scenario deletes many files as close together in time as the test can run.
   # On a very slow system, the file deletes might all happen in different seconds.
   # But on "reasonable" systems, some of the files will be deleted in the same second,
@@ -126,10 +126,42 @@ Feature: files and folders exist in the trashbin after being deleted
       | /folderC/textfile0.txt |
       | /folderD/textfile0.txt |
     # When issue-23151 is fixed, uncomment these lines. They should pass reliably.
-    #Then as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
-    #And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
-    #And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
-    #And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
+    Then as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @notToImplementOnOcis @issue-23151
+  # This scenario deletes many files as close together in time as the test can run.
+  # On a very slow system, the file deletes might all happen in different seconds.
+  # But on "reasonable" systems, some of the files will be deleted in the same second,
+  # thus testing the required behavior.
+  Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "/folderA"
+    And user "Alice" has created folder "/folderB"
+    And user "Alice" has created folder "/folderC"
+    And user "Alice" has created folder "/folderD"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderC/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderD/textfile0.txt"
+    When user "Alice" deletes these files without delays using the WebDAV API
+      | /textfile0.txt         |
+      | /folderA/textfile0.txt |
+      | /folderB/textfile0.txt |
+      | /folderC/textfile0.txt |
+      | /folderD/textfile0.txt |
+    # When issue-23151 is fixed, remove this scenario and use the above one.
+#    Then as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
+#    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
+#    And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
+#    And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |


### PR DESCRIPTION
## Description
In core for `trashbinFilesFolders.feature:136` we always end up with /textfile0.txt being the file that is found in the trashbin when files are deleted close together in time. But in OCIS sometimes the last deleted file `/folderD/textfile0.txt` is the one that ends up in the trashbin. 

So, for now we add `notToImplementOnOcis` tag for the test failing in OCIS because we do not want to implement oC10 bugs on OCIS. After the `issue-23151` is fixed we can implement it on OCIS as well.

## Related Issue
- Fixes: https://github.com/owncloud/ocis/issues/506


## How Has This Been Tested?
- :robot: 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
