### PR TITLE
Allow getting the share list filtered by share type via API

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -229,6 +229,13 @@
 			if (this._sharedWithUser) {
 				requestData.shared_with_me = true;
 				requestData.state = 'all';
+				requestData.share_types = [
+					OC.Share.SHARE_TYPE_USER,
+					OC.Share.SHARE_TYPE_GROUP,
+					OC.Share.SHARE_TYPE_REMOTE
+				].join(',');
+			} else if (this._linksOnly) {
+				requestData.share_types = [OC.Share.SHARE_TYPE_LINK].join(',');
 			}
 			requestData.include_tags = true;
 			var shares = $.ajax({

--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -632,17 +632,13 @@ class Share20OcsController extends OCSController {
 					continue;
 				}
 
-				if ($shareType !== Share::SHARE_TYPE_REMOTE) {
-					$shares = \array_merge(
-						$shares,
-						$this->shareManager->getSharesBy($this->userSession->getUser()->getUID(), $shareType, $node, false, -1, 0)
-					);
-				} elseif ($shareType === Share::SHARE_TYPE_REMOTE && $this->shareManager->outgoingServer2ServerSharesAllowed()) {
-					$shares = \array_merge(
-						$shares,
-						$this->shareManager->getSharesBy($this->userSession->getUser()->getUID(), $shareType, $node, false, -1, 0)
-					);
-				}
+				// if outgoingServer2ServerSharesAllowed is false, remote shares shouldn't be
+				// returned. This must be checked in the caller method, so the remote share type
+				// shouldn't be present if outgoing remotes shares aren't allowed.
+				$shares = \array_merge(
+					$shares,
+					$this->shareManager->getSharesBy($this->userSession->getUser()->getUID(), $shareType, $node, false, -1, 0)
+				);
 			}
 		}
 
@@ -707,6 +703,11 @@ class Share20OcsController extends OCSController {
 			Share::SHARE_TYPE_LINK => false,
 			Share::SHARE_TYPE_REMOTE => false,
 		];
