### PR TITLE
[Tests-Only] wait until delete-confirm dialog is visible for user and group UI tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2962,7 +2962,7 @@ trait Provisioning {
 					$groupCanBeDeleted = true;
 				} else {
 					throw new Exception(
-						"could not create group. "
+						"could not create group '$group'. "
 						. $result->getStatusCode() . " " . $result->getBody()
 					);
 				}
@@ -2973,7 +2973,7 @@ trait Provisioning {
 					$groupCanBeDeleted = true;
 				} else {
 					throw new Exception(
-						"could not create group. {$result['stdOut']} {$result['stdErr']}"
+						"could not create group '$group'. {$result['stdOut']} {$result['stdErr']}"
 					);
 				}
 				break;
@@ -2982,13 +2982,13 @@ trait Provisioning {
 					$this->createLdapGroup($group);
 				} catch (LdapException $e) {
 					throw new Exception(
-						"could not create group. Error: {$e}"
+						"could not create group '$group'. Error: {$e}"
 					);
 				}
 				break;
 			default:
 				throw new InvalidArgumentException(
-					"Invalid method to create a group"
+					"Invalid method to create group '$group'"
 				);
 		}
 

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -526,7 +526,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		} catch (Exception $e) {
 			//do not throw the exception if we expect the folder creation to fail
 			if ($invalid !== "invalid"
-				|| $e->getMessage() !== "could not create folder"
+				|| $e->getMessage() !== "could not create folder '$name'"
 			) {
 				throw $e;
 			}

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -89,7 +89,7 @@ class FilesPage extends FilesPageBasic {
 	 *
 	 */
 	protected function getFilePathInRowXpath() {
-		throw new \Exception("not implemented in FilesPage");
+		throw new \Exception(__METHOD__ . " not implemented in FilesPage");
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -174,7 +174,7 @@ class FilesPageCRUD extends FilesPageBasic {
 	 *
 	 */
 	protected function getFilePathInRowXpath() {
-		throw new \Exception("not implemented");
+		throw new \Exception(__METHOD__ . " not implemented in FilesPageCRUD");
 	}
 
 	/**
@@ -359,7 +359,7 @@ class FilesPageCRUD extends FilesPageBasic {
 		}
 
 		if ($currentTime > $end) {
-			throw new \Exception("could not create folder");
+			throw new \Exception("could not create folder '$name'");
 		}
 		return $name;
 	}

--- a/tests/acceptance/features/lib/FilesPageElement/LockDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/LockDialog.php
@@ -106,6 +106,6 @@ class LockDialog extends OwncloudPage {
 	 * @return void
 	 */
 	public function deleteLockByUserAndLockingResource($user, $resource) {
-		throw new \Exception("not yet implemented");
+		throw new \Exception(__METHOD__ . " not implemented in LockDialog");
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
+++ b/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
@@ -114,6 +114,6 @@ class LockEntry extends OwncloudPage {
 	 * @return void
 	 */
 	public function getLockingResource() {
-		throw new \Exception("not yet implemented");
+		throw new \Exception(__METHOD__ . " not implemented in LockEntry");
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -752,7 +752,7 @@ class SharingDialog extends OwncloudPage {
 			"could not find public link remove buttons"
 		);
 		if ($number < 1) {
-			throw new \Exception("Position cannot be less than 1");
+			throw new \Exception(__METHOD__ . " Position cannot be less than 1");
 		}
 		$publicLinkRemoveBtn = $publicLinkRemoveBtns[$number - 1];
 		$this->assertElementNotNull(

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -293,7 +293,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @return void
 	 */
 	public function deleteLink($name) {
-		throw new Exception("not implemented");
+		throw new Exception(__METHOD__ . " not implemented in PublicLinkTab");
 	}
 
 	/**
@@ -304,7 +304,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @return void
 	 */
 	public function shareLink($name, $service) {
-		throw new Exception("not implemented");
+		throw new Exception(__METHOD__ . " not implemented in PublicLinkTab");
 	}
 
 	/**
@@ -314,7 +314,7 @@ class PublicLinkTab extends OwncloudPage {
 	 * @return void
 	 */
 	public function copyLinkToClipboard($name) {
-		throw new Exception("not implemented");
+		throw new Exception(__METHOD__ . " not implemented in PublicLinkTab");
 	}
 
 	/**

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -95,7 +95,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 *
 	 */
 	protected function getFilePathInRowXpath() {
-		throw new \Exception("not implemented in PublicLinkFilesPage");
+		throw new \Exception(__METHOD__ . " not implemented in PublicLinkFilesPage");
 	}
 
 	/**
@@ -363,7 +363,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * @throws ElementNotFoundException
 	 */
 	public function getTooltipOfFile($fileName, Session $session) {
-		throw new \Exception("not implemented");
+		throw new \Exception(__METHOD__ . " not implemented in PublicLinkFilesPage");
 	}
 
 	/**

--- a/tests/acceptance/features/lib/SharedByLinkPage.php
+++ b/tests/acceptance/features/lib/SharedByLinkPage.php
@@ -82,7 +82,7 @@ class SharedByLinkPage extends FilesPageCRUD {
 	 *
 	 */
 	protected function getFilePathInRowXpath() {
-		throw new \Exception("not implemented in SharedByLinkPage");
+		throw new \Exception(__METHOD__ . " not implemented in SharedByLinkPage");
 	}
 
 	/**

--- a/tests/acceptance/features/lib/SharedWithYouPage.php
+++ b/tests/acceptance/features/lib/SharedWithYouPage.php
@@ -76,7 +76,7 @@ class SharedWithYouPage extends FilesPageBasic {
 	 *
 	 */
 	protected function getFilePathInRowXpath() {
-		throw new \Exception("not implemented in SharedWithYouPage");
+		throw new \Exception(__METHOD__ . " not implemented in SharedWithYouPage");
 	}
 
 	/**

--- a/tests/acceptance/features/lib/UserPageElement/GroupList.php
+++ b/tests/acceptance/features/lib/UserPageElement/GroupList.php
@@ -102,7 +102,7 @@ class GroupList extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->deleteBtnXpath " .
-				"could not find delete button"
+				"could not find delete button for group $name"
 			);
 		}
 		$deleteButton->click();
@@ -118,7 +118,7 @@ class GroupList extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $xpathSelector " .
-				"could not find delete confirm button"
+				"could not find delete confirm button for group $name"
 			);
 		}
 		$confirmButton->click();

--- a/tests/acceptance/features/lib/UserPageElement/GroupList.php
+++ b/tests/acceptance/features/lib/UserPageElement/GroupList.php
@@ -108,9 +108,9 @@ class GroupList extends OwncloudPage {
 		$deleteButton->click();
 
 		if ($confirm) {
-			$confirmButton = $this->find("xpath", $this->deleteConfirmButtonXpath);
+			$confirmButton = $this->waitTillXpathIsVisible($this->deleteConfirmButtonXpath);
 		} else {
-			$confirmButton = $this->find("xpath", $this->deleteNotConfirmButtonXpath);
+			$confirmButton = $this->waitTillXpathIsVisible($this->deleteNotConfirmButtonXpath);
 		}
 
 		if ($confirmButton === null) {

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -659,9 +659,9 @@ class UsersPage extends OwncloudPage {
 		$this->waitForAjaxCallsToStartAndFinish($session);
 
 		if ($confirm) {
-			$confirmBtn = $this->find('xpath', $this->deleteConfirmBtnXpath);
+			$confirmBtn = $this->waitTillXpathIsVisible($this->deleteConfirmBtnXpath);
 		} else {
-			$confirmBtn = $this->find('xpath', $this->deleteNotConfirmBtnXpath);
+			$confirmBtn = $this->waitTillXpathIsVisible($this->deleteNotConfirmBtnXpath);
 		}
 
 		if ($confirmBtn === null) {

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -508,7 +508,7 @@ class UsersPage extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->quotaSelectXpath " .
-				"could not find quota select element"
+				"could not find quota select element for user $username"
 			);
 		}
 		$selectField->click();
@@ -523,7 +523,7 @@ class UsersPage extends OwncloudPage {
 				throw new ElementNotFoundException(
 					__METHOD__ .
 					" xpath $xpathLocator " .
-					"could not find quota option element"
+					"could not find quota option element for user $username"
 				);
 			}
 
@@ -536,7 +536,7 @@ class UsersPage extends OwncloudPage {
 				throw new ElementNotFoundException(
 					__METHOD__ .
 					" xpath $this->manualQuotaInputXpath " .
-					"could not find manual quota input element"
+					"could not find manual quota input element for user $username"
 				);
 			}
 
@@ -652,7 +652,7 @@ class UsersPage extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->deleteUserBtnXpath " .
-				"could not find delete user field "
+				"could not find delete user field for user $username"
 			);
 		}
 		$deleteBtn->click();
@@ -669,7 +669,7 @@ class UsersPage extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $xpathSelector " .
-				"could not find delete confirm button"
+				"could not find delete confirm button for user $username"
 			);
 		}
 
@@ -690,7 +690,7 @@ class UsersPage extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->editDisplayNameBtn " .
-				"could not find edit button "
+				"could not find edit button for user $username"
 			);
 		}
 		$editDisplayNameBtn->focus();
@@ -701,7 +701,7 @@ class UsersPage extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->editDisplayNameInput " .
-				"could not find display name field "
+				"could not find display name field for user $username"
 			);
 		}
 		try {
@@ -726,7 +726,7 @@ class UsersPage extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->editPasswordBtnXpath " .
-				"could not find edit button "
+				"could not find edit button for user $user"
 			);
 		}
 		$editPasswordBtn->focus();
@@ -737,7 +737,7 @@ class UsersPage extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->editPasswordInputXpath " .
-				"could not find password field "
+				"could not find password field for user $user"
 			);
 		}
 		try {
@@ -807,7 +807,7 @@ class UsersPage extends OwncloudPage {
 			throw new ElementNotFoundException(
 				__METHOD__ .
 				" xpath $this->groupLabelInInputXpath " .
-				"could not find groups input"
+				"could not find groups input for user $user"
 			);
 		}
 		$groupInput = $groupsField->find(


### PR DESCRIPTION
## Description
UI tests that delete a group can fail like https://drone.owncloud.com/owncloud/encryption/1422/225/17
```
    When the administrator deletes these groups and confirms the deletion using the webUI: # WebUIUsersContext::theAdminDeletesTheseGroupsUsingTheWebUI()
      | groupname |
      | a/slash   |
      | per%cent  |
      | hash#char |
      | q?mark    |
      Page\UserPageElement\GroupList::deleteGroup xpath .//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style, 'display: none')])]//button[text()='Yes'] could not find delete confirm button (SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException)
```

There is a delete-confirm dialog that pops up. That can take a "moment"  to appear. If the test tries to find the "Yes" button too quickly, then it fails.

1) Report group name in createTheGroup error messages - so that an exception like this will tell us which group it was trying to delete.
2) Enhance page object exception messages - so that other unlikely exceptions will give a bit more information if they happen.
3) wait until delete-confirm dialog is visible for user and group UI tests - use the `waitTillXpathIsVisible` to do a better-controlled wait for the dialog to be visible.

## How Has This Been Tested?
CI and local runs of the group-delete test that failed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
