### PR TITLE
[Tests-Only] Refactored some oC10 bug demonstration scenarios in api test

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -38,8 +38,8 @@ Feature: CORS headers
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
 
-  #merge into previous scenario when fixed
-  @issue-34664
+  #merge into previous scenario when this does not need to be tagged skipOnOcV10
+  @issue-34664 @skipOnOcV10
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
@@ -48,12 +48,12 @@ Feature: CORS headers
       | Origin | https://aphno.badal |
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"
-    Then the following headers should not be set
-      | header                        |
-      | Access-Control-Allow-Headers  |
-      | Access-Control-Expose-Headers |
-      | Access-Control-Allow-Origin   |
-      | Access-Control-Allow-Methods  |
+    Then the following headers should be set
+      | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+      | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
+      | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status                                                                                                                                                                                                                                                                                                                                                                                                                     |
+      | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
     Examples:
       | ocs_api_version | endpoint | ocs-code | http-code |
       | 1               | /config  | 100      | 200       |
@@ -141,7 +141,7 @@ Feature: CORS headers
       | 1               | /cloud/users  | 100      | 200       |
       | 2               | /cloud/users  | 200      | 200       |
 
-  @issue-34679 @files_sharing-app-required
+  @issue-34679 @files_sharing-app-required @skipOnOcV10
   Scenario Outline: CORS headers should be returned when invalid password is used
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
@@ -150,18 +150,12 @@ Feature: CORS headers
       | Origin | https://aphno.badal |
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"
-    Then the following headers should not be set
-      | header                        |
-      | Access-Control-Allow-Headers  |
-      | Access-Control-Expose-Headers |
-      | Access-Control-Allow-Origin   |
-      | Access-Control-Allow-Methods  |
-    #Then the following headers should be set
-    #  | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-    #  | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
-    #  | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status |
-    #  | Access-Control-Allow-Origin   | https://aphno.badal |
-    #  | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
+    Then the following headers should be set
+      | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+      | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
+      | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status                                                                                                                                                                                                                                                                                                                                                                                                                     |
+      | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_external/api/v1/mounts               | 997      | 401       |
@@ -181,7 +175,7 @@ Feature: CORS headers
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
 