+
+		if ($this->shareManager->outgoingServer2ServerSharesAllowed() === false) {
+			// if outgoing remote shares aren't allowed, the remote share type can't be chosen
+			unset($requestedShareTypes[Share::SHARE_TYPE_REMOTE]);
+		}
 		foreach ($shareTypes as $shareType) {
 			if (isset($requestedShareTypes[$shareType])) {
 				$requestedShareTypes[$shareType] = true;
@@ -763,17 +764,10 @@ class Share20OcsController extends OCSController {
 				continue;
 			}
 
-			if ($shareType !== Share::SHARE_TYPE_REMOTE) {
-				$shares = \array_merge(
-					$shares,
-					$this->shareManager->getSharesBy($this->userSession->getUser()->getUID(), $shareType, $path, $reshares, -1, 0)
-				);
-			} elseif ($shareType === Share::SHARE_TYPE_REMOTE && $this->shareManager->outgoingServer2ServerSharesAllowed()) {
-				$shares = \array_merge(
-					$shares,
-					$this->shareManager->getSharesBy($this->userSession->getUser()->getUID(), $shareType, $path, $reshares, -1, 0)
-				);
-			}
+			$shares = \array_merge(
+				$shares,
+				$this->shareManager->getSharesBy($this->userSession->getUser()->getUID(), $shareType, $path, $reshares, -1, 0)
+			);
 		}
 
 		$formatted = [];

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -140,7 +140,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect(fakeServer.requests.length).toEqual(2);
 			expect(fakeServer.requests[0].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=true&state=all&include_tags=true'
+				'shares?format=json&shared_with_me=true&state=all&share_types=0%2C1%2C6&include_tags=true'
 			);
 
 			expect(fakeServer.requests[1].url).toEqual(
@@ -222,7 +222,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect(fakeServer.requests.length).toEqual(2);
 			expect(fakeServer.requests[0].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=true&state=all&include_tags=true'
+				'shares?format=json&shared_with_me=true&state=all&share_types=0%2C1%2C6&include_tags=true'
 			);
 			expect(fakeServer.requests[1].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
@@ -308,7 +308,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			expect(fakeServer.requests.length).toEqual(2);
 			expect(fakeServer.requests[0].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&shared_with_me=true&state=all&include_tags=true'
+				'shares?format=json&shared_with_me=true&state=all&share_types=0%2C1%2C6&include_tags=true'
 			);
 			expect(fakeServer.requests[1].url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
@@ -679,7 +679,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&include_tags=true'
+				'shares?format=json&share_types=3&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(
@@ -732,7 +732,7 @@ describe('OCA.Sharing.FileList tests', function() {
 			request = fakeServer.requests[0];
 			expect(request.url).toEqual(
 				OC.linkToOCS('apps/files_sharing/api/v1') +
-				'shares?format=json&include_tags=true'
+				'shares?format=json&share_types=3&include_tags=true'
 			);
 
 			fakeServer.requests[0].respond(

--- a/changelog/unreleased/38000
+++ b/changelog/unreleased/38000
@@ -1,0 +1,11 @@
+Enhancement: Allow getting the share list filtered by share type via API
+
+Previously, the share API returned all the shares. There were some filters,
+but you weren't able to filter by share type. You couldn't get only your
+link shares.
+
+Now the API allows filtering by share type, along with the filters previously
+available. The web UI is using this filtering now.
+
+https://github.com/owncloud/core/pull/38000
+

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFiltered.feature
@@ -1,5 +1,5 @@
 @api @files_sharing-app-required @notToImplementOnOCIS
-Feature: sharing
+Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)
   So that I can reduce the amount of data that has to be transferred to be just the data that I need

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFiltered.feature
@@ -1,0 +1,55 @@
+@api @files_sharing-app-required @notToImplementOnOCIS
+Feature: sharing
+  As a user
+  I want to be able to know the shares that I have received of a particular type (user, group etc)
+  So that I can reduce the amount of data that has to be transferred to be just the data that I need
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/folderToShareWithUser"
+    And user "Alice" has created folder "/folderToShareWithGroup"
+    And user "Alice" has created folder "/folderToShareWithPublic"
+    And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
+    And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
+    And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+
+  Scenario Outline: getting shares received from users
+    Given using OCS API version "<ocs_api_version>"
+    When user "Brian" gets the user shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And exactly 2 files or folders should be included in the response
+    And folder "folderToShareWithUser" should be included in the response
+    And file "fileToShareWithUser.txt" should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares received from groups
+    Given using OCS API version "<ocs_api_version>"
+    When user "Brian" gets the group shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And exactly 2 files or folders should be included in the response
+    And folder "folderToShareWithGroup" should be included in the response
+    And folder "fileToShareWithGroup.txt" should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFilteredEmpty.feature
@@ -1,0 +1,81 @@
+@api @files_sharing-app-required @notToImplementOnOCIS
+Feature: sharing
+  As a user
+  I want to be able to know the shares that I have received of a particular type (user, group etc)
+  So that I can reduce the amount of data that has to be transferred to be just the data that I need
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/folderToShareWithUser"
+    And user "Alice" has created folder "/folderToShareWithGroup"
+    And user "Alice" has created folder "/folderToShareWithPublic"
+    And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
+    And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
+    And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
+
+  Scenario Outline: getting shares received from users when there are none
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+    When user "Brian" gets the user shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And no files or folders should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares received from groups when there are none
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+    When user "Brian" gets the group shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And no files or folders should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares received from public links when there are none
+    # Note: public links are purposely created in this scenario
+    #       users do not receive public links, so asking for a list of public links
+    #       that are "shared with me" should always return an empty list.
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+    When user "Brian" gets the public link shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And no files or folders should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFilteredEmpty.feature
@@ -1,5 +1,5 @@
 @api @files_sharing-app-required @notToImplementOnOCIS
-Feature: sharing
+Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)
   So that I can reduce the amount of data that has to be transferred to be just the data that I need

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFiltered.feature
@@ -1,0 +1,93 @@
+@api @files_sharing-app-required @notToImplementOnOCIS
+Feature: sharing
+  As a user
+  I want to be able to know the shares that I have made of a particular type (user, group etc)
+  So that I can reduce the amount of data that has to be transferred to be just the data that I need
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/folderToShareWithUser"
+    And user "Alice" has created folder "/folderToShareWithGroup"
+    And user "Alice" has created folder "/folderToShareWithPublic"
+    And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
+    And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
+    And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+
+  Scenario Outline: getting shares shared to users
+    Given using OCS API version "<ocs_api_version>"
+    When user "Alice" gets the user shares shared by him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And folder "folderToShareWithUser" should be included in the response
+    And file "fileToShareWithUser.txt" should be included in the response
+    But folder "folderToShareWithGroup" should not be included in the response
+    And folder "fileToShareWithGroup.txt" should not be included in the response
+    And folder "folderToShareWithPublic" should not be included in the response
+    And folder "fileToShareWithPublic.txt" should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares shared to groups
+    Given using OCS API version "<ocs_api_version>"
+    When user "Alice" gets the group shares shared by him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And folder "folderToShareWithGroup" should be included in the response
+    And folder "fileToShareWithGroup.txt" should be included in the response
+    But folder "folderToShareWithUser" should not be included in the response
+    And file "fileToShareWithUser.txt" should not be included in the response
+    And folder "folderToShareWithPublic" should not be included in the response
+    And folder "fileToShareWithPublic.txt" should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares shared to public links
+    Given using OCS API version "<ocs_api_version>"
+    When user "Alice" gets the public link shares shared by him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And folder "folderToShareWithPublic" should be included in the response
+    And folder "fileToShareWithPublic.txt" should be included in the response
+    But folder "folderToShareWithUser" should not be included in the response
+    And file "fileToShareWithUser.txt" should not be included in the response
+    And folder "folderToShareWithGroup" should not be included in the response
+    And folder "fileToShareWithGroup.txt" should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares shared to users and groups
+    Given using OCS API version "<ocs_api_version>"
+    When user "Alice" gets the user and group shares shared by him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And folder "folderToShareWithUser" should be included in the response
+    And file "fileToShareWithUser.txt" should be included in the response
+    And folder "folderToShareWithGroup" should be included in the response
+    And folder "fileToShareWithGroup.txt" should be included in the response
+    But folder "folderToShareWithPublic" should not be included in the response
+    And folder "fileToShareWithPublic.txt" should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFiltered.feature
@@ -1,5 +1,5 @@
 @api @files_sharing-app-required @notToImplementOnOCIS
-Feature: sharing
+Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)
   So that I can reduce the amount of data that has to be transferred to be just the data that I need

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFilteredEmpty.feature
@@ -17,66 +17,55 @@ Feature: sharing
     And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
     And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
     And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
-    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+
+  Scenario Outline: getting shares shared to users when there are none
+    Given using OCS API version "<ocs_api_version>"
     And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
-    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
     And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
-
-  Scenario Outline: getting shares shared to users
-    Given using OCS API version "<ocs_api_version>"
     When user "Alice" gets the user shares shared by him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And exactly 2 files or folders should be included in the response
-    And folder "folderToShareWithUser" should be included in the response
-    And file "fileToShareWithUser.txt" should be included in the response
+    And no files or folders should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: getting shares shared to groups
+  Scenario Outline: getting shares shared to groups when there are none
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
     When user "Alice" gets the group shares shared by him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And exactly 2 files or folders should be included in the response
-    And folder "folderToShareWithGroup" should be included in the response
-    And folder "fileToShareWithGroup.txt" should be included in the response
+    And no files or folders should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: getting shares shared to public links
+  Scenario Outline: getting shares shared to public links when there are none
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
     When user "Alice" gets the public link shares shared by him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And exactly 2 files or folders should be included in the response
-    And folder "folderToShareWithPublic" should be included in the response
-    And folder "fileToShareWithPublic.txt" should be included in the response
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
-
-  Scenario Outline: getting shares shared to users and groups
-    Given using OCS API version "<ocs_api_version>"
-    When user "Alice" gets the user and group shares shared by him using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And exactly 4 files or folders should be included in the response
-    And folder "folderToShareWithUser" should be included in the response
-    And file "fileToShareWithUser.txt" should be included in the response
-    And folder "folderToShareWithGroup" should be included in the response
-    And folder "fileToShareWithGroup.txt" should be included in the response
+    And no files or folders should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFilteredEmpty.feature
@@ -1,5 +1,5 @@
 @api @files_sharing-app-required @notToImplementOnOCIS
-Feature: sharing
+Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)
   So that I can reduce the amount of data that has to be transferred to be just the data that I need

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesPendingFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesPendingFiltered.feature
@@ -1,7 +1,7 @@
 @api @files_sharing-app-required
-Feature: get the received shares filtered by type (user, group etc)
+Feature: get the pending shares filtered by type (user, group etc)
   As a user
-  I want to be able to know the shares that I have received of a particular type (user, group etc)
+  I want to be able to know the pending shares that I have received of a particular type (user, group etc)
   So that I can reduce the amount of data that has to be transferred to be just the data that I need
 
   Background:
@@ -20,9 +20,7 @@ Feature: get the received shares filtered by type (user, group etc)
     And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
     And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
     And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
-    And user "Brian" has accepted share "/folderToShareWithUser" offered by user "Alice"
     And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
-    And user "Brian" has accepted share "/folderToShareWithGroup" offered by user "Alice"
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
@@ -34,27 +32,25 @@ Feature: get the received shares filtered by type (user, group etc)
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
 
-  Scenario Outline: getting shares received from users
+  Scenario Outline: getting pending shares received from users
     Given using OCS API version "<ocs_api_version>"
-    When user "Brian" gets the user shares shared with him using the sharing API
+    When user "Brian" gets the pending user shares shared with him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And exactly 2 files or folders should be included in the response
+    And exactly 1 file or folder should be included in the response
     And folder "/Shares/folderToShareWithUser" should be included in the response
-    And file "/Shares/fileToShareWithUser.txt" should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: getting shares received from groups
+  Scenario Outline: getting pending shares received from groups
     Given using OCS API version "<ocs_api_version>"
-    When user "Brian" gets the group shares shared with him using the sharing API
+    When user "Brian" gets the pending group shares shared with him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And exactly 2 files or folders should be included in the response
+    And exactly 1 file or folder should be included in the response
     And folder "/Shares/folderToShareWithGroup" should be included in the response
-    And folder "/Shares/fileToShareWithGroup.txt" should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFiltered.feature
@@ -1,0 +1,61 @@
+@api @files_sharing-app-required
+Feature: sharing
+  As a user
+  I want to be able to know the shares that I have received of a particular type (user, group etc)
+  So that I can reduce the amount of data that has to be transferred to be just the data that I need
+
+  Background:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/folderToShareWithUser"
+    And user "Alice" has created folder "/folderToShareWithGroup"
+    And user "Alice" has created folder "/folderToShareWithPublic"
+    And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
+    And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
+    And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Brian" has accepted share "/folderToShareWithUser" offered by user "Alice"
+    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Brian" has accepted share "/folderToShareWithGroup" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Brian" has accepted share "/fileToShareWithUser.txt" offered by user "Alice"
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Brian" has accepted share "/fileToShareWithGroup.txt" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+
+  Scenario Outline: getting shares received from users
+    Given using OCS API version "<ocs_api_version>"
+    When user "Brian" gets the user shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And exactly 2 files or folders should be included in the response
+    And folder "/Shares/folderToShareWithUser" should be included in the response
+    And file "/Shares/fileToShareWithUser.txt" should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares received from groups
+    Given using OCS API version "<ocs_api_version>"
+    When user "Brian" gets the group shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And exactly 2 files or folders should be included in the response
+    And folder "/Shares/folderToShareWithGroup" should be included in the response
+    And folder "/Shares/fileToShareWithGroup.txt" should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFilteredEmpty.feature
@@ -1,5 +1,5 @@
 @api @files_sharing-app-required
-Feature: sharing
+Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)
   So that I can reduce the amount of data that has to be transferred to be just the data that I need

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFilteredEmpty.feature
@@ -1,0 +1,91 @@
+@api @files_sharing-app-required
+Feature: sharing
+  As a user
+  I want to be able to know the shares that I have received of a particular type (user, group etc)
+  So that I can reduce the amount of data that has to be transferred to be just the data that I need
+
+  Background:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/folderToShareWithUser"
+    And user "Alice" has created folder "/folderToShareWithGroup"
+    And user "Alice" has created folder "/folderToShareWithPublic"
+    And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
+    And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
+    And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
+
+  Scenario Outline: getting shares received from users when there are none
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Brian" has accepted share "/folderToShareWithGroup" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Brian" has accepted share "/fileToShareWithGroup.txt" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+    When user "Brian" gets the user shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And no files or folders should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares received from groups when there are none
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Brian" has accepted share "/folderToShareWithUser" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Brian" has accepted share "/fileToShareWithUser.txt" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+    When user "Brian" gets the group shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And no files or folders should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares received from public links when there are none
+    # Note: public links are purposely created in this scenario
+    #       users do not receive public links, so asking for a list of public links
+    #       that are "shared with me" should always return an empty list.
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Brian" has accepted share "/folderToShareWithUser" offered by user "Alice"
+    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Brian" has accepted share "/folderToShareWithGroup" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Brian" has accepted share "/fileToShareWithUser.txt" offered by user "Alice"
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Brian" has accepted share "/fileToShareWithGroup.txt" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+    When user "Brian" gets the public link shares shared with him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And no files or folders should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
@@ -1,5 +1,5 @@
 @api @files_sharing-app-required
-Feature: sharing
+Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)
   So that I can reduce the amount of data that has to be transferred to be just the data that I need

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
@@ -1,11 +1,13 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)
   So that I can reduce the amount of data that has to be transferred to be just the data that I need
 
   Background:
