### PR TITLE
Fix problem with the share icons when the avatars are disabled

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -50,6 +50,7 @@
 	white-space: normal;
 	background: #f8f8f8;
 	border-bottom: 1px solid #aaa;
+	min-height: 32px;
 }
 
 #shareWithList .unshare img {

--- a/changelog/unreleased/37964
+++ b/changelog/unreleased/37964
@@ -1,0 +1,9 @@
+Bugfix: Fix icon alignment when avatars are disabled
+
+Action icons for the sharee list view, when you want to know
+who are you sharing to, where being pushed to the left when the
+avatars were disabled, breaking part of the layout.
+
+Those icons are now aligned.
+
+https://github.com/owncloud/core/pull/37964

--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -22,9 +22,8 @@
 		'		{{#if expirationDate}}' +
 		'		<a class="time"><span class="icon icon-time"></span><span class="hidden-visually">{{unshareLabel}}</span></a>' +
 		'		{{/if}}' +
-		'		{{#if avatarEnabled}}' +
+				// avatar disabled case will be handled via js when it's rendered
 		'		<div class="avatar {{#if modSeed}}imageplaceholderseed{{/if}}" data-username="{{shareWith}}" {{#if modSeed}}data-seed="{{shareWith}} {{shareType}}"{{/if}}></div>' +
-		'		{{/if}}' +
 		'		<span class="has-tooltip username" title="{{shareWith}}">{{shareWithDisplayName}}</span>' +
 		'		{{#if shareWithAdditionalInfo}}' +
 		'		<span class="has-tooltip user-additional-info">({{shareWithAdditionalInfo}})</span>' +
@@ -305,6 +304,8 @@
 						$this.avatar($this.data('username'), 32);
 					}
 				});
+			} else {
+				this.$el.find('.avatar').css({visibility: 'hidden', width: 0});
 			}
 
 			this.$el.find('.has-tooltip').tooltip({

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -211,7 +211,8 @@ describe('OC.Share.ShareDialogView', function() {
 			});
 
 			it('no avatar classes', function() {
-				expect($('.avatar').length).toEqual(0);
+				expect(dialog.$('.avatar:hidden').length).toEqual(3);
+				expect(dialog.$('.avatar:visible').length).toEqual(0);
 				expect(avatarStub.callCount).toEqual(0);
 				expect(placeholderStub.callCount).toEqual(0);
 			});


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Set a minimum height for the sharee list so the icons are properly "floated" to the right

## Related Issue
https://github.com/owncloud/enterprise/issues/4221

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Seen after the avatars were disabled

## Screenshots (if appropriate):
![Screenshot from 2020-10-01 14-49-01](https://user-images.githubusercontent.com/1477829/94811200-569e0700-03f5-11eb-89a1-be2409a48f1a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
