### PR TITLE
Cleaning up autocapitalize="off"

### DIFF
--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -25,9 +25,9 @@
 		'</ul>';
 
 	var TEMPLATE_FILENAME_FORM =
-		'<form class="filenameform">' +
+		'<form class="filenameform" autocapitalize="none">' +
 		'<label class="hidden-visually" for="{{cid}}-input-{{fileType}}">{{fileName}}</label>' +
-		'<input id="{{cid}}-input-{{fileType}}" type="text" value="{{fileName}}" autocomplete="off" autocapitalize="off">' +
+		'<input id="{{cid}}-input-{{fileType}}" type="text" value="{{fileName}}" autocomplete="off">' +
 		'</form>';
 
 	/**

--- a/apps/files_sharing/templates/authenticate.php
+++ b/apps/files_sharing/templates/authenticate.php
@@ -4,7 +4,7 @@
 	style('files_sharing', 'authenticate');
 	script('files_sharing', 'authenticate');
 ?>
-<form method="post">
+<form method="post" autocapitalize="none">
 	<fieldset>
 		<?php if (!isset($_['wrongpw'])): ?>
 			<div class="warning-info"><?php p($l->t('This share is password-protected')); ?></div>
@@ -15,7 +15,7 @@
 		<p>
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 			<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" />
-			<input type="password" name="password" id="password" placeholder="<?php p($l->t('Password')); ?>" value="" autocomplete="off" autocapitalize="off" autocorrect="off" autofocus />
+			<input type="password" name="password" id="password" placeholder="<?php p($l->t('Password')); ?>" value="" autocomplete="off" autocorrect="off" autofocus />
 			<input type="submit" id="password-submit"  class="svg icon-confirm input-button-inline" value="" disabled="disabled" />
 		</p>
 	</fieldset>

--- a/changelog/unreleased/15399
+++ b/changelog/unreleased/15399
@@ -1,0 +1,7 @@
+Bugfix: Cleaning up `autocapitalize="off"` in files
+
+All instances of deprecated `autocapitalize="off"` HTML attributes were replaced
+with `autocapitalize="none"` in the parent <form> tag.
+
+https://github.com/owncloud/core/issues/15399
+https://github.com/owncloud/core/pull/37965

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -8,7 +8,7 @@ script('core', [
 <input type='hidden' id='hasSQLite' value='<?php p($_['hasSQLite']) ?>'>
 <input type='hidden' id='hasPostgreSQL' value='<?php p($_['hasPostgreSQL']) ?>'>
 <input type='hidden' id='hasOracle' value='<?php p($_['hasOracle']) ?>'>
-<form action="index.php" method="post">
+<form action="index.php" method="post" autocapitalize="none">
 <input type="hidden" name="install" value="true">
 	<?php if (\count($_['errors']) > 0): ?>
 	<fieldset class="warning">
@@ -31,14 +31,14 @@ script('core', [
 			<input type="text" name="adminlogin" id="adminlogin"
 				placeholder="<?php p($l->t('Username')); ?>"
 				value="<?php p($_['adminlogin']); ?>"
-				autocomplete="off" autocapitalize="off" autocorrect="off" autofocus required>
+				autocomplete="off" autocorrect="off" autofocus required>
 			<label for="adminlogin" class="infield"><?php p($l->t('Username')); ?></label>
 		</p>
 		<p class="groupbottom">
 			<input type="password" name="adminpass" data-typetoggle="#showadminpass" id="adminpass"
 				placeholder="<?php p($l->t('Password')); ?>"
 				value="<?php p($_['adminpass']); ?>"
-				autocomplete="off" autocapitalize="off" autocorrect="off" required>
+				autocomplete="off" autocorrect="off" required>
 			<label for="adminpass" class="infield"><?php p($l->t('Password')); ?></label>
 			<input type="checkbox" id="showadminpass" name="showadminpass">
 			<label for="showadminpass"></label>
@@ -58,7 +58,7 @@ script('core', [
 			<input type="text" name="directory" id="directory"
 				placeholder="<?php p(OC::$SERVERROOT.'/data'); ?>"
 				value="<?php p($_['directory']); ?>"
-				autocomplete="off" autocapitalize="off" autocorrect="off">
+				autocomplete="off" autocorrect="off">
 		</div>
 	</fieldset>
 	<?php endif; ?>
@@ -98,13 +98,13 @@ script('core', [
 				<input type="text" name="dbuser" id="dbuser"
 					placeholder="<?php p($l->t('Database user')); ?>"
 					value="<?php p($_['dbuser']); ?>"
-					autocomplete="off" autocapitalize="off" autocorrect="off">
+					autocomplete="off" autocorrect="off">
 			</p>
 			<p class="groupmiddle">
 				<input type="password" name="dbpass" id="dbpass" data-typetoggle="#showdbpass"
 					placeholder="<?php p($l->t('Database password')); ?>"
 					value="<?php p($_['dbpass']); ?>"
-					autocomplete="off" autocapitalize="off" autocorrect="off">
+					autocomplete="off" autocorrect="off">
 				<label for="dbpass" class="infield"><?php p($l->t('Database password')); ?></label>
 				<input type="checkbox" id="showdbpass" name="showdbpass">
 				<label for="showdbpass"></label>
@@ -114,7 +114,7 @@ script('core', [
 				<input type="text" name="dbname" id="dbname"
 					placeholder="<?php p($l->t('Database name')); ?>"
 					value="<?php p($_['dbname']); ?>"
-					autocomplete="off" autocapitalize="off" autocorrect="off"
+					autocomplete="off" autocorrect="off"
 					pattern="[0-9a-zA-Z$_-]+">
 			</p>
 			<?php if ($_['hasOracle']): ?>
@@ -124,7 +124,7 @@ script('core', [
 					<input type="text" name="dbtablespace" id="dbtablespace"
 						placeholder="<?php p($l->t('Database tablespace')); ?>"
 						value="<?php p($_['dbtablespace']); ?>"
-						autocomplete="off" autocapitalize="off" autocorrect="off">
+						autocomplete="off" autocorrect="off">
 				</p>
 			</div>
 			<?php endif; ?>
@@ -133,7 +133,7 @@ script('core', [
 				<input type="text" name="dbhost" id="dbhost"
 					placeholder="<?php p($l->t('Database host')); ?>"
 					value="<?php p($_['dbhost']); ?>"
-					autocomplete="off" autocapitalize="off" autocorrect="off">
+					autocomplete="off" autocorrect="off">
 			</p>
 			<p class="info">
 				<?php p($l->t('Please specify the port number along with the host name (e.g., localhost: 5432).')); ?>

--- a/core/templates/login.php
+++ b/core/templates/login.php
@@ -10,7 +10,7 @@ script('core', [
 ?>
 
 <!--[if IE 8]><style>input[type="checkbox"]{padding:0;}</style><![endif]-->
-<form method="post" name="login">
+<form method="post" name="login" autocapitalize="none">
 	<fieldset>
 	<?php if (!empty($_['redirect_url'])) {
 	print_unescaped('<input type="hidden" name="redirect_url" value="' . \OCP\Util::sanitizeHTML($_['redirect_url']) . '">');
@@ -51,7 +51,7 @@ script('core', [
 				placeholder="<?php $_['strictLoginEnforced'] === true ? p($l->t('Login')) : p($l->t('Username or email')); ?>"
 				value="<?php p($_['loginName']); ?>"
 				<?php p($_['user_autofocus'] ? 'autofocus' : ''); ?>
-				autocomplete="on" autocapitalize="off" autocorrect="off" required>
+				autocomplete="on" autocorrect="off" required>
 			<label for="user" class="infield"><?php $_['strictLoginEnforced'] === true ? p($l->t('Login')) : p($l->t('Username or email')); ?></label>
 		</p>
 
@@ -61,7 +61,7 @@ script('core', [
 			<input type="password" name="password" id="password" value=""
 				placeholder="<?php p($l->t('Password')); ?>"
 				<?php p($_['user_autofocus'] ? '' : 'autofocus'); ?>
-				autocomplete="off" autocapitalize="off" autocorrect="off" required>
+				autocomplete="off" autocorrect="off" required>
 			<label for="password" class="infield"><?php p($l->t('Password')); ?></label>
 			<input type="submit" id="submit" class="login primary icon-confirm" title="<?php p($l->t('Login')); ?>" value="" disabled="disabled"/>
 		</p>

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -729,7 +729,7 @@ $(document).ready(function () {
 		var $td = $(this).closest('td');
 		var $tr = $(this).closest('tr');
 		var uid = UserList.getUID($td);
-		var $input = $('<input type="password" autocomplete="new-password" autocapitalize="off" autocorrect="off">');
+		var $input = $('<input type="password" autocomplete="new-password" autocorrect="off">');
 		var isRestoreDisabled = UserList.getRestoreDisabled($td) === true;
 		if(isRestoreDisabled) {
 			$tr.addClass('row-warning');

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -33,13 +33,13 @@ if ($_['enableAvatars']) {
 
 if ($_['displayNameChangeSupported']) {
 	?>
-<form id="displaynameform" class="section">
+<form id="displaynameform" class="section" autocapitalize="none">
 	<h2>
 		<label for="displayName"><?php echo $l->t('Full name'); ?></label>
 	</h2>
 	<input type="text" id="displayName" name="displayName"
 		value="<?php p($_['displayName'])?>"
-		autocomplete="on" autocapitalize="off" autocorrect="off" />
+		autocomplete="on" autocorrect="off" />
     <span class="msg"></span>
 	<input type="hidden" id="oldDisplayName" name="oldDisplayName" value="<?php p($_['displayName'])?>" />
 </form>
@@ -61,13 +61,13 @@ if ($_['displayNameChangeSupported']) {
 <?php
 if ($_['displayNameChangeSupported']) {
 	?>
-<form id="lostpassword" class="section">
+<form id="lostpassword" class="section" autocapitalize="none">
 	<h2>
 		<label for="email"><?php p($l->t('Email')); ?></label>
 	</h2>
 	<input type="email" name="email" id="email" value="<?php p($_['email']); ?>"
 		placeholder="<?php p($l->t('Your email address')); ?>"
-		autocomplete="on" autocapitalize="off" autocorrect="off" />
+		autocomplete="on" autocorrect="off" />
 	<input id="emailbutton" type="button" value="<?php if (isset($_['email'][0])) {
 		echo $l->t('Change email');
 	} else {
@@ -111,7 +111,7 @@ if ($_['displayNameChangeSupported']) {
 <?php
 if ($_['passwordChangeSupported']) {
 		script('jquery-showpassword'); ?>
-<form id="passwordform" class="section">
+<form id="passwordform" class="section" autocapitalize="none">
 	<h2 class="inlineblock"><?php p($l->t('Password')); ?></h2>
 	<div class="hidden icon-checkmark" id="password-changed"></div>
 	<div class="hidden msg error" id="password-error"><?php p($l->t('Unable to change your password')); ?></div>
@@ -119,12 +119,12 @@ if ($_['passwordChangeSupported']) {
 	<label for="pass1" class="hidden-visually"><?php echo $l->t('Current password'); ?>: </label>
 	<input type="password" id="pass1" name="oldpassword"
 		placeholder="<?php echo $l->t('Current password'); ?>"
-		autocomplete="off" autocapitalize="off" autocorrect="off" />
+		autocomplete="off" autocorrect="off" />
 	<label for="pass2" class="hidden-visually"><?php echo $l->t('New password'); ?>: </label>
 	<input type="password" id="pass2" name="personal-password"
 		placeholder="<?php echo $l->t('New password'); ?>"
 		data-typetoggle="#personal-show"
-		autocomplete="off" autocapitalize="off" autocorrect="off" />
+		autocomplete="off" autocorrect="off" />
 	<input type="checkbox" id="personal-show" name="show" /><label for="personal-show"></label>
 	<input id="passwordbutton" type="submit" value="<?php echo $l->t('Change password'); ?>" />
 </form>

--- a/settings/templates/setpassword.php
+++ b/settings/templates/setpassword.php
@@ -23,7 +23,7 @@ script('settings', 'setpassword');
 ?>
 
 <label id="error-message" class="warning" style="display:none"></label>
-<form action="<?php print_unescaped($_['link']) ?>" id="set-password" method="post">
+<form action="<?php print_unescaped($_['link']) ?>" id="set-password" method="post" autocapitalize="none">
 	<fieldset>
 		<p class="groupbottom<?php if (!empty($_['invalidpassword'])) {
 	?> shake<?php
@@ -31,10 +31,10 @@ script('settings', 'setpassword');
 			<label for="password" class="infield"><?php p($l->t('New password')); ?></label>
 			<input type="password" name="password" id="password" value=""
 				   placeholder="<?php p($l->t('New Password')); ?>"
-				   autocomplete="new-password" autocapitalize="off" autocorrect="off"
+				   autocomplete="new-password" autocorrect="off"
 				   required autofocus />
 			<input type="password" name="retypepassword" id="retypepassword" value=""
-				   autocomplete="new-password" autocapitalize="off" autocorrect="off"
+				   autocomplete="new-password" autocorrect="off"
 				   placeholder="<?php p($l->t('Confirm Password')); ?>"/>
 			<span id='message'></span>
 		</p>

--- a/settings/templates/users/part.createuser.php
+++ b/settings/templates/users/part.createuser.php
@@ -1,15 +1,15 @@
 <div id="controls">
-	<form id="newuser" autocomplete="off">
+	<form id="newuser" autocomplete="off" autocapitalize="none">
 		<input id="newusername" type="text"
 			placeholder="<?php p($l->t('Username'))?>"
-			autocomplete="off" autocapitalize="off" autocorrect="off" />
+			autocomplete="off" autocorrect="off" />
 		<input
 			type="password" id="newuserpassword" style="display:none"
 			placeholder="<?php p($l->t('Password'))?>"
-			autocomplete="new-password" autocapitalize="off" autocorrect="off" />
+			autocomplete="new-password" autocorrect="off" />
 		<input id="newemail" type="text"
 			   placeholder="<?php p($l->t('E-Mail'))?>"
-			   autocomplete="off" autocapitalize="off" autocorrect="off" />
+			   autocomplete="off" autocorrect="off" />
 		<div class="groups"><div class="groupsListContainer multiselect button" data-placeholder="<?php p($l->t('Groups'))?>"><span class="title groupsList"></span><span class="icon-triangle-s"></span></div></div>
 		<input type="submit" class="button" value="<?php p($l->t('Create'))?>" />
 	</form>

--- a/settings/tests/js/setpasswordSpec.js
+++ b/settings/tests/js/setpasswordSpec.js
@@ -13,13 +13,13 @@ describe('OCA.UserManagement.SetPassword tests', function () {
 	beforeEach(function () {
 		$('#testArea').append(
 			'<label id="error-message" class="warning" style="display:none"></label>' +
-			'<form id="set-password" method="post">\n' +
+			'<form id="set-password" method="post" autocapitalize="none">\n' +
 			'<fieldset>' +
 			'<p>' +
 			'<label for="password" class="infield">New password</label>' +
 			'<input type="password" name="password" id="password" value=""' +
 			'placeholder="New Password"' +
-			'autocomplete="off" autocapitalize="off" autocorrect="off"' +
+			'autocomplete="off" autocorrect="off"' +
 			'required autofocus />' +
 			'<input type="password" name="retypepassword" id="retypepassword" value=""' +
 			'placeholder="<"Confirm Password">' +


### PR DESCRIPTION
Fixes #15399

## Description
Removes all instances of autocapitalize="off" and adds autocapitalize="none" in the associated <form> element instead.

## Related Issue
- Fixes #15399

## Motivation and Context
Removes deprecated, iOS-only autocapitalize="off"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