-    Given these users have been created with default attributes and without skeleton files:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -18,12 +20,16 @@ Feature: sharing
     And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
     And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
     And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Brian" has accepted share "/folderToShareWithUser" offered by user "Alice"
     And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Brian" has accepted share "/folderToShareWithGroup" offered by user "Alice"
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
     And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Brian" has accepted share "/fileToShareWithUser.txt" offered by user "Alice"
     And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Brian" has accepted share "/fileToShareWithGroup.txt" offered by user "Alice"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
@@ -34,8 +40,8 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And exactly 2 files or folders should be included in the response
-    And folder "folderToShareWithUser" should be included in the response
-    And file "fileToShareWithUser.txt" should be included in the response
+    And folder "/Shares/folderToShareWithUser" should be included in the response
+    And file "/Shares/fileToShareWithUser.txt" should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -47,8 +53,8 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And exactly 2 files or folders should be included in the response
-    And folder "folderToShareWithGroup" should be included in the response
-    And folder "fileToShareWithGroup.txt" should be included in the response
+    And folder "/Shares/folderToShareWithGroup" should be included in the response
+    And folder "/Shares/fileToShareWithGroup.txt" should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -60,8 +66,8 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And exactly 2 files or folders should be included in the response
-    And folder "folderToShareWithPublic" should be included in the response
-    And folder "fileToShareWithPublic.txt" should be included in the response
+    And folder "/Shares/folderToShareWithPublic" should be included in the response
+    And folder "/Shares/fileToShareWithPublic.txt" should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -73,10 +79,10 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And exactly 4 files or folders should be included in the response
-    And folder "folderToShareWithUser" should be included in the response
-    And file "fileToShareWithUser.txt" should be included in the response
-    And folder "folderToShareWithGroup" should be included in the response
-    And folder "fileToShareWithGroup.txt" should be included in the response
+    And folder "/Shares/folderToShareWithUser" should be included in the response
+    And file "/Shares/fileToShareWithUser.txt" should be included in the response
+    And folder "/Shares/folderToShareWithGroup" should be included in the response
+    And folder "/Shares/fileToShareWithGroup.txt" should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFilteredEmpty.feature
@@ -1,5 +1,5 @@
 @api @files_sharing-app-required
