### PR TITLE
[Tests-Only] Refactor etag tests

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -11,50 +11,56 @@ Feature: propagation of etags when deleting a file or folder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
     When user "Alice" deletes file "/upload/sub/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /upload     |
+      | Alice | /upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: deleting a folder changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
     When user "Alice" deletes folder "/upload/sub/toDelete" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /upload     |
+      | Alice | /upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: deleting a folder with content changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/toDelete/file.txt"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
     When user "Alice" deletes folder "/upload/sub/toDelete" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /upload     |
+      | Alice | /upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as share receiver deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -63,19 +69,27 @@ Feature: propagation of etags when deleting a file or folder
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/sub"
     When user "Brian" deletes file "/Shares/upload/sub/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path               |
+      | Alice | /                  |
+      | Alice | /upload            |
+      | Alice | /upload/sub        |
+      | Brian | /                  |
+      | Brian | /Shares            |
+      | Brian | /Shares/upload     |
+      | Brian | /Shares/upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as sharer deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -84,19 +98,27 @@ Feature: propagation of etags when deleting a file or folder
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/sub"
     When user "Alice" deletes file "/upload/sub/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path               |
+      | Alice | /                  |
+      | Alice | /upload            |
+      | Alice | /upload/sub        |
+      | Brian | /                  |
+      | Brian | /Shares            |
+      | Brian | /Shares/upload     |
+      | Brian | /Shares/upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as share receiver deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -107,19 +129,27 @@ Feature: propagation of etags when deleting a file or folder
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/sub"
     When user "Brian" deletes folder "/Shares/upload/sub/toDelete" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path               |
+      | Alice | /                  |
+      | Alice | /upload            |
+      | Alice | /upload/sub        |
+      | Brian | /                  |
+      | Brian | /Shares            |
+      | Brian | /Shares/upload     |
+      | Brian | /Shares/upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as sharer deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -130,16 +160,24 @@ Feature: propagation of etags when deleting a file or folder
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/sub"
     When user "Alice" deletes folder "/upload/sub/toDelete" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path               |
+      | Alice | /                  |
+      | Alice | /upload            |
+      | Alice | /upload/sub        |
+      | Brian | /                  |
+      | Brian | /Shares            |
+      | Brian | /Shares/upload     |
+      | Brian | /Shares/upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
@@ -8,97 +8,109 @@ Feature: propagation of etags when moving files or folders
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
     When user "Alice" moves file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /upload |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: moving a file from one folder to an other changes the etags of both folders
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/src"
     And user "Alice" has created folder "/dst"
     And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
     When user "Alice" moves file "/src/file.txt" to "/dst/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /src |
+      | Alice | /dst |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | src     |
-      | old         | dst     |
-      | new         |         |
-      | new         | src     |
-      | new         | dst     |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: moving a file into a subfolder changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
     When user "Alice" moves file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /upload     |
+      | Alice | /upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: renaming a folder inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/src"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
     When user "Alice" moves folder "/upload/src" to "/upload/dst" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /upload |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: moving a folder from one folder to an other changes the etags of both folders
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/src"
     And user "Alice" has created folder "/src/folder"
     And user "Alice" has created folder "/dst"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
     When user "Alice" moves folder "/src/folder" to "/dst/folder" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /src |
+      | Alice | /dst |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | src     |
-      | old         | dst     |
-      | new         |         |
-      | new         | src     |
-      | new         | dst     |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: moving a folder into a subfolder changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/folder"
     And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
     When user "Alice" moves folder "/upload/folder" to "/upload/sub/folder" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /upload     |
+      | Alice | /upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as share receiver renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -109,17 +121,23 @@ Feature: propagation of etags when moving files or folders
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
     When user "Brian" moves file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path           |
+      | Alice | /              |
+      | Alice | /upload        |
+      | Brian | /              |
+      | Brian | /Shares        |
+      | Brian | /Shares/upload |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as sharer renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -130,17 +148,23 @@ Feature: propagation of etags when moving files or folders
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
     When user "Alice" moves file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path           |
