### PR TITLE
Add ability to explicitly set an license implementation via system co…

### DIFF
--- a/changelog/unreleased/37827
+++ b/changelog/unreleased/37827
@@ -1,0 +1,5 @@
+Change: Add system config to load a different license implementation
+
+The default license implementation can now be replaced.
+
+https://github.com/owncloud/core/pull/37827

--- a/lib/base.php
+++ b/lib/base.php
@@ -582,10 +582,11 @@ class OC {
 		\stream_wrapper_register('quota', 'OC\Files\Stream\Quota');
 
 		\OC::$server->getEventLogger()->start('init_session', 'Initialize session');
-		OC_App::loadApps(['session', 'theme']);
+		OC_App::loadApps(['session']);
 		if (!self::$CLI) {
 			self::initSession();
 		}
+		OC_App::loadApps(['license', 'theme']);
 
 		\OC::$server->getEventLogger()->end('init_session');
 

--- a/lib/private/License/ILicense.php
+++ b/lib/private/License/ILicense.php
@@ -20,8 +20,8 @@
 namespace OC\License;
 
 interface ILicense {
-	const LICENSE_TYPE_NORMAL = 0;
-	const LICENSE_TYPE_DEMO = 1;
+	public const LICENSE_TYPE_NORMAL = 0;
+	public const LICENSE_TYPE_DEMO = 1;
 
 	/**
 	 * get the raw license string, such as "owncloud_28731_df987_234sf"

--- a/lib/public/License/ILicenseManager.php
+++ b/lib/public/License/ILicenseManager.php
@@ -34,17 +34,17 @@ namespace OCP\License;
  */
 interface ILicenseManager {
 	/** The license is valid and hasn't expired yet */
-	const LICENSE_STATE_VALID = 0;
+	public const LICENSE_STATE_VALID = 0;
 	/** No license found */
-	const LICENSE_STATE_MISSING = 1;
+	public const LICENSE_STATE_MISSING = 1;
 	/** The license is invalid or broken. Couldn't parse the license properly */
-	const LICENSE_STATE_INVALID = 2;
+	public const LICENSE_STATE_INVALID = 2;
 	/** The license is "valid" (not broken, can be parsed) but has expired */
-	const LICENSE_STATE_EXPIRED = 3;
+	public const LICENSE_STATE_EXPIRED = 3;
 	/** The license is valid and it's close to its expiration date */
-	const LICENSE_STATE_ABOUT_TO_EXPIRE = 4;
+	public const LICENSE_STATE_ABOUT_TO_EXPIRE = 4;
 
-	const THRESHOLD_ABOUT_TO_EXPIRE = 60;  // 60 days
+	public const THRESHOLD_ABOUT_TO_EXPIRE = 60;  // 60 days
 
 	/**
 	 * @since 10.5.0
@@ -89,6 +89,9 @@ interface ILicenseManager {
 	public function getLicenseStateFor(string $appid): int;
 
 	/**
+	 * @param string $appid the application to be checked
+	 * @param string|null $language the language to translate the messages to.
+	 * @return array containing the information as described above
 	 * @since 10.5.0
 	 * Get a message suitable to be displayed with the state of the license for the app
 	 * The message will be translated to the requested language if there is translation
@@ -104,9 +107,6 @@ interface ILicenseManager {
 	 * "contains_html" -> an array containing which lines of the translated message contains html code
 	 *   The lines start counting at 0
 	 *
-	 * @param string $appid the aplication to be checked
-	 * @param string $language the language to translate the messages to.
-	 * @return array containing the information as described above
 	 */
 	public function getLicenseMessageFor(string $appid, string $language = null): array;
 


### PR DESCRIPTION
…nfig

## Description
An alternative license implementation can be loaded via the system config 'license-class'. 

## Related Issue
-    Fixes owncloud/enterprise#3991

## How Has This Been Tested?
- :hand: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
