### PR TITLE
[Tests-Only] Improve acceptance test error handling

### DIFF
--- a/tests/TestHelpers/AppConfigHelper.php
+++ b/tests/TestHelpers/AppConfigHelper.php
@@ -204,7 +204,7 @@ class AppConfigHelper extends \PHPUnit\Framework\Assert {
 	 * @return string
 	 */
 	public static function getOCSResponse($response) {
-		return HttpRequestHelper::getResponseXml($response)->meta[0]->statuscode;
+		return HttpRequestHelper::getResponseXml($response, __METHOD__)->meta[0]->statuscode;
 	}
 
 	/**
@@ -225,7 +225,15 @@ class AppConfigHelper extends \PHPUnit\Framework\Assert {
 			'/cloud/capabilities',
 			null
 		);
-		self::assertEquals(200, $response->getStatusCode());
+
+		$expectedHttpStatus = 200;
+		$actualHttpStatus = $response->getStatusCode();
+
+		self::assertEquals(
+			$expectedHttpStatus,
+			$actualHttpStatus,
+			__METHOD__ . " expected HTTP status $expectedHttpStatus but got $actualHttpStatus"
+		);
 		return $response;
 	}
 
@@ -235,7 +243,7 @@ class AppConfigHelper extends \PHPUnit\Framework\Assert {
 	 * @return string retrieved capabilities in XML format
 	 */
 	public static function getCapabilitiesXml($response) {
-		return HttpRequestHelper::getResponseXml($response)->data->capabilities;
+		return HttpRequestHelper::getResponseXml($response, __METHOD__)->data->capabilities;
 	}
 
 	/**
@@ -264,10 +272,22 @@ class AppConfigHelper extends \PHPUnit\Framework\Assert {
 			$body,
 			$ocsApiVersion
 		);
-		self::assertEquals("200", $response->getStatusCode());
+
+		$expectedHttpStatus = 200;
+		$actualHttpStatus = $response->getStatusCode();
+
+		self::assertEquals(
+			$expectedHttpStatus,
+			$actualHttpStatus,
+			__METHOD__ . " expected HTTP status $expectedHttpStatus but got $actualHttpStatus"
+		);
 		if ($ocsApiVersion === 1) {
+			$expectedOcsStatus = "100";
+			$actualOcsStatus = self::getOCSResponse($response);
 			self::assertEquals(
-				"100", self::getOCSResponse($response)
+				$expectedOcsStatus,
+				$actualOcsStatus,
+				__METHOD__ . " expected OCS status $expectedOcsStatus but got $actualOcsStatus"
 			);
 		}
 	}
@@ -303,10 +323,22 @@ class AppConfigHelper extends \PHPUnit\Framework\Assert {
 			$body,
 			$ocsApiVersion
 		);
-		self::assertEquals("200", $response->getStatusCode());
+
+		$expectedHttpStatus = 200;
+		$actualHttpStatus = $response->getStatusCode();
+
+		self::assertEquals(
+			$expectedHttpStatus,
+			$actualHttpStatus,
+			__METHOD__ . " expected HTTP status $expectedHttpStatus but got $actualHttpStatus"
+		);
 		if ($ocsApiVersion === 1) {
+			$expectedOcsStatus = "100";
+			$actualOcsStatus = self::getOCSResponse($response);
 			self::assertEquals(
-				"100", self::getOCSResponse($response)
+				$expectedOcsStatus,
+				$actualOcsStatus,
+				__METHOD__ . " expected OCS status $expectedOcsStatus but got $actualOcsStatus"
 			);
 		}
 	}
@@ -334,10 +366,22 @@ class AppConfigHelper extends \PHPUnit\Framework\Assert {
 			$body,
 			$ocsApiVersion
 		);
-		self::assertEquals("200", $response->getStatusCode());
+
+		$expectedHttpStatus = 200;
+		$actualHttpStatus = $response->getStatusCode();
+
+		self::assertEquals(
+			$expectedHttpStatus,
+			$actualHttpStatus,
+			__METHOD__ . " expected HTTP status $expectedHttpStatus but got $actualHttpStatus"
+		);
 		if ($ocsApiVersion === 1) {
+			$expectedOcsStatus = "100";
+			$actualOcsStatus = self::getOCSResponse($response);
 			self::assertEquals(
-				"100", self::getOCSResponse($response)
+				$expectedOcsStatus,
+				$actualOcsStatus,
+				__METHOD__ . " expected OCS status $expectedOcsStatus but got $actualOcsStatus"
 			);
 		}
 	}
@@ -364,10 +408,22 @@ class AppConfigHelper extends \PHPUnit\Framework\Assert {
 			$body,
 			$ocsApiVersion
 		);
-		self::assertEquals("200", $response->getStatusCode());
+
+		$expectedHttpStatus = 200;
+		$actualHttpStatus = $response->getStatusCode();
+
+		self::assertEquals(
+			$expectedHttpStatus,
+			$actualHttpStatus,
+			__METHOD__ . " expected HTTP status $expectedHttpStatus but got $actualHttpStatus"
+		);
 		if ($ocsApiVersion === 1) {
+			$expectedOcsStatus = "100";
+			$actualOcsStatus = self::getOCSResponse($response);
 			self::assertEquals(
-				"100", self::getOCSResponse($response)
+				$expectedOcsStatus,
+				$actualOcsStatus,
+				__METHOD__ . " expected OCS status $expectedOcsStatus but got $actualOcsStatus"
 			);
 		}
 	}
@@ -393,14 +449,26 @@ class AppConfigHelper extends \PHPUnit\Framework\Assert {
 			null,
 			$ocsApiVersion
 		);
-		self::assertEquals("200", $response->getStatusCode());
+
+		$expectedHttpStatus = 200;
+		$actualHttpStatus = $response->getStatusCode();
+
+		self::assertEquals(
+			$expectedHttpStatus,
+			$actualHttpStatus,
+			__METHOD__ . " expected HTTP status $expectedHttpStatus but got $actualHttpStatus"
+		);
 		if ($ocsApiVersion === 1) {
+			$expectedOcsStatus = "100";
+			$actualOcsStatus = self::getOCSResponse($response);
 			self::assertEquals(
-				"100", self::getOCSResponse($response)
+				$expectedOcsStatus,
+				$actualOcsStatus,
+				__METHOD__ . " expected OCS status $expectedOcsStatus but got $actualOcsStatus"
 			);
 		}
 
-		$responseXml = HttpRequestHelper::getResponseXml($response)->data[0];
+		$responseXml = HttpRequestHelper::getResponseXml($response, __METHOD__)->data[0];
 		$response = \json_decode(\json_encode($responseXml), true)['element'];
 		return $response;
 	}
@@ -427,14 +495,26 @@ class AppConfigHelper extends \PHPUnit\Framework\Assert {
 			null,
 			$ocsApiVersion
 		);
-		self::assertEquals("200", $response->getStatusCode());
+
+		$expectedHttpStatus = 200;
+		$actualHttpStatus = $response->getStatusCode();
+
+		self::assertEquals(
+			$expectedHttpStatus,
+			$actualHttpStatus,
+			__METHOD__ . " expected HTTP status $expectedHttpStatus but got $actualHttpStatus"
+		);
 		if ($ocsApiVersion === 1) {
+			$expectedOcsStatus = "100";
+			$actualOcsStatus = self::getOCSResponse($response);
 			self::assertEquals(
-				"100", self::getOCSResponse($response)
+				$expectedOcsStatus,
+				$actualOcsStatus,
+				__METHOD__ . " expected OCS status $expectedOcsStatus but got $actualOcsStatus"
 			);
 		}
 
-		$responseXml = HttpRequestHelper::getResponseXml($response)->data[0];
+		$responseXml = HttpRequestHelper::getResponseXml($response, __METHOD__)->data[0];
 		$response = \json_decode(\json_encode($responseXml), true)['element'];
 		return $response;
 	}

--- a/tests/TestHelpers/Asserts/WebDav.php
+++ b/tests/TestHelpers/Asserts/WebDav.php
@@ -34,15 +34,20 @@ class WebDav extends \PHPUnit\Framework\Assert {
 	 * @param string $element exception|message|reason
 	 * @param string $expectedValue
 	 * @param array $responseXml
+	 * @param string $extraErrorText
 	 *
 	 * @return void
-	 * @throws \Exception
 	 */
 	public static function assertDavResponseElementIs(
-		$element, $expectedValue, $responseXml
+		$element, $expectedValue, $responseXml, $extraErrorText = ''
 	) {
+		if ($extraErrorText !== '') {
+			$extraErrorText = $extraErrorText . " ";
+		}
 		self::assertArrayHasKey(
-			'value', $responseXml, '$responseXml seems not to be a valid array'
+			'value',
+			$responseXml,
+			$extraErrorText . "responseXml does not have key 'value'"
 		);
 		if ($element === "exception") {
 			$result = $responseXml['value'][0]['value'];
@@ -54,7 +59,7 @@ class WebDav extends \PHPUnit\Framework\Assert {
 
 		self::assertEquals(
 			$expectedValue, $result,
-			"Expected '$expectedValue' in element $element got '$result'"
+			__METHOD__ . " " . $extraErrorText . "Expected '$expectedValue' in element $element got '$result'"
 		);
 	}
 

--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -333,11 +333,12 @@ class HttpRequestHelper {
 	 *  | ocs    | http://open-collaboration-services.org/ns |
 	 *
 	 * @param ResponseInterface $response
+	 * @param string $exceptionText text to put at the front of exception messages
 	 *
 	 * @return SimpleXMLElement
 	 * @throws \Exception
 	 */
-	public static function getResponseXml($response) {
+	public static function getResponseXml($response, $exceptionText = '') {
 		// rewind just to make sure we can re-parse it in case it was parsed already...
 		$response->getBody()->rewind();
 		$contents = $response->getBody()->getContents();
@@ -354,10 +355,13 @@ class HttpRequestHelper {
 			);
 			return $responseXmlObject;
 		} catch (\Exception $e) {
-			if ($contents === '') {
-				throw new \Exception("Received empty response where XML was expected");
+			if ($exceptionText !== '') {
+				$exceptionText = $exceptionText . ' ';
 			}
-			$message = "Exception parsing response body: \"" . $contents . "\"";
+			if ($contents === '') {
+				throw new \Exception($exceptionText . "Received empty response where XML was expected");
+			}
+			$message = $exceptionText . "Exception parsing response body: \"" . $contents . "\"";
 			throw new \Exception($message, 0, $e);
 		}
 	}

--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -90,7 +90,7 @@ class LoggingHelper {
 				"could not get logfile content " . $result->getReasonPhrase()
 			);
 		}
-		return HttpRequestHelper::getResponseXml($result)->data->element;
+		return HttpRequestHelper::getResponseXml($result, __METHOD__)->data->element;
 	}
 
 	/**

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -251,7 +251,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 				"could not get sysinfo " . $result->getReasonPhrase()
 			);
 		}
-		return HttpRequestHelper::getResponseXml($result)->data;
+		return HttpRequestHelper::getResponseXml($result, __METHOD__)->data;
 	}
 
 	/**
@@ -505,7 +505,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			$response->getStatusCode(),
 			"Failed to read the file {$fileInCore}"
 		);
-		$localContent = HttpRequestHelper::getResponseXml($response);
+		$localContent = HttpRequestHelper::getResponseXml($response, __METHOD__);
 		$localContent = (string)$localContent->data->element->contentUrlEncoded;
 		return \urldecode($localContent);
 	}
@@ -561,7 +561,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			$response->getStatusCode(),
 			"Failed to read the file {$fileInSkeletonFolder}"
 		);
-		$localContent = HttpRequestHelper::getResponseXml($response);
+		$localContent = HttpRequestHelper::getResponseXml($response, __METHOD__);
 		$localContent = (string)$localContent->data->element->contentUrlEncoded;
 		$localContent = \urldecode($localContent);
 		return $localContent;

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -140,7 +140,7 @@ class TagsHelper extends \PHPUnit\Framework\Assert {
 		$response = WebDavHelper::propfind(
 			$baseUrl, $user, $password, '/systemtags/', $properties, 1, "systemtags"
 		);
-		return HttpRequestHelper::getResponseXml($response);
+		return HttpRequestHelper::getResponseXml($response, __METHOD__);
 	}
 
 	/**

--- a/tests/TestHelpers/UserHelper.php
+++ b/tests/TestHelpers/UserHelper.php
@@ -266,7 +266,7 @@ class UserHelper {
 		$baseUrl, $adminUser, $adminPassword, $search =""
 	) {
 		$result = self::getGroups($baseUrl, $adminUser, $adminPassword, $search);
-		$groups = HttpRequestHelper::getResponseXml($result)->xpath(".//groups")[0];
+		$groups = HttpRequestHelper::getResponseXml($result, __METHOD__)->xpath(".//groups")[0];
 		$return = [];
 		foreach ($groups as $group) {
 			$return[] = $group->__toString();

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -513,7 +513,10 @@ class WebDavHelper {
 			null,
 			$davVersionToUse
 		);
-		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
+		$responseXmlObject = HttpRequestHelper::getResponseXml(
+			$response,
+			__METHOD__
+		);
 		$xmlPart = $responseXmlObject->xpath("//d:getlastmodified");
 
 		return $xmlPart[0]->__toString();
@@ -538,7 +541,10 @@ class WebDavHelper {
 		$response = self::propfind(
 			$baseUrl, $user, $password, $resource, ["getlastmodified"]
 		);
-		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
+		$responseXmlObject = HttpRequestHelper::getResponseXml(
+			$response,
+			__METHOD__
+		);
 		$xmlpart = $responseXmlObject->xpath("//d:getlastmodified");
 		$mtime = new DateTime($xmlpart[0]->__toString());
 		return $mtime->format('U');

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -105,7 +105,7 @@ class AppConfigurationContext implements Context {
 	 */
 	public function getAppParameter($capabilitiesApp, $capabilitiesPath) {
 		$answeredValue = $this->getParameterValueFromXml(
-			$this->getCapabilitiesXml(),
+			$this->getCapabilitiesXml(__METHOD__),
 			$capabilitiesApp,
 			$capabilitiesPath
 		);
@@ -189,10 +189,15 @@ class AppConfigurationContext implements Context {
 	}
 
 	/**
+	 * @param string $exceptionText text to put at the front of exception messages
+	 *
 	 * @return string latest retrieved capabilities in XML format
 	 */
-	public function getCapabilitiesXml() {
-		return $this->featureContext->getResponseXml()->data->capabilities;
+	public function getCapabilitiesXml($exceptionText = '') {
+		if ($exceptionText === '') {
+			$exceptionText = __METHOD__;
+		}
+		return $this->featureContext->getResponseXml(null, $exceptionText)->data->capabilities;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -20,6 +20,7 @@
  */
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use TestHelpers\HttpRequestHelper;
 
@@ -109,21 +110,18 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 	/**
 	 * @Then the CalDAV HTTP status code should be :code
 	 *
-	 * @param int $code
+	 * @param string $expectedStatus
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function theCalDavHttpStatusCodeShouldBe($code) {
-		if ((int) $code !== $this->response->getStatusCode()) {
-			throw new \Exception(
-				\sprintf(
-					'Expected %s got %s',
-					(int) $code,
-					$this->response->getStatusCode()
-				)
-			);
-		}
+	public function theCalDavHttpStatusCodeShouldBe($expectedStatus) {
+		$actualStatus = $this->response->getStatusCode();
+		Assert::assertEquals(
+			(int) $expectedStatus,
+			$actualStatus,
+			__METHOD__ . " Expected HTTP status $expectedStatus but got $actualStatus"
+		);
 	}
 
 	/**
@@ -154,7 +152,7 @@ class CalDavContext implements \Behat\Behat\Context\Context {
 			$davUrl, "MKCALENDAR", $user,
 			$this->featureContext->getPasswordForUser($user), null, $body
 		);
-		$this->theCalDavHttpStatusCodeShouldBe(201);
+		$this->theCalDavHttpStatusCodeShouldBe("201");
 		$this->featureContext->setResponseXml(
 			HttpRequestHelper::parseResponseAsXml($this->response)
 		);

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -48,7 +48,7 @@ class CapabilitiesContext implements Context {
 	 * @return void
 	 */
 	public function checkCapabilitiesResponse(TableNode $formData) {
-		$capabilitiesXML = $this->featureContext->appConfigurationContext->getCapabilitiesXml();
+		$capabilitiesXML = $this->featureContext->appConfigurationContext->getCapabilitiesXml(__METHOD__);
 		$assertedSomething = false;
 
 		$this->featureContext->verifyTableNodeColumns($formData, ['value', 'path_to_element', 'capability']);
@@ -87,7 +87,7 @@ class CapabilitiesContext implements Context {
 		$this->featureContext->appConfigurationContext->userGetsCapabilitiesCheckResponse(
 			$this->featureContext->getCurrentUser()
 		);
-		$capabilitiesXML = $this->featureContext->appConfigurationContext->getCapabilitiesXml();
+		$capabilitiesXML = $this->featureContext->appConfigurationContext->getCapabilitiesXml(__METHOD__);
 		$actualValue = $this->featureContext->appConfigurationContext->getParameterValueFromXml(
 			$capabilitiesXML,
 			"files_sharing",
@@ -108,7 +108,7 @@ class CapabilitiesContext implements Context {
 	 * @return void
 	 */
 	public function theCapabilitiesShouldNotContain(TableNode $formData) {
-		$capabilitiesXML = $this->featureContext->appConfigurationContext->getCapabilitiesXml();
+		$capabilitiesXML = $this->featureContext->appConfigurationContext->getCapabilitiesXml(__METHOD__);
 		$assertedSomething = false;
 
 		foreach ($formData->getHash() as $row) {

--- a/tests/acceptance/features/bootstrap/CommentsContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsContext.php
@@ -140,7 +140,7 @@ class CommentsContext implements Context {
 		// limiting number of results and start from first (offset)
 		$properties = '<oc:limit>200</oc:limit><oc:offset>0</oc:offset>';
 		$elementList = $this->reportElementComments(
-			$user, $commentsPath, $properties
+			$user, $commentsPath, $properties, __METHOD__
 		);
 
 		$this->featureContext->verifyTableNodeColumns($expectedElements, ['user', 'comment']);
@@ -197,7 +197,7 @@ class CommentsContext implements Context {
 		$commentsPath = "/comments/files/$fileId/";
 		$properties = '<oc:limit>200</oc:limit><oc:offset>0</oc:offset>';
 		$elementList = $this->reportElementComments(
-			$user, $commentsPath, $properties
+			$user, $commentsPath, $properties, __METHOD__
 		);
 		$messages = $elementList->xpath("//d:prop/oc:message");
 		Assert::assertCount(
@@ -411,11 +411,12 @@ class CommentsContext implements Context {
 	 * @param string $user
 	 * @param string $path
 	 * @param string $properties properties which needs to be included in the report
+	 * @param string $exceptionText text to put at the front of exception messages
 	 *
 	 * @return SimpleXMLElement
 	 *
 	 */
-	public function reportElementComments($user, $path, $properties) {
+	public function reportElementComments($user, $path, $properties, $exceptionText = '') {
 		$body = '<?xml version="1.0" encoding="utf-8" ?>
 							 <oc:filter-comments xmlns:a="DAV:" xmlns:oc="http://owncloud.org/ns" >
 									' . $properties . '
@@ -426,23 +427,25 @@ class CommentsContext implements Context {
 			$this->featureContext->getPasswordForUser($user), 'REPORT', $path, [],
 			$body, $this->featureContext->getDavPathVersion(), "comments"
 		);
-		return HttpRequestHelper::getResponseXml($response);
+		return HttpRequestHelper::getResponseXml($response, $exceptionText);
 	}
 
 	/**
 	 * @param string $user
 	 * @param string $path
+	 * @param string $exceptionText text to put at the front of exception messages
 	 *
 	 * @return void
 	 */
-	public function getAllInfoOfCommentsOfFolderUsingTheWebdavReportApi($user, $path) {
+	public function getAllInfoOfCommentsOfFolderUsingTheWebdavReportApi($user, $path, $exceptionText = '') {
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
 		$commentsPath = "/comments/files/$fileId/";
 		$this->featureContext->setResponseXmlObject(
 			$this->reportElementComments(
 				$user,
 				$commentsPath,
-				'<oc:limit>200</oc:limit><oc:offset>0</oc:offset>'
+				'<oc:limit>200</oc:limit><oc:offset>0</oc:offset>',
+				$exceptionText
 			)
 		);
 	}
@@ -456,7 +459,11 @@ class CommentsContext implements Context {
 	 * @return void
 	 */
 	public function userGetsAllInfoOfCommentsOfFolderUsingTheWebdavReportApi($user, $path) {
-		$this->getAllInfoOfCommentsOfFolderUsingTheWebdavReportApi($user, $path);
+		$this->getAllInfoOfCommentsOfFolderUsingTheWebdavReportApi(
+			$user,
+			$path,
+			__METHOD__
+		);
 	}
 
 	/**
@@ -469,7 +476,8 @@ class CommentsContext implements Context {
 	public function theUserGetsAllInfoOfCommentsOfFolderUsingTheWebdavReportApi($path) {
 		$this->getAllInfoOfCommentsOfFolderUsingTheWebdavReportApi(
 			$this->featureContext->getCurrentUser(),
-			$path
+			$path,
+			__METHOD__
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/CorsContext.php
+++ b/tests/acceptance/features/bootstrap/CorsContext.php
@@ -22,6 +22,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -97,9 +98,15 @@ class CorsContext implements Context {
 			]
 		);
 		$domains = \json_decode($this->featureContext->getStdOutOfOccCommand());
+
+		Assert::assertIsArray(
+			$domains,
+			__METHOD__ . " The output of 'occ user:setting $user core domains' was not valid JSON"
+		);
+
 		if (!\in_array($domain, $domains)) {
 			throw new \Exception(
-				"domain {$domain} is not included in CORS domain {$domains}, but was expected to be"
+				"domain $domain is not included in CORS domain $domains, but was expected to be"
 			);
 		}
 	}

--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -178,7 +178,10 @@ class EncryptionContext implements Context {
 		$this->featureContext->readFileInServerRoot($filePath);
 
 		$response = $this->featureContext->getResponse();
-		$parsedResponse = HttpRequestHelper::getResponseXml($response);
+		$parsedResponse = HttpRequestHelper::getResponseXml(
+			$response,
+			__METHOD__
+		);
 		$encodedFileContent = (string) $parsedResponse->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($encodedFileContent);
 
@@ -206,7 +209,10 @@ class EncryptionContext implements Context {
 		$this->featureContext->readFileInServerRoot($filePath);
 
 		$response = $this->featureContext->getResponse();
-		$parsedResponse = HttpRequestHelper::getResponseXml($this->featureContext->getResponse());
+		$parsedResponse = HttpRequestHelper::getResponseXml(
+			$this->featureContext->getResponse(),
+			__METHOD__
+		);
 		$encodedFileContent = (string) $parsedResponse->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($encodedFileContent);
 		$expectedContentStart = "HBEGIN:oc_encryption_module:OC_DEFAULT_MODULE:cipher:AES-256-CTR:signed:true";

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1123,15 +1123,19 @@ class FeatureContext extends BehatVariablesContext {
 	 * Parses the response as XML
 	 *
 	 * @param ResponseInterface $response
+	 * @param string $exceptionText text to put at the front of exception messages
 	 *
 	 * @return SimpleXMLElement
 	 */
-	public function getResponseXml($response = null) {
+	public function getResponseXml($response = null, $exceptionText = '') {
 		if ($response === null) {
 			$response = $this->response;
 		}
 
-		return HttpRequestHelper::getResponseXml($response);
+		if ($exceptionText === '') {
+			$exceptionText = __METHOD__;
+		}
+		return HttpRequestHelper::getResponseXml($response, $exceptionText);
 	}
 
 	/**
@@ -1144,7 +1148,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @return string
 	 */
 	public function getXMLKey1Key2Value($response, $key1, $key2) {
-		return $this->getResponseXml($response)->$key1->$key2;
+		return $this->getResponseXml($response, __METHOD__)->$key1->$key2;
 	}
 
 	/**
@@ -1158,7 +1162,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @return string
 	 */
 	public function getXMLKey1Key2Key3Value($response, $key1, $key2, $key3) {
-		return $this->getResponseXml($response)->$key1->$key2->$key3;
+		return $this->getResponseXml($response, __METHOD__)->$key1->$key2->$key3;
 	}
 
 	/**
@@ -1175,7 +1179,7 @@ class FeatureContext extends BehatVariablesContext {
 	public function getXMLKey1Key2Key3AttributeValue(
 		$response, $key1, $key2, $key3, $attribute
 	) {
-		return (string) $this->getResponseXml($response)->$key1->$key2->$key3->attributes()->$attribute;
+		return (string) $this->getResponseXml($response, __METHOD__)->$key1->$key2->$key3->attributes()->$attribute;
 	}
 
 	/**
@@ -2272,7 +2276,7 @@ class FeatureContext extends BehatVariablesContext {
 
 		$this->appConfigurationContext->theAdministratorGetsCapabilitiesCheckResponse();
 		$edition = $this->appConfigurationContext->getParameterValueFromXml(
-			$this->appConfigurationContext->getCapabilitiesXml(),
+			$this->appConfigurationContext->getCapabilitiesXml(__METHOD__),
 			'core',
 			'status@@@edition'
 		);
@@ -2284,7 +2288,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 
 		$productName = $this->appConfigurationContext->getParameterValueFromXml(
-			$this->appConfigurationContext->getCapabilitiesXml(),
+			$this->appConfigurationContext->getCapabilitiesXml(__METHOD__),
 			'core',
 			'status@@@productname'
 		);
@@ -2376,7 +2380,10 @@ class FeatureContext extends BehatVariablesContext {
 			$this->getResponse()->getStatusCode(),
 			"Failed to read the file {$path}"
 		);
-		$fileContent = HttpRequestHelper::getResponseXml($this->getResponse());
+		$fileContent = HttpRequestHelper::getResponseXml(
+			$this->getResponse(),
+			__METHOD__
+		);
 		$fileContent = (string) $fileContent->data->element->contentUrlEncoded;
 		$fileContent = \urldecode($fileContent);
 
@@ -2780,7 +2787,7 @@ class FeatureContext extends BehatVariablesContext {
 			[],
 			$this->getOcsApiVersion()
 		);
-		$configkeyValue = (string) $this->getResponseXml($response)->data[0]->element->value;
+		$configkeyValue = (string) $this->getResponseXml($response, __METHOD__)->data[0]->element->value;
 		Assert::assertEquals(
 			$value, $configkeyValue,
 			"The config key {$key} of app {$appID} was expected to have value {$value} but got {$configkeyValue}"
@@ -2815,10 +2822,14 @@ class FeatureContext extends BehatVariablesContext {
 	 * Returns a list of config keys for the given app
 	 *
 	 * @param string $appID
+	 * @param string $exceptionText text to put at the front of exception messages
 	 *
 	 * @return array
 	 */
-	public function getConfigKeyList($appID) {
+	public function getConfigKeyList($appID, $exceptionText = '') {
+		if ($exceptionText === '') {
+			$exceptionText = __METHOD__;
+		}
 		$response = OcsApiHelper::sendRequest(
 			$this->getBaseUrl(),
 			$this->getAdminUsername(),
@@ -2828,7 +2839,9 @@ class FeatureContext extends BehatVariablesContext {
 			[],
 			$this->getOcsApiVersion()
 		);
-		return $this->parseConfigListFromResponseXml($this->getResponseXml($response));
+		return $this->parseConfigListFromResponseXml(
+			$this->getResponseXml($response, $exceptionText)
+		);
 	}
 
 	/**
@@ -3321,7 +3334,7 @@ class FeatureContext extends BehatVariablesContext {
 	public function resetAppConfigs() {
 		// Remember the current capabilities
 		$this->appConfigurationContext->theAdministratorGetsCapabilitiesCheckResponse();
-		$this->savedCapabilitiesXml[$this->getBaseUrl()] = $this->appConfigurationContext->getCapabilitiesXml();
+		$this->savedCapabilitiesXml[$this->getBaseUrl()] = $this->appConfigurationContext->getCapabilitiesXml(__METHOD__);
 		// Set the required starting values for testing
 		$this->setCapabilities($this->getCommonSharingConfigs());
 	}
@@ -3612,7 +3625,8 @@ class FeatureContext extends BehatVariablesContext {
 			throw new Exception("Could not get the list of trusted servers" . $response->getBody()->getContents());
 		}
 		$responseXml = HttpRequestHelper::getResponseXml(
-			$response
+			$response,
+			__METHOD__
 		);
 		$serverData = \json_decode(
 			\json_encode(

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -160,7 +160,7 @@ class FederationContext implements Context {
 		$previous = $this->featureContext->usingServer($server);
 		$this->userGetsTheListOfPendingFederatedCloudShares($user);
 		$share_id = SharingHelper::getLastShareIdFromResponse(
-			$this->featureContext->getResponseXml()
+			$this->featureContext->getResponseXml(null, __METHOD__)
 		);
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
@@ -197,7 +197,7 @@ class FederationContext implements Context {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->userGetsTheListOfFederatedCloudShares($user);
 		$share_id = SharingHelper::getLastShareIdFromResponse(
-			$this->featureContext->getResponseXml()
+			$this->featureContext->getResponseXml(null, __METHOD__)
 		);
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
@@ -216,7 +216,7 @@ class FederationContext implements Context {
 	 */
 	public function userShouldHaveNoLastPendingFederatedCloudShare($user) {
 		$this->userGetsTheListOfPendingFederatedCloudShares($user);
-		$responseXml = $this->featureContext->getResponseXml();
+		$responseXml = $this->featureContext->getResponseXml(null, __METHOD__);
 		$xmlPart = $responseXml->xpath("//data/element[last()]/id");
 		Assert::assertTrue(
 			!\is_array($xmlPart) || (\count($xmlPart) === 0),
@@ -235,7 +235,7 @@ class FederationContext implements Context {
 	public function userRetrievesInformationOfLastPendingFederatedShare($user) {
 		$this->userGetsTheListOfPendingFederatedCloudShares($user);
 		$share_id = SharingHelper::getLastShareIdFromResponse(
-			$this->featureContext->getResponseXml()
+			$this->featureContext->getResponseXml(null, __METHOD__)
 		);
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
@@ -297,7 +297,7 @@ class FederationContext implements Context {
 			$this->userGetsTheListOfFederatedCloudShares($user);
 		}
 		$share_id = SharingHelper::getLastShareIdFromResponse(
-			$this->featureContext->getResponseXml()
+			$this->featureContext->getResponseXml(null, __METHOD__)
 		);
 		if ($shareType === "pending") {
 			$url = "/apps/files_sharing/api/v1/remote_shares/pending/$share_id";

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -155,7 +155,10 @@ class FilesVersionsContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user, $password, $path, $properties, $folderDepth, "versions"
 		);
-		$responseXml = HttpRequestHelper::getResponseXml($response);
+		$responseXml = HttpRequestHelper::getResponseXml(
+			$response,
+			__METHOD__
+		);
 		return $responseXml;
 	}
 

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -783,7 +783,7 @@ class OCSContext implements Context {
 	 * @throws \Exception
 	 */
 	public function getOCSResponseStatusCode($response) {
-		$responseXml = $this->featureContext->getResponseXml($response);
+		$responseXml = $this->featureContext->getResponseXml($response, __METHOD__);
 		if (isset($responseXml->meta[0], $responseXml->meta[0]->statuscode)) {
 			return (string) $responseXml->meta[0]->statuscode;
 		}
@@ -801,7 +801,7 @@ class OCSContext implements Context {
 	 * @return string
 	 */
 	public function getOCSResponseStatusMessage($response) {
-		return (string) $this->featureContext->getResponseXml($response)->meta[0]->message;
+		return (string) $this->featureContext->getResponseXml($response, __METHOD__)->meta[0]->message;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -880,7 +880,7 @@ trait Provisioning {
 			// Retrieve all failures.
 			foreach ($results as $e) {
 				if ($e instanceof ClientException) {
-					$responseXml = $this->getResponseXml($e->getResponse());
+					$responseXml = $this->getResponseXml($e->getResponse(), __METHOD__);
 					$messageText = (string) $responseXml->xpath("/ocs/meta/message")[0];
 					$ocsStatusCode = (string) $responseXml->xpath("/ocs/meta/statuscode")[0];
 					$httpStatusCode = $e->getResponse()->getStatusCode();
@@ -3700,7 +3700,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theDisplayNameReturnedByTheApiShouldBe($expectedDisplayName) {
-		$responseDisplayName = (string) $this->getResponseXml()->data[0]->displayname;
+		$responseDisplayName = (string) $this->getResponseXml(null, __METHOD__)->data[0]->displayname;
 		Assert::assertEquals(
 			$expectedDisplayName,
 			$responseDisplayName
@@ -3728,7 +3728,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theEmailAddressReturnedByTheApiShouldBe($expectedEmailAddress) {
-		$responseEmailAddress = (string) $this->getResponseXml()->data[0]->email;
+		$responseEmailAddress = (string) $this->getResponseXml(null, __METHOD__)->data[0]->email;
 		Assert::assertEquals(
 			$expectedEmailAddress,
 			$responseEmailAddress
@@ -3757,7 +3757,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theQuotaDefinitionReturnedByTheApiShouldBe($expectedQuotaDefinition) {
-		$responseQuotaDefinition = (string) $this->getResponseXml()->data[0]->quota->definition;
+		$responseQuotaDefinition = (string) $this->getResponseXml(null, __METHOD__)->data[0]->quota->definition;
 		Assert::assertEquals(
 			$expectedQuotaDefinition,
 			$responseQuotaDefinition
@@ -3786,7 +3786,7 @@ trait Provisioning {
 	 */
 	public function getArrayOfUsersResponded($resp) {
 		$listCheckedElements
-			= $this->getResponseXml($resp)->data[0]->users[0]->element;
+			= $this->getResponseXml($resp, __METHOD__)->data[0]->users[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -3801,7 +3801,7 @@ trait Provisioning {
 	 */
 	public function getArrayOfGroupsResponded($resp) {
 		$listCheckedElements
-			= $this->getResponseXml($resp)->data[0]->groups[0]->element;
+			= $this->getResponseXml($resp, __METHOD__)->data[0]->groups[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -3816,7 +3816,7 @@ trait Provisioning {
 	 */
 	public function getArrayOfAppsResponded($resp) {
 		$listCheckedElements
-			= $this->getResponseXml($resp)->data[0]->apps[0]->element;
+			= $this->getResponseXml($resp, __METHOD__)->data[0]->apps[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -3831,7 +3831,7 @@ trait Provisioning {
 	 */
 	public function getArrayOfSubadminsResponded($resp) {
 		$listCheckedElements
-			= $this->getResponseXml($resp)->data[0]->element;
+			= $this->getResponseXml($resp, __METHOD__)->data[0]->element;
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -3846,7 +3846,7 @@ trait Provisioning {
 	 */
 	public function getArrayOfAppInfoResponded($resp) {
 		$listCheckedElements
-			= $this->getResponseXml($resp)->data[0];
+			= $this->getResponseXml($resp, __METHOD__)->data[0];
 		$extractedElementsArray
 			= \json_decode(\json_encode($listCheckedElements), 1);
 		return $extractedElementsArray;
@@ -3934,7 +3934,7 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		Assert::assertEquals(
-			"false", $this->getResponseXml()->data[0]->enabled
+			"false", $this->getResponseXml(null, __METHOD__)->data[0]->enabled
 		);
 	}
 
@@ -3953,7 +3953,7 @@ trait Provisioning {
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
 		Assert::assertEquals(
-			"true", $this->getResponseXml()->data[0]->enabled
+			"true", $this->getResponseXml(null, __METHOD__)->data[0]->enabled
 		);
 	}
 
@@ -4032,7 +4032,7 @@ trait Provisioning {
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
 		);
-		return $this->getResponseXml()->data[0]->home;
+		return $this->getResponseXml(null, __METHOD__)->data[0]->home;
 	}
 
 	/**
@@ -4046,7 +4046,7 @@ trait Provisioning {
 		$this->verifyTableNodeRows($body, [], $this->userResponseFields);
 		$bodyRows = $body->getRowsHash();
 		foreach ($bodyRows as $field => $value) {
-			$data = $this->getResponseXml()->data[0];
+			$data = $this->getResponseXml(null, __METHOD__)->data[0];
 			$field_array = \explode(' ', $field);
 			foreach ($field_array as $field_name) {
 				$data = $data->$field_name;
@@ -4083,7 +4083,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theApiShouldNotReturnAnyData() {
-		$responseData = $this->getResponseXml()->data[0];
+		$responseData = $this->getResponseXml(null, __METHOD__)->data[0];
 		Assert::assertEmpty(
 			$responseData,
 			"Response data is not empty but it should be empty"
@@ -4096,7 +4096,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theListOfUsersReturnedByTheApiShouldBeEmpty() {
-		$usersList = $this->getResponseXml()->data[0]->users[0];
+		$usersList = $this->getResponseXml(null, __METHOD__)->data[0]->users[0];
 		Assert::assertEmpty(
 			$usersList,
 			"Users list is not empty but it should be empty"
@@ -4109,7 +4109,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function theListOfGroupsReturnedByTheApiShouldBeEmpty() {
-		$groupsList = $this->getResponseXml()->data[0]->groups[0];
+		$groupsList = $this->getResponseXml(null, __METHOD__)->data[0]->groups[0];
 		Assert::assertEmpty(
 			$groupsList,
 			"Groups list is not empty but it should be empty"

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -141,7 +141,7 @@ class ShareesContext implements Context {
 	public function getArrayOfShareesResponded(
 		ResponseInterface $response, $shareeType
 	) {
-		$elements = $this->featureContext->getResponseXml($response)->data;
+		$elements = $this->featureContext->getResponseXml($response, __METHOD__)->data;
 		$elements = \json_decode(\json_encode($elements), 1);
 		if (\strpos($shareeType, 'exact ') === 0) {
 			$elements = $elements['exact'];

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -1148,7 +1148,10 @@ class TagsContext implements Context {
 			$this->featureContext->getDavPathVersion('systemtags')
 		);
 		$this->featureContext->setResponse($response);
-		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
+		$responseXmlObject = HttpRequestHelper::getResponseXml(
+			$response,
+			__METHOD__
+		);
 		return $responseXmlObject;
 	}
 
@@ -1678,7 +1681,10 @@ class TagsContext implements Context {
 			$baseUrl, $user, $password, "REPORT", null, null, $body, 2
 		);
 		$this->featureContext->setResponse($response);
-		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
+		$responseXmlObject = HttpRequestHelper::getResponseXml(
+			$response,
+			__METHOD__
+		);
 		$responseXmlObject->registerXPathNamespace('d', 'DAV:');
 		$responseXmlObject->registerXPathNamespace('oc', 'http://owncloud.org/ns');
 		$this->featureContext->setResponseXmlObject($responseXmlObject);

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -160,7 +160,10 @@ class TrashbinContext implements Context {
 			],
 			'trash-bin'
 		);
-		$responseXml = HttpRequestHelper::getResponseXml($response);
+		$responseXml = HttpRequestHelper::getResponseXml(
+			$response,
+			__METHOD__
+		);
 
 		$this->featureContext->setResponseXmlObject($responseXml);
 		$files = $this->getTrashbinContentFromResponseXml($responseXml);
@@ -205,7 +208,10 @@ class TrashbinContext implements Context {
 			2
 		);
 		$this->featureContext->setResponse($response);
-		$responseXmlObject = HttpRequestHelper::getResponseXml($response);
+		$responseXmlObject = HttpRequestHelper::getResponseXml(
+			$response,
+			__METHOD__
+		);
 		$this->featureContext->setResponseXmlObject($responseXmlObject);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -402,7 +402,10 @@ trait WebDav {
 	public function theNumberOfVersionsShouldBe($number) {
 		$resXml = $this->getResponseXmlObject();
 		if ($resXml === null) {
-			$resXml = HttpRequestHelper::getResponseXml($this->getResponse());
+			$resXml = HttpRequestHelper::getResponseXml(
+				$this->getResponse(),
+				__METHOD__
+			);
 		}
 		$xmlPart = $resXml->xpath("//d:getlastmodified");
 		$actualNumber = \count($xmlPart);
@@ -514,12 +517,14 @@ trait WebDav {
 		$this->response = $this->makeDavRequest(
 			$user, "MOVE", $fileSource, $headers
 		);
-		if ($this->response->getStatusCode() !== 201) {
-			throw new Exception(
-				__METHOD__ . " Failed moving resource '$fileSource' to '$fileDestination'."
-				. " Expected status code was '201' but got '" . $this->response->getStatusCode() . "'"
-			);
-		}
+		$expectedStatusCode = 201;
+		$actualStatusCode = $this->response->getStatusCode();
+		Assert::assertEquals(
+			$expectedStatusCode,
+			$actualStatusCode,
+			__METHOD__ . " Failed moving resource '$fileSource' to '$fileDestination'."
+			. " Expected status code was '$expectedStatusCode' but got '$actualStatusCode'"
+		);
 	}
 
 	/**
@@ -1193,7 +1198,10 @@ trait WebDav {
 	 * @return void
 	 */
 	public function theSizeOfTheFileShouldBe($size) {
-		$responseXml = HttpRequestHelper::getResponseXml($this->response);
+		$responseXml = HttpRequestHelper::getResponseXml(
+			$this->response,
+			__METHOD__
+		);
 		$xmlPart = $responseXml->xpath("//d:prop/d:getcontentlength");
 		$actualSize = (string) $xmlPart[0];
 		Assert::assertEquals(
@@ -1319,7 +1327,8 @@ trait WebDav {
 		if ($statusCode < 401 || $statusCode > 404) {
 			try {
 				$this->responseXmlObject = HttpRequestHelper::getResponseXml(
-					$response
+					$response,
+					__METHOD__
 				);
 			} catch (\Exception $e) {
 				Assert::fail(
@@ -1447,7 +1456,8 @@ trait WebDav {
 		return HttpRequestHelper::getResponseXml(
 			$this->listFolder(
 				$user, $path, $folderDepth, $properties, $type
-			)
+			),
+			__METHOD__
 		);
 	}
 
@@ -1522,7 +1532,7 @@ trait WebDav {
 				&& (!isset($element[0]) || $element[0]->__toString() !== $webdavPath)
 			) {
 				Assert::fail(
-					"$webdavPath is not in propfind answer but should"
+					"$webdavPath is not in propfind answer but should be"
 				);
 			} elseif (!$expectedToBeListed && isset($element[0])
 			) {
@@ -3360,7 +3370,7 @@ trait WebDav {
 	 */
 	public function theDavElementShouldBe($element, $message) {
 		WebDavAssert::assertDavResponseElementIs(
-			$element, $message, $this->responseXml
+			$element, $message, $this->responseXml, __METHOD__
 		);
 	}
 
@@ -3430,6 +3440,15 @@ trait WebDav {
 				HttpRequestHelper::parseResponseAsXml($this->response)
 			);
 		}
+		Assert::assertIsArray(
+			$this->responseXml,
+			__METHOD__ . " responseXml is not an array"
+		);
+		Assert::assertArrayHasKey(
+			"value",
+			$this->responseXml,
+			__METHOD__ . " responseXml does not have key 'value'"
+		);
 		$multistatusResults = $this->responseXml["value"];
 		if ($multistatusResults === null) {
 			$multistatusResults = [];
@@ -3548,6 +3567,15 @@ trait WebDav {
 		// topWebDavPath should be something like /remote.php/webdav/ or
 		// /remote.php/dav/files/alice/
 		$topWebDavPath = "/" . $this->getFullDavFilesPath($user) . "/";
+		Assert::assertIsArray(
+			$this->responseXml,
+			__METHOD__ . " responseXml for user $user is not an array"
+		);
+		Assert::assertArrayHasKey(
+			"value",
+			$this->responseXml,
+			__METHOD__ . " responseXml for user $user does not have key 'value'"
+		);
 		$multistatusResults = $this->responseXml["value"];
 		$results = [];
 		if ($multistatusResults !== null) {

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -97,7 +97,7 @@ class WebDavLockingContext implements Context {
 		);
 
 		$this->featureContext->setResponse($response);
-		$responseXml = $this->featureContext->getResponseXml();
+		$responseXml = $this->featureContext->getResponseXml(null, __METHOD__);
 		$this->featureContext->setResponseXmlObject($responseXml);
 		$xmlPart = $responseXml->xpath("//d:locktoken/d:href");
 		if (isset($xmlPart[0])) {
@@ -453,7 +453,7 @@ class WebDavLockingContext implements Context {
 			$baseUrl, $user, $password, "PROPFIND", $file, null, $body,
 			$this->featureContext->getDavPathVersion()
 		);
-		$responseXml = $this->featureContext->getResponseXml($response);
+		$responseXml = $this->featureContext->getResponseXml($response, __METHOD__);
 		$xmlPart = $responseXml->xpath("//d:response//d:lockdiscovery/d:activelock");
 		Assert::assertCount(
 			(int) $count, $xmlPart,

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -370,7 +370,10 @@ class WebDavPropertiesContext implements Context {
 		$propertyName, $namespaceString, $propertyValue
 	) {
 		$this->featureContext->setResponseXmlObject(
-			HttpRequestHelper::getResponseXml($this->featureContext->getResponse())
+			HttpRequestHelper::getResponseXml(
+				$this->featureContext->getResponse(),
+				__METHOD__
+			)
 		);
 		$responseXmlObject = $this->featureContext->getResponseXmlObject();
 		//calculate the namespace prefix and namespace
@@ -410,7 +413,10 @@ class WebDavPropertiesContext implements Context {
 		// let's unescape quotes first
 		$propertyValue = \str_replace('\"', '"', $propertyValue);
 		$this->featureContext->setResponseXmlObject(
-			HttpRequestHelper::getResponseXml($this->featureContext->getResponse())
+			HttpRequestHelper::getResponseXml(
+				$this->featureContext->getResponse(),
+				__METHOD__
+			)
 		);
 		$responseXmlObject = $this->featureContext->getResponseXmlObject();
 		//calculate the namespace prefix and namespace
@@ -573,7 +579,10 @@ class WebDavPropertiesContext implements Context {
 	public function assertValueOfItemInResponseAboutUserIs($xpath, $user, $expectedValue) {
 		$resXml = $this->featureContext->getResponseXmlObject();
 		if ($resXml === null) {
-			$resXml = HttpRequestHelper::getResponseXml($this->featureContext->getResponse());
+			$resXml = HttpRequestHelper::getResponseXml(
+				$this->featureContext->getResponse(),
+				__METHOD__
+			);
 		}
 		$xmlPart = $resXml->xpath($xpath);
 		Assert::assertTrue(
@@ -621,7 +630,10 @@ class WebDavPropertiesContext implements Context {
 	public function assertValueOfItemInResponseToUserRegExp($xpath, $user, $pattern) {
 		$resXml = $this->featureContext->getResponseXmlObject();
 		if ($resXml === null) {
-			$resXml = HttpRequestHelper::getResponseXml($this->featureContext->getResponse());
+			$resXml = HttpRequestHelper::getResponseXml(
+				$this->featureContext->getResponse(),
+				__METHOD__
+			);
 		}
 		$xmlPart = $resXml->xpath($xpath);
 		Assert::assertTrue(

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1076,12 +1076,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 				break;
 			}
 		}
-		if ($found === false) {
-			throw new Exception(
-				__METHOD__ .
-				" could not find share '$share' offered by '$offeredByUserDisplayName'"
-			);
-		}
+		Assert::assertTrue(
+			$found,
+			__METHOD__ . " could not find share '$share' offered by '$offeredByUserDisplayName'"
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
When I run the `toImplementOnOCIS` oC10 API tests on OCIS, there are lots of failures - which is expected. Those test scenarios are for things that are (mostly) not yet implemented on OCIS.

But in many places the failure message is not helpful.

Improve the error handling so that more helpful test failure messages are emitted.

## Related Issue
https://github.com/owncloud/ocis-reva/issues/415

## How Has This Been Tested?
CI
https://github.com/owncloud/ocis-reva/pull/460

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