-Feature: sharing
+Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)
   So that I can reduce the amount of data that has to be transferred to be just the data that I need

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)
@@ -17,66 +17,63 @@ Feature: sharing
     And user "Alice" has uploaded file with content "file to share with user" to "/fileToShareWithUser.txt"
     And user "Alice" has uploaded file with content "file to share with group" to "/fileToShareWithGroup.txt"
     And user "Alice" has uploaded file with content "file to share with public" to "/fileToShareWithPublic.txt"
-    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+
+  Scenario Outline: getting shares shared to users when there are none
+    Given using OCS API version "<ocs_api_version>"
     And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Brian" has accepted share "/folderToShareWithGroup" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /folderToShareWithPublic |
+      | permissions | read                     |
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Brian" has accepted share "/fileToShareWithGroup.txt" offered by user "Alice"
+    And user "Alice" has created a public link share with settings
+      | path        | /fileToShareWithPublic.txt |
+      | permissions | read                       |
+    When user "Alice" gets the user shares shared by him using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And no files or folders should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: getting shares shared to groups when there are none
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Brian" has accepted share "/folderToShareWithUser" offered by user "Alice"
     And user "Alice" has created a public link share with settings
       | path        | /folderToShareWithPublic |
       | permissions | read                     |
     And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
-    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Brian" has accepted share "/fileToShareWithUser.txt" offered by user "Alice"
     And user "Alice" has created a public link share with settings
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
-
-  Scenario Outline: getting shares shared to users
-    Given using OCS API version "<ocs_api_version>"
-    When user "Alice" gets the user shares shared by him using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And exactly 2 files or folders should be included in the response
-    And folder "folderToShareWithUser" should be included in the response
-    And file "fileToShareWithUser.txt" should be included in the response
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
-
-  Scenario Outline: getting shares shared to groups
-    Given using OCS API version "<ocs_api_version>"
     When user "Alice" gets the group shares shared by him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And exactly 2 files or folders should be included in the response
