### PR TITLE
[Tests-Only] Make scenario outline for creating a share with no permissions

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecial1/createShareExpirationDate.feature
@@ -158,7 +158,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +15 days   |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+    And the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_type  | group      |
       | file_target | /FOLDER    |
       | uid_owner   | %username% |
@@ -185,7 +185,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +15 days   |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+    And the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_type  | group      |
       | file_target | /FOLDER    |
       | uid_owner   | %username% |
@@ -213,7 +213,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +15 days   |
     And the administrator sets parameter "shareapi_default_expire_date_group_share" of app "core" to "no"
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+    Then the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_type  | group      |
       | file_target | /FOLDER    |
       | uid_owner   | %username% |
@@ -242,7 +242,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | expireDate  | +3 days    |
     And the administrator sets parameter "shareapi_default_expire_date_group_share" of app "core" to "no"
     And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+    Then the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_type  | group      |
       | file_target | /FOLDER    |
       | uid_owner   | %username% |
@@ -382,7 +382,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
-    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+    Then the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_type  | group          |
       | file_target | /textfile0.txt |
       | uid_owner   | %username%     |
@@ -428,7 +428,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
-    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+    Then the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_type  | group          |
       | file_target | /textfile0.txt |
       | uid_owner   | %username%     |

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -152,7 +152,7 @@ Feature: sharing
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+    And the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_with             | grp1              |
       | share_with_displayname | grp1              |
       | file_target            | /textfile0.txt    |
@@ -177,7 +177,7 @@ Feature: sharing
     When user "Alice" shares folder "/FOLDER" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+    And the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_with             | grp1                 |
       | share_with_displayname | grp1                 |
       | file_target            | /FOLDER              |
@@ -432,7 +432,7 @@ Feature: sharing
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+    And the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_with  | grp1           |
       | file_target | /textfile0.txt |
       | path        | /textfile0.txt |

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -94,18 +94,18 @@ Feature: sharing
       | 1               | 2                     | 2                   | 100             |
       | 2               | 2                     | 2                   | 200             |
 
-  Scenario: Creating a share of a file with no permissions should fail
-    Given using OCS API version "1"
+  Scenario Outline: Creating a share of a file with no permissions should fail
+    Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "Random data" to "randomfile.txt"
     When user "Alice" shares file "randomfile.txt" with user "Brian" with permissions "0" using the sharing API
     Then the OCS status code should be "400"
-    And the HTTP status code should be "200"
+    And the HTTP status code should be "<http_status_code>"
     And as "Brian" file "randomfile.txt" should not exist
-#    Examples:
-#      | ocs_api_version | http_status_code |
-#      | 1               | 200              |
-#      | 2               | 400              |
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 400              |
 
   Scenario Outline: Creating a share of a folder with no permissions should fail
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareManagementBasic/createShare.feature
+++ b/tests/acceptance/features/apiShareManagementBasic/createShare.feature
@@ -361,7 +361,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
-    And user "Alice" has shared file "randomfile.txt" with group "grp1"
+    When user "Alice" shares file "randomfile.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "Brian" should see the following elements
@@ -440,7 +440,7 @@ Feature: sharing
     And as "Brian" file "/textfile0.txt" should exist
     And as "Carol" file "/textfile0.txt" should exist
     When the administrator deletes group "grp1" using the provisioning API
-    When user "Alice" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
+    And user "Alice" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And file "/textfile0.txt" should not be included as path in the response
@@ -468,7 +468,7 @@ Feature: sharing
     And user "Brian" has moved file "/textfile0.txt" to "/common/textfile0.txt"
     And user "Brian" has moved file "/common/textfile0.txt" to "/common/sub/textfile0.txt"
     When user "Carol" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0.txt" using the WebDAV API
-    And the content of file "/common/sub/textfile0.txt" for user "Carol" should be "BLABLABLA" plus end-of-line
+    Then the content of file "/common/sub/textfile0.txt" for user "Carol" should be "BLABLABLA" plus end-of-line
     And the content of file "/textfile0.txt" for user "Carol" should be "BLABLABLA" plus end-of-line
     And user "Carol" should see the following elements
       | /common/sub/textfile0.txt |


### PR DESCRIPTION
## Description
1) This scenario outline was changed to just a single scenario in #37721 (I am not sure why).

It passes fine as a scenario outline that tests both OCS API v1 and v2. So put it back the way it was.

2) The step `Then the fields of the last response to user "Alice" sharing with` can specify either a user or group. In some places it accidentally specified `user "Brian"` when it should say `group "grp1"` - fix these.

Note: that did not create a problem, because actually at the moment the group name is not getting substituted into the step table anyway - supporting that kind of substitution of variable group names during test runs is not happening yet. So fixing these is just to reduce future confusion.

3) Adjust a couple of `When` and `Then` words in scenarios.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
