### PR TITLE
Fix display of public link shares in case avatars are disabled

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1898,8 +1898,10 @@
 					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('files', 'via') + " " + folder.name });
 					var $name = $('<strong>', { class : 'shareTree-item-name', text : shareWith });
 					var $icon = $('<div>',    { class : 'shareTree-item-avatar' });
-
-					$icon.avatar(share.share_with, 32);
+                                       
+					if (oc_config.enable_avatars) {
+					       $icon.avatar(share.share_with, 32);
+					}
 
 					$('<li class="shareTree-item">').append( $icon, $name, $path).appendTo($list).click(function() {
 						self.changeDirectory(share.path.replace(folder.name, ''), true).then(function() {

--- a/changelog/unreleased/37945
+++ b/changelog/unreleased/37945
@@ -1,0 +1,5 @@
+Bugfix: fix display of public link shares in case avatars are disabled
+
+In case avatars were disabled through config.php and a public link was created for some file, a "sharing is not allowed" message was displayed when leaving the sharing panel and trying to access it again for that specific file. The behavior has now been fixed.
+
+https://github.com/owncloud/core/pull/37945


### PR DESCRIPTION
## Description

Fix display of public link shares in case avatars are disabled

## Related issue

https://github.com/owncloud/enterprise/issues/4190

## Motivation and Context

This PR fixes the display of public link shares in case avatars are disabled through config.php. Previously, a "sharing is not allowed" message was displayed and public link was not visible in the sharing panel of the "All files" view. The reason for this was a missing check at https://github.com/owncloud/core/blob/master/apps/files/js/filelist.js#L1902 for avatars being enabled/disabled.

## How Has This Been Tested?

Manually:

- setting `'enable_avatars' => false,` in config.php
- create a folder and place some files inside that folder
- share that folder with another user
- (still as the same user) go in to the folder you just shared and try to create a public link on one of the files

Before this fix:

The public link was correctly created in DB but when leaving the sharing panel and trying to access it again via the "All files" view, a "sharing is not allowed" message was shown. It could be accessed via the "Shared with you" page only.

With this fix:

Public link is correctly displayed in the sharing panel of the "All files" view.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [x] Changelog item