### PR TITLE
[Tests-Only] Refactored some more bug demonstration scenarios for api test

### DIFF
--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
@@ -367,7 +367,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | no                  | 100             |
       | 2               | no                  | no                  | 200             |
 
-  @skipOnOcV10.3 @issue-37013
+  @skipOnOcV10 @skipOnOcV10.3 @issue-37013
   Scenario Outline: reshare extends the received expiry date up to the default by default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -394,17 +394,17 @@ Feature: resharing a resource with an expiration date
     And the information of the last share of user "Alice" should include
       | expiration | +20 days |
     And the response when user "Carol" gets the info of the last share should include
-      | expiration | <actual-expire-date> |
+      | expiration | +20 |
     Examples:
-      | ocs_api_version | default-expire-date | enforce-expire-date | actual-expire-date | ocs_status_code |
-      | 1               | yes                 | yes                 | +30 days           | 100             |
-      | 2               | yes                 | yes                 | +30 days           | 200             |
-      | 1               | yes                 | no                  |                    | 100             |
-      | 2               | yes                 | no                  |                    | 200             |
-      | 1               | no                  | no                  |                    | 100             |
-      | 2               | no                  | no                  |                    | 200             |
+      | ocs_api_version | default-expire-date | enforce-expire-date | ocs_status_code |
+      | 1               | yes                 | yes                 | 100             |
+      | 2               | yes                 | yes                 | 200             |
+      | 1               | yes                 | no                  | 100             |
+      | 2               | yes                 | no                  | 200             |
+      | 1               | no                  | no                  | 100             |
+      | 2               | no                  | no                  | 200             |
 
-  @skipOnOcV10.3 @issue-37013
+  @skipOnOcV10 @skipOnOcV10.3 @issue-37013
   Scenario Outline: reshare can extend the received expiry date further into the future
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -424,23 +424,19 @@ Feature: resharing a resource with an expiration date
       | permissions | change                |
       | shareWith   | Carol                 |
       | expireDate  | +40 days              |
-    Then the HTTP status code should be "200"
-    And the OCS status code should be "<ocs_status_code>"
-    When user "Carol" accepts share "/textfile0.txt" offered by user "Brian" using the sharing API
-    Then the HTTP status code should be "200"
-    And the OCS status code should be "<ocs_status_code>"
+    #The action of changing the expiration date while resharing should be forbidden
+    Then the HTTP status code should be "403"
+    And the OCS status code should be "403"
     And the information of the last share of user "Alice" should include
       | expiration | +20 days |
-    And the response when user "Carol" gets the info of the last share should include
-      | expiration | +40 days |
     Examples:
-      | ocs_api_version | default-expire-date | ocs_status_code |
-      | 1               | yes                 | 100             |
-      | 2               | yes                 | 200             |
-      | 1               | no                  | 100             |
-      | 2               | no                  | 200             |
+      | ocs_api_version | default-expire-date |
+      | 1               | yes                 |
+      | 2               | yes                 |
+      | 1               | no                  |
+      | 2               | no                  |
 
-  @skipOnOcV10.3 @issue-37013
+  @skipOnOcV10 @skipOnOcV10.3 @issue-37013
   Scenario Outline: reshare cannot extend the received expiry date past the default when the default is enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -460,11 +456,11 @@ Feature: resharing a resource with an expiration date
       | permissions | change                |
       | shareWith   | Carol                 |
       | expireDate  | +40 days              |
-    Then the HTTP status code should be "<http_status_code>"
-    And the OCS status code should be "404"
+    Then the HTTP status code should be "403"
+    And the OCS status code should be "403"
     And the information of the last share of user "Alice" should include
       | expiration | +20 days |
     Examples:
