### PR TITLE
[Tests-Only] Increase the number of parts for apiProxySmoke tests to reduce elapsed time

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -258,7 +258,7 @@ config = {
 			'useHttps': False,
 			'filterTags': '@smokeTest&&~@notifications-app-required',
 			'runAllSuites': True,
-			'numberOfParts': 5,
+			'numberOfParts': 8,
 		},
 	}
 }


### PR DESCRIPTION
## Description
The `apiProxySmoke` tests are currently run in 5 parts. Parts 1 to 4  take about 30 to 45 minutes each. Part 5 is taking a full hour or more. That is consistently the last pipeline to finish these days.

Split into 8 parts so that the maximum elapsed time is lower.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
