### PR TITLE
[Tests-Only] Refactor apiShareNotifications to use Shares folder

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -123,7 +123,8 @@ config = {
 		},
 		'apiNotifications': {
 			'suites': [
-				'apiSharingNotifications',
+				'apiSharingNotificationsRoot',
+				'apiSharingNotificationsShares',
 			],
 			'extraApps': {
 				'notifications': 'composer install'

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -327,14 +327,24 @@ default:
         - WebDavPropertiesContext:
         - AppConfigurationContext:
 
-    apiSharingNotifications:
+    apiSharingNotificationsRoot:
       paths:
-        - '%paths.base%/../features/apiSharingNotifications'
+        - '%paths.base%/../features/apiSharingNotificationsRoot'
       context: *common_ldap_suite_context
       contexts:
         - FeatureContext: *common_feature_context_params
         - NotificationsCoreContext:
         - AppConfigurationContext:
+
+    apiSharingNotificationsShares:
+      paths:
+        - '%paths.base%/../features/apiSharingNotificationsShares'
+      context: *common_ldap_suite_context
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - NotificationsCoreContext:
+        - AppConfigurationContext:
+        - OccContext:
 
     apiTags:
       paths:

--- a/tests/acceptance/features/apiSharingNotificationsRoot/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsRoot/sharingNotifications.feature
@@ -1,0 +1,152 @@
+@api @app-required @notifications-app-required @files_sharing-app-required @notToImplementOnOCIS
+Feature: Display notifications when receiving a share
+  As a user
+  I want to see notifications about shares that have been offered to me
+  So that I can easily decide what I want to do with new received shares
+
+  Background:
+    Given app "notifications" has been enabled
+    And using OCS API version "1"
+    And using new DAV path
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Carol    |
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+
+  @smokeTest
+  Scenario: share to user sends notification
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
+    And user "Alice" shares file "/textfile0.txt" with user "Brian" using the sharing API
+    Then user "Brian" should have 2 notifications
+    And the last notification of user "Brian" should match these regular expressions about user "Alice"
+      | key         | regex                                           |
+      | app         | /^files_sharing$/                               |
+      | subject     | /^"%displayname%" shared "PARENT" with you$/     |
+      | message     | /^"%displayname%" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/         |
+      | object_type | /^local_share$/                                 |
+
+  Scenario: share to group sends notification to every member
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
+    And user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
+    Then user "Brian" should have 2 notifications
+    And the last notification of user "Brian" should match these regular expressions about user "Alice"
+      | key         | regex                                           |
+      | app         | /^files_sharing$/                               |
+      | subject     | /^"%displayname%" shared "PARENT" with you$/     |
+      | message     | /^"%displayname%" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/         |
+      | object_type | /^local_share$/                                 |
+    And user "Carol" should have 2 notifications
+    And the last notification of user "Carol" should match these regular expressions about user "Alice"
+      | key         | regex                                           |
+      | app         | /^files_sharing$/                               |
+      | subject     | /^"%displayname%" shared "PARENT" with you$/     |
+      | message     | /^"%displayname%" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/         |
+      | object_type | /^local_share$/                                 |
+
+	# This scenario documents behavior discussed in core issue 31870
+	# An old share keeps its old auto-accept behavior, even after auto-accept has been disabled.
+  @skipOnLDAP
+  Scenario: share to group does not send notifications to either existing or new members for an old share created before auto-accept is disabled
+    Given user "Alice" has shared folder "/PARENT" with group "grp1"
+    When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "no"
+    And the administrator creates user "David" using the provisioning API
+    And the administrator adds user "David" to group "grp1" using the provisioning API
+    Then user "Brian" should have 0 notifications
+    And user "Carol" should have 0 notifications
+    And user "David" should have 0 notifications
+
+	# This scenario documents behavior discussed in core issue 31870
+	# As users are added to an existing group, they are not sent notifications about group shares.
+  @skipOnLDAP
+  Scenario: share to group sends notifications to existing members, but not to new members, for a share created after auto-accept is disabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
+    And the administrator creates user "David" using the provisioning API
+    And the administrator adds user "David" to group "grp1" using the provisioning API
+    Then user "Brian" should have 1 notification
+    And the last notification of user "Brian" should match these regular expressions about user "Alice"
+      | key         | regex                                           |
+      | app         | /^files_sharing$/                               |
+      | subject     | /^"%displayname%" shared "PARENT" with you$/     |
+      | message     | /^"%displayname%" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/         |
+      | object_type | /^local_share$/                                 |
+    And user "Carol" should have 1 notification
+    And the last notification of user "Carol" should match these regular expressions about user "Alice"
+      | key         | regex                                           |
+      | app         | /^files_sharing$/                               |
+      | subject     | /^"%displayname%" shared "PARENT" with you$/     |
+      | message     | /^"%displayname%" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/         |
+      | object_type | /^local_share$/                                 |
+    And user "David" should have 0 notifications
+
+	# This scenario documents behavior discussed in core issue 31870
+	# Similar to the previous scenario, a new user added to the group does not get a notification,
+	# even though the group, when originally created, had notifications on.
+  @skipOnLDAP
+  Scenario: share to group sends notifications to existing members, but not to new members, for an old share created before auto-accept is enabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has shared folder "/PARENT" with group "grp1"
+    When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "yes"
+    And the administrator creates user "David" using the provisioning API
+    And the administrator adds user "David" to group "grp1" using the provisioning API
+    Then user "Brian" should have 1 notification
+    And the last notification of user "Brian" should match these regular expressions about user "Alice"
+      | key         | regex                                           |
+      | app         | /^files_sharing$/                               |
+      | subject     | /^"%displayname%" shared "PARENT" with you$/     |
+      | message     | /^"%displayname%" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/         |
+      | object_type | /^local_share$/                                 |
+    And user "Carol" should have 1 notification
+    And the last notification of user "Carol" should match these regular expressions about user "Alice"
+      | key         | regex                                           |
+      | app         | /^files_sharing$/                               |
+      | subject     | /^"%displayname%" shared "PARENT" with you$/     |
+      | message     | /^"%displayname%" invited you to view "PARENT"$/ |
+      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/         |
+      | object_type | /^local_share$/                                 |
+    And user "David" should have 0 notifications
+
+  @skipOnLDAP
+  Scenario: share to group does not send notifications to existing and new members for a share created after auto-accept is enabled
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
+    And the administrator creates user "David" using the provisioning API
+    And the administrator adds user "David" to group "grp1" using the provisioning API
+    Then user "Brian" should have 0 notifications
+    And user "Carol" should have 0 notifications
+    And user "David" should have 0 notifications
+
+  Scenario: when auto-accepting is enabled no notifications are sent
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
+    And user "Alice" shares file "/textfile0.txt" with user "Brian" using the sharing API
+    Then user "Brian" should have 0 notifications
+
+  @skipOnLDAP
+  Scenario: discard notification if target user is not member of the group anymore
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
+    And the administrator removes user "Brian" from group "grp1" using the provisioning API
+    Then user "Brian" should have 0 notifications
+    Then user "Carol" should have 1 notification
+
+  Scenario: discard notification if group is deleted
+    Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
+    And the administrator deletes group "grp1" from the default user backend
+    Then user "Brian" should have 0 notifications
+    Then user "Carol" should have 0 notifications

--- a/tests/acceptance/features/apiSharingNotificationsShares/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsShares/sharingNotifications.feature
@@ -5,7 +5,8 @@ Feature: Display notifications when receiving a share
   So that I can easily decide what I want to do with new received shares
 
   Background:
-    Given app "notifications" has been enabled
+    Given the administrator has set the default folder for received shares to "Shares"
+    And app "notifications" has been enabled
     And using OCS API version "1"
     And using new DAV path
     And these users have been created with default attributes and skeleton files:
@@ -53,18 +54,6 @@ Feature: Display notifications when receiving a share
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
       | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/         |
       | object_type | /^local_share$/                                 |
-
-	# This scenario documents behavior discussed in core issue 31870
-	# An old share keeps its old auto-accept behavior, even after auto-accept has been disabled.
-  @skipOnLDAP
-  Scenario: share to group does not send notifications to either existing or new members for an old share created before auto-accept is disabled
-    Given user "Alice" has shared folder "/PARENT" with group "grp1"
-    When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "no"
-    And the administrator creates user "David" using the provisioning API
-    And the administrator adds user "David" to group "grp1" using the provisioning API
-    Then user "Brian" should have 0 notifications
-    And user "Carol" should have 0 notifications
-    And user "David" should have 0 notifications
 
 	# This scenario documents behavior discussed in core issue 31870
 	# As users are added to an existing group, they are not sent notifications about group shares.


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This PR makes `apiSharingNotifications` test scenarios to be valid in both oC10 and OCIS. OCIS always puts received shares into a folder called Shares for the share receiver. On OCIS, auto-accept shares is always disabled.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/518


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
