### PR TITLE
with user sync command error properly exit and log

### DIFF
--- a/changelog/unreleased/37951
+++ b/changelog/unreleased/37951
@@ -1,0 +1,7 @@
+Bugfix: properly exit and log during error in user sync command
+
+If there is an error when doing occ user:sync then the command will exit with
+return 1 and properly log the error.
+
+https://github.com/owncloud/core/pull/37951
+https://github.com/owncloud/enterprise/issues/4218

--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -130,16 +130,16 @@ class SyncService {
 				$uid = $account->getUserId(); // get correct case
 				// clean the user's preferences
 				$this->cleanPreferences($uid);
+				if (\is_callable($callback)) {
+					$callback($uid, null);
+				}
 			} catch (\Exception $e) {
 				// Error syncing this user
 				$backendClass = \get_class($backend);
-				$this->logger->error("Error syncing user with uid: $uid and backend: $backendClass");
-				$this->logger->logException($e);
-			}
-
-			// call the callback
-			if (\is_callable($callback)) {
-				$callback($uid);
+				$this->logger->logException($e, ['message' => "Error syncing user with uid: $uid and backend: $backendClass"]);
+				if (\is_callable($callback)) {
+					$callback($uid, $e);
+				}
 			}
 		}
 	}

--- a/tests/lib/Command/User/SyncBackendTest.php
+++ b/tests/lib/Command/User/SyncBackendTest.php
@@ -269,9 +269,7 @@ class SyncBackendTest extends TestCase {
 
 	/**
 	 */
-	public function testSingleUserSyncExistingUserException() {
-		$this->expectException(\LengthException::class);
-
+	public function testSingleUserSyncExistingUserError() {
 		$inputInterface = $this->createMock(InputInterface::class);
 		$outputInterface = $this->createMock(OutputInterface::class);
 		$syncService = $this->createMock(SyncService::class);
@@ -283,7 +281,12 @@ class SyncBackendTest extends TestCase {
 		$missingAccountsAction = 'disable';
 		$syncService->expects($this->never())->method('run');
 
-		static::invokePrivate($this->command, 'syncSingleUser', [
+		$outputInterface
+			->expects($this->at(1))
+			->method('writeln')
+			->with('<error>Multiple users returned from backend for: existing-uid. Cancelling sync.</error>');
+
+		$return = static::invokePrivate($this->command, 'syncSingleUser', [
 			$inputInterface,
 			$outputInterface,
 			$syncService,
@@ -291,6 +294,8 @@ class SyncBackendTest extends TestCase {
 			'existing-uid',
 			$missingAccountsAction,
 		]);
+
+		$this->assertFalse($return);
 	}
 
 	public function testSingleUserSyncExistingUser() {
@@ -312,7 +317,7 @@ class SyncBackendTest extends TestCase {
 			$this->anything()
 		);
 
-		static::invokePrivate($this->command, 'syncSingleUser', [
+		$return = static::invokePrivate($this->command, 'syncSingleUser', [
 			$inputInterface,
 			$outputInterface,
 			$syncService,
@@ -320,6 +325,7 @@ class SyncBackendTest extends TestCase {
 			'existing-uid',
 			$missingAccountsAction,
 		]);
+		$this->assertTrue($return);
 	}
 
 	public function removedUserProvider() {
@@ -368,7 +374,7 @@ class SyncBackendTest extends TestCase {
 			$removedUser->expects($this->never())->method('setEnabled');
 		}
 
-		static::invokePrivate($this->command, 'syncSingleUser', [
+		$return = static::invokePrivate($this->command, 'syncSingleUser', [
 			$inputInterface,
 			$outputInterface,
 			$syncService,
@@ -376,6 +382,7 @@ class SyncBackendTest extends TestCase {
 			'removed-uid',
 			$action,
 		]);
+		$this->assertTrue($return);
 	}
 
 	public function testSyncMultipleUsersExistingUsers() {
@@ -404,13 +411,14 @@ class SyncBackendTest extends TestCase {
 			$this->anything()
 		);
 
-		static::invokePrivate($this->command, 'syncMultipleUsers', [
+		$return = static::invokePrivate($this->command, 'syncMultipleUsers', [
 			$inputInterface,
 			$outputInterface,
 			$syncService,
 			$this->dummyBackend,
 			$missingAccountsAction,
 		]);
+		$this->assertTrue($return);
 	}
 
 	/**
@@ -457,13 +465,14 @@ class SyncBackendTest extends TestCase {
 			$removedUser->expects($this->never())->method('setEnabled');
 		}
 
-		static::invokePrivate($this->command, 'syncMultipleUsers', [
+		$return = static::invokePrivate($this->command, 'syncMultipleUsers', [
 			$inputInterface,
 			$outputInterface,
 			$syncService,
 			$this->dummyBackend,
 			$action,
 		]);
+		$this->assertTrue($return);
 	}
 
 	public function testReEnableAction() {

--- a/tests/lib/User/SyncServiceTest.php
+++ b/tests/lib/User/SyncServiceTest.php
@@ -138,8 +138,7 @@ class SyncServiceTest extends TestCase {
 		$this->mapper->expects($this->once())->method('getByUid')->with($backendUids[0])->willThrowException(new MultipleObjectsReturnedException('Trigger error'));
 
 		// Should log an error in the log and log the exception
-		$this->logger->expects($this->at(0))->method('error');
-		$this->logger->expects($this->at(1))->method('logException');
+		$this->logger->expects($this->at(0))->method('logException');
 
 		$s = new SyncService($this->config, $this->logger, $this->mapper);
 		$s->run($backend, new BackendUsersIterator($backend));


### PR DESCRIPTION
When running `./occ user:sync` make sure to exit on error with non-zero, plus add log to console informing on error

- [x] add tests
- [x] add changelog

Related: https://github.com/owncloud/enterprise/issues/4218