### PR TITLE
[Tests-Only] Enable Provisioning Api Tests for OCIS

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: add user
   As an admin
   I want to be able to add users
@@ -44,6 +44,7 @@ Feature: add user
     And the HTTP status code should be "200"
     And the API should not return any data
 
+  @notToImplementOnOCIS
   Scenario: Admin creates a new user and adds him directly to a group
     Given group "brand-new-group" has been created
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" group "brand-new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: access user provisioning API using app password
   As an ownCloud user
   I want to be able to use the provisioning API with an app password
@@ -7,7 +7,7 @@ Feature: access user provisioning API using app password
   Background:
     Given using OCS API version "1"
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: admin deletes the user
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -18,6 +18,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
+  @notToImplementOnOCIS
   Scenario: subadmin gets users in their group
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -46,6 +47,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
 
+  @notToImplementOnOCIS
   Scenario: subadmin tries to get users of other group
     Given these users have been created with default attributes and skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group
@@ -7,7 +7,7 @@ Feature: create a subadmin
   Background:
     Given using OCS API version "1"
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: admin creates a subadmin
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -16,6 +16,7 @@ Feature: create a subadmin
     And the HTTP status code should be "200"
     And user "brand-new-user" should be a subadmin of group "brand-new-group"
 
+  @notToImplementOnOCIS
   Scenario: admin tries to create a subadmin using a user which does not exist
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
@@ -32,6 +33,7 @@ Feature: create a subadmin
     And the HTTP status code should be "200"
     And the API should not return any data
 
+  @notToImplementOnOCIS
   Scenario: subadmin of a group tries to make another user subadmin of their group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: delete users
   As an admin
   I want to be able to delete users
@@ -36,7 +36,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: subadmin deletes a user in their group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app
@@ -15,6 +15,7 @@ Feature: disable an app
     And the HTTP status code should be "200"
     And app "comments" should be disabled
 
+  @notToImplementOnOCIS
   Scenario: subadmin tries to disable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: disable user
   As an admin
   I want to be able to disable a user
@@ -29,7 +29,7 @@ Feature: disable user
       | a@-+_.b  | a.b@example.com     |
       | a space  | a.space@example.com |
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: Subadmin should be able to disable an user in their group
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -44,6 +44,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "Alice" should be disabled
 
+  @notToImplementOnOCIS
   Scenario: Subadmin should not be able to disable an user not in their group
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -59,6 +60,7 @@ Feature: disable user
     And the HTTP status code should be "401"
     And user "Alice" should be enabled
 
+  @notToImplementOnOCIS
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
     Given these users have been created with default attributes and skeleton files:
       | username      |
@@ -82,6 +84,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "another-admin" should be disabled
 
+  @notToImplementOnOCIS
   Scenario: Admin can disable subadmins in the same group
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -111,6 +114,7 @@ Feature: disable user
     And the HTTP status code should be "401"
     And user "Brian" should be enabled
 
+  @notToImplementOnOCIS
   Scenario: Subadmin should not be able to disable himself
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: edit users
   As an admin, subadmin or as myself
   I want to be able to edit user information
@@ -81,7 +81,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be ""
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin should be able to edit the user information in their group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app
@@ -16,6 +16,7 @@ Feature: enable an app
     And app "comments" should be enabled
     And the information for app "comments" should have a valid version
 
+  @notToImplementOnOCIS
   Scenario: subadmin tries to enable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: enable user
   As an admin
   I want to be able to enable a user
@@ -40,6 +40,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "another-admin" should be enabled
 
+  @notToImplementOnOCIS
   Scenario: admin enables subadmins in the same group
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -70,6 +71,7 @@ Feature: enable user
     And the HTTP status code should be "401"
     And user "Brian" should be disabled
 
+  @notToImplementOnOCIS
   Scenario: subadmin tries to enable himself
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group
@@ -7,7 +7,7 @@ Feature: get subadmins
   Background:
     Given using OCS API version "1"
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: admin gets subadmin users of a group
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -26,6 +26,7 @@ Feature: get subadmins
     And the HTTP status code should be "200"
     And the API should not return any data
 
+  @notToImplementOnOCIS
   Scenario: subadmin tries to get other subadmins of the same group
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -39,6 +40,7 @@ Feature: get subadmins
     And the HTTP status code should be "401"
     And the API should not return any data
 
+  @notToImplementOnOCIS
   Scenario: normal user tries to get the subadmins of the group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get user
   As an admin, subadmin or as myself
   I want to be able to retrieve user information
@@ -50,7 +50,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin gets information of a user in their group
     Given these users have been created with default attributes and skeleton files:
       | username       | displayname |
@@ -65,6 +65,7 @@ Feature: get user
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
 
+  @notToImplementOnOCIS
   Scenario: a subadmin tries to get information of a user not in their group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get users
   As an admin
   I want to be able to list the users that exist
@@ -17,7 +17,7 @@ Feature: get users
       | brand-new-user |
       | admin          |
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: subadmin gets the users in their group
     Given these users have been created with default attributes and skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password
@@ -23,7 +23,7 @@ Feature: reset user password
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
 
-  @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
+  @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57 @notToImplementOnOCIS
   Scenario: subadmin should be able to reset the password of a user in their group
     Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |
@@ -38,6 +38,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
+  @notToImplementOnOCIS
   Scenario: subadmin should not be able to reset the password of a user not in their group
     Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: add user
   As an admin
   I want to be able to add users
@@ -44,6 +44,7 @@ Feature: add user
     And the HTTP status code should be "400"
     And the API should not return any data
 
