### PR TITLE
[Tests-Only] Do not run long tests after PR merge

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -668,9 +668,6 @@ def phpstan():
 				}
 			}
 
-			for branch in config['branches']:
-				result['trigger']['ref'].append('refs/heads/%s' % branch)
-
 			pipelines.append(result)
 
 	return pipelines
@@ -744,9 +741,6 @@ def phan():
 					]
 				}
 			}
-
-			for branch in config['branches']:
-				result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 			pipelines.append(result)
 
@@ -911,9 +905,6 @@ def litmus():
 				}
 			}
 
-			for branch in config['branches']:
-				result['trigger']['ref'].append('refs/heads/%s' % branch)
-
 			pipelines.append(result)
 
 	return pipelines
@@ -1006,9 +997,6 @@ def dav():
 						]
 					}
 				}
-
-				for branch in config['branches']:
-					result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 				pipelines.append(result)
 
@@ -1104,9 +1092,6 @@ def javascript():
 				],
 			}
 		})
-
-	for branch in config['branches']:
-		result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 	return [result]
 
@@ -1287,9 +1272,6 @@ def phptests(testType):
 								],
 							}
 						})
-
-					for branch in config['branches']:
-						result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 					pipelines.append(result)
 
@@ -1519,9 +1501,6 @@ def acceptance(ctx):
 										]
 									}
 								}
-
-								for branch in config['branches']:
-									result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 								pipelines.append(result)
 


### PR DESCRIPTION
## Description
We have been running the whole set of tests in CI after every merge to `master`. And actually if that merge-CI fails, nobody really notices it. They notice when they do another PR  and something goes wrong.

For regular PRs, the whole drone CI  test suite has already passed before merging.

We could run less stuff in the merge-CI.

I stopped it from running these things in the CI that happens after a PR is merged:
- no phan/phpstan code analysis
- no JavaScript unit tests
- no PHP unit tests
- no Behat acceptance tests

It should still run:
- dependency cache update
- changelog processing
- code-style (just to have something happen!)
- notify to rocketchat


## How Has This Been Tested?
CI - but we need to merge it to see what actually runs when a PR is merged.

The CI in the PR  did run all the usual pipelines, so nothing got lost.

@xoxys @micbar is it this easy? Just removing the trigger `refs/heads/master` from various pipelines?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