-  @issue-34679
+  @issue-34679 @skipOnOcV10
   Scenario Outline: CORS headers should be returned when invalid password is used (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
     And the administrator has added "https://aphno.badal" to the list of personal CORS domains
@@ -192,18 +186,12 @@ Feature: CORS headers
       | Origin | https://aphno.badal |
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"
-    Then the following headers should not be set
-      | header                        |
-      | Access-Control-Allow-Headers  |
-      | Access-Control-Expose-Headers |
-      | Access-Control-Allow-Origin   |
-      | Access-Control-Allow-Methods  |
-    #Then the following headers should be set
-    #  | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-    #  | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
-    #  | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status |
-    #  | Access-Control-Allow-Origin   | https://aphno.badal |
-    #  | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
+    Then the following headers should be set
+      | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+      | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
+      | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status                                                                                                                                                                                                                                                                                                                                                                                                                     |
+      | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
     Examples:
       | ocs_api_version | endpoint      | ocs-code | http-code |
       | 1               | /cloud/apps   | 997      | 401       |

--- a/tests/acceptance/features/apiAuth/corsOc10Issue34664.feature
+++ b/tests/acceptance/features/apiAuth/corsOc10Issue34664.feature
@@ -1,0 +1,23 @@
+@api @notToImplementOnOCIS
+Feature: CORS headers current oC10 behavior for issue-34664
+
+  @issue-34664
+  Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header
+    Given user "Alice" has been created with default attributes and skeleton files
+    And using OCS API version "<ocs_api_version>"
+    And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
+    When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
+      | header | value               |
+      | Origin | https://aphno.badal |
+    Then the OCS status code should be "<ocs-code>"
+    And the HTTP status code should be "<http-code>"
+    Then the following headers should not be set
+      | header                        |
+      | Access-Control-Allow-Headers  |
+      | Access-Control-Expose-Headers |
+      | Access-Control-Allow-Origin   |
+      | Access-Control-Allow-Methods  |
+    Examples:
+      | ocs_api_version | endpoint | ocs-code | http-code |
+      | 1               | /config  | 100      | 200       |
+      | 2               | /config  | 200      | 200       |

--- a/tests/acceptance/features/apiAuth/corsOc10Issue34679.feature
+++ b/tests/acceptance/features/apiAuth/corsOc10Issue34679.feature
@@ -1,0 +1,77 @@
+@api @notToImplementOnOCIS
+Feature: CORS headers current oC10 behavior for issue-34679
+
+  Background:
+    Given user "Alice" has been created with default attributes and skeleton files
+
+  @issue-34679 @files_sharing-app-required
+  Scenario Outline: CORS headers should be returned when invalid password is used
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
+    When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers using password "invalid"
+      | header | value               |
+      | Origin | https://aphno.badal |
+    Then the OCS status code should be "<ocs-code>"
+    And the HTTP status code should be "<http-code>"
+    Then the following headers should not be set
+      | header                        |
+      | Access-Control-Allow-Headers  |
+      | Access-Control-Expose-Headers |
+      | Access-Control-Allow-Origin   |
+      | Access-Control-Allow-Methods  |
+    #Then the following headers should be set
+    #  | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+    #  | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
+    #  | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status |
+    #  | Access-Control-Allow-Origin   | https://aphno.badal |
+    #  | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
+    Examples:
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
+      | 1               | /apps/files_external/api/v1/mounts               | 997      | 401       |
+      | 2               | /apps/files_external/api/v1/mounts               | 997      | 401       |
+      | 1               | /apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
+      | 2               | /apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
+      | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
+      | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
+      | 1               | /apps/files_sharing/api/v1/shares                | 997      | 401       |
+      | 2               | /apps/files_sharing/api/v1/shares                | 997      | 401       |
+      | 1               | /privatedata/getattribute                        | 997      | 401       |
+      | 2               | /privatedata/getattribute                        | 997      | 401       |
+      | 1               | /cloud/apps                                      | 997      | 401       |
+      | 2               | /cloud/apps                                      | 997      | 401       |
+      | 1               | /cloud/groups                                    | 997      | 401       |
+      | 2               | /cloud/groups                                    | 997      | 401       |
+      | 1               | /cloud/users                                     | 997      | 401       |
+      | 2               | /cloud/users                                     | 997      | 401       |
+
+  @issue-34679
+  Scenario Outline: CORS headers should be returned when invalid password is used (admin only endpoints)
+    Given using OCS API version "<ocs_api_version>"
+    And the administrator has added "https://aphno.badal" to the list of personal CORS domains
+    And user "another-admin" has been created with default attributes and without skeleton files
+    And user "another-admin" has been added to group "admin"
+    When user "another-admin" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers using password "invalid"
+      | header | value               |
+      | Origin | https://aphno.badal |
+    Then the OCS status code should be "<ocs-code>"
+    And the HTTP status code should be "<http-code>"
+    Then the following headers should not be set
+      | header                        |
+      | Access-Control-Allow-Headers  |
+      | Access-Control-Expose-Headers |
+      | Access-Control-Allow-Origin   |
+      | Access-Control-Allow-Methods  |
+    #Then the following headers should be set
+    #  | header                        | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+    #  | Access-Control-Allow-Headers  | OC-Checksum,OC-Total-Length,OCS-APIREQUEST,X-OC-Mtime,Accept,Authorization,Brief,Content-Length,Content-Range,Content-Type,Date,Depth,Destination,Host,If,If-Match,If-Modified-Since,If-None-Match,If-Range,If-Unmodified-Since,Location,Lock-Token,Overwrite,Prefer,Range,Schedule-Reply,Timeout,User-Agent,X-Expected-Entity-Length,Accept-Language,Access-Control-Request-Method,Access-Control-Allow-Origin,ETag,OC-Autorename,OC-CalDav-Import,OC-Chunked,OC-Etag,OC-FileId,OC-LazyOps,OC-Total-File-Length,Origin,X-Request-ID,X-Requested-With |
+    #  | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,Vary,Webdav-Location,X-Sabre-Status |
+    #  | Access-Control-Allow-Origin   | https://aphno.badal |
+    #  | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT |
+    Examples:
+      | ocs_api_version | endpoint      | ocs-code | http-code |
+      | 1               | /cloud/apps   | 997      | 401       |
+      | 2               | /cloud/apps   | 997      | 401       |
+      | 1               | /cloud/groups | 997      | 401       |
+      | 2               | /cloud/groups | 997      | 401       |
+      | 1               | /cloud/users  | 997      | 401       |
+      | 2               | /cloud/users  | 997      | 401       |

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -4,8 +4,9 @@ Feature: auth
   Background:
     Given user "another-admin" has been created with default attributes and without skeleton files
 
-  @smokeTest @issue-32068 @issue-ocis-reva-30 @issue-ocis-reva-65
+  @smokeTest @issue-ocis-reva-30 @issue-ocis-reva-65
   @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @skipOnOcV10 @issue-32068
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     Given user "another-admin" has been added to group "admin"
     When user "another-admin" requests these endpoints with "DELETE" using password "invalid" about user "Alice"
@@ -28,4 +29,4 @@ Feature: auth
       | /ocs/v1.php/cloud/users/%username%/subadmins                    |
       | /ocs/v2.php/cloud/users/%username%/subadmins                    |
     Then the HTTP status code of responses on all endpoints should be "401"
-    And the OCS status code of responses on all endpoints should be "997"
+    And the OCS status code of responses on all endpoints should be "401"

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuthOc10Issue32068.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuthOc10Issue32068.feature
@@ -1,0 +1,30 @@
+@api @files_sharing-app-required @notToImplementOnOCIS
+Feature: current oC10 behavior for issue-32068
+
+  @smokeTest @issue-32068 @issue-ocis-reva-30 @issue-ocis-reva-65
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  Scenario: send DELETE requests to OCS endpoints as admin with wrong password
+    Given user "another-admin" has been created with default attributes and without skeleton files
+    And user "another-admin" has been added to group "admin"
+    When user "another-admin" requests these endpoints with "DELETE" using password "invalid" about user "Alice"
+      | endpoint                                                        |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending/123 |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/123 |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/123         |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/123         |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares/123                |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares/pending/123        |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares/pending/123        |
+      | /ocs/v1.php/cloud/apps/testing                                  |
+      | /ocs/v2.php/cloud/apps/testing                                  |
+      | /ocs/v1.php/cloud/groups/group1                                 |
+      | /ocs/v2.php/cloud/groups/group1                                 |
+      | /ocs/v1.php/cloud/users/%username%                              |
+      | /ocs/v2.php/cloud/users/%username%                              |
+      | /ocs/v1.php/cloud/users/%username%/groups                       |
+      | /ocs/v2.php/cloud/users/%username%/groups                       |
+      | /ocs/v1.php/cloud/users/%username%/subadmins                    |
+      | /ocs/v2.php/cloud/users/%username%/subadmins                    |
+    Then the HTTP status code of responses on all endpoints should be "401"
+    And the OCS status code of responses on all endpoints should be "997"
+    #And the OCS status code of responses on all endpoints should be "401"

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -4,7 +4,7 @@ Feature: auth
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @issue-32068
+  @issue-32068 @skipOnOcV10
   @issue-ocis-reva-30
   @smokeTest
   Scenario: using OCS anonymously
@@ -27,7 +27,7 @@ Feature: auth
       | /ocs/v1.php/privatedata/getattribute                        |
       | /ocs/v2.php/privatedata/getattribute                        |
     Then the HTTP status code of responses on all endpoints should be "401"
-    And the OCS status code of responses on all endpoints should be "997"
+    And the OCS status code of responses on all endpoints should be "401"
 
   @issue-ocis-reva-29
   Scenario: ocs config end point accessible by unauthorized users
@@ -42,7 +42,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @issue-32068
+  @issue-32068 @skipOnOcV10
   @issue-ocis-reva-11
   @issue-ocis-reva-30
   @issue-ocis-reva-31
@@ -80,9 +80,9 @@ Feature: auth
       | /ocs/v2.php/cloud/groups |
       | /ocs/v2.php/cloud/users  |
     Then the HTTP status code of responses on all endpoints should be "401"
-    And the OCS status code of responses on all endpoints should be "997"
+    And the OCS status code of responses on all endpoints should be "401"
 
-  @issue-32068 @issue-ocis-reva-29 @issue-ocis-reva-30
+  @issue-32068 @skipOnOcV10 @issue-ocis-reva-29 @issue-ocis-reva-30
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as normal user with wrong password
@@ -105,7 +105,7 @@ Feature: auth
       | /ocs/v1.php/privatedata/getattribute                        |
       | /ocs/v2.php/privatedata/getattribute                        |
     Then the HTTP status code of responses on all endpoints should be "401"
-    And the OCS status code of responses on all endpoints should be "997"
+    And the OCS status code of responses on all endpoints should be "401"
     When user "Alice" requests these endpoints with "GET" using password "invalid"
       | endpoint           |
       | /ocs/v1.php/config |

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuthOc10Issue32068.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuthOc10Issue32068.feature
@@ -1,0 +1,108 @@
+@api @notToImplementOnOCIS @files_sharing-app-required @issue-32068
+Feature: current oC10 behavior for issue-32068
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  @issue-32068
+  @issue-ocis-reva-30
+  @smokeTest
+  Scenario: using OCS anonymously
+    When a user requests these endpoints with "GET" and no authentication
+      | endpoint                                                    |
+      | /ocs/v1.php/apps/files_external/api/v1/mounts               |
+      | /ocs/v2.php/apps/files_external/api/v1/mounts               |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares         |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares         |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares                |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares                |
+      | /ocs/v1.php/cloud/apps                                      |
+      | /ocs/v2.php/cloud/apps                                      |
+      | /ocs/v1.php/cloud/groups                                    |
+      | /ocs/v2.php/cloud/groups                                    |
+      | /ocs/v1.php/cloud/users                                     |
+      | /ocs/v2.php/cloud/users                                     |
+      | /ocs/v1.php/privatedata/getattribute                        |
+      | /ocs/v2.php/privatedata/getattribute                        |
+    Then the HTTP status code of responses on all endpoints should be "401"
+    And the OCS status code of responses on all endpoints should be "997"
+    #And the OCS status code of responses on all endpoints should be "401"
+
+  @issue-32068
+  @issue-ocis-reva-11
+  @issue-ocis-reva-30
+  @issue-ocis-reva-31
+  @issue-ocis-reva-32
+  @issue-ocis-reva-33
+  @issue-ocis-reva-34
+  @issue-ocis-reva-35
+  Scenario: using OCS with non-admin basic auth
+    When the user "Alice" requests these endpoints with "GET" with basic auth
+      | endpoint                                                    |
+      | /ocs/v1.php/apps/files_external/api/v1/mounts               |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares         |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares                |
+      | /ocs/v1.php/config                                          |
+      | /ocs/v1.php/privatedata/getattribute                        |
+    Then the HTTP status code of responses on all endpoints should be "200"
+    And the OCS status code of responses on all endpoints should be "100"
+    When the user "Alice" requests these endpoints with "GET" with basic auth
+      | endpoint                                                    |
+      | /ocs/v2.php/apps/files_external/api/v1/mounts               |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares         |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares                |
+      | /ocs/v2.php/config                                          |
+      | /ocs/v2.php/privatedata/getattribute                        |
+    Then the HTTP status code of responses on all endpoints should be "200"
+    And the OCS status code of responses on all endpoints should be "200"
+    When the user "Alice" requests these endpoints with "GET" with basic auth
+      | endpoint                 |
+      | /ocs/v1.php/cloud/apps   |
+      | /ocs/v1.php/cloud/groups |
+      | /ocs/v1.php/cloud/users  |
+      | /ocs/v2.php/cloud/apps   |
+      | /ocs/v2.php/cloud/groups |
+      | /ocs/v2.php/cloud/users  |
+    Then the HTTP status code of responses on all endpoints should be "401"
+    And the OCS status code of responses on all endpoints should be "997"
+    #And the OCS status code of responses on all endpoints should be "401"
+
+  @issue-32068 @issue-ocis-reva-29 @issue-ocis-reva-30
+  @smokeTest
+  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  Scenario: using OCS as normal user with wrong password
+    When user "Alice" requests these endpoints with "GET" using password "invalid"
+      | endpoint                                                    |
+      | /ocs/v1.php/apps/files_external/api/v1/mounts               |
+      | /ocs/v2.php/apps/files_external/api/v1/mounts               |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares         |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares         |
+      | /ocs/v1.php/apps/files_sharing/api/v1/remote_shares/pending |
+      | /ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending |
+      | /ocs/v1.php/apps/files_sharing/api/v1/shares                |
+      | /ocs/v2.php/apps/files_sharing/api/v1/shares                |
+      | /ocs/v1.php/cloud/apps                                      |
+      | /ocs/v2.php/cloud/apps                                      |
+      | /ocs/v1.php/cloud/groups                                    |
+      | /ocs/v2.php/cloud/groups                                    |
+      | /ocs/v1.php/cloud/users                                     |
+      | /ocs/v2.php/cloud/users                                     |
+      | /ocs/v1.php/privatedata/getattribute                        |
+      | /ocs/v2.php/privatedata/getattribute                        |
+    Then the HTTP status code of responses on all endpoints should be "401"
+    And the OCS status code of responses on all endpoints should be "997"
+    #And the OCS status code of responses on all endpoints should be "401"
+    When user "Alice" requests these endpoints with "GET" using password "invalid"
+      | endpoint           |
+      | /ocs/v1.php/config |
+    Then the HTTP status code of responses on all endpoints should be "200"
+    And the OCS status code of responses on all endpoints should be "100"
+    When user "Alice" requests these endpoints with "GET" using password "invalid"
+      | endpoint           |
+      | /ocs/v2.php/config |
+    Then the HTTP status code of responses on all endpoints should be "200"
+    And the OCS status code of responses on all endpoints should be "200"

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -75,8 +75,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @smokeTest @toImplementOnOCIS
-  @issue-ocis-reva-39
+  @smokeTest
   Scenario Outline: Get favorited elements of a folder
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/FOLDER" using the WebDAV API
@@ -92,8 +91,6 @@ Feature: favorite
       | old         |
       | new         |
 
-  @toImplementOnOCIS
-  @issue-ocis-reva-39
   Scenario Outline: Get favorited elements of a subfolder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/subfolder"
@@ -115,8 +112,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required @toImplementOnOCIS
-  @issue-ocis-reva-39
+  @files_sharing-app-required
   Scenario Outline: moving a favorite file out of a share keeps favorite state
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -132,8 +128,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @issue-33840 @toImplementOnOCIS
-  @issue-ocis-reva-39
+  @issue-33840 @skipOnOcV10
   Scenario Outline: Get favorited elements and limit count of entries
     Given using <dav_version> DAV path
     And user "Alice" has favorited element "/textfile0.txt"
@@ -142,8 +137,7 @@ Feature: favorite
     And user "Alice" has favorited element "/textfile3.txt"
     And user "Alice" has favorited element "/textfile4.txt"
     When user "Alice" lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
-    #Then the search result of "Alice" should contain any "3" of these entries:
-    Then the search result should contain any "0" of these entries:
+    Then the search result should contain any "3" of these entries:
       | /textfile0.txt |
       | /textfile1.txt |
       | /textfile2.txt |
@@ -154,8 +148,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @issue-33840 @toImplementOnOCIS
-  @issue-ocis-reva-39
+  @issue-33840 @skipOnOcV10
   Scenario Outline: Get favorited elements paginated in subfolder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/subfolder"
@@ -172,8 +165,7 @@ Feature: favorite
     And user "Alice" has favorited element "/subfolder/textfile4.txt"
     And user "Alice" has favorited element "/subfolder/textfile5.txt"
     When user "Alice" lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
-    #Then the search result of "Alice" should contain any "3" of these entries:
-    Then the search result should contain any "0" of these entries:
+    Then the search result should contain any "3" of these entries:
       | /subfolder/textfile0.txt |
       | /subfolder/textfile1.txt |
       | /subfolder/textfile2.txt |
@@ -184,8 +176,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required @toImplementOnOCIS
-  @issue-ocis-reva-39
+  @files_sharing-app-required
   Scenario Outline: sharer file favorite state should not change the favorite state of sharee
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -199,8 +190,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required @toImplementOnOCIS
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @files_sharing-app-required
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -214,7 +204,6 @@ Feature: favorite
       | old         |
       | new         |
 
-  @issue-ocis-reva-39
   Scenario Outline: favoriting a folder does not change the favorite state of elements inside the folder
     Given using <dav_version> DAV path
     When user "Alice" favorites element "/PARENT/parent.txt" using the WebDAV API

--- a/tests/acceptance/features/apiFavorites/favoritesOc10Issue33840.feature
+++ b/tests/acceptance/features/apiFavorites/favoritesOc10Issue33840.feature
@@ -1,0 +1,64 @@
+@api @notToImplementOnOCIS
+Feature: current oC10 behavior for issue-33840
+
+  Background:
+    Given using OCS API version "1"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Alice" has uploaded file with content "some data" to "/textfile2.txt"
+    And user "Alice" has uploaded file with content "some data" to "/textfile3.txt"
+    And user "Alice" has uploaded file with content "some data" to "/textfile4.txt"
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+
+  @issue-33840 @issue-ocis-reva-39
+  Scenario Outline: Get favorited elements and limit count of entries
+    Given using <dav_version> DAV path
+    And user "Alice" has favorited element "/textfile0.txt"
+    And user "Alice" has favorited element "/textfile1.txt"
+    And user "Alice" has favorited element "/textfile2.txt"
+    And user "Alice" has favorited element "/textfile3.txt"
+    And user "Alice" has favorited element "/textfile4.txt"
+    When user "Alice" lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
+    #Then the search result should contain any "3" of these entries:
+    Then the search result should contain any "0" of these entries:
+      | /textfile0.txt |
+      | /textfile1.txt |
+      | /textfile2.txt |
+      | /textfile3.txt |
+      | /textfile4.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @issue-33840 @issue-ocis-reva-39
+  Scenario Outline: Get favorited elements paginated in subfolder
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/subfolder"
+    And user "Alice" has copied file "/textfile0.txt" to "/subfolder/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/subfolder/textfile1.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/subfolder/textfile2.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/subfolder/textfile3.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/subfolder/textfile4.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/subfolder/textfile5.txt"
+    And user "Alice" has favorited element "/subfolder/textfile0.txt"
+    And user "Alice" has favorited element "/subfolder/textfile1.txt"
+    And user "Alice" has favorited element "/subfolder/textfile2.txt"
+    And user "Alice" has favorited element "/subfolder/textfile3.txt"
+    And user "Alice" has favorited element "/subfolder/textfile4.txt"
+    And user "Alice" has favorited element "/subfolder/textfile5.txt"
+    When user "Alice" lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
+    #Then the search result should contain any "3" of these entries:
+    Then the search result should contain any "0" of these entries:
+      | /subfolder/textfile0.txt |
+      | /subfolder/textfile1.txt |
+      | /subfolder/textfile2.txt |
+      | /subfolder/textfile3.txt |
+      | /subfolder/textfile4.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiFederationToRoot1/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federated.feature
@@ -292,13 +292,13 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password
     Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last federated cloud share with password "invalid" using the sharing API
-    Then the OCS status code should be "997"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should see the following elements
       | /textfile0%20(2).txt |
@@ -339,12 +339,12 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario Outline: Remote sharee tries to delete a pending federated share sending wrong password
     Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last pending federated cloud share with password "invalid" using the sharing API
-    Then the OCS status code should be "997"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should not see the following elements
       | /textfile0%20(2).txt |

--- a/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
@@ -1,0 +1,67 @@
+@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+Feature: current oC10 behavior for issue-31276
+
+  Background:
+    Given using server "REMOTE"
+    And user "Alice" has been created with default attributes and skeleton files
+    And using server "LOCAL"
+    And user "Brian" has been created with default attributes and skeleton files
+
+  @issue-31276
+  Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password
+    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using OCS API version "<ocs-api-version>"
+    When user "Brian" deletes the last federated cloud share with password "invalid" using the sharing API
+    #Then the OCS status code should be "401"
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "Brian" should see the following elements
+      | /textfile0%20(2).txt |
+    When user "Brian" gets the list of federated cloud shares using the sharing API
+    Then the fields of the last response about user "Alice" sharing with user "Brian" should include
+      | id          | A_STRING                 |
+      | remote      | REMOTE                   |
+      | remote_id   | A_STRING                 |
+      | share_token | A_TOKEN                  |
+      | name        | /textfile0.txt           |
+      | owner       | %username%               |
+      | user        | %username%               |
+      | mountpoint  | /textfile0 (2).txt       |
+      | accepted    | 1                        |
+      | type        | file                     |
+      | permissions | share,delete,update,read |
+    When user "Brian" gets the list of pending federated cloud shares using the sharing API
+    Then the response should contain 0 entries
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |
+
+  @issue-31276
+  Scenario Outline: Remote sharee tries to delete a pending federated share sending wrong password
+    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
+    When user "Brian" deletes the last pending federated cloud share with password "invalid" using the sharing API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "Brian" should not see the following elements
+      | /textfile0%20(2).txt |
+    When user "Brian" gets the list of pending federated cloud shares using the sharing API
+    Then the fields of the last response about user "Alice" sharing with user "Brian" should include
+      | id          | A_STRING                                   |
+      | remote      | REMOTE                                     |
+      | remote_id   | A_STRING                                   |
+      | share_token | A_TOKEN                                    |
+      | name        | /textfile0.txt                             |
+      | owner       | %username%                                 |
+      | user        | %username%                                 |
+      | mountpoint  | {{TemporaryMountPointName#/textfile0.txt}} |
+      | accepted    | 0                                          |
+    When user "Brian" gets the list of federated cloud shares using the sharing API
+    Then the response should contain 0 entries
+    Examples:
+      | ocs-api-version |
+      | 1               |
+      | 2               |

--- a/tests/acceptance/features/apiFederationToRoot2/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot2/federated.feature
@@ -7,11 +7,9 @@ Feature: federated
     And using server "LOCAL"
     And user "Brian" has been created with default attributes and skeleton files
 
-  @issue-35839
+  @issue-35839 @skipOnOcV10
   Scenario: "Auto accept from trusted servers" enabled with remote server
     Given the trusted server list is cleared
-    # Remove this line once the issue is resolved
-    And parameter "autoAddServers" of app "federation" has been set to "0"
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     When the administrator adds url "%remote_server%" as trusted server using the testing API
     And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
@@ -19,11 +17,9 @@ Feature: federated
     Then as "Brian" file "textfile1 (2).txt" should exist
     And url "%remote_server%" should be a trusted server
 
-  @issue-35839
+  @issue-35839 @skipOnOcV10
   Scenario: "Auto accept from trusted servers" disabled with remote server
     Given the trusted server list is cleared
-    # Remove this line once the issue is resolved
-    And parameter "autoAddServers" of app "federation" has been set to "0"
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
     When the administrator adds url "%remote_server%" as trusted server using the testing API
     And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
@@ -50,7 +46,7 @@ Feature: federated
     Then as "Brian" file "textfile1 (2).txt" should exist
     And url "%remote_server%" should not be a trusted server
 
-  @issue-35839
+  @issue-35839 @skipOnOcV10
   Scenario: enable "Add server automatically" once a federated share was created successfully
     Given using server "LOCAL"
     And parameter "autoAddServers" of app "federation" has been set to "1"
@@ -60,11 +56,9 @@ Feature: federated
     And using server "LOCAL"
     Then url "%remote_server%" should be a trusted server
     When user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
-    # Uncomment this line once the issue is resolved
-    # Then as "Brian" file "textfile1 (2).txt" should exist
-    Then as "Brian" file "textfile1 (2).txt" should not exist
+    Then as "Brian" file "textfile1 (2).txt" should exist
 
-  @issue-35839
+  @issue-35839 @skipOnOcV10
   Scenario: disable "Add server automatically" once a federated share was created successfully
     Given using server "LOCAL"
     And the trusted server list is cleared
@@ -74,9 +68,7 @@ Feature: federated
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
     Then url "%remote_server%" should not be a trusted server
-    # Remove this line once the issue is resolved
-    When the administrator sets parameter "autoAddServers" of app "federation" to "0"
-    And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
+    When user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
     And as "Brian" file "textfile1 (2).txt" should not exist
 
   Scenario Outline: federated share receiver sees the original content of a received file

--- a/tests/acceptance/features/apiFederationToRoot2/federatedOc10Issue35839.feature
+++ b/tests/acceptance/features/apiFederationToRoot2/federatedOc10Issue35839.feature
@@ -1,0 +1,59 @@
+@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+Feature: current oC10 behavior for issue-35839
+
+  Background:
+    Given using server "REMOTE"
+    And user "Alice" has been created with default attributes and skeleton files
+    And using server "LOCAL"
+    And user "Brian" has been created with default attributes and skeleton files
+
+  @issue-35839
+  Scenario: "Auto accept from trusted servers" enabled with remote server
+    Given the trusted server list is cleared
+    # Remove this line once the issue is resolved
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    When the administrator adds url "%remote_server%" as trusted server using the testing API
+    And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    Then as "Brian" file "textfile1 (2).txt" should exist
+    And url "%remote_server%" should be a trusted server
+
+  @issue-35839
+  Scenario: "Auto accept from trusted servers" disabled with remote server
+    Given the trusted server list is cleared
+    # Remove this line once the issue is resolved
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
+    When the administrator adds url "%remote_server%" as trusted server using the testing API
+    And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
+    And using server "LOCAL"
+    Then as "Brian" file "textfile1 (2).txt" should not exist
+    And url "%remote_server%" should be a trusted server
+
+  @issue-35839
+  Scenario: enable "Add server automatically" once a federated share was created successfully
+    Given parameter "autoAddServers" of app "federation" has been set to "1"
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    When user "Alice" from server "REMOTE" shares "/textfile0.txt" with user "Brian" from server "LOCAL" using the sharing API
+    And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
+    Then url "%remote_server%" should be a trusted server
+    When user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
+    #Then as "Brian" file "textfile1 (2).txt" should exist
+    Then as "Brian" file "textfile1 (2).txt" should not exist
+
+  @issue-35839
+  Scenario: disable "Add server automatically" once a federated share was created successfully
+    Given using server "LOCAL"
+    And the trusted server list is cleared
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    When user "Alice" from server "REMOTE" shares "/textfile0.txt" with user "Brian" from server "LOCAL" using the sharing API
+    And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
+    Then url "%remote_server%" should not be a trusted server
+    # Remove this line once the issue is resolved
+    When the administrator sets parameter "autoAddServers" of app "federation" to "0"
+    And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
+    And as "Brian" file "textfile1 (2).txt" should not exist

--- a/tests/acceptance/features/apiFederationToShares1/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares1/federated.feature
@@ -296,13 +296,13 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password
     Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last federated cloud share with password "invalid" using the sharing API
-    Then the OCS status code should be "997"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should see the following elements
       | /Shares/textfile0.txt |
@@ -343,12 +343,12 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario Outline: Remote sharee tries to delete a pending federated share sending wrong password
     Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last pending federated cloud share with password "invalid" using the sharing API
-    Then the OCS status code should be "997"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should not see the following elements
       | /Shares/textfile0.txt |

--- a/tests/acceptance/features/apiFederationToShares2/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares2/federated.feature
@@ -11,11 +11,9 @@ Feature: federated
     And auto-accept shares has been disabled
     And user "Brian" has been created with default attributes and skeleton files
 
-  @issue-35839
+  @issue-35839 @skipOnOcV10
   Scenario: "Auto accept from trusted servers" enabled with remote server
     Given the trusted server list is cleared
-    # Remove this line once the issue is resolved
-    And parameter "autoAddServers" of app "federation" has been set to "0"
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     When the administrator adds url "%remote_server%" as trusted server using the testing API
     And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
@@ -23,11 +21,9 @@ Feature: federated
     Then as "Brian" file "Shares/textfile1.txt" should exist
     And url "%remote_server%" should be a trusted server
 
-  @issue-35839
+  @issue-35839 @skipOnOcV10
   Scenario: "Auto accept from trusted servers" disabled with remote server
     Given the trusted server list is cleared
-    # Remove this line once the issue is resolved
-    And parameter "autoAddServers" of app "federation" has been set to "0"
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
     When the administrator adds url "%remote_server%" as trusted server using the testing API
     And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
@@ -54,7 +50,7 @@ Feature: federated
     Then as "Brian" file "Shares/textfile1.txt" should exist
     And url "%remote_server%" should not be a trusted server
 
-  @issue-35839
+  @issue-35839 @skipOnOcV10
   Scenario: enable "Add server automatically" once a federated share was created successfully
     Given using server "LOCAL"
     And parameter "autoAddServers" of app "federation" has been set to "1"
@@ -64,11 +60,9 @@ Feature: federated
     And using server "LOCAL"
     Then url "%remote_server%" should be a trusted server
     When user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
-    # Uncomment this line once the issue is resolved
-    # Then as "Brian" file "Shares/textfile1.txt" should exist
-    Then as "Brian" file "Shares/textfile1.txt" should not exist
+    Then as "Brian" file "Shares/textfile1.txt" should exist
 
-  @issue-35839
+  @issue-35839 @skipOnOcV10
   Scenario: disable "Add server automatically" once a federated share was created successfully
     Given using server "LOCAL"
     And the trusted server list is cleared
@@ -78,9 +72,7 @@ Feature: federated
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
     Then url "%remote_server%" should not be a trusted server
-    # Remove this line once the issue is resolved
-    When the administrator sets parameter "autoAddServers" of app "federation" to "0"
-    And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
+    When user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
     And as "Brian" file "Shares/textfile1.txt" should not exist
 
   Scenario Outline: federated share receiver sees the original content of a received file

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -46,7 +46,6 @@ Feature: external-storage
     And as "Alice" file "/local_storage/foo2/textfile0.txt" should not exist
     And as "Brian" file "/local.txt" should exist
 
-  @issue-37723
   Scenario: Download a file that exists in filecache but not storage fails with 404
     Given user "Alice" has been created with default attributes and skeleton files
     And user "Alice" has created folder "/local_storage/foo3"
@@ -54,8 +53,9 @@ Feature: external-storage
     And file "foo3/textfile0.txt" has been deleted from local storage on the server
     When user "Alice" downloads file "local_storage/foo3/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "404"
+    # See issue-37723 for discussion. In this case the server still reports the file exists
+    # in the folder. The file cache will be cleared after the local storage is scanned.
     And as "Alice" file "local_storage/foo3/textfile0.txt" should exist
-#   And as "Alice" file "local_storage/foo3/textfile0.txt" should not exist
 
   Scenario: Upload a file to external storage while quota is set on home storage
     Given user "Alice" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -31,7 +31,7 @@ Feature: create a subadmin
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: subadmin of a group tries to make another user subadmin of their group
     Given these users have been created with default attributes and skeleton files:
       | username       |
@@ -41,7 +41,6 @@ Feature: create a subadmin
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And user "brand-new-user" has been added to group "brand-new-group"
     When user "subadmin" makes user "brand-new-user" a subadmin of group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "brand-new-user" should not be a subadmin of group "brand-new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdminOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdminOc10Issue31276.feature
@@ -1,0 +1,21 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: current oC10 behavior for issue-31276
+  As an admin
+  I want to be able to make a user the subadmin of a group
+  So that I can give administrative privilege of a group to a user
+
+  @issue-31276
+  Scenario: subadmin of a group tries to make another user subadmin of their group
+    Given using OCS API version "2"
+    And these users have been created with default attributes and skeleton files:
+      | username       |
+      | subadmin       |
+      | brand-new-user |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "brand-new-user" has been added to group "brand-new-group"
+    When user "subadmin" makes user "brand-new-user" a subadmin of group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "brand-new-user" should not be a subadmin of group "brand-new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -50,14 +50,13 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to delete a user
     Given these users have been created with default attributes and skeleton files:
       | username |
       | Alice    |
       | Brian    |
     When user "Alice" deletes user "Brian" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should exist

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUserOc10Issue31276.feature
@@ -1,0 +1,18 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: current oC10 behavior for issue-31276
+  As an admin
+  I want to be able to delete users
+  So that I can remove user from ownCloud
+
+  @issue-31276
+  Scenario: normal user tries to delete a user
+    Given using OCS API version "2"
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    When user "Alice" deletes user "Brian" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "Brian" should exist

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -15,24 +15,22 @@ Feature: disable an app
     And the HTTP status code should be "200"
     And app "comments" should be disabled
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to disable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And app "comments" has been enabled
     When user "subadmin" disables app "comments"
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And app "comments" should be enabled
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to disable an app
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And app "comments" has been enabled
     When user "brand-new-user" disables app "comments"
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And app "comments" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v2/disableAppOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableAppOc10Issue31276.feature
@@ -1,0 +1,30 @@
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: current oC10 behavior for issue-31276
+  As an admin
+  I want to be able to disable an enabled app
+  So that I can stop the app features being used
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: subadmin tries to disable an app
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And app "comments" has been enabled
+    When user "subadmin" disables app "comments"
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And app "comments" should be enabled
+
+  @issue-31276
+  Scenario: normal user tries to disable an app
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And app "comments" has been enabled
+    When user "brand-new-user" disables app "comments"
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And app "comments" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -44,7 +44,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "Alice" should be disabled
 
-  @issue-31276 @notToImplementOnOCIS
+  @issue-31276 @skipOnOcV10
   Scenario: Subadmin should not be able to disable an user not in their group
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -56,12 +56,11 @@ Feature: disable user
     And user "Alice" has been added to group "another-group"
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" disables user "Alice" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Alice" should be enabled
 
-  @issue-31276 @notToImplementOnOCIS
+  @issue-31276 @skipOnOcV10
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
     Given these users have been created with default attributes and skeleton files:
       | username      |
@@ -73,8 +72,7 @@ Feature: disable user
     And user "another-admin" has been added to group "brand-new-group"
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" disables user "another-admin" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "another-admin" should be enabled
 
@@ -106,15 +104,14 @@ Feature: disable user
     And the HTTP status code should be "400"
     And user "another-admin" should be enabled
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: disable an user with a regular user
     Given these users have been created with default attributes and skeleton files:
       | username |
       | Alice    |
       | Brian    |
     When user "Alice" disables user "Brian" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should be enabled
 

--- a/tests/acceptance/features/apiProvisioning-v2/disableUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUserOc10Issue31276.feature
@@ -1,0 +1,54 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: current oC10 behavior for issue-31276
+  As an admin
+  I want to be able to disable a user
+  So that I can remove access to files and resources for a user, without actually deleting the files and resources
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: Subadmin should not be able to disable an user not in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | subadmin |
+    And group "brand-new-group" has been created
+    And group "another-group" has been created
+    And user "subadmin" has been added to group "brand-new-group"
+    And user "Alice" has been added to group "another-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" disables user "Alice" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "Alice" should be enabled
+
+  @issue-31276
+  Scenario: Subadmins should not be able to disable users that have admin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username      |
+      | subadmin      |
+      | another-admin |
+    And group "brand-new-group" has been created
+    And user "another-admin" has been added to group "admin"
+    And user "subadmin" has been added to group "brand-new-group"
+    And user "another-admin" has been added to group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" disables user "another-admin" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "another-admin" should be enabled
+
+  @issue-31276
+  Scenario: disable an user with a regular user
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    When user "Alice" disables user "Brian" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "Brian" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -15,24 +15,22 @@ Feature: enable an app
     And the HTTP status code should be "200"
     And app "comments" should be enabled
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to enable an app
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And app "comments" has been disabled
     When user "subadmin" enables app "comments"
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And app "comments" should be disabled
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to enable an app
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And app "comments" has been disabled
     When user "brand-new-user" enables app "comments"
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And app "comments" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v2/enableAppOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableAppOc10Issue31276.feature
@@ -1,0 +1,30 @@
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: enable an app - current oC10 behavior for issue-31276
+  As an admin
+  I want to be able to enable a disabled app
+  So that I can use the app features again
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: subadmin tries to enable an app
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And app "comments" has been disabled
+    When user "subadmin" enables app "comments"
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And app "comments" should be disabled
+
+  @issue-31276
+  Scenario: normal user tries to enable an app
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And app "comments" has been disabled
+    When user "brand-new-user" enables app "comments"
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And app "comments" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -60,7 +60,7 @@ Feature: enable user
     When user "another-admin" tries to enable user "another-admin" using the provisioning API
     Then user "another-admin" should be disabled
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to enable other user
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -68,8 +68,7 @@ Feature: enable user
       | Brian    |
     And user "Brian" has been disabled
     When user "Alice" tries to enable user "Brian" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should be disabled
 

--- a/tests/acceptance/features/apiProvisioning-v2/enableUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUserOc10Issue31276.feature
@@ -1,0 +1,19 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: enable user - current oC10 behavior for issue-31276
+  As an admin
+  I want to be able to enable a user
+  So that I can give a user access to their files and resources again if they are now authorized for that
+
+  @issue-31276
+  Scenario: normal user tries to enable other user
+    Given using OCS API version "2"
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Brian" has been disabled
+    When user "Alice" tries to enable user "Brian" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "Brian" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -26,7 +26,7 @@ Feature: get subadmins
     And the HTTP status code should be "400"
     And the API should not return any data
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to get other subadmins of the same group
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -36,12 +36,11 @@ Feature: get subadmins
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And user "another-subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" gets all the subadmins of group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get the subadmins of the group
     Given these users have been created with default attributes and skeleton files:
       | username       |
@@ -50,7 +49,6 @@ Feature: get subadmins
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "brand-new-user" gets all the subadmins of group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdminsOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdminsOc10Issue31276.feature
@@ -1,0 +1,37 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: get subadmins - current oC10 behavior for issue-31276
+  As an admin
+  I want to be able to get the list of subadmins of a group
+  So that I can manage subadmins of a group
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: subadmin tries to get other subadmins of the same group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" gets all the subadmins of group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data
+
+  @issue-31276
+  Scenario: normal user tries to get the subadmins of the group
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | subadmin       |
+      | brand-new-user |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "brand-new-user" gets all the subadmins of group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -78,15 +78,14 @@ Feature: get user
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: a normal user tries to get information of another user
     Given these users have been created with default attributes and skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
     When user "another-new-user" retrieves the information of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And the API should not return any data
 

--- a/tests/acceptance/features/apiProvisioning-v2/getUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserOc10Issue31276.feature
@@ -1,0 +1,20 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: get user - current oC10 behavior for issue-31276
+  As an admin, subadmin or as myself
+  I want to be able to retrieve user information
+  So that I can see the information
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: a normal user tries to get information of another user
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | brand-new-user   |
+      | another-new-user |
+    When user "another-new-user" retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -40,14 +40,13 @@ Feature: get users
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get other users
     Given these users have been created with default attributes and skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
     When user "brand-new-user" gets the list of all users using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/getUsersOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsersOc10Issue31276.feature
@@ -1,0 +1,20 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: get users - current oC10 behavior for issue-31276
+  As an admin, subadmin or as myself
+  I want to be able to retrieve user information
+  So that I can see the information
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: normal user tries to get other users
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | brand-new-user   |
+      | another-new-user |
+    When user "brand-new-user" gets the list of all users using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -17,7 +17,7 @@ Feature: remove subadmin
     And the HTTP status code should be "200"
     And user "brand-new-user" should not be a subadmin of group "brand-new-group"
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to remove other subadmin in the group
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -27,12 +27,11 @@ Feature: remove subadmin
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And user "another-subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" removes user "another-subadmin" from being a subadmin of group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "another-subadmin" should be a subadmin of group "brand-new-group"
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to remove subadmin in the group
     Given these users have been created with default attributes and skeleton files:
       | username       |
@@ -42,7 +41,6 @@ Feature: remove subadmin
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And user "brand-new-user" has been added to group "brand-new-group"
     When user "brand-new-user" removes user "subadmin" from being a subadmin of group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "subadmin" should be a subadmin of group "brand-new-group"

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdminOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdminOc10Issue31276.feature
@@ -1,0 +1,38 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: remove subadmin - current oC10 behavior for issue-31276
+  As an admin
+  I want to be able to remove subadmin rights to a user from a group
+  So that I cam manage administrative access rights for groups
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: subadmin tries to remove other subadmin in the group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" removes user "another-subadmin" from being a subadmin of group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "another-subadmin" should be a subadmin of group "brand-new-group"
+
+  @issue-31276
+  Scenario: normal user tries to remove subadmin in the group
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | subadmin       |
+      | brand-new-user |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "brand-new-user" has been added to group "brand-new-group"
+    When user "brand-new-user" removes user "subadmin" from being a subadmin of group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "subadmin" should be a subadmin of group "brand-new-group"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -58,22 +58,12 @@ Feature: add groups
       | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
 
-    # Note: these groups do get created OK, but:
-    # 1) the "should exist" step fails because the API to check their existence does not work.
-    # 2) the ordinary group deletion in AfterScenario does not work, because the
-    #    that group-delete API does not work for groups with a slash in the name
-  @issue-31015
+  @issue-31015 @skipOnOcV10
   Scenario Outline: admin creates a group with a forward-slash in the group name
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    # After fixing issue-31015, change the following step to "should exist"
-    And group "<group_id>" should not exist
-    #And group "<group_id>" should exist
-    #
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
+    And group "<group_id>" should exist
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |
@@ -81,20 +71,15 @@ Feature: add groups
       | var/../etc       | using slash-dot-dot                |
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-	# A group name must not end in "/subadmins" because that would create ambiguity
-	# with the endpoint for getting the subadmins of a group
-  @issue-31015
+  # A group name must not end in "/subadmins" because that would create ambiguity
+  # with the endpoint for getting the subadmins of a group
+  @issue-31015 @skipOnOcV10
   Scenario: admin tries to create a group with name ending in "/subadmins"
     Given group "brand-new-group" has been created
     When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
-    # After fixing issue-31015, change the expected status to "101"
-    Then the OCS status code should be "100"
-    #Then the OCS status code should be "101"
+    Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     And group "priv/subadmins" should not exist
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "priv/subadmins" using the occ command
 
   Scenario: admin tries to create a group that already exists
     Given group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroupOc10Issue31015.feature
@@ -1,0 +1,44 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: add groups
+  As an admin
+  I want to be able to add groups
+  So that I can more easily manage access to resources by groups rather than individual users
+
+  Background:
+    Given using OCS API version "1"
+
+    # Note: these groups do get created OK, but:
+    # 1) the "should exist" step fails because the API to check their existence does not work.
+    # 2) the ordinary group deletion in AfterScenario does not work, because the
+    #    group-delete API does not work for groups with a slash in the name
+  @issue-31015
+  Scenario Outline: admin creates a group with a forward-slash in the group name
+    When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "<group_id>" should not exist
+    #And group "<group_id>" should exist
+    #
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, this should not be needed.
+    And the administrator deletes group "<group_id>" using the occ command
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
+
+  # A group name must not end in "/subadmins" because that would create ambiguity
+  # with the endpoint for getting the subadmins of a group
+  @issue-31015
+  Scenario: admin tries to create a group with name ending in "/subadmins"
+    Given group "brand-new-group" has been created
+    When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
+    Then the OCS status code should be "100"
+    #Then the OCS status code should be "101"
+    And the HTTP status code should be "200"
+    And group "priv/subadmins" should not exist
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, this should not be needed.
+    And the administrator deletes group "priv/subadmins" using the occ command

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -62,20 +62,13 @@ Feature: delete groups
       | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
 
-  @issue-31015
+  @issue-31015 @skipOnOcV10
   Scenario Outline: admin deletes a group that has a forward-slash in the group name
-    # After fixing issue-31015, change the following step to "has been created"
-    Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #Given group "<group_id>" has been created
+    Given group "<group_id>" has been created
     When the administrator deletes group "<group_id>" using the provisioning API
-    # After fixing issue-31015, change the expected status to "100"
-    #Then the OCS status code should be "100"
-    And the HTTP status code should be "404"
-    #And the HTTP status code should be "200"
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
     And group "<group_id>" should not exist
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroupOc10Issue31015.feature
@@ -1,0 +1,29 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: delete groups
+  As an admin
+  I want to be able to delete groups
+  So that I can remove unnecessary groups
+
+  Background:
+    Given using OCS API version "1"
+
+  @issue-31015
+  Scenario Outline: admin deletes a group that has a forward-slash in the group name
+    # After fixing issue-31015, change the following step to "has been created"
+    Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #Given group "<group_id>" has been created
+    When the administrator deletes group "<group_id>" using the provisioning API
+    # After fixing issue-31015, change the expected status to "100"
+    #Then the OCS status code should be "100"
+    And the HTTP status code should be "404"
+    #And the HTTP status code should be "200"
+    And group "<group_id>" should not exist
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -34,48 +34,23 @@ Feature: get user groups
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
 
-	# Note: when the issue is fixed, use this scenario and delete the scenario above.
-  @issue-31015
+  @issue-31015 @skipOnOcV10
   Scenario: admin gets groups of an user, including groups containing a slash
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created
-    And group "brand-new-group" has been created
-    And group "0" has been created
-    And group "Admin & Finance (NP)" has been created
-    And group "admin:Pokhara@Nepal" has been created
-    And group "नेपाली" has been created
-    # After fixing issue-31015, change the following steps to "has been created"
-    And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API
-    And the administrator sends a group creation request for group "var/../etc" using the provisioning API
-    And the administrator sends a group creation request for group "priv/subadmins/1" using the provisioning API
-    #And group "Mgmt/Sydney" has been created
-    #And group "var/../etc" has been created
-    #And group "priv/subadmins/1" has been created
-    And user "brand-new-user" has been added to group "brand-new-group"
-    And user "brand-new-user" has been added to group "0"
-    And user "brand-new-user" has been added to group "Admin & Finance (NP)"
-    And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
-    And user "brand-new-user" has been added to group "नेपाली"
+    And group "Mgmt/Sydney" has been created
+    And group "var/../etc" has been created
+    And group "priv/subadmins/1" has been created
     And user "brand-new-user" has been added to group "Mgmt/Sydney"
     And user "brand-new-user" has been added to group "var/../etc"
     And user "brand-new-user" has been added to group "priv/subadmins/1"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the groups returned by the API should be
-      | brand-new-group      |
-      | 0                    |
-      | Admin & Finance (NP) |
-      | admin:Pokhara@Nepal  |
-      | नेपाली               |
       | Mgmt/Sydney          |
       | var/../etc           |
       | priv/subadmins/1     |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
-    # The following steps are needed so that the groups do get cleaned up.
-    # After fixing issue-31015, remove the following steps:
-    And the administrator deletes group "Mgmt/Sydney" using the occ command
-    And the administrator deletes group "var/../etc" using the occ command
-    And the administrator deletes group "priv/subadmins/1" using the occ command
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroupsOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroupsOc10Issue31015.feature
@@ -1,0 +1,35 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: get user groups
+  As an admin
+  I want to be able to get groups
+  So that I can manage group membership
+
+  Background:
+    Given using OCS API version "1"
+
+  @issue-31015
+  Scenario: admin gets groups of an user, including groups containing a slash
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And group "unused-group" has been created
+    # After fixing issue-31015, change the following steps to "has been created"
+    And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API
+    And the administrator sends a group creation request for group "var/../etc" using the provisioning API
+    And the administrator sends a group creation request for group "priv/subadmins/1" using the provisioning API
+    #And group "Mgmt/Sydney" has been created
+    #And group "var/../etc" has been created
+    #And group "priv/subadmins/1" has been created
+    And user "brand-new-user" has been added to group "Mgmt/Sydney"
+    And user "brand-new-user" has been added to group "var/../etc"
+    And user "brand-new-user" has been added to group "priv/subadmins/1"
+    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
+    Then the groups returned by the API should be
+      | Mgmt/Sydney          |
+      | var/../etc           |
+      | priv/subadmins/1     |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # The following steps are needed so that the groups do get cleaned up.
+    # After fixing issue-31015, remove the following steps:
+    And the administrator deletes group "Mgmt/Sydney" using the occ command
+    And the administrator deletes group "var/../etc" using the occ command
+    And the administrator deletes group "priv/subadmins/1" using the occ command

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -50,20 +50,15 @@ Feature: remove a user from a group
       | staff?group         | Question mark                           |
       | 😁 😂               | emoji                                   |
 
-  @issue-31015
+  @issue-31015 @skipOnOcV10
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes and skeleton files
-    # After fixing issue-31015, change the following step to "has been created"
-    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #And group "<group_id>" has been created
+    And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroupOc10Issue31015.feature
@@ -1,0 +1,29 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: remove a user from a group
+  As an admin
+  I want to be able to remove a user from a group
+  So that I can manage user access to group resources
+
+  Background:
+    Given using OCS API version "1"
+
+  @issue-31015
+  Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    # After fixing issue-31015, change the following step to "has been created"
+    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #And group "<group_id>" has been created
+    And user "brand-new-user" has been added to group "<group_id>"
+    When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id>"
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -58,22 +58,12 @@ Feature: add groups
       | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
 
-    # Note: these groups do get created OK, but:
-    # 1) the "should exist" step fails because the API to check their existence does not work.
-    # 2) the ordinary group deletion in AfterScenario does not work, because the
-    #    that group-delete API does not work for groups with a slash in the name
-  @issue-31015
+  @issue-31015 @skipOnOcV10
   Scenario Outline: admin creates a group with a forward-slash in the group name
     When the administrator sends a group creation request for group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    # After fixing issue-31015, change the following step to "should exist"
-    And group "<group_id>" should not exist
-    #And group "<group_id>" should exist
-    #
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
+    And group "<group_id>" should exist
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |
@@ -81,21 +71,15 @@ Feature: add groups
       | var/../etc       | using slash-dot-dot                |
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-	# A group name must not end in "/subadmins" because that would create ambiguity
-	# with the endpoint for getting the subadmins of a group
-  @issue-31015
+  # A group name must not end in "/subadmins" because that would create ambiguity
+  # with the endpoint for getting the subadmins of a group
+  @issue-31015 @skipOnOcV10
   Scenario: admin tries to create a group with name ending in "/subadmins"
     Given group "brand-new-group" has been created
     When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
-    # After fixing issue-31015, change the expected status to "400"
-    Then the OCS status code should be "200"
-    #Then the OCS status code should be "400"
-    And the HTTP status code should be "200"
-    #And the HTTP status code should be "400"
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
     And group "priv/subadmins" should not exist
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "priv/subadmins" using the occ command
 
   Scenario: admin tries to create a group that already exists
     Given group "brand-new-group" has been created
@@ -104,12 +88,11 @@ Feature: add groups
     And the HTTP status code should be "400"
     And group "brand-new-group" should exist
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to create a group
     Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" tries to send a group creation request for group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And group "brand-new-group" should not exist
 

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31015.feature
@@ -1,0 +1,47 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: add groups
+  As an admin
+  I want to be able to add groups
+  So that I can more easily manage access to resources by groups rather than individual users
+
+  Background:
+    Given using OCS API version "2"
+
+    # Note: these groups do get created OK, but:
+    # 1) the "should exist" step fails because the API to check their existence does not work.
+    # 2) the ordinary group deletion in AfterScenario does not work, because the
+    #    group-delete API does not work for groups with a slash in the name
+  @issue-31015
+  Scenario Outline: admin creates a group with a forward-slash in the group name
+    When the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    # After fixing issue-31015, change the following step to "should exist"
+    And group "<group_id>" should not exist
+    #And group "<group_id>" should exist
+    #
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |
+
+  # A group name must not end in "/subadmins" because that would create ambiguity
+  # with the endpoint for getting the subadmins of a group
+  @issue-31015
+  Scenario: admin tries to create a group with name ending in "/subadmins"
+    Given group "brand-new-group" has been created
+    When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
+    # After fixing issue-31015, change the expected status to "400"
+    Then the OCS status code should be "200"
+    #Then the OCS status code should be "400"
+    And the HTTP status code should be "200"
+    #And the HTTP status code should be "400"
+    And group "priv/subadmins" should not exist
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "priv/subadmins" using the occ command

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31276.feature
@@ -1,0 +1,17 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: add groups
+  As an admin
+  I want to be able to add groups
+  So that I can more easily manage access to resources by groups rather than individual users
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: normal user tries to create a group
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    When user "brand-new-user" tries to send a group creation request for group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #And the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And group "brand-new-group" should not exist

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -47,18 +47,13 @@ Feature: add users to group
       | staff?group         | Question mark                           |
       | 😅 😆               | emoji                                   |
 
-  @issue-31015 @skipOnLDAP
+  @issue-31015 @skipOnOcV10
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes and skeleton files
-    # After fixing issue-31015, change the following step to "has been created"
-    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #And group "<group_id>" has been created
+    And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |
@@ -84,12 +79,11 @@ Feature: add users to group
       | Mixed-Case-User | case-sensitive-group | CASE-SENSITIVE-GROUP | Case-Sensitive-Group |
       | mixed-case-user | CASE-SENSITIVE-GROUP | Case-Sensitive-Group | case-sensitive-group |
 
-  @issue-31276 @skipOnLDAP
+  @issue-31276 @skipOnLDAP @skipOnOcV10
   Scenario: normal user tries to add himself to a group
     Given user "brand-new-user" has been created with default attributes and skeleton files
     When user "brand-new-user" tries to add himself to group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And the API should not return any data
 

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31015.feature
@@ -1,0 +1,27 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: add users to group
+  As a admin
+  I want to be able to add users to a group
+  So that I can give a user access to the resources of the group
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31015 @skipOnLDAP
+  Scenario Outline: adding a user to a group that has a forward-slash in the group name
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    # After fixing issue-31015, change the following step to "has been created"
+    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #And group "<group_id>" has been created
+    When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31276.feature
@@ -1,0 +1,17 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: add users to group
+  As a admin
+  I want to be able to add users to a group
+  So that I can give a user access to the resources of the group
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276 @skipOnLDAP
+  Scenario: normal user tries to add himself to a group
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    When user "brand-new-user" tries to add himself to group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #And the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -62,20 +62,13 @@ Feature: delete groups
       | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group |
 
-  @issue-31015
+  @issue-31015 @skipOnOcV10
   Scenario Outline: admin deletes a group that has a forward-slash in the group name
-    # After fixing issue-31015, change the following step to "has been created"
-    Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #Given group "<group_id>" has been created
+    Given group "<group_id>" has been created
     When the administrator deletes group "<group_id>" using the provisioning API
-    # After fixing issue-31015, change the expected status to "200"
-    #Then the OCS status code should be "200"
-    And the HTTP status code should be "404"
-    #And the HTTP status code should be "200"
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
     And group "<group_id>" should not exist
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |
@@ -83,24 +76,22 @@ Feature: delete groups
       | var/../etc       | using slash-dot-dot                |
       | priv/subadmins/1 | Subadmins mentioned not at the end |
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to delete the group
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
     And user "brand-new-user" has been added to group "brand-new-group"
     When user "brand-new-user" tries to delete group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And group "brand-new-group" should exist
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: subadmin of the group tries to delete the group
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" tries to delete group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And group "brand-new-group" should exist

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31015.feature
@@ -1,0 +1,29 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: delete groups
+  As an admin
+  I want to be able to delete groups
+  So that I can remove unnecessary groups
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31015
+  Scenario Outline: admin deletes a group that has a forward-slash in the group name
+    # After fixing issue-31015, change the following step to "has been created"
+    Given the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #Given group "<group_id>" has been created
+    When the administrator deletes group "<group_id>" using the provisioning API
+    # After fixing issue-31015, change the expected status to "200"
+    #Then the OCS status code should be "200"
+    And the HTTP status code should be "404"
+    #And the HTTP status code should be "200"
+    And group "<group_id>" should not exist
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31276.feature
@@ -1,0 +1,30 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: delete groups
+  As an admin
+  I want to be able to delete groups
+  So that I can remove unnecessary groups
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: normal user tries to delete the group
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And user "brand-new-user" has been added to group "brand-new-group"
+    When user "brand-new-user" tries to delete group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #And the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And group "brand-new-group" should exist
+
+  @issue-31276
+  Scenario: subadmin of the group tries to delete the group
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" tries to delete group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #And the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And group "brand-new-group" should exist

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
@@ -66,22 +66,20 @@ Feature: get group
       | Alice |
       | Brian |
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to get users in a group they are not responsible for
     Given user "subadmin" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" gets all the members of group "another-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get users in their group
     Given user "newuser" has been created with default attributes and skeleton files
     And group "brand-new-group" has been created
     When user "newuser" gets all the members of group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroupOc10Issue31276.feature
@@ -1,0 +1,28 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: get group
+  As an admin
+  I want to be able to get group details
+  So that I can know which users are in a group
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: subadmin tries to get users in a group they are not responsible for
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And group "another-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" gets all the members of group "another-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #And the OCS status code should be "401"
+    And the HTTP status code should be "401"
+
+  @issue-31276
+  Scenario: normal user tries to get users in their group
+    Given user "newuser" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    When user "newuser" gets all the members of group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #And the OCS status code should be "401"
+    And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -34,48 +34,23 @@ Feature: get user groups
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 
-	# Note: when the issue is fixed, use this scenario and delete the scenario above.
-  @issue-31015
+  @issue-31015 @skipOnOcV10
   Scenario: admin gets groups of an user, including groups containing a slash
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created
-    And group "brand-new-group" has been created
-    And group "0" has been created
-    And group "Admin & Finance (NP)" has been created
-    And group "admin:Pokhara@Nepal" has been created
-    And group "नेपाली" has been created
-    # After fixing issue-31015, change the following steps to "has been created"
-    And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API
-    And the administrator sends a group creation request for group "var/../etc" using the provisioning API
-    And the administrator sends a group creation request for group "priv/subadmins/1" using the provisioning API
-    #And group "Mgmt/Sydney" has been created
-    #And group "var/../etc" has been created
-    #And group "priv/subadmins/1" has been created
-    And user "brand-new-user" has been added to group "brand-new-group"
-    And user "brand-new-user" has been added to group "0"
-    And user "brand-new-user" has been added to group "Admin & Finance (NP)"
-    And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
-    And user "brand-new-user" has been added to group "नेपाली"
+    And group "Mgmt/Sydney" has been created
+    And group "var/../etc" has been created
+    And group "priv/subadmins/1" has been created
     And user "brand-new-user" has been added to group "Mgmt/Sydney"
     And user "brand-new-user" has been added to group "var/../etc"
     And user "brand-new-user" has been added to group "priv/subadmins/1"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the groups returned by the API should be
-      | brand-new-group      |
-      | 0                    |
-      | Admin & Finance (NP) |
-      | admin:Pokhara@Nepal  |
-      | नेपाली               |
       | Mgmt/Sydney          |
       | var/../etc           |
       | priv/subadmins/1     |
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
-    # The following steps are needed so that the groups do get cleaned up.
-    # After fixing issue-31015, remove the following steps:
-    And the administrator deletes group "Mgmt/Sydney" using the occ command
-    And the administrator deletes group "var/../etc" using the occ command
-    And the administrator deletes group "priv/subadmins/1" using the occ command
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group
@@ -94,7 +69,7 @@ Feature: get user groups
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get the groups of another user
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -103,7 +78,6 @@ Feature: get user groups
     And group "brand-new-group" has been created
     And user "brand-new-user" has been added to group "brand-new-group"
     When user "another-new-user" gets all the groups of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And the API should not return any data

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31015.feature
@@ -1,0 +1,35 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: get user groups
+  As an admin
+  I want to be able to get groups
+  So that I can manage group membership
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31015
+  Scenario: admin gets groups of an user, including groups containing a slash
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    And group "unused-group" has been created
+    # After fixing issue-31015, change the following steps to "has been created"
+    And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API
+    And the administrator sends a group creation request for group "var/../etc" using the provisioning API
+    And the administrator sends a group creation request for group "priv/subadmins/1" using the provisioning API
+    #And group "Mgmt/Sydney" has been created
+    #And group "var/../etc" has been created
+    #And group "priv/subadmins/1" has been created
+    And user "brand-new-user" has been added to group "Mgmt/Sydney"
+    And user "brand-new-user" has been added to group "var/../etc"
+    And user "brand-new-user" has been added to group "priv/subadmins/1"
+    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
+    Then the groups returned by the API should be
+      | Mgmt/Sydney          |
+      | var/../etc           |
+      | priv/subadmins/1     |
+    And the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    # The following steps are needed so that the groups do get cleaned up.
+    # After fixing issue-31015, remove the following steps:
+    And the administrator deletes group "Mgmt/Sydney" using the occ command
+    And the administrator deletes group "var/../etc" using the occ command
+    And the administrator deletes group "priv/subadmins/1" using the occ command

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31276.feature
@@ -1,0 +1,22 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: get user groups
+  As an admin
+  I want to be able to get groups
+  So that I can manage group membership
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: normal user tries to get the groups of another user
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | brand-new-user   |
+      | another-new-user |
+    And group "brand-new-group" has been created
+    And user "brand-new-user" has been added to group "brand-new-group"
+    When user "another-new-user" gets all the groups of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "997"
+    #And the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -50,20 +50,15 @@ Feature: remove a user from a group
       | staff?group         | Question mark                           |
       | 😅 😆               | emoji                                   |
 
-  @issue-31015
+  @issue-31015 @skipOnOcV10
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
     Given user "brand-new-user" has been created with default attributes and skeleton files
-      # After fixing issue-31015, change the following step to "has been created"
-    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
-    #And group "<group_id>" has been created
+    And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "<group_id>"
-    # The following step is needed so that the group does get cleaned up.
-    # After fixing issue-31015, remove the following step:
-    And the administrator deletes group "<group_id>" using the occ command
     Examples:
       | group_id         | comment                            |
       | Mgmt/Sydney      | Slash (special escaping happens)   |
@@ -127,7 +122,7 @@ Feature: remove a user from a group
     And the HTTP status code should be "403"
     And user "brand-new-user" should belong to group "brand-new-group"
 
-  @issue-31276
+  @issue-31276 @skipOnOcV10
   Scenario: normal user tries to remove a user in their group
     Given these users have been created with default attributes and skeleton files:
       | username         |
@@ -137,7 +132,6 @@ Feature: remove a user from a group
     And user "brand-new-user" has been added to group "brand-new-group"
     And user "another-new-user" has been added to group "brand-new-group"
     When user "brand-new-user" tries to remove user "another-new-user" from group "brand-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "another-new-user" should belong to group "brand-new-group"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31015.feature
@@ -1,0 +1,29 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: remove a user from a group
+  As an admin
+  I want to be able to remove a user from a group
+  So that I can manage user access to group resources
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31015
+  Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+      # After fixing issue-31015, change the following step to "has been created"
+    And the administrator sends a group creation request for group "<group_id>" using the provisioning API
+    #And group "<group_id>" has been created
+    And user "brand-new-user" has been added to group "<group_id>"
+    When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not belong to group "<group_id>"
+    # The following step is needed so that the group does get cleaned up.
+    # After fixing issue-31015, remove the following step:
+    And the administrator deletes group "<group_id>" using the occ command
+    Examples:
+      | group_id         | comment                            |
+      | Mgmt/Sydney      | Slash (special escaping happens)   |
+      | Mgmt//NSW/Sydney | Multiple slash                     |
+      | var/../etc       | using slash-dot-dot                |
+      | priv/subadmins/1 | Subadmins mentioned not at the end |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31276.feature
@@ -1,0 +1,23 @@
+@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS
+Feature: remove a user from a group
+  As an admin
+  I want to be able to remove a user from a group
+  So that I can manage user access to group resources
+
+  Background:
+    Given using OCS API version "2"
+
+  @issue-31276
+  Scenario: normal user tries to remove a user in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | brand-new-user   |
+      | another-new-user |
+    And group "brand-new-group" has been created
+    And user "brand-new-user" has been added to group "brand-new-group"
+    And user "another-new-user" has been added to group "brand-new-group"
+    When user "brand-new-user" tries to remove user "another-new-user" from group "brand-new-group" using the provisioning API
+    Then the OCS status code should be "997"
+    #And the OCS status code should be "401"
+    And the HTTP status code should be "401"
+    And user "another-new-user" should belong to group "brand-new-group"

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: share resources with a disabled user
 
   Background:
@@ -15,12 +15,11 @@ Feature: share resources with a disabled user
       | ocs_api_version | ocs_status_code |
       | 1               | 997             |
 
-  @issue-32068
+  @issue-32068 @skipOnOcV10
   Scenario: Creating a new share with a disabled user
     Given using OCS API version "2"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
     When user "Alice" shares file "welcome.txt" with user "Brian" using the sharing API
-    Then the OCS status code should be "997"
-    #And the OCS status code should be "401"
+    Then the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
@@ -1,0 +1,15 @@
+@api @files_sharing-app-required @issue-ocis-reva-243 @notToImplementOnOCIS
+Feature: share resources with a disabled user - current oC10 behavior for issue-32068
+
+  Background:
+    Given user "Alice" has been created with default attributes and skeleton files
+
+  @issue-32068
+  Scenario: Creating a new share with a disabled user
+    Given using OCS API version "2"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has been disabled
+    When user "Alice" shares file "welcome.txt" with user "Brian" using the sharing API
+    Then the OCS status code should be "997"
+    #Then the OCS status code should be "401"
+    And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:
@@ -74,19 +74,16 @@ Feature: sharing
     And as "Alice" file "/folderToShare/renamedFile" should exist
     But as "Alice" file "/folderToShare/fileInside" should not exist
 
-  @issue-30325
+  @issue-30325 @skipOnOcV10
   Scenario: receiver tries to rename a received share with share, read permissions
     Given user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
     And user "Alice" has shared folder "folderToShare" with user "Brian" with permissions "share,read"
     When user "Brian" moves folder "folderToShare" to "myFolder" using the WebDAV API
-    Then the HTTP status code should be "403"
-#    Then the HTTP status code should be "201"
-    And as "Brian" folder "myFolder" should not exist
-#    And as "Brian" folder "myFolder" should exist
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "myFolder" should exist
     But as "Alice" folder "myFolder" should not exist
-#    When user "Brian" moves file "/myFolder/fileInside" to "/myFolder/renamedFile" using the WebDAV API
-    When user "Brian" moves file "/folderToShare/fileInside" to "/folderToShare/renamedFile" using the WebDAV API
+    When user "Brian" moves file "/myFolder/fileInside" to "/myFolder/renamedFile" using the WebDAV API
     Then the HTTP status code should be "403"
-    And as "Brian" file "/folderToShare/renamedFile" should not exist
-    But as "Brian" file "/folderToShare/fileInside" should exist
+    And as "Brian" file "/myFolder/renamedFile" should not exist
+    But as "Brian" file "/myFolder/fileInside" should exist

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareOc10Issue30325.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareOc10Issue30325.feature
@@ -1,0 +1,29 @@
+@api @files_sharing-app-required @notToImplementOnOCIS
+Feature: sharing - current oC10 behavior for issue-30325
+
+  Background:
+    Given using OCS API version "1"
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Carol    |
+
+  @issue-30325
+  Scenario: receiver tries to rename a received share with share, read permissions
+    Given user "Alice" has created folder "folderToShare"
+    And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
+    And user "Alice" has shared folder "folderToShare" with user "Brian" with permissions "share,read"
+    When user "Brian" moves folder "folderToShare" to "myFolder" using the WebDAV API
+    Then the HTTP status code should be "403"
+#    Then the HTTP status code should be "201"
+    And as "Brian" folder "myFolder" should not exist
+#    And as "Brian" folder "myFolder" should exist
+    But as "Alice" folder "myFolder" should not exist
+#    When user "Brian" moves file "/myFolder/fileInside" to "/myFolder/renamedFile" using the WebDAV API
+    When user "Brian" moves file "/folderToShare/fileInside" to "/folderToShare/renamedFile" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Brian" file "/folderToShare/renamedFile" should not exist
+#    And as "Brian" file "/myFolder/renamedFile" should not exist
+    But as "Brian" file "/folderToShare/fileInside" should exist
+#    But as "Brian" file "/myFolder/fileInside" should exist

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -389,7 +389,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-36442 @issue-ocis-reva-41
+  @issue-36442 @skipOnOcV10
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -397,23 +397,20 @@ Feature: create a public link share
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /afolder    |
       | permissions | read,create |
-    # And the fields of the last response to user "Alice" should include
-    #  | id          | A_STRING    |
-    #  | share_type  | public_link |
-    #  | permissions | read        |
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the fields of the last response to user "Alice" should include
+      | id          | A_STRING    |
+      | share_type  | public_link |
+      | permissions | read        |
+    And the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the OCS status message should be "Public upload not allowed"
-    # And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
-    # And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 403             | 200              |
-      #| 1               | 100             | 200              |
-      | 2               | 403             | 403              |
-      #| 2               | 200             | 200              |
+      | 1               | 100             | 200              |
+      | 2               | 200             | 200              |
 
-  @issue-36442 @issue-ocis-reva-41
+  @issue-36442 @skipOnOcV10
   Scenario Outline: Creating a public link share with create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -421,23 +418,20 @@ Feature: create a public link share
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /afolder |
       | permissions | create   |
-    # And the fields of the last response to user "Alice" should include
-    #  | id          | A_STRING    |
-    #  | share_type  | public_link |
-    #  | permissions | read        |
+    Then the fields of the last response to user "Alice" should include
+      | id          | A_STRING    |
+      | share_type  | public_link |
+      | permissions | read        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the OCS status message should be "Public upload disabled by the administrator"
-    # And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
-    # And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 403             | 200              |
-      #| 1               | 100             | 200              |
-      | 2               | 403             | 403              |
-      #| 2               | 200             | 200              |
+      | 1               | 100             | 200              |
+      | 2               | 200             | 200              |
 
-  @issue-36442 @issue-ocis-reva-41
+  @issue-36442 @skipOnOcV10
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -447,23 +441,20 @@ Feature: create a public link share
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     When user "Alice" tries to update the last share using the sharing API with
       | permissions | read,create |
-    # And the fields of the last response to user "Alice" should include
-    #  | id          | A_STRING    |
-    #  | share_type  | public_link |
-    #  | permissions | read        |
+    Then the fields of the last response to user "Alice" should include
+      | id          | A_STRING    |
+      | share_type  | public_link |
+      | permissions | read        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the OCS status message should be "Public upload not allowed"
-    # And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
-    # And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 400             | 200              |
-      #| 1               | 100             | 200              |
-      | 2               | 400             | 400              |
-      #| 2               | 200             | 200              |
+      | 1               | 100             | 200              |
+      | 2               | 200             | 200              |
 
-  @issue-36442 @issue-ocis-reva-41
+  @issue-36442 @skipOnOcV10
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -473,29 +464,22 @@ Feature: create a public link share
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     When user "Alice" tries to update the last share using the sharing API with
       | permissions | <permission> |
-    # And the fields of the last response to user "Alice" should include
-    #  | id          | A_STRING    |
-    #  | share_type  | public_link |
-    #  | permissions | read        |
+    Then the fields of the last response to user "Alice" should include
+      | id          | A_STRING    |
+      | share_type  | public_link |
+      | permissions | read        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And the OCS status message should be "Public upload disabled by the administrator"
-    # And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
-    # And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | permission                |
-      | 1               | 403             | 200              | create                    |
-      #| 1               | 100             | 200              | create                     |
-      | 2               | 403             | 403              | create                    |
-      #| 2               | 200             | 200              | create                     |
-      | 1               | 403             | 200              | create,read,update        |
-      #| 1               | 100             | 200              | create,read,update         |
-      | 2               | 403             | 403              | create,read,update        |
-      #| 2               | 200             | 200              | create,read,update         |
-      | 1               | 403             | 200              | read,create,update,delete |
-      #| 1               | 100             | 200              | read,create,update,delete  |
-      | 2               | 403             | 403              | read,create,update,delete |
-      #| 2               | 200             | 200              | read,create,update,delete  |
+      | 1               | 100             | 200              | create                    |
+      | 2               | 200             | 200              | create                    |
+      | 1               | 100             | 200              | create,read,update        |
+      | 2               | 200             | 200              | create,read,update        |
+      | 1               | 100             | 200              | read,create,update,delete |
+      | 2               | 200             | 200              | read,create,update,delete |
 
   @issue-ocis-reva-41
   Scenario Outline: Creating a link share with read+update+create permissions defaults to read permissions when public upload disabled globally
@@ -805,8 +789,7 @@ Feature: create a public link share
       | old         |
       | new         |
 
-  @issue-37605
-  #after fixing all issues make this scenario like the one in OCIS, and delete the one in OCIS
+  @issue-37605 @skipOnOcV10
   Scenario: Get the mtime of a file inside a folder shared by public link using new webDAV version
     Given user "Alice" has created folder "testFolder"
     And user "Alice" has created a public link share with settings
@@ -814,22 +797,17 @@ Feature: create a public link share
       | permissions | read,update,create,delete |
     When the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then as "Alice" file "testFolder/file.txt" should exist
-    And as "Alice" the mtime of the file "testFolder/file.txt" should not be "Thu, 08 Aug 2019 04:18:13 GMT"
-#    And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
-    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should not be "Thu, 08 Aug 2019 04:18:13 GMT"
-#    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
 
-  @issue-37605
-  #after fixing all issues make this scenario like the one in OCIS, and delete the one in OCIS
+  @issue-37605 @skipOnOcV10
   Scenario: overwriting a file changes its mtime (new public webDAV API)
     Given user "Alice" has created folder "testFolder"
     When user "Alice" uploads file with content "uploaded content for file name ending with a dot" to "testFolder/file.txt" using the WebDAV API
     And user "Alice" has created a public link share with settings
-      | path        | /testFolder |
+      | path        | /testFolder               |
       | permissions | read,update,create,delete |
     And the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then as "Alice" file "/testFolder/file.txt" should exist
-    And as "Alice" the mtime of the file "testFolder/file.txt" should not be "Thu, 08 Aug 2019 04:18:13 GMT"
-#    And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
-    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should not be "Thu, 08 Aug 2019 04:18:13 GMT"
-#    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue36442.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue36442.feature
@@ -1,0 +1,114 @@
+@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS
+
+Feature: create a public link share
+
+  Background:
+    Given user "Alice" has been created with default attributes and skeleton files
+
+  @issue-36442
+  Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    And user "Alice" has created folder "/afolder"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | /afolder    |
+      | permissions | read,create |
+    # And the fields of the last response to user "Alice" should include
+    #  | id          | A_STRING    |
+    #  | share_type  | public_link |
+    #  | permissions | read        |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    And the OCS status message should be "Public upload not allowed"
+    # And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    # And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 403             | 200              |
+      #| 1               | 100             | 200              |
+      | 2               | 403             | 403              |
+      #| 2               | 200             | 200              |
+
+  @issue-36442
+  Scenario Outline: Creating a public link share with create permissions defaults to read permissions when public upload disabled globally
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    And user "Alice" has created folder "/afolder"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path        | /afolder |
+      | permissions | create   |
+    # And the fields of the last response to user "Alice" should include
+    #  | id          | A_STRING    |
+    #  | share_type  | public_link |
+    #  | permissions | read        |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    And the OCS status message should be "Public upload disabled by the administrator"
+    # And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    # And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 403             | 200              |
+      #| 1               | 100             | 200              |
+      | 2               | 403             | 403              |
+      #| 2               | 200             | 200              |
+
+  @issue-36442
+  Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/afolder"
+    And user "Alice" has created a public link share with settings
+      | path        | /afolder |
+      | permissions | read     |
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    When user "Alice" tries to update the last share using the sharing API with
+      | permissions | read,create |
+    # And the fields of the last response to user "Alice" should include
+    #  | id          | A_STRING    |
+    #  | share_type  | public_link |
+    #  | permissions | read        |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    And the OCS status message should be "Public upload not allowed"
+    # And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    # And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 400             | 200              |
+      #| 1               | 100             | 200              |
+      | 2               | 400             | 400              |
+      #| 2               | 200             | 200              |
+
+  @issue-36442
+  Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/afolder"
+    And user "Alice" has created a public link share with settings
+      | path        | /afolder |
+      | permissions | read     |
+    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    When user "Alice" tries to update the last share using the sharing API with
+      | permissions | <permission> |
+    # And the fields of the last response to user "Alice" should include
+    #  | id          | A_STRING    |
+    #  | share_type  | public_link |
+    #  | permissions | read        |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    And the OCS status message should be "Public upload disabled by the administrator"
+    # And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    # And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code | permission                |
+      | 1               | 403             | 200              | create                    |
+      #| 1               | 100             | 200              | create                     |
+      | 2               | 403             | 403              | create                    |
+      #| 2               | 200             | 200              | create                     |
+      | 1               | 403             | 200              | create,read,update        |
+      #| 1               | 100             | 200              | create,read,update         |
+      | 2               | 403             | 403              | create,read,update        |
+      #| 2               | 200             | 200              | create,read,update         |
+      | 1               | 403             | 200              | read,create,update,delete |
+      #| 1               | 100             | 200              | read,create,update,delete  |
+      | 2               | 403             | 403              | read,create,update,delete |
+      #| 2               | 200             | 200              | read,create,update,delete  |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
@@ -1,0 +1,33 @@
+@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS
+
+Feature: create a public link share
+
+  Background:
+    Given user "Alice" has been created with default attributes and skeleton files
+
+  @issue-37605
+  Scenario: Get the mtime of a file inside a folder shared by public link using new webDAV version
+    Given user "Alice" has created folder "testFolder"
+    And user "Alice" has created a public link share with settings
+      | path        | /testFolder               |
+      | permissions | read,update,create,delete |
+    When the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+    Then as "Alice" file "testFolder/file.txt" should exist
+    And as "Alice" the mtime of the file "testFolder/file.txt" should not be "Thu, 08 Aug 2019 04:18:13 GMT"
+#    And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should not be "Thu, 08 Aug 2019 04:18:13 GMT"
+#    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
+
+  @issue-37605
+  Scenario: overwriting a file changes its mtime (new public webDAV API)
+    Given user "Alice" has created folder "testFolder"
+    When user "Alice" uploads file with content "uploaded content for file name ending with a dot" to "testFolder/file.txt" using the WebDAV API
+    And user "Alice" has created a public link share with settings
+      | path        | /testFolder               |
+      | permissions | read,update,create,delete |
+    And the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+    Then as "Alice" file "/testFolder/file.txt" should exist
+    And as "Alice" the mtime of the file "testFolder/file.txt" should not be "Thu, 08 Aug 2019 04:18:13 GMT"
+#    And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should not be "Thu, 08 Aug 2019 04:18:13 GMT"
+#    And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -5,8 +5,7 @@ Feature: update a public link share
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @toImplementOnOCIS @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-37653
-  #after fixing all the issues merge this scenario with the one below
+  @issue-37653 @skipOnOcV10
   Scenario Outline: API responds with a full set of parameters when owner changes the expireDate of a public share
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -14,7 +13,7 @@ Feature: update a public link share
     And user "Alice" updates the last share using the sharing API with
       | expireDate | +3 days |
     Then the OCS status code should be "<ocs_status_code>"
-    And the OCS status message should be ""
+    And the OCS status message should be "Ok"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
       | id                         | A_STRING             |

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShareOc10Issue37653.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShareOc10Issue37653.feature
@@ -1,0 +1,46 @@
+@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS
+Feature: update a public link share
+
+  Background:
+    Given using OCS API version "1"
+    And user "Alice" has been created with default attributes and skeleton files
+
+  @issue-37653
+  Scenario Outline: API responds with a full set of parameters when owner changes the expireDate of a public share
+    Given using OCS API version "<ocs_api_version>"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | FOLDER |
+    And user "Alice" updates the last share using the sharing API with
+      | expireDate | +3 days |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the OCS status message should be ""
+    #And the OCS status message should be "Ok"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | id                         | A_STRING             |
+      | share_type                 | public_link          |
+      | uid_owner                  | %username%           |
+      | displayname_owner          | %displayname%        |
+      | permissions                | read                 |
+      | stime                      | A_NUMBER             |
+      | parent                     |                      |
+      | expiration                 | A_STRING             |
+      | token                      | A_STRING             |
+      | uid_file_owner             | %username%           |
+      | displayname_file_owner     | %displayname%        |
+      | additional_info_owner      |                      |
+      | additional_info_file_owner |                      |
+      | item_type                  | folder               |
+      | item_source                | A_STRING             |
+      | path                       | /FOLDER              |
+      | mimetype                   | httpd/unix-directory |
+      | storage_id                 | A_STRING             |
+      | storage                    | A_NUMBER             |
+      | file_source                | A_STRING             |
+      | file_target                | /FOLDER              |
+      | mail_send                  | 0                    |
+      | name                       |                      |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |


### PR DESCRIPTION
## Description
Refactored some API test scenarios demonstrating the actual behaviors. New scenarios demonstrating bugs in Oc10 are tagged `skipOnOcV10` since these show the expected behavior and `notToImplementOnOCIS`  because it only demonstrates an oC10 bug. Features files containing these new scenarios have been named with respect to the issue that it demonstrates.

## Related Issue
- Part of https://github.com/owncloud/core/issues/37891

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