-    And folder "folderToShareWithGroup" should be included in the response
-    And folder "fileToShareWithGroup.txt" should be included in the response
+    And no files or folders should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: getting shares shared to public links
+  Scenario Outline: getting shares shared to public links when there are none
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared folder "/folderToShareWithUser" with user "Brian"
+    And user "Brian" has accepted share "/folderToShareWithUser" offered by user "Alice"
+    And user "Alice" has shared folder "/folderToShareWithGroup" with group "grp1"
+    And user "Brian" has accepted share "/folderToShareWithGroup" offered by user "Alice"
+    And user "Alice" has shared file "/fileToShareWithUser.txt" with user "Brian"
+    And user "Brian" has accepted share "/fileToShareWithUser.txt" offered by user "Alice"
+    And user "Alice" has shared file "/fileToShareWithGroup.txt" with group "grp1"
+    And user "Brian" has accepted share "/fileToShareWithGroup.txt" offered by user "Alice"
     When user "Alice" gets the public link shares shared by him using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And exactly 2 files or folders should be included in the response
-    And folder "folderToShareWithPublic" should be included in the response
-    And folder "fileToShareWithPublic.txt" should be included in the response
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
-
-  Scenario Outline: getting shares shared to users and groups
-    Given using OCS API version "<ocs_api_version>"
-    When user "Alice" gets the user and group shares shared by him using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And exactly 4 files or folders should be included in the response
-    And folder "folderToShareWithUser" should be included in the response
-    And file "fileToShareWithUser.txt" should be included in the response
-    And folder "folderToShareWithGroup" should be included in the response
-    And folder "fileToShareWithGroup.txt" should be included in the response
+    And no files or folders should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1066,7 +1066,7 @@ trait Sharing {
 		$count = (int) $count;
 		$data = $this->getResponseXml(null, __METHOD__)->data[0];
 		Assert::assertIsObject($data, __METHOD__ . " data not found in response XML");
-		Assert::assertCount($count, $data);
+		Assert::assertCount($count, $data, __METHOD__ . " the response does not contain $count entries");
 	}
 
 	/**
@@ -1735,15 +1735,21 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" gets the (user|group|user and group|public link) shares shared with him using the sharing API$/
+	 * @When /^user "([^"]*)" gets the (|pending)\s?(user|group|user and group|public link) shares shared with him using the sharing API$/
 	 *
 	 * @param string $user
+	 * @param string $pending
 	 * @param string $shareType
 	 *
 	 * @return void
 	 */
