### PR TITLE
[tests-only] API tests for etag propagation

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -537,6 +537,19 @@ default:
         - OccContext:
         - PublicWebDavContext:
 
+    apiWebdavEtagPropagation:
+      paths:
+        - '%paths.base%/../features/apiWebdavEtagPropagation'
+      context: *common_ldap_suite_context
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - LoggingContext:
+        - OccContext:
+        - TrashbinContext:
+        - PublicWebDavContext:
+        - FilesVersionsContext:
+        - WebDavPropertiesContext:
+
     apiTranslation:
       paths:
         - '%paths.base%/../features/apiTranslation'

--- a/tests/acceptance/features/apiWebdavEtagPropagation/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation/createFolder.feature
@@ -1,0 +1,34 @@
+@api @skipOnOcis-OC-Storage
+Feature: propagation of etags when creating folders
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  Scenario Outline: creating a folder inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" creates folder "/folder/new" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element |
+      | old         |         |
+      | old         | folder  |
+      | new         |         |
+      | new         | folder  |
+
+  Scenario Outline: creating an invalid folder inside a folder should not change any etags
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has created folder "/folder/sub"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" creates folder "/folder/sub/.." using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should not have changed
+    Examples:
+      | dav_version | element    |
+      | old         |            |
+      | old         | folder     |
+      | old         | folder/sub |
+      | new         |            |
+      | new         | folder     |
+      | new         | folder/sub |

--- a/tests/acceptance/features/apiWebdavEtagPropagation/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation/deleteFileFolder.feature
@@ -1,0 +1,55 @@
+@api @skipOnOcis-OC-Storage
+Feature: propagation of etags when deleting a file or folder
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/upload"
+
+  Scenario Outline: deleting a file changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" deletes file "/upload/sub/file.txt" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element    |
+      | old         |            |
+      | old         | upload     |
+      | old         | upload/sub |
+      | new         |            |
+      | new         | upload     |
+      | new         | upload/sub |
+
+  Scenario Outline: deleting a folder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has created folder "/upload/sub/toDelete"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" deletes folder "/upload/sub/toDelete" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element    |
+      | old         |            |
+      | old         | upload     |
+      | old         | upload/sub |
+      | new         |            |
+      | new         | upload     |
+      | new         | upload/sub |
+
+  Scenario Outline: deleting a folder with content changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has created folder "/upload/sub/toDelete"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/toDelete/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" deletes folder "/upload/sub/toDelete" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element    |
+      | old         |            |
+      | old         | upload     |
+      | old         | upload/sub |
+      | new         |            |
+      | new         | upload     |
+      | new         | upload/sub |

--- a/tests/acceptance/features/apiWebdavEtagPropagation/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation/moveFileFolder.feature
@@ -1,0 +1,101 @@
+@api @skipOnOcis-OC-Storage
+Feature: propagation of etags when moving files or folders
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  Scenario Outline: renaming a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" moves file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element |
+      | old         |         |
+      | old         | upload  |
+      | new         |         |
+      | new         | upload  |
+
+  Scenario Outline: moving a file from one folder to an other changes the etags of both folders
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" moves file "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element |
+      | old         |         |
+      | old         | src     |
+      | old         | dst     |
+      | new         |         |
+      | new         | src     |
+      | new         | dst     |
+
+  Scenario Outline: moving a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" moves file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element    |
+      | old         |            |
+      | old         | upload     |
+      | old         | upload/sub |
+      | new         |            |
+      | new         | upload     |
+      | new         | upload/sub |
+
+  Scenario Outline: renaming a folder inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/src"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" moves folder "/upload/src" to "/upload/dst" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element |
+      | old         |         |
+      | old         | upload  |
+      | new         |         |
+      | new         | upload  |
+
+  Scenario Outline: moving a folder from one folder to an other changes the etags of both folders
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has created folder "/src/folder"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" moves folder "/src/folder" to "/dst/folder" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element |
+      | old         |         |
+      | old         | src     |
+      | old         | dst     |
+      | new         |         |
+      | new         | src     |
+      | new         | dst     |
+
+  Scenario Outline: moving a folder into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/folder"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" moves folder "/upload/folder" to "/upload/sub/folder" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element    |
+      | old         |            |
+      | old         | upload     |
+      | old         | upload/sub |
+      | new         |            |
+      | new         | upload     |
+      | new         | upload/sub |

