### PR TITLE
[Tests-Only] Add sleep step to acceptance test ccode

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1199,6 +1199,22 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * This step may be useful when debugging a test. You can add the step into
+	 * a scenario and give time to look at some system state, or see if slowing
+	 * things down helps, or... Please do not use this step in the final scenarios
+	 * that are committed and run in CI.
+	 *
+	 * @When the test sleeps for :seconds seconds
+	 *
+	 * @param string $seconds
+	 *
+	 * @return void
+	 */
+	public function theTestSleeps($seconds) {
+		\sleep($seconds);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" sends HTTP method "([^"]*)" to URL "([^"]*)"$/
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
Sometimes when debugging the flow of a test, it is handy to make the test runner stop for a while between test steps.
This provides a step that will let developers easily do this without needing to work too hard. Just insert in the test scenario:
```
And the test sleeps for 60 seconds
```

And you have 60 seconds to examine the state of the system-under-test, or do whatever other magic you have in mind to understand what the issue is with the test.

## How Has This Been Tested?
Locally add this step to a scenario and see that it sleeps.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
