### PR TITLE
[Tests-Only] Do not run sonar codecov analysis for merge CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1593,9 +1593,6 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 		}
 	}
 
-	for branch in config['branches']:
-		result['trigger']['ref'].append('refs/heads/%s' % branch)
-
 	return result
 
 


### PR DESCRIPTION
## Description
We just added sonar-cloud code coverage to CI in #37984 

The CI on merge tried to run the sonar-cloud code coverage, but we do not run unit tests on merge any more. So there is no possibility to get codecov from the merge CI. https://drone.owncloud.com/owncloud/core/27161/4/7 
```
mc: <ERROR> Unable to stat source `cache/cache/owncloud/core/a5093d543d2e48ecd0a60d1356176f27ee1af8aa-27161/coverage`. Object does not exist.
```

Fix the starlark so that it does not try to do the sonar-cloud coverage analysis.

Note: as a separate task, I will see what happens in sonar-cloud since it will not receive merge-CI results. Maybe it will update itself with the coverage from the PR, or not?

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