-      | ocs_api_version | default-expire-date | http_status_code |
-      | 1               | yes                 | 200              |
-      | 2               | yes                 | 404              |
+      | ocs_api_version | default-expire-date |
+      | 1               | yes                 |
+      | 2               | yes                 |

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
@@ -1,0 +1,110 @@
+@api @files_sharing-app-required @issue-ocis-reva-243 @issue-ocis-reva-333 @notToImplementOnOCIS
+Feature: resharing a resource with an expiration date
+
+  Background:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+
+  @skipOnOcV10.3 @issue-37013
+  Scenario Outline: reshare extends the received expiry date up to the default by default
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce-expire-date>"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created a share with settings
+      | path        | textfile0.txt |
+      | shareType   | user          |
+      | permissions | all           |
+      | shareWith   | Brian         |
+      | expireDate  | +20 days      |
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" creates a share using the sharing API with settings
+      | path        | /Shares/textfile0.txt |
+      | shareType   | user                  |
+      | permissions | change                |
+      | shareWith   | Carol                 |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    When user "Carol" accepts share "/textfile0.txt" offered by user "Brian" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And the information of the last share of user "Alice" should include
+      | expiration | +20 days |
+    And the response when user "Carol" gets the info of the last share should include
+      | expiration | <actual-expire-date> |
+    Examples:
+      | ocs_api_version | default-expire-date | enforce-expire-date | actual-expire-date | ocs_status_code |
+      | 1               | yes                 | yes                 | +30 days           | 100             |
+      | 2               | yes                 | yes                 | +30 days           | 200             |
+      | 1               | yes                 | no                  |                    | 100             |
+      | 2               | yes                 | no                  |                    | 200             |
+      | 1               | no                  | no                  |                    | 100             |
+      | 2               | no                  | no                  |                    | 200             |
+
+  @skipOnOcV10.3 @issue-37013
+  Scenario Outline: reshare can extend the received expiry date further into the future
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "no"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created a share with settings
+      | path        | textfile0.txt |
+      | shareType   | user          |
+      | permissions | all           |
+      | shareWith   | Brian         |
+      | expireDate  | +20 days      |
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" creates a share using the sharing API with settings
+      | path        | /Shares/textfile0.txt |
+      | shareType   | user                  |
+      | permissions | change                |
+      | shareWith   | Carol                 |
+      | expireDate  | +40 days              |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    When user "Carol" accepts share "/textfile0.txt" offered by user "Brian" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And the information of the last share of user "Alice" should include
+      | expiration | +20 days |
+    And the response when user "Carol" gets the info of the last share should include
+      | expiration | +40 days |
+    Examples:
+      | ocs_api_version | default-expire-date | ocs_status_code |
+      | 1               | yes                 | 100             |
+      | 2               | yes                 | 200             |
+      | 1               | no                  | 100             |
+      | 2               | no                  | 200             |
+
+  @skipOnOcV10.3 @issue-37013
+  Scenario Outline: reshare cannot extend the received expiry date past the default when the default is enforced
+    Given using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created a share with settings
+      | path        | textfile0.txt |
+      | shareType   | user          |
+      | permissions | all           |
+      | shareWith   | Brian         |
+      | expireDate  | +20 days      |
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" creates a share using the sharing API with settings
+      | path        | /Shares/textfile0.txt |
+      | shareType   | user                  |
+      | permissions | change                |
+      | shareWith   | Carol                 |
+      | expireDate  | +40 days              |
+    Then the HTTP status code should be "<http_status_code>"
+    And the OCS status code should be "404"
+    And the information of the last share of user "Alice" should include
+      | expiration | +20 days |
+    Examples:
+      | ocs_api_version | default-expire-date | http_status_code |
+      | 1               | yes                 | 200              |
+      | 2               | yes                 | 404              |

--- a/tests/acceptance/features/apiShareUpdateToRoot/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToRoot/updateShare.feature
@@ -265,7 +265,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-37217
+  @skipOnOcV10 @issue-37217
   Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -282,8 +282,7 @@ Feature: sharing
     And user "Alice" updates the last share using the sharing API with
       | permissions | read |
       | expireDate  | +28  |
-    Then the OCS status message should be "Expiration date is in the past"
-#    Then the OCS status message should be "Cannot set expiration date more than 10 days in the future"
+    Then the OCS status message should be "Cannot set expiration date more than 10 days in the future"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "404"
     When user "Alice" gets the info of the last share using the sharing API

--- a/tests/acceptance/features/apiShareUpdateToRoot/updateShareOc10Issue37217.feature
+++ b/tests/acceptance/features/apiShareUpdateToRoot/updateShareOc10Issue37217.feature
@@ -1,0 +1,34 @@
+@api @files_sharing-app-required @notToImplementOnOCIS
+Feature: sharing
+
+  @issue-37217
+  Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
+    Given using OCS API version "1"
+    And user "Alice" has been created with default attributes and skeleton files
+    And using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created a share with settings
+      | path        | textfile0.txt |
+      | shareType   | user          |
+      | shareWith   | Brian         |
+      | permissions | read,share    |
+      | expireDate  | +30 days      |
+    When the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "10"
+    And user "Alice" updates the last share using the sharing API with
+      | permissions | read |
+      | expireDate  | +28  |
+    Then the OCS status message should be "Expiration date is in the past"
+#    Then the OCS status message should be "Cannot set expiration date more than 10 days in the future"
+    And the HTTP status code should be "<http_status_code>"
+    And the OCS status code should be "404"
+    When user "Alice" gets the info of the last share using the sharing API
+    Then the fields of the last response to user "Alice" should include
+      | permissions | read, share |
+      | expiration  | +30 days    |
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -334,7 +334,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-37217 @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @skipOnOcV10 @issue-37217 @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -352,8 +352,7 @@ Feature: sharing
     And user "Alice" updates the last share using the sharing API with
       | permissions | read |
       | expireDate  | +28  |
