### PR TITLE
List all apps with cloud/apps API endpoint

### DIFF
--- a/apps/provisioning_api/lib/Apps.php
+++ b/apps/provisioning_api/lib/Apps.php
@@ -45,7 +45,7 @@ class Apps {
 	 * @return OC_OCS_Result
 	 */
 	public function getApps($parameters) {
-		$apps = OC_App::listAllApps();
+		$apps = OC_App::listAllApps(true);
 		$list = [];
 		foreach ($apps as $app) {
 			$list[] = $app['id'];

--- a/apps/provisioning_api/tests/AppsTest.php
+++ b/apps/provisioning_api/tests/AppsTest.php
@@ -76,7 +76,7 @@ class AppsTest extends TestCase {
 
 		$this->assertTrue($result->succeeded());
 		$data = $result->getData();
-		$this->assertCount(\count(\OC_App::listAllApps(false, true)), $data['apps']);
+		$this->assertCount(\count(\OC_App::listAllApps(true)), $data['apps']);
 	}
 
 	public function testGetAppsEnabled() {
@@ -92,7 +92,7 @@ class AppsTest extends TestCase {
 		$result = $this->api->getApps(['filter' => 'disabled']);
 		$this->assertTrue($result->succeeded());
 		$data = $result->getData();
-		$apps = \OC_App::listAllApps(false, true);
+		$apps = \OC_App::listAllApps(true);
 		$list =  [];
 		foreach ($apps as $app) {
 			$list[] = $app['id'];

--- a/changelog/unreleased/37884
+++ b/changelog/unreleased/37884
@@ -1,0 +1,7 @@
+Bugfix: Fix list of apps returned by OCS Provisioning API apps endpoint
+
+Requests to ocs/v1.php/cloud/apps without any filter now return all apps,
+including the always-enabled apps.
+
+https://github.com/owncloud/core/issues/37884
+https://github.com/owncloud/core/pull/37901

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -764,19 +764,21 @@ class OC_App {
 	/**
 	 * List all apps, this is used in apps.php
 	 *
-	 * @param bool $onlyLocal
-	 * @param bool $includeUpdateInfo Should we check whether there is an update
-	 *                                in the app store?
+	 * @param bool $listEveryApp including always-enabled apps
 	 * @return array
 	 */
-	public static function listAllApps() {
+	public static function listAllApps(bool $listEveryApp = false) {
 		$installedApps = OC_App::getAllApps();
 
 		//TODO which apps do we want to blacklist and how do we integrate
 		// blacklisting with the multi apps folder feature?
 
-		//we don't want to show configuration for these
-		$blacklist = \OC::$server->getAppManager()->getAlwaysEnabledApps();
+		if ($listEveryApp) {
+			$blacklist = [];
+		} else {
+			//we don't want to show configuration for these
+			$blacklist = \OC::$server->getAppManager()->getAlwaysEnabledApps();
+		}
 		$appList = [];
 		$urlGenerator = \OC::$server->getURLGenerator();
 

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -73,7 +73,7 @@ Feature: get apps
       | updatenotification   |
       | files_external       |
 
-  @comments-app-required @issue-37884
+  @comments-app-required
   Scenario: admin gets all apps
     Given app "comments" has been disabled
     When the administrator gets all apps using the provisioning API
@@ -81,15 +81,10 @@ Feature: get apps
     And the HTTP status code should be "200"
     And the apps returned by the API should include
       | comments             |
-    #  | dav                  |
-    #  | federatedfilesharing |
-      | federation           |
-    #  | files                |
-    #  | files_external       |
-      | files_sharing        |
-      | updatenotification   |
-    And the apps returned by the API should not include
       | dav                  |
       | federatedfilesharing |
+      | federation           |
       | files                |
       | files_external       |
+      | files_sharing        |
+      | updatenotification   |

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -73,7 +73,7 @@ Feature: get apps
       | updatenotification   |
       | files_external       |
 
-  @comments-app-required @issue-37884
+  @comments-app-required
   Scenario: admin gets all apps
     Given app "comments" has been disabled
     When the administrator gets all apps using the provisioning API
@@ -81,15 +81,10 @@ Feature: get apps
     And the HTTP status code should be "200"
     And the apps returned by the API should include
       | comments             |
-    #  | dav                  |
-    #  | federatedfilesharing |
-      | federation           |
-    #  | files                |
-    #  | files_external       |
-      | files_sharing        |
-      | updatenotification   |
-    And the apps returned by the API should not include
       | dav                  |
       | federatedfilesharing |
+      | federation           |
       | files                |
       | files_external       |
+      | files_sharing        |
+      | updatenotification   |


### PR DESCRIPTION
## Description
See issue - make the `cloud/apps` OCS API endpoint really return all apps when no filter is specified.

## Related Issue
- Fixes #37884 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