--- a/tests/acceptance/features/apiWebdavEtagPropagation/restoreFromTrash.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation/restoreFromTrash.feature
@@ -1,0 +1,79 @@
+@api @skipOnOcis-OC-Storage
+Feature: propagation of etags when restoring a file or folder from trash
+
+  Background:
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/upload"
+
+  Scenario Outline: restoring a file to its original location changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
+    And user "Alice" has deleted file "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" restores the file with original path "/upload/sub/file.txt" using the trashbin API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element    |
+      | old         |            |
+      | old         | upload     |
+      | old         | upload/sub |
+      | new         |            |
+      | new         | upload     |
+      | new         | upload/sub |
+
+  Scenario Outline: restoring a file to an other location changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has created folder "/restore"
+    And user "Alice" has created folder "/restore/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
+    And user "Alice" has deleted file "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" restores the file with original path "/upload/sub/file.txt" to "/restore/sub/file.txt" using the trashbin API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element     |
+      | old         |             |
+      | old         | restore     |
+      | old         | restore/sub |
+      | new         |             |
+      | new         | restore     |
+      | new         | restore/sub |
+
+  Scenario Outline: restoring a folder to its original location changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has created folder "/upload/sub/toDelete"
+    And user "Alice" has deleted folder "/upload/sub/toDelete"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" restores the folder with original path "/upload/sub/toDelete" using the trashbin API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element    |
+      | old         |            |
+      | old         | upload     |
+      | old         | upload/sub |
+      | new         |            |
+      | new         | upload     |
+      | new         | upload/sub |
+
+  Scenario Outline: restoring a folder to an other location changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has created folder "/upload/sub/toDelete"
+    And user "Alice" has deleted folder "/upload/sub/toDelete"
+    And user "Alice" has created folder "/restore"
+    And user "Alice" has created folder "/restore/sub"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" restores the folder with original path "/upload/sub/toDelete" to "/restore/sub/toDelete" using the trashbin API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element     |
+      | old         |             |
+      | old         | restore     |
+      | old         | restore/sub |
+      | new         |             |
+      | new         | restore     |
+      | new         | restore/sub |

--- a/tests/acceptance/features/apiWebdavEtagPropagation/restoreVersion.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation/restoreVersion.feature
@@ -1,0 +1,21 @@
+@api @skipOnOcis-OC-Storage
+Feature: propagation of etags when restoring a version of a file
+
+  Background:
+    Given using OCS API version "2"
+    And using new DAV path
+    And user "Alice" has been created with default attributes and without skeleton files
+
+  Scenario Outline: Restoring a file changes the etags of all parents
+    Given user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
+    And user "Alice" has uploaded file with content "changed content" to "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" restores version index "1" of file "/upload/sub/file.txt" using the WebDAV API
+    Then the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | element    |
+      |            |
+      | upload     |
+      | upload/sub |

--- a/tests/acceptance/features/apiWebdavEtagPropagation/upload.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation/upload.feature
@@ -1,0 +1,35 @@
+@api @skipOnOcis-OC-Storage
+Feature: propagation of etags when uploading data
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/upload"
+
+  Scenario Outline: uploading a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" uploads file with content "uploaded content" to "/upload/file.txt" using the WebDAV API
+    Then the content of file "/upload/file.txt" for user "Alice" should be "uploaded content"
+    And the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element |
+      | old         |         |
+      | old         | upload  |
+      | new         |         |
+      | new         | upload  |
+
+  Scenario Outline: overwriting a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/<element>"
+    When user "Alice" uploads file with content "new content" to "/upload/file.txt" using the WebDAV API
+    Then the content of file "/upload/file.txt" for user "Alice" should be "new content"
+    And the etag of element "/<element>" of user "Alice" should have changed
+    Examples:
+      | dav_version | element         |
+      | old         |                 |
+      | old         | upload          |
+      | old         | upload/file.txt |
+      | new         |                 |
+      | new         | upload          |
+      | new         | upload/file.txt |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -183,18 +183,3 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
-
-  @toImplementOnOCIS @issue-product-127
-  Scenario Outline: uploading a file inside a folder changes its etag
-    Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has stored etag of element "/<element>"
-    When user "Alice" uploads file with content "uploaded content" to "/upload/file.txt" using the WebDAV API
-    Then the content of file "/upload/file.txt" for user "Alice" should be "uploaded content"
-    And the etag of element "/<element>" of user "Alice" should have changed
-    Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |


### PR DESCRIPTION
## Description
etag propagation tests

## Related Issue
part of https://github.com/owncloud/product/issues/144

## Motivation and Context
OCIS has now etag propagation implemented in the OCIS-storage, that need to be tested

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
