### PR TITLE
[Tests-Only] List UNEXPECTED_PASSED_SCENARIOS on separate lines

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1290,7 +1290,7 @@ then
       fi
     done
   else
-    ACTUAL_UNEXPECTED_PASS="${UNEXPECTED_PASSED_SCENARIOS[@]}"
+    ACTUAL_UNEXPECTED_PASS=("${UNEXPECTED_PASSED_SCENARIOS[@]}")
   fi
 
   tput setaf 3; echo "runsh: Total unexpected passed scenarios throughout the test run:"


### PR DESCRIPTION
## Description
When using the expected-failures-file and there are unexpected passes, the newly-passing scenarios are printed out in one long line. That's annoying. (The unexpected failures are printed out on separate lines)

For example: https://drone.owncloud.com/owncloud/ocis/320/16/7
```
runsh: Total unexpected failed scenarios throughout the test run:
apiAuthOcs/ocsDELETEAuth.feature:10
apiFavorites/favorites.feature:91
apiFavorites/favorites.feature:92
apiFavorites/favorites.feature:112
apiFavorites/favorites.feature:113
apiFavorites/favorites.feature:128
apiFavorites/favorites.feature:129
apiFavorites/favorites.feature:148
apiFavorites/favorites.feature:149
apiFavorites/favorites.feature:176
apiFavorites/favorites.feature:177
apiFavorites/favorites.feature:190
apiFavorites/favorites.feature:191
apiFavorites/favorites.feature:204
apiFavorites/favorites.feature:205
apiFavorites/favorites.feature:217
apiFavorites/favorites.feature:218
apiProvisioning-v2/disableUser.feature:48
apiProvisioning-v2/disableUser.feature:64
apiProvisioning-v2/disableUser.feature:79
apiProvisioning-v2/disableUser.feature:99
apiProvisioning-v2/disableUser.feature:108
apiProvisioning-v2/disableUser.feature:130
apiProvisioning-v2/enableUser.feature:87
runsh: Total unexpected passed scenarios throughout the test run:
apiAuthOcs/ocsDELETEAuth.feature:9 apiFavorites/favorites.feature:228 apiFavorites/favorites.feature:229 apiProvisioning-v2/disableUser.feature:81 apiProvisioning-v2/disableUser.feature:101 apiProvisioning-v2/disableUser.feature:110 apiProvisioning-v2/disableUser.feature:133 apiProvisioning-v2/enableUser.feature:88
```

Fix the bash script so that the list of unexpected passed scenarios is a proper array, and so the entries get printed on separate lines.

## How Has This Been Tested?
Make a bash script like this and run it:
```
UNEXPECTED_PASSED_SCENARIOS=("abc.feature:13" "abc.feature:42" "defgh.feature:21" "xyz123.feature:123")
printf "%s\n" "${UNEXPECTED_PASSED_SCENARIOS[@]}"
ACTUAL_UNEXPECTED_PASS=("${UNEXPECTED_PASSED_SCENARIOS[@]}")
printf "%s\n" "${ACTUAL_UNEXPECTED_PASS[@]}"
```
See that both `printf` are output as 4 separate lines, so the array copy worked.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
