### PR TITLE
[Tests-Only] Skip new and changed tests on old ownCloud10

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -73,7 +73,7 @@ Feature: get apps
       | updatenotification   |
       | files_external       |
 
-  @comments-app-required
+  @comments-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: admin gets all apps
     Given app "comments" has been disabled
     When the administrator gets all apps using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -73,7 +73,7 @@ Feature: get apps
       | updatenotification   |
       | files_external       |
 
-  @comments-app-required
+  @comments-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: admin gets all apps
     Given app "comments" has been disabled
     When the administrator gets all apps using the provisioning API

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -227,7 +227,7 @@ Feature: Unlock locked files and folders
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver1" by the WebDAV API
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver2" by the WebDAV API
 
-  @files_sharing-app-required @skipOnLDAP
+  @files_sharing-app-required @skipOnLDAP @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: deleting a lock that was created by an other user
     Given these users have been created with skeleton files:
       | username  |


### PR DESCRIPTION
## Description
1) PR #37885 adjusted tests for the Provisioning API "get apps" endpoint. PR #37901 fixed a problem with the output of that endpoint, so the tests now fail on old ownCloud10 releases. Skip on old releases.

2) PR #37875 changed the built-in notifications for the webUI so that "file locked" notifications can be dismissed. The acceptance tests use this, so they now fail on old ownCloud10 releases. Skip on old releases.

This will fix nightly app CI for apps that run the core API tests, e.g. user_ldap, encryption etc.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