+  @notToImplementOnOCIS
   Scenario: Admin creates a new user and adds him directly to a group
     Given group "brand-new-group" has been created
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" group "brand-new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: access user provisioning API using app password
   As an ownCloud user
   I want to be able to use the provisioning API with an app password
@@ -7,7 +7,7 @@ Feature: access user provisioning API using app password
   Background:
     Given using OCS API version "2"
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: admin deletes the user
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -18,6 +18,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
+  @notToImplementOnOCIS
   Scenario: subadmin gets users in their group
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -46,6 +47,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
 
+  @notToImplementOnOCIS
   Scenario: subadmin tries to get users of other group
     Given these users have been created with default attributes and skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group
@@ -7,7 +7,7 @@ Feature: create a subadmin
   Background:
     Given using OCS API version "2"
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: admin creates a subadmin
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -16,6 +16,7 @@ Feature: create a subadmin
     And the HTTP status code should be "200"
     And user "brand-new-user" should be a subadmin of group "brand-new-group"
 
+  @notToImplementOnOCIS
   Scenario: admin tries to create a subadmin using a user which does not exist
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
@@ -31,7 +32,7 @@ Feature: create a subadmin
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
 
-  @issue-31276
+  @issue-31276 @notToImplementOnOCIS
   Scenario: subadmin of a group tries to make another user subadmin of their group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: delete users
   As an admin
   I want to be able to delete users
@@ -36,7 +36,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: subadmin deletes a user in their group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app
@@ -15,7 +15,7 @@ Feature: disable an app
     And the HTTP status code should be "200"
     And app "comments" should be disabled
 
-  @issue-31276
+  @issue-31276 @notToImplementOnOCIS
   Scenario: subadmin tries to disable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: disable user
   As an admin
   I want to be able to disable a user
@@ -29,7 +29,7 @@ Feature: disable user
       | a@-+_.b  | a.b@example.com     |
       | a space  | a.space@example.com |
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: Subadmin should be able to disable an user in their group
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -44,7 +44,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "Alice" should be disabled
 
-  @issue-31276
+  @issue-31276 @notToImplementOnOCIS
   Scenario: Subadmin should not be able to disable an user not in their group
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -61,7 +61,7 @@ Feature: disable user
     And the HTTP status code should be "401"
     And user "Alice" should be enabled
 
-  @issue-31276
+  @issue-31276 @notToImplementOnOCIS
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
     Given these users have been created with default attributes and skeleton files:
       | username      |
@@ -86,6 +86,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "another-admin" should be disabled
 
+  @notToImplementOnOCIS
   Scenario: Admin can disable subadmins in the same group
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -117,6 +118,7 @@ Feature: disable user
     And the HTTP status code should be "401"
     And user "Brian" should be enabled
 
+  @notToImplementOnOCIS
   Scenario: Subadmin should not be able to disable himself
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: edit users
   As an admin, subadmin or as myself
   I want to be able to edit user information
@@ -81,7 +81,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be ""
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin should be able to edit the user information in their group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app
@@ -15,7 +15,7 @@ Feature: enable an app
     And the HTTP status code should be "200"
     And app "comments" should be enabled
 
-  @issue-31276
+  @issue-31276 @notToImplementOnOCIS
   Scenario: subadmin tries to enable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: enable user
   As an admin
   I want to be able to enable a user
@@ -40,6 +40,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "another-admin" should be enabled
 
+  @notToImplementOnOCIS
   Scenario: admin enables subadmins in the same group
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -72,6 +73,7 @@ Feature: enable user
     And the HTTP status code should be "401"
     And user "Brian" should be disabled
 
+  @notToImplementOnOCIS
   Scenario: subadmin tries to enable himself
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group
@@ -7,7 +7,7 @@ Feature: get subadmins
   Background:
     Given using OCS API version "2"
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: admin gets subadmin users of a group
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -26,7 +26,7 @@ Feature: get subadmins
     And the HTTP status code should be "400"
     And the API should not return any data
 
-  @issue-31276
+  @issue-31276 @notToImplementOnOCIS
   Scenario: subadmin tries to get other subadmins of the same group
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -41,7 +41,7 @@ Feature: get subadmins
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @issue-31276
+  @issue-31276 @notToImplementOnOCIS
   Scenario: normal user tries to get the subadmins of the group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get user
   As an admin, subadmin or as myself
   I want to be able to retrieve user information
@@ -50,7 +50,7 @@ Feature: get user
     And the HTTP status code should be "404"
     And the API should not return any data
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin gets information of a user in their group
     Given these users have been created with default attributes and skeleton files:
       | username       | displayname |
@@ -65,6 +65,7 @@ Feature: get user
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
 
+  @notToImplementOnOCIS
   Scenario: a subadmin tries to get information of a user not in their group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get users
   As an admin
   I want to be able to list the users that exist
@@ -17,7 +17,7 @@ Feature: get users
       | brand-new-user |
       | admin          |
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: subadmin gets the users in their group
     Given these users have been created with default attributes and skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password
@@ -23,7 +23,7 @@ Feature: reset user password
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
 
-  @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
+  @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57 @notToImplementOnOCIS
   Scenario: subadmin should be able to reset the password of a user in their group
     Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |
@@ -38,6 +38,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
+  @notToImplementOnOCIS
   Scenario: subadmin should not be able to reset the password of a user not in their group
     Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |


### PR DESCRIPTION
## Description
This PR enables the ocs api tests which have been implemented in ocis.

## Related Issue
- https://github.com/owncloud/ocis/issues/512

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/513


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
