### PR TITLE
[Tests-Only] Report HTTP status when file content is wrong

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -863,10 +863,15 @@ trait WebDav {
 	 */
 	public function downloadedContentShouldBe($content) {
 		$actualContent = (string) $this->response->getBody();
+		// For this test we really care about the content.
+		// A separate "Then" step can specifically check the HTTP status.
+		// But if the content is wrong (e.g. empty) then it is useful to
+		// report the HTTP status to give some clue what might be the problem.
+		$actualStatus = $this->response->getStatusCode();
 		Assert::assertEquals(
 			$content,
 			$actualContent,
-			"The downloaded content was expected to be '$content', but actually is '$actualContent'."
+			"The downloaded content was expected to be '$content', but actually is '$actualContent'. HTTP status was $actualStatus"
 		);
 	}
 


### PR DESCRIPTION
## Description
https://github.com/cs3org/reva/pull/1170#issuecomment-692734081

If the downloaded content of a file is wrong (often if it is empty) and the test step fails, then report the HTTP status of the download response (as well as the difference between the actual and expected content). That can be helpful to whoever is trying to work out what was the problem.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
