### PR TITLE
[Tests-Only] skip scenarios on old oC10 that were fixed in PR 37973

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
@@ -24,7 +24,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares with expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -51,7 +51,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date not enabled, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -151,7 +151,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares with expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -180,7 +180,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date not enabled for groups, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -267,7 +267,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date enabled and enforced for users, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -309,7 +309,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date enabled and enforced for users/max expire date is set, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -389,7 +389,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date enabled and enforced for groups, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -435,7 +435,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date enabled and enforced for groups/max expire date is set, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
@@ -44,7 +44,7 @@ Feature: share with groups, group names are case-sensitive
       | 2               | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 200             |
       | 2               | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 200             |
 
-  @skipOnLDAP @issue-ldap-250
+  @skipOnLDAP @issue-ldap-250 @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: group names are case-sensitive, sharing with non-existent groups with different upper and lower case names
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
@@ -24,6 +24,7 @@ Feature: accept/decline shares coming from internal users to the Shares folder
     When user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
     Then the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: When accepting a share of a file, the response is valid
     Given user "Alice" has shared file "/textfile0.txt" with user "Brian"
     When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
@@ -43,6 +44,7 @@ Feature: accept/decline shares coming from internal users to the Shares folder
       | share_type             | user                  |
     And the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: When accepting a share of a folder, the response is valid
     Given user "Alice" has shared file "/PARENT" with user "Brian"
     When user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API

--- a/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
@@ -120,6 +120,7 @@ Feature: sharing
       | 1               | 200              | 17                   | 15                  |
       | 2               | 404              | 17                   | 15                  |
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: User is allowed to reshare file and set create (4) or delete (8) permissions bits, which get ignored
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions <received_permissions>


### PR DESCRIPTION
## Description
PR #37973 fixed a problem with the response when accepting a share. That fix will be in the next release. Skip the tests when testing against old releases.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
