### PR TITLE
[Tests-Only] Add test scenarios for get all and disabled apps with API

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -38,3 +38,58 @@ Feature: get apps
       | files_sharing        |
       | updatenotification   |
       | files_external       |
+
+  @comments-app-required
+  Scenario: admin gets enabled apps when some app is disabled
+    Given app "comments" has been disabled
+    When the administrator gets all enabled apps using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
+      | updatenotification   |
+      | files_external       |
+    And the apps returned by the API should not include
+      | comments |
+
+  @comments-app-required
+  Scenario: admin gets disabled apps
+    Given app "comments" has been disabled
+    When the administrator gets all disabled apps using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | comments |
+    And the apps returned by the API should not include
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
+      | updatenotification   |
+      | files_external       |
+
+  @comments-app-required @issue-37884
+  Scenario: admin gets all apps
+    Given app "comments" has been disabled
+    When the administrator gets all apps using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | comments             |
+    #  | dav                  |
+    #  | federatedfilesharing |
+      | federation           |
+    #  | files                |
+    #  | files_external       |
+      | files_sharing        |
+      | updatenotification   |
+    And the apps returned by the API should not include
+      | dav                  |
+      | federatedfilesharing |
+      | files                |
+      | files_external       |

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -38,3 +38,58 @@ Feature: get apps
       | files_sharing        |
       | updatenotification   |
       | files_external       |
+
+  @comments-app-required
+  Scenario: admin gets enabled apps when some app is disabled
+    Given app "comments" has been disabled
+    When the administrator gets all enabled apps using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
+      | updatenotification   |
+      | files_external       |
+    And the apps returned by the API should not include
+      | comments |
+
+  @comments-app-required
+  Scenario: admin gets disabled apps
+    Given app "comments" has been disabled
+    When the administrator gets all disabled apps using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | comments |
+    And the apps returned by the API should not include
+      | dav                  |
+      | federatedfilesharing |
+      | federation           |
+      | files                |
+      | files_sharing        |
+      | updatenotification   |
+      | files_external       |
+
+  @comments-app-required @issue-37884
+  Scenario: admin gets all apps
+    Given app "comments" has been disabled
+    When the administrator gets all apps using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the apps returned by the API should include
+      | comments             |
+    #  | dav                  |
+    #  | federatedfilesharing |
+      | federation           |
+    #  | files                |
+    #  | files_external       |
+      | files_sharing        |
+      | updatenotification   |
+    And the apps returned by the API should not include
+      | dav                  |
+      | federatedfilesharing |
+      | files                |
+      | files_external       |

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1155,12 +1155,30 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When the administrator gets all apps using the provisioning API
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsAllAppsUsingTheProvisioningApi() {
+		$this->getAllApps();
+	}
+
+	/**
 	 * @When the administrator gets all enabled apps using the provisioning API
 	 *
 	 * @return void
 	 */
 	public function theAdministratorGetsAllEnabledAppsUsingTheProvisioningApi() {
 		$this->getEnabledApps();
+	}
+
+	/**
+	 * @When the administrator gets all disabled apps using the provisioning API
+	 *
+	 * @return void
+	 */
+	public function theAdministratorGetsAllDisabledAppsUsingTheProvisioningApi() {
+		$this->getDisabledApps();
 	}
 
 	/**
@@ -3696,7 +3714,32 @@ trait Provisioning {
 		$appsSimplified = $this->simplifyArray($apps);
 		$respondedArray = $this->getArrayOfAppsResponded($this->response);
 		foreach ($appsSimplified as $app) {
-			Assert::assertContains($app, $respondedArray);
+			Assert::assertContains(
+				$app,
+				$respondedArray,
+				"The apps returned by the API should include $app but $app was not included"
+			);
+		}
+	}
+
+	/**
+	 * @Then /^the apps returned by the API should not include$/
+	 *
+	 * @param TableNode|null $appList
+	 *
+	 * @return void
+	 */
+	public function theAppsShouldNotInclude($appList) {
+		$this->verifyTableNodeColumnsCount($appList, 1);
+		$apps = $appList->getRows();
+		$appsSimplified = $this->simplifyArray($apps);
+		$respondedArray = $this->getArrayOfAppsResponded($this->response);
+		foreach ($appsSimplified as $app) {
+			Assert::assertNotContains(
+				$app,
+				$respondedArray,
+				"The apps returned by the API should not include $app but $app was included"
+			);
 		}
 	}
 
@@ -4324,7 +4367,21 @@ trait Provisioning {
 	}
 
 	/**
-	 * Returns array of enabled apps
+	 * Returns an array of all apps reported by the cloud/apps endpoint
+	 *
+	 * @return array
+	 */
+	public function getAllApps() {
+		$fullUrl = $this->getBaseUrl()
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/apps";
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
+		);
+		return ($this->getArrayOfAppsResponded($this->response));
+	}
+
+	/**
+	 * Returns array of enabled apps reported by the cloud/apps endpoint
 	 *
 	 * @return array
 	 */
@@ -4338,7 +4395,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * Returns array of disabled apps
+	 * Returns array of disabled apps reported by the cloud/apps endpoint
 	 *
 	 * @return array
 	 */


### PR DESCRIPTION
## Description
Add tests to cover parts of the `cloud/apps` API that do not have test cases:
- get a list of all apps
- get a list of all disabled apps

## Related Issue
- helps to cover current behavior related to #37884 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