-    Then the OCS status message should be "Expiration date is in the past"
-#    Then the OCS status message should be "Cannot set expiration date more than 10 days in the future"
+    Then the OCS status message should be "Cannot set expiration date more than 10 days in the future"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "404"
     When user "Alice" gets the info of the last share using the sharing API

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShareOc10Issue37217.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShareOc10Issue37217.feature
@@ -1,0 +1,37 @@
+@api @files_sharing-app-required @notToImplementOnOCIS
+Feature: sharing
+
+  @issue-37217 @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And using OCS API version "1"
+    And user "Alice" has been created with default attributes and skeleton files
+    And using OCS API version "<ocs_api_version>"
+    And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
+    And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created a share with settings
+      | path        | textfile0.txt |
+      | shareType   | user          |
+      | shareWith   | Brian         |
+      | permissions | read,share    |
+      | expireDate  | +30 days      |
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "10"
+    And user "Alice" updates the last share using the sharing API with
+      | permissions | read |
+      | expireDate  | +28  |
+    Then the OCS status message should be "Expiration date is in the past"
+#    Then the OCS status message should be "Cannot set expiration date more than 10 days in the future"
+    And the HTTP status code should be "<http_status_code>"
+    And the OCS status code should be "404"
+    When user "Alice" gets the info of the last share using the sharing API
+    Then the fields of the last response to user "Alice" should include
+      | permissions | read, share |
+      | expiration  | +30 days    |
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -125,7 +125,6 @@ Feature: files and folders exist in the trashbin after being deleted
       | /folderB/textfile0.txt |
       | /folderC/textfile0.txt |
       | /folderD/textfile0.txt |
-    # When issue-23151 is fixed, uncomment these lines. They should pass reliably.
     Then as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
     And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
     And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
@@ -136,7 +135,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  @notToImplementOnOCIS @issue-23151
+  @skipOnOcV10 @notToImplementOnOCIS @issue-23151
   # This scenario deletes many files as close together in time as the test can run.
   # On a very slow system, the file deletes might all happen in different seconds.
   # But on "reasonable" systems, some of the files will be deleted in the same second,
@@ -157,11 +156,10 @@ Feature: files and folders exist in the trashbin after being deleted
       | /folderB/textfile0.txt |
       | /folderC/textfile0.txt |
       | /folderD/textfile0.txt |
-    # When issue-23151 is fixed, remove this scenario and use the above one.
-#    Then as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
-#    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
-#    And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
-#    And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
+    Then as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
@@ -1,0 +1,76 @@
+@api @files_trashbin-app-required @issue-ocis-reva-52 @notToImplementOnOCIS
+Feature: files and folders exist in the trashbin after being deleted
+  As a user
+  I want deleted files and folders to be available in the trashbin
+  So that I can recover data easily
+
+  Background:
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "to delete" to "/textfile0.txt"
+
+  @issue-23151
+  # This scenario deletes many files as close together in time as the test can run.
+  # On a very slow system, the file deletes might all happen in different seconds.
+  # But on "reasonable" systems, some of the files will be deleted in the same second,
+  # thus testing the required behavior.
+  Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "/folderA"
+    And user "Alice" has created folder "/folderB"
+    And user "Alice" has created folder "/folderC"
+    And user "Alice" has created folder "/folderD"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderC/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderD/textfile0.txt"
+    When user "Alice" deletes these files without delays using the WebDAV API
+      | /textfile0.txt         |
+      | /folderA/textfile0.txt |
+      | /folderB/textfile0.txt |
+      | /folderC/textfile0.txt |
+      | /folderD/textfile0.txt |
+    # When issue-23151 is fixed, uncomment these lines. They should pass reliably.
+    # These files may or may not exist in the trashbin
+#    Then as "Alice" the folder with original path "/folderA/textfile0.txt" should not exist in the trashbin
+#    And as "Alice" the folder with original path "/folderB/textfile0.txt" should not exist in the trashbin
+#    And as "Alice" the folder with original path "/folderC/textfile0.txt" should not exist in the trashbin
+#    And as "Alice" the folder with original path "/folderD/textfile0.txt" should not exist in the trashbin
+    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @notToImplementOnOCIS @issue-23151
+  # This scenario deletes many files as close together in time as the test can run.
+  # On a very slow system, the file deletes might all happen in different seconds.
+  # But on "reasonable" systems, some of the files will be deleted in the same second,
+  # thus testing the required behavior.
+  Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "/folderA"
+    And user "Alice" has created folder "/folderB"
+    And user "Alice" has created folder "/folderC"
+    And user "Alice" has created folder "/folderD"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderC/textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/folderD/textfile0.txt"
+    When user "Alice" deletes these files without delays using the WebDAV API
+      | /textfile0.txt         |
+      | /folderA/textfile0.txt |
+      | /folderB/textfile0.txt |
+      | /folderC/textfile0.txt |
+      | /folderD/textfile0.txt |
+    # When issue-23151 is fixed, remove this scenario and use the above one.
+    # These files may or may not exist in the trashbin
+#    Then as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
+#    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
+#    And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
+#    And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -116,7 +116,7 @@ Feature: Restore deleted files/folders
       | old      | /textfile0.txt          | PARENT/textfile0.txt |
       | new      | /textfile0.txt          | PARENT/textfile0.txt |
 
