### PR TITLE
[Tests-Only] Fix federated tests when PR is from a fork

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2025,7 +2025,16 @@ def installFederated(ctx, federatedServerVersion, db, dbSuffix = '-federated'):
 	}
 
 	if (federatedServerVersion == 'git'):
-		installerSettings['git_reference'] = ctx.build.source
+		if (ctx.build.source_repo == ctx.repo.slug):
+			# The PR comes from a branch that is in the same repo
+			# So use that branch for installing the federated server
+			installerSettings['git_reference'] = ctx.build.source
+		else:
+			# The PR comes from a branch that is in some other repo
+			# e.g. a community contribution from a fork
+			# Rather than jumping through hoops to find that code,
+			# install the federated server from owncloud/core master
+			installerSettings['git_reference'] = 'master'
 	else:
 		installerSettings['version'] = federatedServerVersion
 


### PR DESCRIPTION
## Description
If the PR is from a branch that is in `owncloud/core` then continue to do what we do now - install the federated server using the code in the branch (rather than using the master branch).

But if the PR is from a branch in another repo then that branch does not exist in `owncloud/core`. So install the federated server using the code in `owncloud/core` `master`. This is what used to happen anyway, and it is only a problem if someone fixes something to do with federated sharing that depends on the fix being applied to both the local and remote servers "together".

Without this PR, community contributions get fails in drone CI for federated server acceptance tests, because the step to "install federated" fails trying to checkout their branch.

## Related Issue
- Fixes #37966 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
