### PR TITLE
make invisible container not mess with mouse events

### DIFF
--- a/changelog/unreleased/37941
+++ b/changelog/unreleased/37941
@@ -1,0 +1,3 @@
+Bugfix: Fix invisible notification container blocking mouse events
+
+https://github.com/owncloud/core/pull/37941

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -645,8 +645,10 @@ td.avatar {
 	width: 100%;
 	text-align: center;
 	z-index: 8000;
+	pointer-events: none;
 }
 #notification {
+	pointer-events: auto;
 	margin: 0 auto;
 	max-width: 60%;
 	background-color: #fef4f6;


### PR DESCRIPTION
Invisible notifications container blocked clicking on call-to-actions beneath