-  @issue-35974
+  @skipOnOcV10 @issue-35974
   Scenario Outline: restoring a file to an already existing path overrides the file
     Given user "Alice" has uploaded file with content "file to delete" to "/.hiddenfile0.txt"
     And using <dav-path> DAV path
@@ -128,14 +128,13 @@ Feature: Restore deleted files/folders
     # Sometimes <upload-path> is found in the trashbin. Should it? Or not?
     # That seems to be what happens when the restore-overwrite happens properly,
     # The original <upload-path> seems to be "deleted" and so goes to the trashbin
-    #And as "Alice" the file with original path <upload-path> should not exist in the trashbin
+    And as "Alice" the file with original path <upload-path> should not exist in the trashbin
     And as "Alice" file <upload-path> should exist
     # sometimes the restore from trashbin does overwrite the existing file, but sometimes it does not. That is also surprising.
     # the current observed behavior is that if the original <upload-path> ended up in the trashbin,
     # then the new <upload-path> has the "file to delete" content.
     # otherwise <upload-path> has its old content
-    And the content of file <upload-path> for user "Alice" if the file is also in the trashbin should be "file to delete" otherwise "PARENT file content"
-    #And the content of file <upload-path> for user "Alice" should be "file to delete"
+    And the content of file <upload-path> for user "Alice" should be "file to delete"
     Examples:
       | dav-path | upload-path                | delete-path        |
       | old      | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
@@ -143,7 +142,7 @@ Feature: Restore deleted files/folders
       | old      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
       | new      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
 
-  @issue-35900 @files_sharing-app-required
+  @skipOnOcV10 @issue-35900 @files_sharing-app-required
   Scenario Outline: restoring a file to a read-only folder
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -152,20 +151,16 @@ Feature: Restore deleted files/folders
     And as "Alice" folder "/shareFolderParent" should exist
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
-    Then the HTTP status code should be "201"
-    #Then the HTTP status code should be "403"
-    And as "Alice" the file with original path "/textfile0.txt" should not exist in the trashbin
-    #And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" file "/shareFolderParent/textfile0.txt" should exist
-    #And as "Alice" file "/shareFolderParent/textfile0.txt" should not exist
-    And as "Brian" file "/shareFolderParent/textfile0.txt" should exist
-    #And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
+    Then the HTTP status code should be "403"
+    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" file "/shareFolderParent/textfile0.txt" should not exist
+    And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
     Examples:
       | dav-path |
       | old      |
       | new      |
 
