### PR TITLE
redesign ugly, yellow notification center

### DIFF
--- a/changelog/unreleased/37875
+++ b/changelog/unreleased/37875
@@ -1,0 +1,9 @@
+Enhancement: Re-design UI yellow notification bar
+
+The yellow notification center has been redesigned:
+- not blocking the top centered logo anymore
+- gets more attention using icons and red color
+- looks more modern
+- shows a close button by default so users can dismiss most notifications
+
+https://github.com/owncloud/core/pull/37875

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -639,25 +639,36 @@ td.avatar {
 
 
 #notification-container {
-	position: absolute;
-	top: 0;
+	position: fixed;
+	bottom: 0;
+	top: auto;
 	width: 100%;
 	text-align: center;
+	z-index: 8000;
 }
 #notification {
 	margin: 0 auto;
 	max-width: 60%;
-	z-index: 8000;
-	background-color: #fc4;
+	background-color: #fef4f6;
+	background-image: url('../img/actions/exclamation-triangle-solid.svg');
+	background-position: 20px 50%;
+	background-repeat: no-repeat;
+	background-size: 42px;
+	color: #f0506e;
 	border: 0;
-	padding: 1px 8px;
+	padding: 10px 40px 0px 75px;
 	display: none;
 	position: relative;
 	top: 0;
-	border-bottom-left-radius: 3px;
-	border-bottom-right-radius: 3px;
+	border-radius: 3px;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=90)";
 	opacity: .9;
+	max-height: none;
+}
+
+#notification-container #notification * {
+	color: #f0506e !important;
+	font-weight: bold;
 }
 #notification span {
 	cursor: pointer;
@@ -666,20 +677,33 @@ td.avatar {
 #notification {
 	overflow-x: hidden;
 	overflow-y: auto;
-	max-height: 100px;
+}
+#notification-container #notification a:hover {
+	text-decoration: underline;
 }
 #notification .row {
 	position: relative;
+	border-bottom: 1px solid #fdc7d1;
+	padding-bottom: 5px;
+	margin-bottom: 5px;
+	text-align: left;
 }
+#notification .row:last-child {
+	border: none;
+}
+
 #notification .row .close {
 	display: inline-block;
 	vertical-align: middle;
 	position: absolute;
 	right: 0;
-	top: 0;
+	top: calc(50% - 7px);
 }
 #notification .row.closeable {
 	padding-right: 20px;
+}
+#notification .row .close.icon-close {
+	background-image: url('../img/actions/close-red.svg');
 }
 
 tr .action:not(.permanent),

--- a/core/img/actions/close-red.svg
+++ b/core/img/actions/close-red.svg
@@ -1,0 +1,1 @@
+<svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" data-svg="close-icon"><line fill="none" stroke="#f0506e" stroke-width="1.1" x1="1" y1="1" x2="13" y2="13"></line><line fill="none" stroke="#f0506e" stroke-width="1.1" x1="13" y1="1" x2="1" y2="13"></line></svg>

--- a/core/img/actions/exclamation-triangle-solid.svg
+++ b/core/img/actions/exclamation-triangle-solid.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" focusable="false" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	 x="0px" y="0px" viewBox="0 0 576 512" style="enable-background:new 0 0 576 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#F0506E;}
+</style>
+<path class="st0" d="M569.5,440c18.5,32-4.7,72-41.6,72H48.1c-36.9,0-60-40.1-41.6-72L246.4,24c18.5-32,64.7-32,83.2,0L569.5,440
+	L569.5,440z M288,354c-25.4,0-46,20.6-46,46s20.6,46,46,46s46-20.6,46-46S313.4,354,288,354z M244.3,188.7l7.4,136
+	c0.3,6.4,5.6,11.3,12,11.3h48.5c6.4,0,11.6-5,12-11.3l7.4-136c0.4-6.9-5.1-12.7-12-12.7h-63.4C249.4,176,244,181.8,244.3,188.7
+	L244.3,188.7z"/>
+</svg>

