### PR TITLE
Adjust some sonarcloud items

### DIFF
--- a/apps/comments/lib/Dav/CommentNode.php
+++ b/apps/comments/lib/Dav/CommentNode.php
@@ -218,11 +218,13 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 	 * conforming to the list of requested properties.
 	 * The Server class will filter out the extra.
 	 *
-	 * @param array $properties
+	 * @param array|null $properties requested properties or null for all
 	 * @return array
 	 */
 	public function getProperties($properties) {
-		$properties = \array_keys($this->properties);
+		if (($properties === null) || ($properties === [])) {
+			$properties = \array_keys($this->properties);
+		}
 
 		$result = [];
 		foreach ($properties as $property) {

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -428,9 +428,9 @@ class FilesPlugin extends ServerPlugin {
 		if (!$this->server->tree->nodeExists($filePath)) {
 			return;
 		}
-		$node = $this->server->tree->getNodeForPath($filePath);
-		if ($node instanceof \OCA\DAV\Connector\Sabre\Node) {
-			$fileId = $node->getFileId();
+		$nodeForPath = $this->server->tree->getNodeForPath($filePath);
+		if ($nodeForPath instanceof \OCA\DAV\Connector\Sabre\Node) {
+			$fileId = $nodeForPath->getFileId();
 			if ($fileId !== null) {
 				$this->server->httpResponse->setHeader('OC-FileId', $fileId);
 			}

--- a/apps/federatedfilesharing/lib/Controller/OcmController.php
+++ b/apps/federatedfilesharing/lib/Controller/OcmController.php
@@ -380,13 +380,6 @@ class OcmController extends Controller {
 						['message' => "Notification of type {$notificationType} is not supported"],
 						Http::STATUS_NOT_IMPLEMENTED
 					);
-
-					// owner or sender unshared a resource
-					$share = $this->ocmMiddleware->getValidShare(
-						$providerId, $notification['sharedSecret']
-					);
-					$this->fedShareManager->undoReshare($share);
-					break;
 				default:
 					return new JSONResponse(
 						['message' => "Notification of type {$notificationType} is not supported"],

--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -56,9 +56,9 @@ class SMB extends ExternalBackend {
 	 * @param IUser $user
 	 */
 	public function manipulateStorageConfig(IStorageConfig &$storage, IUser $user = null) {
-		$user = $storage->getBackendOption('user');
+		$userFromBackendOption = $storage->getBackendOption('user');
 		if ($domain = $storage->getBackendOption('domain')) {
-			$storage->setBackendOption('user', $domain.'\\'.$user);
+			$storage->setBackendOption('user', $domain.'\\'.$userFromBackendOption);
 		}
 	}
 }

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -364,7 +364,7 @@ class ShareController extends Controller {
 			}
 		}
 
-		$shareTmpl['canDownload'] = !!($share->getPermissions() & \OCP\Constants::PERMISSION_READ > 0);
+		$shareTmpl['canDownload'] = ($share->getPermissions() & \OCP\Constants::PERMISSION_READ) > 0;
 		$shareTmpl['sharePermission'] = $share->getPermissions();
 		$shareTmpl['downloadURL'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.downloadShare', ['token' => $token]);
 		$shareTmpl['shareUrl'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $token]);

--- a/core/Command/Log/Manage.php
+++ b/core/Command/Log/Manage.php
@@ -123,10 +123,14 @@ class Manage extends Command {
 
 	/**
 	 * @param string $timezone
-	 * @throws \Exception
+	 * @throws \InvalidArgumentException
 	 */
 	protected function validateTimezone($timezone) {
-		new \DateTimeZone($timezone);
+		try {
+			new \DateTimeZone($timezone);
+		} catch (\Exception $e) {
+			throw new \InvalidArgumentException("Invalid timezone ($timezone)");
+		}
 	}
 
 	/**

--- a/lib/private/AppFramework/Http/Output.php
+++ b/lib/private/AppFramework/Http/Output.php
@@ -86,7 +86,7 @@ class Output implements IOutput {
 	 * @param bool $httpOnly
 	 */
 	public function setCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly) {
-		$path = $this->webRoot ? : '/';
-		\setcookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+		$localPath = $this->webRoot ? : '/';
+		\setcookie($name, $value, $expire, $localPath, $domain, $secure, $httpOnly);
 	}
 }

--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -98,7 +98,7 @@ class Comment implements IComment {
 	/**
 	 * returns the parent ID of the comment
 	 *
-	 * @return string
+	 * @return string the parent id or "0" if there is no parent
 	 * @since 9.0.0
 	 */
 	public function getParentId() {

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -380,7 +380,7 @@ class Manager implements ICommentsManager {
 	public function getNumberOfUnreadCommentsForNodes($objectType, $objectIds, IUser $user) {
 		$qbMain = $this->dbConn->getQueryBuilder();
 		$qbSup = $this->dbConn->getQueryBuilder();
-		
+
 		$unreadCountsForNodes = [];
 		$objectIdChunks = \array_chunk($objectIds, 100);
 		foreach ($objectIdChunks as $objectIdChunk) {
@@ -545,7 +545,8 @@ class Manager implements ICommentsManager {
 				$result = $this->update($comment);
 			}
 
-			if ($result && !!$comment->getParentId()) {
+			// getParentId() returns a "falsey" string such as "0" if there is no parent
+			if ($result && (bool) $comment->getParentId()) {
 				$this->updateChildrenInformation(
 					$comment->getParentId(),
 					$comment->getCreationDateTime()

--- a/lib/private/DateTimeFormatter.php
+++ b/lib/private/DateTimeFormatter.php
@@ -124,7 +124,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @return string Formatted relative date string
 	 */
 	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
-		if (\substr($format, -1) !== '*' && \substr($format, -1) !== '*') {
+		if (\substr($format, -1) !== '*') {
 			$format .= '^';
 		}
 

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -306,9 +306,9 @@ class CacheJail extends CacheWrapper {
 	 */
 	public function moveFromCache(\OCP\Files\Cache\ICache $sourceCache, $sourcePath, $targetPath) {
 		if ($sourceCache === $this) {
-			return $this->move($sourcePath, $targetPath);
+			$this->move($sourcePath, $targetPath);
 		}
-		return $this->cache->moveFromCache($sourceCache, $sourcePath, $this->getSourcePath($targetPath));
+		$this->cache->moveFromCache($sourceCache, $sourcePath, $this->getSourcePath($targetPath));
 	}
 
 	protected function getMoveInfo($path) {


### PR DESCRIPTION
## Description
Fix some things reported by SonarCloud, so I can see what an "improved" report looks like.
Unfortunately the SonarCloud UI does not show issues that will be resolved by the code in the PR - you have to "hope for the best" and merge the PR in order to see if you fixed the issues. https://community.sonarsource.com/t/view-all-issues-in-a-branch-not-only-new-ones/12172/11

1) Adjust use of properties parameter in CommentNode.php - the parameter was ignored and immediately overwritten.
2) Do not re-use input parameter as local variable in sendFileIdHeader - renamed the local variable. But the parameter `$node` is not used (and never was used)
3) Comment out unreachable code in OcmController.php - what to do about this unreachable code? Was it a good example of what might be done in future? Or should it be deleted?
4) Do not re-use input parameter as local variable in manipulateStorageConfig - renamed the local variable. But the parameter `$user` is not used (and never was used)
5) Fixup operator precedence in ShareController showShare - remove a `!!` double-not (that was there to force `bool`). Fix the operator precedence by adding brackets so that the `bool` type is calculated directly. Note: the previous code did actually end up with correct answers, so there was no actual bug - just lucky :)
6) Standardize exception handling in Log/Manage.php validateTimezone - SonarCloud did not like having a method that just instantiates an object and does nothing with it. This method was doing that just for the side-effect that an exception would be thrown if the timezone is invalid. Re-organize the code so that it explicitly throws `InvalidArgumentException` when the timezone is invalid (similar to what happens for other validation in the same file)
7) Do not re-use input parameter as local variable in Output.php setCookie - rename the variable. The input parameter `$path` was never used, and is still not used.
8) Remove double !! usage in Comments/Manager.php save - and explain in a comment what is going on casting `getParentId()` to `bool`
9)  Simplify redundant sub-exxpressions in formatDateRelativeDay - The same expression was used twice in a conditional. I have no idea what the 2nd one was supposed to be. Also, I don't see where the method `formatDateRelativeDay` is called anyway.
10) Remove useless returns from CacheJail.php moveFromCache - The methods `move` and `moveFromCache` do not return a value anyway, so "returning their return value" is not useful. And anyway, `moveFromCache` is not documented to return anything.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
