### PR TITLE
don't treat Google Docs special for file size

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -369,13 +369,7 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 			if ($this->filetype($path) === 'dir') {
 				$stat['size'] = 0;
 			} else {
-				// Check if this is a Google Doc
-				if ($this->isGoogleDocFile($file)) {
-					// Return unknown file size
-					$stat['size'] = \OCP\Files\FileInfo::SPACE_UNKNOWN;
-				} else {
-					$stat['size'] = $file->getSize();
-				}
+				$stat['size'] = $file->getSize();
 			}
 			$stat['atime'] = \strtotime($file->getViewedByMeTime());
 			$stat['mtime'] = \strtotime($file->getModifiedTime());

--- a/changelog/unreleased/37993
+++ b/changelog/unreleased/37993
@@ -1,0 +1,6 @@
+Bugfix: Fix for Google Docs not syncing with error "server reported no size"
+
+Users with Google Drive connected external storage were previously subjected to a "server reported no size" error in desktop sync client for every Google Doc that attempted to sync. Additionally, the Google Doc would not be downloaded.
+
+https://github.com/owncloud/core/issues/37997
+https://github.com/owncloud/core/pull/37993


### PR DESCRIPTION
## Description
Don't treat Google Docs (in Google Drive connected external storage) differently from other files with respect to file size. Under the hood, the Google Drive SDK will return undefined which likely converts to `0` in ownCloud server response.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/37977

## Motivation and Context
Bugfix, Google Docs were not syncing with desktop client and spamming error notifications.

## How Has This Been Tested?
- test environment:
  - on my production server (OC 15.0, Ubuntu 18.04, Apache 2.4, PHP 7.2, MySQL 5.7)
  - latest 15.0 docker image
- test case 1:
  1. connect to Google Drive storage
  1. add Google Doc
  1. connect client to server with Google Drive storage
  1. Expect Google Doc to sync

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
