### PR TITLE
Clean preferences only if they exist

### DIFF
--- a/changelog/unreleased/37947
+++ b/changelog/unreleased/37947
@@ -1,0 +1,15 @@
+Bugfix: Clean the user's preferences only if they exist during user sync
+
+Previously, the user's preferences were cleaned during the user:sync command.
+This was done regardless of the preferences existance, which was causing the
+"userpreference.afterDeleteValue" event to be triggered always, and then,
+as consequence, the admin_audit app was logging those events.
+Basically, this bug was causing a log flood by the admin_audit app even if
+those preferences weren't there in the first place.
+
+Now we check first if those preferences exist before attempting to delete them.
+If they exist, the admin_audit app will still log that deletion, but if not
+nothing happens because the deletion won't be attempted.
+
+https://github.com/owncloud/core/pull/37947
+

--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -424,9 +424,15 @@ class SyncService {
 	 * @param string $uid
 	 */
 	private function cleanPreferences($uid) {
-		$this->config->deleteUserValue($uid, 'core', 'enabled');
-		$this->config->deleteUserValue($uid, 'login', 'lastLogin');
-		$this->config->deleteUserValue($uid, 'settings', 'email');
-		$this->config->deleteUserValue($uid, 'files', 'quota');
+		$this->deletePreferenceIfExists($uid, 'core', 'enabled');
+		$this->deletePreferenceIfExists($uid, 'login', 'lastLogin');
+		$this->deletePreferenceIfExists($uid, 'settings', 'email');
+		$this->deletePreferenceIfExists($uid, 'files', 'quota');
+	}
+
+	private function deletePreferenceIfExists($uid, $app, $key) {
+		if ($this->config->getUserValue($uid, $app, $key, null) !== null) {
+			$this->config->deleteUserValue($uid, $app, $key);
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Remove the user's preferences only if they exist. This will prevent triggering the `userpreferences.afterDeleteValue` event while syncing users

## Related Issue
https://github.com/owncloud/enterprise/issues/4212

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested just syncing the users via occ command

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
