### PR TITLE
[Tests-Only] Add some more flexible provisioning API tests for getUsers

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -7,7 +7,7 @@ Feature: get users
   Background:
     Given using OCS API version "1"
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: admin gets all users
     Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator gets the list of all users using the provisioning API
@@ -16,6 +16,14 @@ Feature: get users
     And the users returned by the API should be
       | brand-new-user |
       | admin          |
+
+  Scenario: admin gets all users
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    When the administrator gets the list of all users using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the users returned by the API should include
+      | brand-new-user |
 
   @smokeTest @notToImplementOnOCIS
   Scenario: subadmin gets the users in their group

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -7,7 +7,7 @@ Feature: get users
   Background:
     Given using OCS API version "2"
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario: admin gets all users
     Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator gets the list of all users using the provisioning API
@@ -16,6 +16,14 @@ Feature: get users
     And the users returned by the API should be
       | brand-new-user |
       | admin          |
+
+  Scenario: admin gets all users
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    When the administrator gets the list of all users using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the users returned by the API should include
+      | brand-new-user |
 
   @smokeTest @notToImplementOnOCIS
   Scenario: subadmin gets the users in their group

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -3159,6 +3159,7 @@ trait Provisioning {
 		$user = $this->getActualUsername($user);
 		$this->disableOrEnableUser($this->getAdminUsername(), $user, 'disable');
 		$this->theHTTPStatusCodeShouldBeSuccess();
+		$this->ocsContext->assertOCSResponseIndicatesSuccess();
 	}
 
 	/**
@@ -3609,6 +3610,34 @@ trait Provisioning {
 		Assert::assertEqualsCanonicalizing(
 			$usersSimplified, $respondedArray
 		);
+	}
+
+	/**
+	 * @Then /^the users returned by the API should include$/
+	 *
+	 * @param TableNode $usersList
+	 *
+	 * @return void
+	 */
+	public function theUsersShouldInclude($usersList) {
+		$this->verifyTableNodeColumnsCount($usersList, 1);
+		$users = $usersList->getRows();
+		$usersSimplified = \array_map(
+			function ($user) {
+				return $this->getActualUsername($user);
+			},
+			$this->simplifyArray($users)
+		);
+		$respondedArray = $this->getArrayOfUsersResponded($this->response);
+		foreach ($usersSimplified as $userElement) {
+			Assert::assertContains(
+				$userElement,
+				$respondedArray,
+				__METHOD__
+				. " user $userElement is not present in the users list: \n"
+				. \join("\n", $respondedArray)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
Add some tests for provisoning API "get users" that do not require a user "admin" to exist.

## Related Issue
- https://github.com/owncloud/ocis/issues/512

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