+      | Alice | /              |
+      | Alice | /upload        |
+      | Brian | /              |
+      | Brian | /Shares        |
+      | Brian | /Shares/upload |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |
+      | dav_version |
+      | old         |
+      | new         |
 
 
   Scenario Outline: as sharer moving a file from one folder to an other changes the etags of both folders for all collaborators
@@ -155,19 +179,27 @@ Feature: propagation of etags when moving files or folders
     And user "Brian" has accepted share "/src" offered by user "Alice"
     And user "Alice" has shared folder "/dst" with user "Brian"
     And user "Brian" has accepted share "/dst" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/src"
+    And user "Brian" has stored etag of element "/Shares/dst"
     When user "Alice" moves file "/src/file.txt" to "/dst/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /src        |
+      | Alice | /dst        |
+      | Brian | /           |
+      | Brian | /Shares     |
+      | Brian | /Shares/src |
+      | Brian | /Shares/dst |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | src     |
-      | old         | dst     |
-      | new         |         |
-      | new         | src     |
-      | new         | dst     |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as share receiver moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -181,19 +213,27 @@ Feature: propagation of etags when moving files or folders
     And user "Brian" has accepted share "/src" offered by user "Alice"
     And user "Alice" has shared folder "/dst" with user "Brian"
     And user "Brian" has accepted share "/dst" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/src"
+    And user "Brian" has stored etag of element "/Shares/dst"
     When user "Brian" moves file "/Shares/src/file.txt" to "/Shares/dst/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /src        |
+      | Alice | /dst        |
+      | Brian | /           |
+      | Brian | /Shares     |
+      | Brian | /Shares/src |
+      | Brian | /Shares/dst |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | src     |
-      | old         | dst     |
-      | new         |         |
-      | new         | src     |
-      | new         | dst     |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as sharer moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -207,19 +247,27 @@ Feature: propagation of etags when moving files or folders
     And user "Brian" has accepted share "/src" offered by user "Alice"
     And user "Alice" has shared folder "/dst" with user "Brian"
     And user "Brian" has accepted share "/dst" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/src"
+    And user "Brian" has stored etag of element "/Shares/dst"
     When user "Alice" moves folder "/src/toMove" to "/dst/toMove" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /src        |
+      | Alice | /dst        |
+      | Brian | /           |
+      | Brian | /Shares     |
+      | Brian | /Shares/src |
+      | Brian | /Shares/dst |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | src     |
-      | old         | dst     |
-      | new         |         |
-      | new         | src     |
-      | new         | dst     |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as share receiver moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -233,16 +281,24 @@ Feature: propagation of etags when moving files or folders
     And user "Brian" has accepted share "/src" offered by user "Alice"
     And user "Alice" has shared folder "/dst" with user "Brian"
     And user "Brian" has accepted share "/dst" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/src"
+    And user "Brian" has stored etag of element "/Shares/dst"
     When user "Brian" moves folder "/Shares/src/toMove" to "/Shares/dst/toMove" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /src        |
+      | Alice | /dst        |
+      | Brian | /           |
+      | Brian | /Shares     |
+      | Brian | /Shares/src |
+      | Brian | /Shares/dst |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | src     |
-      | old         | dst     |
-      | new         |         |
-      | new         | src     |
-      | new         | dst     |
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
@@ -9,31 +9,35 @@ Feature: propagation of etags when creating folders
   Scenario Outline: creating a folder inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/folder"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/folder"
     When user "Alice" creates folder "/folder/new" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /folder |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | folder  |
-      | new         |         |
-      | new         | folder  |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: creating an invalid folder inside a folder should not change any etags
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/folder"
     And user "Alice" has created folder "/folder/sub"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/folder/sub"
     When user "Alice" creates folder "/folder/sub/.." using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should not have changed
