### PR TITLE
Remove progress bar from the DropOldTables repair job

### DIFF
--- a/changelog/unreleased/37953
+++ b/changelog/unreleased/37953
@@ -1,0 +1,6 @@
+Change: DropOldTables repair job won't show a progress bar
+
+The "DropOldTables" repair job that happens during upgrade won't show
+a progress bar any longer.
+
+https://github.com/owncloud/core/pull/37953

--- a/lib/private/Repair/DropOldTables.php
+++ b/lib/private/Repair/DropOldTables.php
@@ -55,15 +55,11 @@ class DropOldTables implements IRepairStep {
 	 * @throws \Exception in case of failure
 	 */
 	public function run(IOutput $output) {
-		$tables = $this->oldDatabaseTables();
-		$output->startProgress(\count($tables));
 		foreach ($this->oldDatabaseTables() as $tableName) {
 			if ($this->connection->tableExists($tableName)) {
 				$this->connection->dropTable($tableName);
 			}
-			$output->advance(1, "Drop old database table: $tableName");
 		}
-		$output->finishProgress();
 	}
 
 	/**

--- a/tests/Core/Command/Maintenance/RepairTest.php
+++ b/tests/Core/Command/Maintenance/RepairTest.php
@@ -75,7 +75,7 @@ class RepairTest extends TestCase {
 			[[], false, 0, 'Turn on maintenance mode to use this command'],
 			[['--single' => '\OC\UnexistingClass'], true, 1, 'Repair step not found'],
 			[['--single' => 'OC\Repair\RepairMimeTypes'], true, 0, 'Repair mime types'],
-			[[], true, 0, '100%'],
+			[[], true, 0, 'Step:'],
 			[['--include-expensive' => true], true, 0, 'Remove shares of old group memberships']
 		];
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Remove the progress bar as requested in the issue

## Related Issue
https://github.com/owncloud/enterprise/issues/4205

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually changing the version in the config.php file and running the `occ upgrade` job.
```
........
2020-09-28T11:33:20+00:00 Repair step: Clean tags and favorites
2020-09-28T11:33:20+00:00 Repair info: 0 tags of deleted users have been removed.
2020-09-28T11:33:20+00:00 Repair info: 0 tags for delete files have been removed.
2020-09-28T11:33:20+00:00 Repair info: 0 tag entries for deleted tags have been removed.
2020-09-28T11:33:20+00:00 Repair info: 0 tags with no entries have been removed.
2020-09-28T11:33:20+00:00 Repair step: Drop old database tables
2020-09-28T11:33:20+00:00 Repair step: Drop old background jobs
2020-09-28T11:33:20+00:00 Repair step: Remove getetag entries in properties table
2020-09-28T11:33:20+00:00 Repair info: Removed 0 unneeded "{DAV:}getetag" entries from properties table.
2020-09-28T11:33:20+00:00 Repair step: Repair invalid shares
..........
```
The behaviour is expected to be the same as with a full-fledged upgrade.

Also checked with the `occ maintenance:repair` command:
```
# occ maintenance:repair -s 'OC\Repair\DropOldTables'
ownCloud is in maintenance mode - no app have been loaded

 - Step: Drop old database tables

```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
