### PR TITLE
[tests-only] test etag propagation when changes happen on public links

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -181,3 +181,31 @@ Feature: propagation of etags when deleting a file or folder
       | dav_version |
       | old         |
       | new         |
+
+  Scenario: deleting a file in a publicly shared folder changes its etag for the sharer
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    When the public deletes file "file.txt" from the last public share using the new public WebDAV API
+    Then these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /upload |
+
+  Scenario: deleting a folder in a publicly shared folder changes its etag for the sharer
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    When the public deletes folder "sub" from the last public share using the new public WebDAV API
+    Then these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /upload |

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
@@ -302,3 +302,33 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
+  Scenario: renaming a file in a publicly shared folder changes its etag for the sharer
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    When the public renames file "file.txt" to "renamed.txt" from the last public share using the new public WebDAV API
+    Then these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /upload |
+
+  Scenario: renaming a folder in a publicly shared folder changes its etag for the sharer
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    When the public renames folder "sub" to "renamed" from the last public share using the new public WebDAV API
+    Then these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /upload |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
@@ -86,3 +86,17 @@ Feature: propagation of etags when creating folders
       | dav_version |
       | old         |
       | new         |
+
+  Scenario: creating a folder in a publicly shared folder changes its etag for the sharer
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has created a public link share with settings
+      | path        | folder |
+      | permissions | create |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/folder"
+    When the public creates folder "created-by-public" using the new public WebDAV API
+    Then these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /folder |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
@@ -133,3 +133,16 @@ Feature: propagation of etags when uploading data
       | dav_version |
       | old         |
       | new         |
+
+  Scenario: uploading a file into a publicly shared folder changes its etag for the sharer
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | create |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    When the public uploads file "file.txt" with content "new content" using the new public WebDAV API
+    Then these etags should have changed:
+      | user  | path    |
+      | Alice | /       |
+      | Alice | /upload |

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -108,7 +108,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public deletes file "([^"]*)" from the last public share using the (old|new) public WebDAV API$/
+	 * @When /^the public deletes (?:file|folder|entry) "([^"]*)" from the last public share using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 * @param string $publicWebDAVAPIVersion
@@ -147,7 +147,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public renames file "([^"]*)" to "([^"]*)" from the last public share using the (old|new) public WebDAV API$/
+	 * @When /^the public renames (?:file|folder|entry) "([^"]*)" to "([^"]*)" from the last public share using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 * @param string $toFileName
@@ -979,6 +979,34 @@ class PublicWebDavContext implements Context {
 			false,
 			["X-OC-Mtime" => $mtime],
 			$davVersion
+		);
+	}
+
+	/**
+	 * @When the public creates folder :destination using the new public WebDAV API
+	 *
+	 * @param String $destination
+	 *
+	 * @return void
+	 */
+	public function publicCreatesFolder($destination) {
+		$token = $this->featureContext->getLastShareToken();
+		$davPath = WebDavHelper::getDavPath(
+			$token, 0, "public-files-new"
+		);
+		$url = $this->featureContext->getBaseUrl() . "/$davPath";
+		$userName = $this->getUsernameForPublicWebdavApi(
+			$token, '', "new"
+		);
+		$filename = \implode(
+			'/', \array_map('rawurlencode', \explode('/', $destination))
+		);
+		$url .= \ltrim($filename, '/');
+
+		$this->featureContext->setResponse(
+			HttpRequestHelper::sendRequest(
+				$url, 'MKCOL', $userName, ''
+			)
 		);
 	}
 


### PR DESCRIPTION
## Description
more tests for etag propagation, this time when the change is made in a public link, the etag should have changed for the sharer

## Related Issue
https://github.com/owncloud/product/issues/144

## Motivation and Context
test etags specially in OCIS

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