+    Then these etags should not have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /folder     |
+      | Alice | /folder/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | folder     |
-      | old         | folder/sub |
-      | new         |            |
-      | new         | folder     |
-      | new         | folder/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as share receiver creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -41,17 +45,23 @@ Feature: propagation of etags when creating folders
     And user "Alice" has created folder "/folder"
     And user "Alice" has shared folder "/folder" with user "Brian"
     And user "Brian" has accepted share "/folder" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/folder"
     When user "Brian" creates folder "/Shares/folder/new" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path           |
+      | Alice | /              |
+      | Alice | /folder        |
+      | Brian | /              |
+      | Brian | /Shares        |
+      | Brian | /Shares/folder |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | folder  |
-      | new         |         |
-      | new         | folder  |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as sharer creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -59,15 +69,20 @@ Feature: propagation of etags when creating folders
     And user "Alice" has created folder "/folder"
     And user "Alice" has shared folder "/folder" with user "Brian"
     And user "Brian" has accepted share "/folder" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/folder"
     When user "Alice" creates folder "/folder/new" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path           |
+      | Alice | /              |
+      | Alice | /folder        |
+      | Brian | /              |
+      | Brian | /Shares        |
+      | Brian | /Shares/folder |
     Examples:
-      | dav_version | element       |
-      | old         |               |
-      | old         | folder        |
-      | new         |               |
-      | new         | folder        |
-
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
@@ -11,17 +11,19 @@ Feature: propagation of etags when restoring a file or folder from trash
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
     And user "Alice" has deleted file "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
     When user "Alice" restores the file with original path "/upload/sub/file.txt" using the trashbin API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /upload     |
+      | Alice | /upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: restoring a file to an other location changes the etags of all parents
     Given using <dav_version> DAV path
@@ -30,34 +32,38 @@ Feature: propagation of etags when restoring a file or folder from trash
     And user "Alice" has created folder "/restore/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
     And user "Alice" has deleted file "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/restore"
+    And user "Alice" has stored etag of element "/restore/sub"
     When user "Alice" restores the file with original path "/upload/sub/file.txt" to "/restore/sub/file.txt" using the trashbin API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path         |
+      | Alice | /            |
+      | Alice | /restore     |
+      | Alice | /restore/sub |
     Examples:
-      | dav_version | element     |
-      | old         |             |
-      | old         | restore     |
-      | old         | restore/sub |
-      | new         |             |
-      | new         | restore     |
-      | new         | restore/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: restoring a folder to its original location changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created folder "/upload/sub/toDelete"
     And user "Alice" has deleted folder "/upload/sub/toDelete"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
     When user "Alice" restores the folder with original path "/upload/sub/toDelete" using the trashbin API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /upload     |
+      | Alice | /upload/sub |
     Examples:
-      | dav_version | element    |
-      | old         |            |
-      | old         | upload     |
-      | old         | upload/sub |
-      | new         |            |
-      | new         | upload     |
-      | new         | upload/sub |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: restoring a folder to an other location changes the etags of all parents
     Given using <dav_version> DAV path
@@ -66,14 +72,16 @@ Feature: propagation of etags when restoring a file or folder from trash
     And user "Alice" has deleted folder "/upload/sub/toDelete"
     And user "Alice" has created folder "/restore"
     And user "Alice" has created folder "/restore/sub"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/restore"
+    And user "Alice" has stored etag of element "/restore/sub"
     When user "Alice" restores the folder with original path "/upload/sub/toDelete" to "/restore/sub/toDelete" using the trashbin API
-    Then the etag of element "/<element>" of user "Alice" should have changed
+    Then these etags should have changed:
+      | user  | path         |
+      | Alice | /            |
+      | Alice | /restore     |
+      | Alice | /restore/sub |
     Examples:
-      | dav_version | element     |
-      | old         |             |
-      | old         | restore     |
-      | old         | restore/sub |
-      | new         |             |
-      | new         | restore     |
-      | new         | restore/sub |
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/restoreVersion.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/restoreVersion.feature
@@ -7,16 +7,17 @@ Feature: propagation of etags when restoring a version of a file
     And user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnStorage:ceph @skipOnStorage:scality @issue-files_primary_s3-387