-	public function userGetsFilteredSharesSharedWithHimUsingTheSharingApi($user, $shareType) {
+	public function userGetsFilteredSharesSharedWithHimUsingTheSharingApi($user, $pending, $shareType) {
 		$user = $this->getActualUsername($user);
+		if ($pending === "pending") {
+			$pendingClause = "&state=" . SharingHelper::SHARE_STATES['pending'];
+		} else {
+			$pendingClause = "";
+		}
 		if ($shareType === 'public link') {
 			$shareType = 'public_link';
 		}
@@ -1756,7 +1762,7 @@ trait Sharing {
 			$user,
 			'GET',
 			$this->getSharesEndpointPath(
-				"?shared_with_me=true&share_types=" . $rawShareTypes
+				"?shared_with_me=true" . $pendingClause . "&share_types=" . $rawShareTypes
 			),
 			null
 		);

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1045,6 +1045,31 @@ trait Sharing {
 	}
 
 	/**
+	 * @Then no files or folders should be included in the response
+	 *
+	 * @return void
+	 */
+	public function checkNoFilesFoldersInResponse() {
+		$data = $this->getResponseXml(null, __METHOD__)->data[0];
+		Assert::assertIsObject($data, __METHOD__ . " data not found in response XML");
+		Assert::assertCount(0, $data);
+	}
+
+	/**
+	 * @Then exactly :count file/files or folder/folders should be included in the response
+	 *
+	 * @param string $count
+	 *
+	 * @return void
+	 */
+	public function checkCountFilesFoldersInResponse($count) {
+		$count = (int) $count;
+		$data = $this->getResponseXml(null, __METHOD__)->data[0];
+		Assert::assertIsObject($data, __METHOD__ . " data not found in response XML");
+		Assert::assertCount($count, $data);
+	}
+
+	/**
 	 * @Then /^(?:file|folder|entry) "([^"]*)" should be included in the response$/
 	 *
 	 * @param string $filename
@@ -1705,6 +1730,34 @@ trait Sharing {
 			$user,
 			'GET',
 			$url,
+			null
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" gets the (user|group|user and group|public link) shares shared with him using the sharing API$/
+	 *
+	 * @param string $user
+	 * @param string $shareType
+	 *
+	 * @return void
+	 */
+	public function userGetsFilteredSharesSharedWithHimUsingTheSharingApi($user, $shareType) {
+		$user = $this->getActualUsername($user);
+		if ($shareType === 'public link') {
+			$shareType = 'public_link';
+		}
+		if ($shareType === 'user and group') {
+			$rawShareTypes = SharingHelper::SHARE_TYPES['user'] . "," . SharingHelper::SHARE_TYPES['group'];
+		} else {
+			$rawShareTypes = SharingHelper::SHARE_TYPES[$shareType];
+		}
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$user,
+			'GET',
+			$this->getSharesEndpointPath(
+				"?shared_with_me=true&share_types=" . $rawShareTypes
+			),
 			null
 		);
 	}

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1759,6 +1759,35 @@ trait Sharing {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" gets the (user|group|user and group|public link) shares shared by him using the sharing API$/
+	 *
+	 * @param string $user
+	 * @param string $shareType
+	 *
+	 * @return void
+	 */
+	public function userGetsFilteredSharesSharedByHimUsingTheSharingApi($user, $shareType) {
+		$user = $this->getActualUsername($user);
+		if ($shareType === 'public link') {
+			$shareType = 'public_link';
+		}
+		if ($shareType === 'user and group') {
+			$rawShareTypes = SharingHelper::SHARE_TYPES['user'] . "," . SharingHelper::SHARE_TYPES['group'];
+		} else {
+			$rawShareTypes = SharingHelper::SHARE_TYPES[$shareType];
+		}
+		$this->response = OcsApiHelper::sendRequest(
+			$this->getBaseUrl(),
+			$user,
+			$this->getPasswordForUser($user),
+			"GET",
+			$this->getSharesEndpointPath("?share_types=" . $rawShareTypes),
+			[],
+			$this->ocsApiVersion
+		);
+	}
+
+	/**
 	 * @When user :user gets all the shares from the file :path using the sharing API
 	 *
 	 * @param string $user


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Allow filtering by share type while getting the shares. This should speed up a bit the web UI because the server will need to fetch and send less data.
Changes are backwards-compatible: if no filter is sent, all the shares will be returned, same as before.

## Related Issue
https://github.com/owncloud/enterprise/issues/4107

## Motivation and Context
The "share by link" view is expected to perform faster since there are less requests done to the DB to fetch data. Furthermore, the view doesn't need to ask for remote shares, which could slow down things if there are problems with the remote server.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
