### PR TITLE
[Tests-Only] Skip tests that fail due to issue-files_primary_s3-387

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation/restoreVersion.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation/restoreVersion.feature
@@ -6,6 +6,7 @@ Feature: propagation of etags when restoring a version of a file
     And using new DAV path
     And user "Alice" has been created with default attributes and without skeleton files
 
+  @skipOnStorage:ceph @skipOnStorage:scality @issue-files_primary_s3-387
   Scenario Outline: Restoring a file changes the etags of all parents
     Given user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/sub"


### PR DESCRIPTION
## Description
These new etag-propagation tests fail on S3 storage - see the issue.
Skip them on S3 storage.

## Related Issue
https://github.com/owncloud/files_primary_s3/issues/387

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
