### PR TITLE
Retry moving mountpoint sane amount of times

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -29,6 +29,7 @@
 
 namespace OCA\Files_Sharing\External;
 
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\Files\Filesystem;
 use OC\User\NoUserException;
 use OCA\Files_Sharing\Helper;
@@ -315,7 +316,11 @@ class Manager {
 			WHERE `mountpoint_hash` = ?
 			AND `user` = ?
 		');
-		$result = (bool)$query->execute([$target, $targetHash, $sourceHash, $this->uid]);
+		try {
+			$result = (bool)$query->execute([$target, $targetHash, $sourceHash, $this->uid]);
+		} catch (UniqueConstraintViolationException $e) {
+			$result = false;
+		}
 
 		return $result;
 	}

--- a/apps/files_sharing/lib/External/Mount.php
+++ b/apps/files_sharing/lib/External/Mount.php
@@ -54,8 +54,9 @@ class Mount extends MountPoint implements MoveableMount {
 	 */
 	public function moveMount($target) {
 		$result = $this->manager->setMountPoint($this->mountPoint, $target);
-		$this->setMountPoint($target);
-
+		if ($result === true) {
+			$this->setMountPoint($target);
+		}
 		return $result;
 	}
 

--- a/changelog/unreleased/37956
+++ b/changelog/unreleased/37956
@@ -1,0 +1,10 @@
+Bugfix: Add a configurable number of retries on unsuccessful mountpoint move
+
+Handling of conflicting mountpoints across different share backends was improved 
+by adding a configurable number of the mountpoint rename attempts. Now when the
+mountpoint rename has been failed on the user filesystem initialization due to 
+internal backend-specific reasons the used mountpoint name is considered
+to be taken, a new name is generated and the rename operation could be repeated
+several times until it either succeeds or rename attempts limit is reached.
+
+https://github.com/owncloud/core/pull/37956

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1388,6 +1388,18 @@ $CONFIG = [
 'filesystem_check_changes' => 0,
 
 /**
+ * Define unsuccessful mountpoint rename attempts
+ * This config value avoids infinite loops for seldom cases where a file renaming
+ * conflict between different share backends could occur.
+ * The value defines how many unsuccessful mountpoint rename attempts are allowed.
+ * e.g. target mountpoint name could be claimed as unused by the filesystem but
+ * renaming to this target name will fail due to some other reasons like database
+ * constraints.
+ * Change this value only under supervision of ownCloud support.
+ */
+'filesystem.max_mountpoint_move_attempts' => 10,
+
+/**
  * Define where part files are located
  * By default ownCloud will store the part files created during upload in the
  * same storage as the upload target. Setting this to false will store the part

--- a/lib/private/Files/Config/MountProviderCollection.php
+++ b/lib/private/Files/Config/MountProviderCollection.php
@@ -39,7 +39,7 @@ use OCP\IUser;
 class MountProviderCollection implements IMountProviderCollection, Emitter {
 	use EmitterTrait;
 
-	const MAX_MOVE_ATTEMPTS_PER_MOUNTPOINT = 10;
+	const DEFAULT_MOVE_ATTEMPTS_PER_MOUNTPOINT = 10;
 
 	/**
 	 * @var \OCP\Files\Config\IHomeMountProvider[]
@@ -87,11 +87,12 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 
 		$mergedMounts = [];
 		$takenMountpoints = [];
+		$maxMoveAttempts = $this->getMaxMoveAttempts();
 		foreach ($mounts as $providerMounts) {
 			foreach ($providerMounts as $mount) {
 				$mountpoint = $mount->getMountPoint();
 				if (\in_array($mountpoint, $takenMountpoints)) {
-					for ($i = 0; $i < self::MAX_MOVE_ATTEMPTS_PER_MOUNTPOINT; $i++) {
+					for ($i = 0; $i < $maxMoveAttempts; $i++) {
 						$newMountpoint = $this->generateUniqueTarget(
 							$mountpoint,
 							new View('/' . $user->getUID() . '/files'),
@@ -196,5 +197,10 @@ class MountProviderCollection implements IMountProviderCollection, Emitter {
 		}
 
 		return $path;
+	}
+
+	protected function getMaxMoveAttempts() {
+		return \OC::$server->getConfig()
+			->getSystemValue('filesystem.max_mountpoint_move_attempts', self::DEFAULT_MOVE_ATTEMPTS_PER_MOUNTPOINT);
 	}
 }


### PR DESCRIPTION
# Description
- Catch and handle integrity constraint violations and return `false` as expected
- Make 10 attempts to move the mountpoint

## Related Issue
- https://github.com/owncloud/enterprise/issues/4094

## Motivation and Context
a newly generated mounpoint path may exist but hasn't been mount yet. An attempt to move to this path will cause breaking constraint on index `sh_external_mp` for `oc_share_external` table

## How Has This Been Tested?
no exact reproduction steps provided :no_good:

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
