### PR TITLE
[Tests-Only] Send coverage to SonarCloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ RCS/*
 .project
 .settings
 
-# netbeans 
+# netbeans
 nbproject
 
 # phpStorm
@@ -89,7 +89,7 @@ nbproject
 
 # ack(-grep)
 .ackrc
-	
+
 # Mac OS
 .DS_Store
 
@@ -142,3 +142,6 @@ clover.xml
 
 # Generated from .drone.star
 .drone.yml
+
+# SonarCloud scanner
+.scannerwork

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,36 @@
+# Organization and project keys are displayed in the right sidebar of the project homepage
+sonar.organization=owncloud-1
+sonar.projectKey=owncloud_core
+sonar.projectVersion=1.0
+sonar.host.url=https://sonarcloud.io
+
+# =====================================================
+#   Meta-data for the project
+# =====================================================
+
+sonar.links.homepage=https://github.com/owncloud/core
+sonar.links.ci=https://drone.owncloud.com/owncloud/core/
+sonar.links.scm=https://github.com/owncloud/core
+sonar.links.issue=https://github.com/owncloud/core/issues
+
+# =====================================================
+#   Properties that will be shared amongst all modules
+# =====================================================
+
+# Just look in these directories for code
+sonar.sources=.
+sonar.inclusions=apps/**,core/**,lib/**,ocs/**,settings/**
+
+# Pull Requests
+sonar.pullrequest.provider=GitHub
+sonar.pullrequest.github.repository=owncloud/core
+sonar.pullrequest.base=${env.SONAR_PULL_REQUEST_BASE}
+sonar.pullrequest.branch=${env.SONAR_PULL_REQUEST_BRANCH}
+sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
+
+# Properties specific to language plugins:
+sonar.php.coverage.reportPaths=results/clover-phpunit-php7.2-mariadb10.2.xml,results/clover-phpunit-php7.2-mariadb10.3.xml,results/clover-phpunit-php7.2-mariadb10.4.xml,results/clover-phpunit-php7.2-mariadb10.5.xml,results/clover-phpunit-php7.2-mysql5.5.xml,results/clover-phpunit-php7.2-mysql5.7.xml,results/clover-phpunit-php7.2-mysql8.0.xml,results/clover-phpunit-php7.2-oracle.xml,results/clover-phpunit-php7.2-postgres10.3.xml,results/clover-phpunit-php7.2-postgres9.4.xml,results/clover-phpunit-php7.2-sqlite-samba-samba.xml,results/clover-phpunit-php7.2-sqlite-samba.xml,results/clover-phpunit-php7.2-sqlite-scality.xml,results/clover-phpunit-php7.2-sqlite-sftp-sftp.xml,results/clover-phpunit-php7.2-sqlite-sftp.xml,results/clover-phpunit-php7.2-sqlite-webdav-webdav.xml,results/clover-phpunit-php7.2-sqlite-webdav.xml,results/clover-phpunit-php7.2-sqlite-windows-windows.xml,results/clover-phpunit-php7.2-sqlite-windows.xml,results/clover-phpunit-php7.2-sqlite.xml,results/clover-phpunit-php7.3-mariadb10.2.xml,results/clover-phpunit-php7.3-sqlite.xml,results/clover-phpunit-php7.4-mariadb10.2.xml,results/clover-phpunit-php7.4-sqlite.xml
+sonar.javascript.lcov.reportPaths=results/lcov.info
+
+# Exclude translation, dependency, 3rd-party and test files
+sonar.exclusions=core/l10n/**,lib/l10n/**,lib/composer/**,settings/l10n/**,apps/files_external/3rdparty/**,apps/**/l10n/**,apps/**/tests/**,build/**,core/vendor/**,vendor-bin/**,apps/**/vendor/**,core/vendor/**

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -266,7 +266,8 @@ module.exports = function(config) {
 			dir:'tests/output/coverage',
 			reporters: [
 				{ type: 'html' },
-				{ type: 'cobertura' }
+				{ type: 'cobertura' },
+				{ type: 'lcov' },
 			]
 		},
 


### PR DESCRIPTION
## Description
Analyse and upload to SonarCloud.

1) At the end of each JavaScript and PHPunit pipeline that collects coverage, sync the coverage report to an S3 cache
2) After all coverage-related pipelines are finished, sync the coverage reports from the S3 cache to a local pipeline `sonar-analysis`
3) Setup a "server" in that analysis pipeline so that the source code is there to analyse.
4) Run the Sonar analysis and let it upload to SonarCloud

SonarCloud analysis in drone is at https://drone.owncloud.com/owncloud/core/27145/34/9
The report is at https://sonarcloud.io/dashboard?id=owncloud_core&pullRequest=37982

The report shows 55.1% coverage. I was hoping that it would show about 64% like the old covedcov reports, e.g. https://github.com/owncloud/core/pull/37956#issuecomment-700255057

The analysis emits messages like:
```
INFO: Analyzing PHPUnit coverage report: results/clover-phpunit-php7.2-mariadb10.2.xml
WARN: Could not resolve 5098 file paths in clover-phpunit-php7.2-mariadb10.2.xml, first unresolved path: /drone/src/config/config.php
```

I have not been able to work out why the `WARN` is there. The source files are in `/drone/src` - I asked in chat https://community.sonarsource.com/t/how-to-get-total-coverage-from-multiple-unit-test-runs/31719/11 but no response.

Note: This is a cleaned-up, rebased and squashed version of PR #37946 

## Related Issue


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
