### PR TITLE
[tests-only] use new default OCIS data root

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -65,7 +65,7 @@ class OcisHelper {
 			$deleteCmd = \sprintf($deleteCmd, $user);
 			\exec($deleteCmd);
 		} else {
-			self::recurseRmdir(self::getOcisRevaDataRoot() . "/data/" . $user);
+			self::recurseRmdir(self::getOcisRevaDataRoot() . $user);
 		}
 	}
 
@@ -194,7 +194,7 @@ class OcisHelper {
 	private static function getOcisRevaDataRoot() {
 		$root = \getenv("OCIS_REVA_DATA_ROOT");
 		if (($root === false || $root === "") && self::isTestingOnOcis()) {
-			$root = "/var/tmp/reva/";
+			$root = "/var/tmp/ocis/owncloud/";
 		}
 		if (!\file_exists($root)) {
 			echo "WARNING: reva data root folder ($root) does not exist\n";


### PR DESCRIPTION
## Description
use new ocis data directory as default when testing ocis

## Motivation and Context
make tests work again as described in the docs

## How Has This Been Tested?
ran tests as described in the documentation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
