### PR TITLE
allow scope by user in troubleshoot transfer

### DIFF
--- a/apps/files/tests/Command/TroubleshootTransferOwnershipTest.php
+++ b/apps/files/tests/Command/TroubleshootTransferOwnershipTest.php
@@ -123,7 +123,7 @@ class TroubleshootTransferOwnershipTest extends TestCase {
 			'share_with' => 'user3',
 		];
 		$invalidUidOwnerShareWithPointingToStorage = [
-			'share_id' => '1',
+			'share_id' => '2',
 			'share_type' => '0',
 			'share_parent' => '',
 			'file_source' => '1',
@@ -139,7 +139,7 @@ class TroubleshootTransferOwnershipTest extends TestCase {
 
 		$command->expects($this->at(0))->method('getAllInvalidShareStorages')->with('home::')->willReturn($invalidShareStorages);
 		$command->expects($this->at(1))->method('getAllInvalidShareStorages')->with('object::user:')->willReturn([]);
-		$command->expects($this->exactly(1))->method('deleteCorruptedShare')->with($invalidUidOwnerShareWithPointingToStorage)->willReturn(null);
+		$command->expects($this->exactly(1))->method('deleteCorruptedShare')->with('2', 0)->willReturn(null);
 		$command->expects($this->exactly(1))->method('adjustShareOwner')->with('1', 'user1')->willReturn(null);
 
 		$commandTester = new CommandTester($command);

--- a/changelog/unreleased/37860
+++ b/changelog/unreleased/37860
@@ -1,0 +1,5 @@
+Change: Add command to troubleshoot transfer ownership runs for issues
+
+https://github.com/owncloud/core/pull/37950
+https://github.com/owncloud/core/pull/37860
+https://github.com/owncloud/enterprise/issues/4121

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -325,10 +325,8 @@ Feature: transfer-ownership
     Then the command should have been successful
     And the command output should contain the text "Searching for reshares that have invalid uid_initiator"
     And the command output should contain the text "Found 0 invalid initiator reshares"
-    And the command output should contain the text "Repaired 0 invalid initiator reshares"
     And the command output should contain the text "Searching for shares that have invalid uid_owner"
     And the command output should contain the text "Found 0 invalid share owners"
-    And the command output should contain the text "Repaired 0 invalid share owners"
 
   @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: troubleshoot transfer ownerships for invalid-initiator with reshare
@@ -344,7 +342,6 @@ Feature: transfer-ownership
     Then the command should have been successful
     And the command output should contain the text "Searching for reshares that have invalid uid_initiator"
     And the command output should contain the text "Found 0 invalid initiator reshares"
-    And the command output should contain the text "Repaired 0 invalid initiator reshares"
 
   @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: troubleshoot transfer ownerships for invalid-owner with share
@@ -359,4 +356,3 @@ Feature: transfer-ownership
     Then the command should have been successful
     And the command output should contain the text "Searching for shares that have invalid uid_owner"
     And the command output should contain the text "Found 0 invalid share owners"
-    And the command output should contain the text "Repaired 0 invalid share owners"


### PR DESCRIPTION
Extension of https://github.com/owncloud/core/pull/37860 with additional option for scoping for user

- [x] add docs issue https://github.com/owncloud/docs/issues/2794

```
occ files:troubleshoot-transfer-ownership all  --uid <userid>
```

Related: https://github.com/owncloud/enterprise/issues/4121