### PR TITLE
[Tests-Only] Add behat-stepthroughextension to acceptance test runner

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -970,3 +970,5 @@ default:
       outputDir: '%paths.base%/../output/'
 
     rdx\behatvars\BehatVariablesExtension: ~
+
+    Cjm\Behat\StepThroughExtension: ~

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -18,8 +18,12 @@ then
 else
     BEHAT=${BEHAT_BIN}
 fi
-
 BEHAT_TAGS_OPTION_FOUND=false
+
+if [ -n "${STEP_THROUGH}" ]
+then
+    STEP_THROUGH_OPTION="--step-through"
+fi
 
 # The following environment variables can be specified:
 #
@@ -98,6 +102,7 @@ fi
 # --part - run a subset of scenarios, need two numbers.
 #          first number: which part to run
 #          second number: in how many parts to divide the set of scenarios
+# --step-through - pause after each test step
 
 # Command line options processed here will override environment variables that
 # might have been set by the caller, or in the code above.
@@ -153,6 +158,9 @@ do
 			;;
 		--norerun)
 			RERUN_FAILED_WEBUI_SCENARIOS=false
+			;;
+		--step-through)
+			STEP_THROUGH_OPTION="--step-through"
 			;;
 		*)
 			# A "random" parameter is presumed to be a feature file to run.
@@ -368,7 +376,7 @@ function run_behat_tests() {
 		cat ${SCRIPT_PATH}/usernames.json
 	fi
 
-	${BEHAT} --colors --strict -c ${BEHAT_YML} -f junit -f pretty ${BEHAT_SUITE_OPTION} --tags ${BEHAT_FILTER_TAGS} ${BEHAT_FEATURE} -v  2>&1 | tee -a ${TEST_LOG_FILE}
+	${BEHAT} --colors --strict ${STEP_THROUGH_OPTION} -c ${BEHAT_YML} -f junit -f pretty ${BEHAT_SUITE_OPTION} --tags ${BEHAT_FILTER_TAGS} ${BEHAT_FEATURE} -v  2>&1 | tee -a ${TEST_LOG_FILE}
 
 	BEHAT_EXIT_STATUS=${PIPESTATUS[0]}
 

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -5,6 +5,7 @@
         "behat/mink-extension": "^2.3",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
+        "ciaranmcnulty/behat-stepthroughextension" : "dev-master",
         "jarnaiz/behat-junit-formatter": "^1.3",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.3",


### PR DESCRIPTION
## Description
When doing test development, or investigating problems with the test or with the system-under-test, it is handy to be able to stop the test at each step while investigating what happens.

1) Add `ciaranmcnulty/behat-stepthroughextension` to the Behat test runner
2) Allow it to be invoked with the env variable `STEP_THROUGH`

If you are currently running an acceptance test scenario with a command like:
```
$ make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiComments/createComments.feature:35
```

Then just include `STEP_THROUGH=true`
```
$ make test-acceptance-api STEP_THROUGH=true BEHAT_FEATURE=tests/acceptance/features/apiComments/createComments.feature:35
```

And the step-through extension will be invoked.

The extension comes from repo https://github.com/ciaranmcnulty/behat-stepthroughextension

## How Has This Been Tested?
Local acceptance test run:
```
$ make test-acceptance-api STEP_THROUGH=true BEHAT_FEATURE=tests/acceptance/features/apiComments/createComments.feature:35
composer install
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating optimized autoload files
Composer cleaner: Removed 5 files or directories.
composer bin behat install --no-progress
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files
ocramius/package-versions: Generating version class...
ocramius/package-versions: ...done generating version class
./tests/acceptance/run.sh --type api
Script path: /home/phil/git/owncloud/core/tests/acceptance
Not using php inbuilt server for running scenario ...
Updating .htaccess for proper rewrites

Running apiComments tests tagged ~@skipWhenTestingRemoteSystems&&~@skipOnFedOcV10&&~@skipOnFedOcV10.6&&~@skipOnFedOcV10.6.0&&~@skipOnOcV10&&~@skipOnOcV10.6&&~@skipOnOcV10.6.0&&@api&&~@skip 
@api @comments-app-required @files_sharing-app-required @issue-ocis-reva-38
Feature: Comments

  Background:                                                                     # /home/phil/git/owncloud/core/tests/acceptance/features/apiComments/createComments.feature:4
    Given using new DAV path                                                      # FeatureContext::usingOldOrNewDavPath()
  [Paused after "using new DAV path" - press enter to continue]
    And these users have been created with default attributes and skeleton files: # FeatureContext::theseUsersHaveBeenCreated()
      | username |
      | Alice    |
      | Brian    |
  [Paused after "these users have been created with default attributes and skeleton files:" - press enter to continue]

  Scenario: sharee comments on a group shared file                                                                    # /home/phil/git/owncloud/core/tests/acceptance/features/apiComments/createComments.feature:35
    Given group "grp1" has been created                                                                               # FeatureContext::groupHasBeenCreated()
  [Paused after "group "grp1" has been created" - press enter to continue]
    And user "Brian" has been added to group "grp1"                                                                   # FeatureContext::userHasBeenAddedToGroup()
  [Paused after "user "Brian" has been added to group "grp1"" - press enter to continue]
    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"                        # FeatureContext::userHasUploadedAFileTo()
  [Paused after "user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"" - press enter to continue]
    And user "Alice" has shared file "/myFileToComment.txt" with group "grp1"                                         # FeatureContext::userHasSharedFileWithGroupUsingTheSharingApi()
  [Paused after "user "Alice" has shared file "/myFileToComment.txt" with group "grp1"" - press enter to continue]
    When user "Brian" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API # CommentsContext::userCommentsWithContentOnEntry()
  [Paused after "user "Brian" comments with content "Comment from sharee" on file "/myFileToComment.txt" using the WebDAV API" - press enter to continue]
    Then the HTTP status code should be "201"                                                                         # FeatureContext::thenTheHTTPStatusCodeShouldBe()
  [Paused after "the HTTP status code should be "201"" - press enter to continue]
    And user "Alice" should have the following comments on file "/myFileToComment.txt"                                # CommentsContext::checkComments()
      | user  | comment             |
      | Brian | Comment from sharee |
  [Paused after "user "Alice" should have the following comments on file "/myFileToComment.txt"" - press enter to continue]

1 scenario (1 passed)
9 steps (9 passed)
0m34.25s (17.69Mb)
runsh: Total 1 scenarios (1 passed, 0 failed)
runsh: Exit code of main run: 0
runsh: There were no unexpected failures.
runsh: There were no unexpected success.
```

It stopped after each step and waited for me to press return.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
