### PR TITLE
[Tests-Only] subadmin and app-enable-disable-list are notToImplementOnOCIS

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app
@@ -15,7 +15,6 @@ Feature: disable an app
     And the HTTP status code should be "200"
     And app "comments" should be disabled
 
-  @notToImplementOnOCIS
   Scenario: subadmin tries to disable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app
@@ -16,7 +16,6 @@ Feature: enable an app
     And app "comments" should be enabled
     And the information for app "comments" should have a valid version
 
-  @notToImplementOnOCIS
   Scenario: subadmin tries to enable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP
+@api @provisioning_api-app-required @skipOnLDAP @toImplementOnOCIS
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group
@@ -7,7 +7,7 @@ Feature: get subadmins
   Background:
     Given using OCS API version "1"
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: admin gets subadmin users of a group
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -26,7 +26,6 @@ Feature: get subadmins
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @notToImplementOnOCIS
   Scenario: subadmin tries to get other subadmins of the same group
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -40,7 +39,6 @@ Feature: get subadmins
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @notToImplementOnOCIS
   Scenario: normal user tries to get the subadmins of the group
     Given these users have been created with default attributes and skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app
@@ -15,7 +15,7 @@ Feature: disable an app
     And the HTTP status code should be "200"
     And app "comments" should be disabled
 
-  @issue-31276 @notToImplementOnOCIS
+  @issue-31276
   Scenario: subadmin tries to disable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app
@@ -15,7 +15,7 @@ Feature: enable an app
     And the HTTP status code should be "200"
     And app "comments" should be enabled
 
-  @issue-31276 @notToImplementOnOCIS
+  @issue-31276
   Scenario: subadmin tries to enable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @notToImplementOnOCIS
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP
+@api @provisioning_api-app-required @skipOnLDAP @toImplementOnOCIS
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group
@@ -7,7 +7,7 @@ Feature: get subadmins
   Background:
     Given using OCS API version "2"
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: admin gets subadmin users of a group
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
@@ -26,7 +26,7 @@ Feature: get subadmins
     And the HTTP status code should be "400"
     And the API should not return any data
 
-  @issue-31276 @notToImplementOnOCIS
+  @issue-31276
   Scenario: subadmin tries to get other subadmins of the same group
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -41,7 +41,7 @@ Feature: get subadmins
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @issue-31276 @notToImplementOnOCIS
+  @issue-31276
   Scenario: normal user tries to get the subadmins of the group
     Given these users have been created with default attributes and skeleton files:
       | username       |


### PR DESCRIPTION
## Description
The features related to sub-admin, and app enable/disable/list are not to implement on OCIS. Tag them so that they do not get run accidentally in OCIS CI. This will reduce the number of unnecessary scenarios to be added to expected-failures in OCIS.

If similar features are created in OCIS (e.g. enable/disable of extensions...) then those will be implemented in some quite different way. So the core test scenarios are not likely to be relevant anyway.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
