### PR TITLE
[Tests-Only] Make PROPFIND response href test checks more flexible

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -50,9 +50,9 @@ Feature: get file properties
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file1.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file2.txt"
     When user "Alice" gets the properties of folder "<folder_name>" with depth 1 using the WebDAV API
-    Then the value of the item "//d:response[1]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\//"
-    And the value of the item "//d:response[2]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\/file1.txt/"
-    And the value of the item "//d:response[3]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\/file2.txt/"
+    Then there should be an entry with href matching "/remote\.php\/<expected_href>\//" in the response to user "Alice"
+    And there should be an entry with href matching "/remote\.php\/<expected_href>\/file1.txt/" in the response to user "Alice"
+    And there should be an entry with href matching "/remote\.php\/<expected_href>\/file2.txt/" in the response to user "Alice"
     Examples:
       | dav_version | folder_name     | expected_href                                                                  |
       | old         | /upload         | webdav\/upload                                                                 |

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -618,6 +618,45 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
+	 * @Then there should be an entry with href matching :pattern in the response to user :user
+	 *
+	 * @param string $pattern
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function assertEntryWithHrefMatchingRegExpInResponseToUser($pattern, $user) {
+		$resXml = $this->featureContext->getResponseXmlObject();
+		if ($resXml === null) {
+			$resXml = HttpRequestHelper::getResponseXml(
+				$this->featureContext->getResponse(),
+				__METHOD__
+			);
+		}
+
+		$user = $this->featureContext->getActualUsername($user);
+		$pattern = $this->featureContext->substituteInLineCodes(
+			$pattern, $user, ['preg_quote' => ['/']]
+		);
+
+		$index = 0;
+		while (true) {
+			$index++;
+			$xpath = "//d:response[$index]/d:href";
+			$xmlPart = $resXml->xpath($xpath);
+			// If we have run out of entries in the response, then fail the test
+			Assert::assertTrue(
+				isset($xmlPart[0]), "Cannot find any entry with href matching $pattern in response to $user"
+			);
+			$value = $xmlPart[0]->__toString();
+			if (\preg_match($pattern, $value) === 1) {
+				break;
+			}
+		}
+	}
+
+	/**
 	 * @Then the value of the item :xpath in the response to user :user should match :value
 	 *
 	 * @param string $xpath


### PR DESCRIPTION
## Description
Make a more generic test step for checking for entries of files in a PROPFIND of a folder.
The step is more flexible so that the files do not have to be in a specific sorted order - they can be in any order in the list of files in the response.

## Related Issue
- Fixes https://github.com/owncloud/ocis-reva/issues/471

## How Has This Been Tested?
CI and local test runs

PR https://github.com/owncloud/ocis-reva/pull/474 to demonstrate this passes in `owncloud/ocis-reva`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
