### PR TITLE
[Tests-Only] Run JS and PHP unit tests on merge

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1060,6 +1060,9 @@ def javascript(ctx):
 			}
 		)
 
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
 	return [result]
 
 def phptests(ctx, testType):
@@ -1279,6 +1282,9 @@ def phptests(ctx, testType):
 									}
 								}
 							})
+
+					for branch in config['branches']:
+						result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 					pipelines.append(result)
 
@@ -1592,6 +1598,9 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 			]
 		}
 	}
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 	return result
 


### PR DESCRIPTION
## Description
PR #37958 stopped various test pipelines from running in the merge CI.

Now we are wanting to update coverage information in SonarCloud. It seems that we need to generate coverage information of the actual merged commit to master, and send that. So this PR enables JS and PHP unit tests, and the SonarCloud processing pipelines in the merge CI.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
