### PR TITLE
OCS and Public WebDAV Apis should handle LoginException

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/PublicSharingAuth.php
+++ b/apps/dav/lib/Files/PublicFiles/PublicSharingAuth.php
@@ -20,9 +20,11 @@
  */
 namespace OCA\DAV\Files\PublicFiles;
 
+use OC\User\LoginException;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use Sabre\DAV\Auth\Backend\AbstractBasic;
+use Sabre\DAV\Exception\NotAuthenticated;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\INode;
 use Sabre\DAV\Server;
@@ -86,6 +88,7 @@ class PublicSharingAuth extends AbstractBasic {
 	 * @param ResponseInterface $response
 	 * @return array
 	 * @throws NotFound
+	 * @throws NotAuthenticated
 	 */
 	public function check(RequestInterface $request, ResponseInterface $response) {
 		$node = $this->resolveShare($request->getPath());
@@ -98,7 +101,11 @@ class PublicSharingAuth extends AbstractBasic {
 			return [true, 'principals/system/public'];
 		}
 
-		return parent::check($request, $response);
+		try {
+			return parent::check($request, $response);
+		} catch (LoginException $e) {
+			throw new NotAuthenticated($e->getMessage(), $e->getCode(), $e);
+		}
 	}
 
 	/**

--- a/changelog/unreleased/37948
+++ b/changelog/unreleased/37948
@@ -1,0 +1,7 @@
+Bugfix: OCS and Public WebDAV Apis should handle LoginException
+
+OCS api and new public webdav api was not handle LoginException.
+This situation was causing HTTP 500 error in response. This bug has been resolved.
+
+https://github.com/owncloud/brute_force_protection/issues/112
+https://github.com/owncloud/core/pull/37948

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -35,6 +35,7 @@ use OC\AppFramework\Utility\ControllerMethodReflector;
 use OC\Core\Controller\LoginController;
 use OC\OCS\Result;
 use OC\Security\CSP\ContentSecurityPolicyManager;
+use OC\User\LoginException;
 use OCP\API;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -190,6 +191,9 @@ class SecurityMiddleware extends Middleware {
 		if ($controller instanceof OCSController) {
 			if ($exception instanceof NotLoggedInException) {
 				return $controller->buildResponse(new Result(null, API::RESPOND_UNAUTHORISED, 'Unauthorised'));
+			}
+			if ($exception instanceof LoginException) {
+				return $controller->buildResponse(new Result(null, API::RESPOND_UNAUTHORISED, $exception->getMessage()));
 			}
 			if ($exception instanceof NotAdminException) {
 				return $controller->buildResponse(new Result(null, $exception->getCode(), $exception->getMessage()));

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -83,7 +83,7 @@ try {
 
 	OC::$server->getRouter()->match('/ocsapp'.\OC::$server->getRequest()->getRawPathInfo());
 } catch (LoginException $e) {
-	OC_API::respond(new Result(null, \OCP\API::RESPOND_UNAUTHORISED, 'Unauthorised'), OC_API::requestedFormat());
+	OC_API::respond(new Result(null, \OCP\API::RESPOND_UNAUTHORISED, $e->getMessage()), OC_API::requestedFormat());
 } catch (ResourceNotFoundException $e) {
 	OC_API::setContentType();
 	OC_API::notFound();


### PR DESCRIPTION
## Description
OCS api and new public webdav api was not handle LoginException.
This situation was causing HTTP 500 error in response. This bug has been resolved.

## Related Issue
- Fixes https://github.com/owncloud/brute_force_protection/issues/112

## How Has This Been Tested?
https://github.com/owncloud/brute_force_protection/pull/139 proves the related issue has resolved.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
