### PR TITLE
[Tests-Only] Fix timing problem in testScanShareInvalidLastScan

### DIFF
--- a/apps/files_sharing/tests/External/ScanExternalSharesJobTest.php
+++ b/apps/files_sharing/tests/External/ScanExternalSharesJobTest.php
@@ -271,11 +271,11 @@ class ScanExternalSharesJobTest extends TestCase {
 			'token'	=> 'test',
 			'password' => 'test',
 			'mountpoint' => 'test',
-			'lastscan' => \time(),
+			'lastscan' => \time() - 10,
 			'owner'	=> 'test'
 		];
 		$lastLoginThreshold = '1';
-		$lastScanThreshold = '2';
+		$lastScanThreshold = '20';
 		$result = $this->invokePrivate($scanShares, 'shouldScan', [$share, $lastLoginThreshold, $lastScanThreshold]);
 
 		$this->assertEquals(false, $result);

--- a/apps/files_sharing/tests/External/ScanExternalSharesJobTest.php
+++ b/apps/files_sharing/tests/External/ScanExternalSharesJobTest.php
@@ -275,7 +275,7 @@ class ScanExternalSharesJobTest extends TestCase {
 			'owner'	=> 'test'
 		];
 		$lastLoginThreshold = '1';
-		$lastScanThreshold = '1';
+		$lastScanThreshold = '2';
 		$result = $this->invokePrivate($scanShares, 'shouldScan', [$share, $lastLoginThreshold, $lastScanThreshold]);
 
 		$this->assertEquals(false, $result);

--- a/apps/files_sharing/tests/External/ScanExternalSharesJobTest.php
+++ b/apps/files_sharing/tests/External/ScanExternalSharesJobTest.php
@@ -230,7 +230,7 @@ class ScanExternalSharesJobTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->exactly(1))
 			->method('getLastLogin')
-			->willReturn(\time() - 2);
+			->willReturn(\time() - 20);
 
 		$this->userManager->expects($this->exactly(1))
 			->method('get')
@@ -245,7 +245,7 @@ class ScanExternalSharesJobTest extends TestCase {
 			'mountpoint' => 'test',
 			'owner'	=> 'test'
 		];
-		$lastLoginThreshold = '1';
+		$lastLoginThreshold = '10';
 		$lastScanThreshold = '1';
 		$result = $this->invokePrivate($scanShares, 'shouldScan', [$share, $lastLoginThreshold, $lastScanThreshold]);
 


### PR DESCRIPTION
## Description
https://drone.owncloud.com/owncloud/core/26677/35/9
```
There was 1 failure:

1) OCA\Files_Sharing\Tests\External\ScanExternalSharesJobTest::testScanShareInvalidLastScan
Failed asserting that true matches expected false.

/drone/src/apps/files_sharing/tests/External/ScanExternalSharesJobTest.php:281
```

If the system time ticks over the 1-second boundary just after the test has remembered the time in to return in the mock of `getLastLogin` and the time that is put in `lastscan`, then `$now` in `shouldScan` becomes 1 second later. This happens to make both reasons to return false be false, and `shouldScan` unexpectedly returns true.

Putting a \sleep(1); just before:
`$this->invokePrivate($scanShares, 'shouldScan', [$share, $lastLoginThreshold, $lastScanThreshold]);`
Makes the test fail consistently.

Adjust `$lastScanThreshold` so that an accidental 1-second change in the system time will not make the test fail.

## How Has This Been Tested?
Local unit test runs

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