--- a/core/js/integritycheck-failed-notification.js
+++ b/core/js/integritycheck-failed-notification.js
@@ -31,7 +31,8 @@ $(document).ready(function(){
 	OC.Notification.showHtml(
 		text,
 		{
-			isHTML: true
+			isHTML: true,
+			showCloseButton: false
 		}
 	);
 });

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1134,13 +1134,15 @@ OC.Notification = {
 	 *
 	 * @param {string} html Message to display
 	 * @param {Object} [options] options
-	 * @param {string] [options.type] notification type
+	 * @param {string} [options.type] notification type
+	 * @param {string} [options.showCloseButton] show close button
 	 * @param {int} [options.timeout=0] timeout value, defaults to 0 (permanent)
 	 * @return {jQuery} jQuery element for notification row
 	 */
 	showHtml: function (html, options) {
 		options = options || {};
 		_.defaults(options, {
+			showCloseButton: true,
 			timeout: 0
 		});
 
@@ -1153,7 +1155,7 @@ OC.Notification = {
 		if (options.type) {
 			$row.addClass('type-' + options.type);
 		}
-		if (options.type === 'error') {
+		if (options.showCloseButton === true) {
 			// add a close button
 			var $closeButton = $('<a class="action close icon-close" href="#"></a>');
 			$closeButton.attr('alt', t('core', 'Dismiss'));
@@ -1184,6 +1186,7 @@ OC.Notification = {
 	 * @param {string} text Message to display
 	 * @param {Object} [options] options
 	 * @param {string} [options.type] notification type
+	 * @param {string} [options.showCloseButton] show close button
 	 * @param {int} [options.timeout=0] timeout value, defaults to 0 (permanent)
 	 * @return {jQuery} jQuery element for notification row
 	 */

--- a/core/js/license-state-notification.js
+++ b/core/js/license-state-notification.js
@@ -18,6 +18,6 @@
 $(document).ready(function() {
 	$.get(OC.generateUrl('/license/licenseMessage'), {app: 'core'})
 		.done(function(data) {
-			OC.Notification.showHtml(data.translated_message.join('<br/>'), {type: 'error'});
+			OC.Notification.showHtml(data.translated_message.join('<br/>'), {showCloseButton: false});
 		});
 });

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -647,7 +647,7 @@ describe('Core base tests', function() {
 					['	122.1 MB ', 128031130],
 					['122.1    MB ', 128031130],
 					[' 125', 125],
-					[' 125 ', 125],					
+					[' 125 ', 125],
 				];
 				for (var i = 0; i < data.length; i++) {
 					expect(OC.Util.computerFileSize(data[i][0])).toEqual(data[i][1]);
@@ -887,7 +887,7 @@ describe('Core base tests', function() {
 
 				expect(showSpy.calledOnce).toEqual(true);
 				expect(showSpy.firstCall.args[0]).toEqual('My notification test');
-				expect(showSpy.firstCall.args[1]).toEqual({isHTML: false, timeout: 7});
+				expect(showSpy.firstCall.args[1]).toEqual({isHTML: false, timeout: 7, showCloseButton: true});
 
 				expect($row).toBeDefined();
 				expect($row.text()).toEqual('My notification test');
@@ -898,7 +898,7 @@ describe('Core base tests', function() {
 				expect(showSpy.notCalled).toEqual(true);
 				expect(showHtmlSpy.calledOnce).toEqual(true);
 				expect(showHtmlSpy.firstCall.args[0]).toEqual('<a>My notification test</a>');
-				expect(showHtmlSpy.firstCall.args[1]).toEqual({isHTML: true, timeout: 7});
+				expect(showHtmlSpy.firstCall.args[1]).toEqual({isHTML: true, timeout: 7, showCloseButton: true});
 
 				expect($row).toBeDefined();
 				expect($row.text()).toEqual('My notification test');
@@ -965,18 +965,37 @@ describe('Core base tests', function() {
 			expect($rows.eq(0).is($row1)).toEqual(true);
 			expect($rows.eq(1).is($row3)).toEqual(true);
 		});
-		it('shows close button for error types', function() {
-			var $row = OC.Notification.showTemporary('One');
+		it('shows close button when specified', function() {
+			var $row1 = OC.Notification.showTemporary('One', {showCloseButton: true});
+			var $row2 = OC.Notification.showTemporary('Two', {showCloseButton: true});
+			expect($row1.find('.close').length).toEqual(1);
+			expect($row2.find('.close').length).toEqual(1);
+
+			// after clicking, a row is gone
+			$row2.find('.close').click();
+
+			var $rows = $('#notification').find('.row');
+			expect($rows.length).toEqual(1);
+			expect($rows.eq(0).is($row1)).toEqual(true);
+		});
+		it('does not show close button when set to false', function() {
+			var $row1 = OC.Notification.showTemporary('One', {showCloseButton: false});
+			var $row2 = OC.Notification.showTemporary('Two', {showCloseButton: true});
+			expect($row1.find('.close').length).toEqual(0);
+			expect($row2.find('.close').length).toEqual(1);
+		});
+		it('shows close button by default for both error and non-error types', function() {
+			var $rowDefault = OC.Notification.showTemporary('One');
 			var $rowError = OC.Notification.showTemporary('Two', {type: 'error'});
-			expect($row.find('.close').length).toEqual(0);
+			expect($rowDefault.find('.close').length).toEqual(1);
 			expect($rowError.find('.close').length).toEqual(1);
 
-			// after clicking, row is gone
+			// after clicking, error row is gone
 			$rowError.find('.close').click();
 
 			var $rows = $('#notification').find('.row');
 			expect($rows.length).toEqual(1);
-			expect($rows.eq(0).is($row)).toEqual(true);
+			expect($rows.eq(0).is($rowDefault)).toEqual(true);
 		});
 		it('fades out the last notification but not the other ones', function() {
 			var fadeOutStub = sinon.stub($.fn, 'fadeOut');

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -286,6 +286,16 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the user dismisses the notification on the webUI
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function theUserDismissesTheNotificationOnTheWebUI() {
+		$this->owncloudPage->dismissNotification();
+	}
+
+	/**
 	 * @Then no notification should be displayed on the webUI
 	 *
 	 * @return void
@@ -337,10 +347,10 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 		$matching, TableNode $table
 	) {
 		$this->featureContext->verifyTableNodeColumnsCount($table, 1);
-		$actualNotifications = $this->owncloudPage->getNotifications();
-		$numActualNotifications = \count($actualNotifications);
 		$expectedNotifications = $table->getRows();
 		$numExpectedNotifications = \count($expectedNotifications);
+		$actualNotifications = $this->owncloudPage->getNotifications($numExpectedNotifications);
+		$numActualNotifications = \count($actualNotifications);
 
 		Assert::assertGreaterThanOrEqual(
 			$numExpectedNotifications,

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -236,11 +236,8 @@ Feature: add users
     And the administrator creates a user with the name "<user_id2>" and the password "password" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Error creating user: A user with that name already exists. |
-    When the administrator creates a user with the name "<user_id3>" and the password "password" using the webUI
-    Then notifications should be displayed on the webUI with the text
-      | Error creating user: A user with that name already exists. |
     Examples:
-      | user_id1        | user_id2        | user_id3        |
-      | Mixed-Case-user | mixed-case-user | MIXED-CASE-USER |
-      | mixed-case-user | MIXED-CASE-USER | Mixed-Case-user |
-      | MIXED-CASE-USER | Mixed-Case-user | mixed-case-user |
+      | user_id1        | user_id2        |
+      | Mixed-Case-user | mixed-case-user |
+      | mixed-case-user | MIXED-CASE-USER |
+      | MIXED-CASE-USER | Mixed-Case-user |

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -239,7 +239,9 @@ Feature: Unlock locked files and folders
     When the user unlocks the lock no 1 of file "lorem.txt" on the webUI
     Then notifications should be displayed on the webUI with the text
       | Could not unlock, please contact the lock owner receiver1 |
-    And file "lorem.txt" should be marked as locked on the webUI
+    # Note: dismiss the notification so that it does not accidentally obscure the files page
+    When the user dismisses the notification on the webUI
+    Then file "lorem.txt" should be marked as locked on the webUI
     And file "lorem.txt" should be marked as locked by user "receiver1" in the locks tab of the details panel on the webUI
     And 1 locks should be reported for file "lorem.txt" of user "brand-new-user" by the WebDAV API
     And 1 locks should be reported for file "lorem (2).txt" of user "receiver1" by the WebDAV API
@@ -256,7 +258,9 @@ Feature: Unlock locked files and folders
     Then notifications should be displayed on the webUI with the text
       | The file "lorem.txt" is locked and cannot be deleted. |
     And as "brand-new-user" file "lorem.txt" should exist
-    And file "lorem.txt" should be listed on the webUI
+    # Note: dismiss the notification so that it does not accidentally obscure the files page
+    When the user dismisses the notification on the webUI
+    Then file "lorem.txt" should be listed on the webUI
     And file "lorem.txt" should be marked as locked on the webUI
     And file "lorem.txt" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
     And 1 locks should be reported for file "lorem.txt" of user "brand-new-user" by the WebDAV API


### PR DESCRIPTION
While working on some changes for oc.online I redesigned the (ugly) yellow notification center.
Before:
<img width="1439" alt="grafik" src="https://user-images.githubusercontent.com/16665512/91991153-da030480-ed32-11ea-9e98-b2ac102194d9.png">

After:
<img width="722" alt="grafik" src="https://user-images.githubusercontent.com/16665512/91991564-539af280-ed33-11ea-98e6-4df22c37533c.png">

- Moved the notification bar to the bottom of the screen to not block the centered top logo
- Stacking messages is not a problem, lines are separating messages
- Closing button is also re-designed and long messages do not overlap the button and wrap nicely.

As discussed with @pmaier1 @PVince81 and @micbar I created this PR to adopt this change for OC in general.