### PR TITLE
Adjust scanner flags

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -191,9 +191,7 @@ class Scanner extends BasicEmitter implements IScanner {
 						if (isset($data['storage_mtime'], $cacheData['storage_mtime']) && $data['storage_mtime'] === $cacheData['storage_mtime']) {
 							$data['mtime'] = $cacheData['mtime'];
 							if (($reuseExisting & self::REUSE_SIZE) && ($data['size'] === -1)) {
-								if (($data['mimetype'] !== 'httpd/unix-directory') || !($reuseExisting & self::REUSE_ONLY_FOR_FILES)) {
-									$data['size'] = $cacheData['size'];
-								}
+								$data['size'] = $cacheData['size'];
 							}
 							if ($reuseExisting & self::REUSE_ETAG) {
 								if (($data['mimetype'] !== 'httpd/unix-directory') || !($reuseExisting & self::REUSE_ONLY_FOR_FILES)) {

--- a/lib/private/Files/Cache/Watcher.php
+++ b/lib/private/Files/Cache/Watcher.php
@@ -100,7 +100,7 @@ class Watcher implements IWatcher {
 	 */
 	public function update($path, $cachedData) {
 		if ($this->storage->is_dir($path)) {
-			$this->scanner->scan($path, Scanner::SCAN_SHALLOW, Scanner::REUSE_ETAG | Scanner::REUSE_ONLY_FOR_FILES);
+			$this->scanner->scan($path, Scanner::SCAN_SHALLOW, Scanner::REUSE_ETAG | Scanner::REUSE_SIZE | Scanner::REUSE_ONLY_FOR_FILES);
 		} else {
 			$this->scanner->scanFile($path);
 		}

--- a/lib/public/Files/Cache/IScanner.php
+++ b/lib/public/Files/Cache/IScanner.php
@@ -34,7 +34,7 @@ interface IScanner {
 	const REUSE_NONE = 0;
 	const REUSE_ETAG = 1;
 	const REUSE_SIZE = 2;
-	const REUSE_ONLY_FOR_FILES = 4;  // apply the reuse (either tag or size) only to files, not folders
+	const REUSE_ONLY_FOR_FILES = 4;  // apply the etag reuse only to files, not folders
 
 	/**
 	 * scan a single file and store it in the cache


### PR DESCRIPTION
The scanner's update method will reuse the size if possible.
REUSE_ONLY_FOR_FILES flag will only be applicable to etag, not size
Links to https://github.com/owncloud/core/pull/37218

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Fixes some problems detected with GDrive due to https://github.com/owncloud/core/pull/37218 . There are also some changes pending in the GDrive storage regarding the handling of google document files.

Might be related to https://github.com/owncloud/enterprise/issues/4129

For the GDrive case, the folder was showing "Pending" with a size of -1 in the DB if the folder contained a google document. This should be fixed with this patch, but the etag still changes for the folder because the gdrive implementation detects a file newer with mtime newer than the folder (google doesn't update the mtime of the folder)

I haven't tested yet for https://github.com/owncloud/enterprise/issues/4129 because the step to reproduce aren't clear

## Related Issue
https://github.com/owncloud/enterprise/issues/4129

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
