### PR TITLE
[Tests-Only] Skip troubleshoot-transfer-ownership tests on old oC10

### DIFF
--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -309,7 +309,7 @@ Feature: transfer-ownership
     Then the command output should contain the text "No files/folders to transfer"
     And the command should have failed with exit code 1
 
-  @skipOnEncryptionType:user-keys
+  @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: troubleshoot transfer ownerships for all with share and reshare
     Given user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and skeleton files
@@ -330,7 +330,7 @@ Feature: transfer-ownership
     And the command output should contain the text "Found 0 invalid share owners"
     And the command output should contain the text "Repaired 0 invalid share owners"
 
-  @skipOnEncryptionType:user-keys
+  @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: troubleshoot transfer ownerships for invalid-initiator with reshare
     Given user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and skeleton files
@@ -346,7 +346,7 @@ Feature: transfer-ownership
     And the command output should contain the text "Found 0 invalid initiator reshares"
     And the command output should contain the text "Repaired 0 invalid initiator reshares"
 
-  @skipOnEncryptionType:user-keys
+  @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: troubleshoot transfer ownerships for invalid-owner with share
     Given user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and skeleton files


### PR DESCRIPTION
## Description
These test scenarios were added in PR #37860 
They are only useful on oC10.6 onwards. The command only exists from then.
Skip them on older oC10 versions.

Note: these failed in https://drone.owncloud.com/owncloud/user_ldap/2752/223/14 - the nightly job that runs tests with user_ldap installed on core `latest` which is currently oC10.5

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
