### PR TITLE
[Tests-Only] Acceptance tests for issue 37883

### DIFF
--- a/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature
@@ -1,0 +1,71 @@
+@api @files_sharing-app-required
+Feature: accept/decline shares coming from internal users to the Shares folder
+  As a user
+  I want to have control of which received shares I accept
+  So that I can keep my file system clean
+
+  Background:
+    Given using OCS API version "1"
+    And using new DAV path
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+
+  Scenario: When accepting a share of a file, the received file is accessible
+    Given the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    When user "Brian" accepts the share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+
+  Scenario: When accepting a share of a folder, the received folder is accessible
+    Given the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has shared file "/PARENT" with user "Brian"
+    When user "Brian" accepts the share "/PARENT" offered by user "Alice" using the sharing API
+    Then the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line
+
+  @skipOnOcV10 @issue-37883
+  Scenario: When accepting a share of a file, the response is valid
+    Given the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    When user "Brian" accepts the share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_with             | %username%            |
+      | share_with_displayname | %displayname%         |
+      | file_target            | /Shares/textfile0.txt |
+      | path                   | /Shares/textfile0.txt |
+      | permissions            | share,read,update     |
+      | uid_owner              | %username%            |
+      | displayname_owner      | %displayname%         |
+      | item_type              | file                  |
+      | mimetype               | text/plain            |
+      | storage_id             | ANY_VALUE             |
+      | share_type             | user                  |
+    And the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+
+  @skipOnOcV10 @issue-37883
+  Scenario: When accepting a share of a folder, the response is valid
+    Given the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has shared file "/PARENT" with user "Brian"
+    When user "Brian" accepts the share "/PARENT" offered by user "Alice" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_with             | %username%           |
+      | share_with_displayname | %displayname%        |
+      | file_target            | /Shares/PARENT       |
+      | path                   | /Shares/PARENT       |
+      | permissions            | all                  |
+      | uid_owner              | %username%           |
+      | displayname_owner      | %displayname%        |
+      | item_type              | folder               |
+      | mimetype               | httpd/unix-directory |
+      | storage_id             | ANY_VALUE            |
+      | share_type             | user                 |
+    And the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line

--- a/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolderOc10Issue37883.feature
+++ b/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolderOc10Issue37883.feature
@@ -1,0 +1,59 @@
+@api @files_sharing-app-required
+Feature: accept/decline shares coming from internal users to the Shares folder
+  As a user
+  I want to have control of which received shares I accept
+  So that I can keep my file system clean
+
+  Background:
+    Given using OCS API version "1"
+    And using new DAV path
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+
+  @notToImplementOnOCIS @issue-37883
+  Scenario: When accepting a share of a file, the response has valid fields
+    # When fixing this issue on oC10, delete this scenario and enable the scenario in acceptSharesToSharesFolder
+    Given the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    When user "Brian" accepts the share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_with             | %username%                   |
+      | share_with_displayname | %displayname%                |
+      | file_target            | /Shares/Shares/textfile0.txt |
+      | path                   | /Shares/textfile0.txt        |
+      | permissions            | share,read,update            |
+      | uid_owner              | %username%                   |
+      | displayname_owner      | %displayname%                |
+      | item_type              | file                         |
+      | mimetype               | text/plain                   |
+      | storage_id             | ANY_VALUE                    |
+      | share_type             | user                         |
+    And the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+
+  @notToImplementOnOCIS @issue-37883
+  Scenario: When accepting a share of a folder, the response has valid fields
+    # When fixing this issue on oC10, delete this scenario and enable the scenario in acceptSharesToSharesFolder
+    Given the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has shared file "/PARENT" with user "Brian"
+    When user "Brian" accepts the share "/PARENT" offered by user "Alice" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_with             | %username%            |
+      | share_with_displayname | %displayname%         |
+      | file_target            | /Shares/Shares/PARENT |
+      | path                   | /Shares/PARENT        |
+      | permissions            | all                   |
+      | uid_owner              | %username%            |
+      | displayname_owner      | %displayname%         |
+      | item_type              | folder                |
+      | mimetype               | httpd/unix-directory  |
+      | storage_id             | ANY_VALUE             |
+      | share_type             | user                  |
+    And the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line


### PR DESCRIPTION
# Description
Add acceptance tests that define the good behavior and demonstrate the bad behavior for issue #37883 

Add test scenarios that share into a `Shares` folder and examine the response fields when the share receiver accepts the share:

1) the expected good behavior scenarios are in `acceptSharesToSharesFolder.feature` and are tagged `skipOnOcV10` because they do not currently pass on oCV10. These will run on OCIS (and we will see if OCIS passes or not)

2) the scenarios that demonstrate the bad behavior on oCV10 are in 
`acceptSharesToSharesFolderOc10Issue37883.feature` and are tagged `notToImplementOnOCIS` because we do not want to imitate this behavior on OCIS. Putting these scenarios in a separate feature file means that we can delete them when the issue is fixed in oCV10 and the line numbers of the good behavior scenarios in the other file will not need to change.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