-  Scenario Outline: Restoring a file changes the etags of all parents
+  Scenario: Restoring a file changes the etags of all parents
     Given user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/sub/file.txt"
     And user "Alice" has uploaded file with content "changed content" to "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/sub"
     When user "Alice" restores version index "1" of file "/upload/sub/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    Examples:
-      | element    |
-      |            |
-      | upload     |
-      | upload/sub |
+    Then these etags should have changed:
+      | user  | path        |
+      | Alice | /           |
+      | Alice | /upload     |
+      | Alice | /upload/sub |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
@@ -9,66 +9,82 @@ Feature: propagation of etags when uploading data
 
   Scenario Outline: uploading a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
     When user "Alice" uploads file with content "uploaded content" to "/upload/file.txt" using the WebDAV API
     Then the content of file "/upload/file.txt" for user "Alice" should be "uploaded content"
-    And the etag of element "/<element>" of user "Alice" should have changed
+    And these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /upload |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: overwriting a file inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
     When user "Alice" uploads file with content "new content" to "/upload/file.txt" using the WebDAV API
     Then the content of file "/upload/file.txt" for user "Alice" should be "new content"
-    And the etag of element "/<element>" of user "Alice" should have changed
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /upload          |
+      | Alice | /upload/file.txt |
     Examples:
-      | dav_version | element         |
-      | old         |                 |
-      | old         | upload          |
-      | old         | upload/file.txt |
-      | new         |                 |
-      | new         | upload          |
-      | new         | upload/file.txt |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as share receiver uploading a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
     When user "Brian" uploads file with content "uploaded content" to "/Shares/upload/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path           |
+      | Alice | /              |
+      | Alice | /upload        |
+      | Brian | /              |
+      | Brian | /Shares        |
+      | Brian | /Shares/upload |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as sharer uploading a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
     When user "Alice" uploads file with content "uploaded content" to "/upload/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path           |
+      | Alice | /              |
+      | Alice | /upload        |
+      | Brian | /              |
+      | Brian | /Shares        |
+      | Brian | /Shares/upload |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as share receiver overwriting a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -76,17 +92,23 @@ Feature: propagation of etags when uploading data
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
     When user "Brian" uploads file with content "new content" to "/Shares/upload/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path           |
+      | Alice | /              |
+      | Alice | /upload        |
+      | Brian | /              |
+      | Brian | /Shares        |
+      | Brian | /Shares/upload |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |
+      | dav_version |
+      | old         |
+      | new         |
 
   Scenario Outline: as sharer overwriting a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -94,14 +116,20 @@ Feature: propagation of etags when uploading data
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has shared folder "/upload" with user "Brian"
     And user "Brian" has accepted share "/upload" offered by user "Alice"
-    And user "Alice" has stored etag of element "/<element>"
-    And user "Brian" has stored etag of element "/Shares/<element>"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
     When user "Alice" uploads file with content "new content" to "/upload/file.txt" using the WebDAV API
-    Then the etag of element "/<element>" of user "Alice" should have changed
-    And the etag of element "/Shares/<element>" of user "Brian" should have changed
+    Then these etags should have changed:
+      | user  | path           |
+      | Alice | /              |
+      | Alice | /upload        |
+      | Brian | /              |
+      | Brian | /Shares        |
+      | Brian | /Shares/upload |
     Examples:
-      | dav_version | element |
-      | old         |         |
-      | old         | upload  |
-      | new         |         |
-      | new         | upload  |
+      | dav_version |
+      | old         |
+      | new         |


### PR DESCRIPTION
## Description
Add test steps for `theseEtagsShouldNotHaveChanged` and `theseEtagsShouldHaveChanged` to do checks of a table of etags and report a message about all the etags that do not pass the test.

Reduce the number of example scenarios in the etag tests by using the new steps to check for etag changes in multiple elements.

## Related Issue


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