-  @issue-35900 @files_sharing-app-required
+  @skipOnOcV10 @issue-35900 @files_sharing-app-required
   Scenario Outline: restoring a file to a read-only sub-folder
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -175,14 +170,10 @@ Feature: Restore deleted files/folders
     And as "Alice" folder "/shareFolderParent/shareFolderChild" should exist
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
-    Then the HTTP status code should be "201"
-    #Then the HTTP status code should be "403"
-    And as "Alice" the file with original path "/textfile0.txt" should not exist in the trashbin
-    #And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" file "/shareFolderParent/shareFolderChild/textfile0.txt" should exist
-    #And as "Alice" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
-    And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should exist
-    #And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    Then the HTTP status code should be "403"
+    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestoreOc10Issue35900.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestoreOc10Issue35900.feature
@@ -1,0 +1,55 @@
+@api @files_trashbin-app-required @issue-ocis-reva-52 @notToImplementOnOCIS
+Feature: Restore deleted files/folders
+  As a user
+  I would like to restore files/folders
+  So that I can recover accidentally deleted files/folders in ownCloud
+
+  Background:
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "file to delete" to "/textfile0.txt"
+
+  @issue-35900 @files_sharing-app-required
+  Scenario Outline: restoring a file to a read-only folder
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "shareFolderParent"
+    And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
+    And as "Alice" folder "/shareFolderParent" should exist
+    And user "Alice" has deleted file "/textfile0.txt"
+    When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
+    Then the HTTP status code should be "201"
+    #Then the HTTP status code should be "403"
+    And as "Alice" the file with original path "/textfile0.txt" should not exist in the trashbin
+    #And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" file "/shareFolderParent/textfile0.txt" should exist
+    #And as "Alice" file "/shareFolderParent/textfile0.txt" should not exist
+    And as "Brian" file "/shareFolderParent/textfile0.txt" should exist
+    #And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @issue-35900 @files_sharing-app-required
+  Scenario Outline: restoring a file to a read-only sub-folder
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "shareFolderParent"
+    And user "Brian" has created folder "shareFolderParent/shareFolderChild"
+    And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
+    And as "Alice" folder "/shareFolderParent/shareFolderChild" should exist
+    And user "Alice" has deleted file "/textfile0.txt"
+    When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
+    Then the HTTP status code should be "201"
+    #Then the HTTP status code should be "403"
+    And as "Alice" the file with original path "/textfile0.txt" should not exist in the trashbin
+    #And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" file "/shareFolderParent/shareFolderChild/textfile0.txt" should exist
+    #And as "Alice" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should exist
+    #And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestoreOc10Issue35974.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestoreOc10Issue35974.feature
@@ -1,0 +1,35 @@
+@api @files_trashbin-app-required @issue-ocis-reva-52 @notToImplementOnOCIS
+Feature: Restore deleted files/folders
+  As a user
+  I would like to restore files/folders
+  So that I can recover accidentally deleted files/folders in ownCloud
+
+  @issue-35974
+  Scenario Outline: restoring a file to an already existing path overrides the file
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "file to delete" to "/textfile0.txt"
+    And user "Alice" has uploaded file with content "file to delete" to "/.hiddenfile0.txt"
+    And using <dav-path> DAV path
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "PARENT file content" to <upload-path>
+    And user "Alice" has deleted file <delete-path>
+    When user "Alice" restores the file with original path <delete-path> to <upload-path> using the trashbin API
+    Then the HTTP status code should be "204"
+    # Sometimes <upload-path> is found in the trashbin. Should it? Or not?
+    # That seems to be what happens when the restore-overwrite happens properly,
+    # The original <upload-path> seems to be "deleted" and so goes to the trashbin
+    #And as "Alice" the file with original path <upload-path> should not exist in the trashbin
+    And as "Alice" file <upload-path> should exist
+    # sometimes the restore from trashbin does overwrite the existing file, but sometimes it does not. That is also surprising.
+    # the current observed behavior is that if the original <upload-path> ended up in the trashbin,
+    # then the new <upload-path> has the "file to delete" content.
+    # otherwise <upload-path> has its old content
+    And the content of file <upload-path> for user "Alice" if the file is also in the trashbin should be "file to delete" otherwise "PARENT file content"
+    #And the content of file <upload-path> for user "Alice" should be "file to delete"
+    Examples:
+      | dav-path | upload-path                | delete-path        |
+      | old      | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
+      | new      | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
+      | old      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
+      | new      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |


### PR DESCRIPTION
## Description
Refactored some API test scenarios demonstrating the actual behaviors.

Scenarios demonstrating bugs in Oc10 are now in new feature files and tagged `notToImplementOnOCIS`  because they only demonstrate an oC10 bug that needs to be fixed. These feature files have been named with respect to the issue that each one demonstrates.

The main scenarios now demonstrate the expected behavior, which we want to happen on both Oc10 and OCIS. They are tagged `skipOnOcV10` for now, because they would currently fail on Oc10.

## Related Issue
- Part of https://github.com/owncloud/core/issues/37891

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
