### PR TITLE
[Tests-Only] Refactored some more bug demonstration scenarios for API test

### DIFF
--- a/tests/acceptance/features/apiShareUpdateToShares/updateShareOc10Issue37217.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShareOc10Issue37217.feature
@@ -1,7 +1,7 @@
 @api @files_sharing-app-required @notToImplementOnOCIS
 Feature: sharing
 
-  @issue-37217 @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @issue-37217 @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -110,14 +110,14 @@ Feature: dav-versions
     And as user "Alice" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-156
-  @issue-ocis-reva-196 @skip @issue-37026
+  @skipOnOcV10 @issue-ocis-reva-196 @skip @issue-37026
   Scenario: Restore a file and check, if the content and correct checksum is now in the current file
     Given user "Alice" has uploaded file with content "AAAAABBBBBCCCCC" and checksum "MD5:45a72715acdd5019c5be30bdbb75233e" to "/davtest.txt"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/davtest.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     And the version folder of file "/davtest.txt" for user "Alice" should contain "1" element
     When user "Alice" restores version index "1" of file "/davtest.txt" using the WebDAV API
     Then the content of file "/davtest.txt" for user "Alice" should be "AAAAABBBBBCCCCC"
-    And as user "Alice" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
+    And as user "Alice" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
 
   Scenario: User cannot access meta folder of a file which is owned by somebody else
     Given user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiVersions/fileVersionsOc10Issue37026.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsOc10Issue37026.feature
@@ -1,0 +1,16 @@
+@api @files_versions-app-required @skipOnOcis-EOS-Storage @issue-ocis-reva-275 @notToImplementOnOCIS
+
+Feature: dav-versions
+
+  @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-156
+  @issue-ocis-reva-196 @skip @issue-37026
+  Scenario: Restore a file and check, if the content and correct checksum is now in the current file
+    Given using OCS API version "2"
+    And using new DAV path
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "AAAAABBBBBCCCCC" and checksum "MD5:45a72715acdd5019c5be30bdbb75233e" to "/davtest.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/davtest.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
+    And the version folder of file "/davtest.txt" for user "Alice" should contain "1" element
+    When user "Alice" restores version index "1" of file "/davtest.txt" using the WebDAV API
+    Then the content of file "/davtest.txt" for user "Alice" should be "AAAAABBBBBCCCCC"
+    And as user "Alice" the webdav checksum of "/davtest.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -50,17 +50,15 @@ Feature: there can be only one exclusive lock on a resource
       | new      | shared     |
       | new      | exclusive  |
 
-  @issue-34358
+  @skipOnOcV10 @issue-34358
   Scenario Outline: if a child resource is exclusively locked a parent resource cannot be locked again
     Given using <dav-path> DAV path
     And user "Alice" has locked folder "PARENT/CHILD" setting following properties
       | lockscope | exclusive |
     When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
       | lockscope | <lock-scope> |
-    Then the HTTP status code should be "200"
-    And 2 locks should be reported for file "PARENT/CHILD/child.txt" of user "Alice" by the WebDAV API
-    #Then the HTTP status code should be "423"
-    #And 1 locks should be reported for file "PARENT/CHILD/child.txt" of user "Alice" by the WebDAV API
+    Then the HTTP status code should be "423"
+    And 1 locks should be reported for file "PARENT/CHILD/child.txt" of user "Alice" by the WebDAV API
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
@@ -1,0 +1,19 @@
+@api @notToImplementOnOCIS @issue-ocis-reva-172
+Feature: there can be only one exclusive lock on a resource
+
+  @issue-34358
+  Scenario Outline: if a child resource is exclusively locked a parent resource cannot be locked again
+    Given user "Alice" has been created with default attributes and skeleton files
+    And using <dav-path> DAV path
+    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+      | lockscope | exclusive |
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then the HTTP status code should be "200"
+    And 2 locks should be reported for file "PARENT/CHILD/child.txt" of user "Alice" by the WebDAV API
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
@@ -1,19 +1,20 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required
+@notToImplementOnOCIS @issue-ocis-reva-172
 Feature: persistent-locking in case of a public link
 
   Background:
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has been created with default attributes and skeleton files
 
-  @skipOnOcV10 @smokeTest @issue-36064
+  @smokeTest @issue-36064
   Scenario Outline: Uploading a file into a locked public folder
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share of folder "FOLDER" with change permission
     When user "Alice" locks folder "FOLDER" using the WebDAV API setting following properties
       | lockscope | <lock-scope> |
     Then uploading a file should not work using the old public WebDAV API
-    And uploading a file should not work using the new public WebDAV API
     And the HTTP status code should be "423"
+    And uploading a file should work using the new public WebDAV API
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |
@@ -21,7 +22,7 @@ Feature: persistent-locking in case of a public link
       | new      | shared     |
       | new      | exclusive  |
 
-  @skipOnOcV10 @issue-36064
+  @issue-36064
   Scenario Outline: Uploading a file into a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT/CHILD" setting following properties
@@ -33,10 +34,26 @@ Feature: persistent-locking in case of a public link
     But the content of file "/PARENT/test.txt" for user "Alice" should be "test"
     Examples:
       | public-webdav-api-version | lock-scope |
+      | old                       | shared     |
+      | old                       | exclusive  |
+
+  @issue-36064
+  #after fixing the issue delete this Scenario and use the one above
+  Scenario Outline: Uploading a file into a locked subfolder of a public folder
+    Given user "Alice" has created a public link share of folder "PARENT" with change permission
+    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    And the public uploads file "CHILD/test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "/PARENT/CHILD/test.txt" should exist
+    But the content of file "/PARENT/test.txt" for user "Alice" should be "test"
+    Examples:
+      | public-webdav-api-version | lock-scope |
       | new                       | shared     |
       | new                       | exclusive  |
 
-  @skipOnOcV10 @smokeTest @issue-36064
+  @smokeTest @issue-36064
   Scenario Outline: Overwrite a file inside a locked public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT" setting following properties
@@ -46,10 +63,24 @@ Feature: persistent-locking in case of a public link
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent" plus end-of-line
     Examples:
       | public-webdav-api-version | lock-scope |
+      | old                       | shared     |
+      | old                       | exclusive  |
+
+  @smokeTest @issue-36064
+  #after fixing the issue delete this Scenario and use the one above
+  Scenario Outline: Overwrite a file inside a locked public folder
+    Given user "Alice" has created a public link share of folder "PARENT" with change permission
+    And user "Alice" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "parent.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/PARENT/parent.txt" for user "Alice" should be "test"
+    Examples:
+      | public-webdav-api-version | lock-scope |
       | new                       | shared     |
       | new                       | exclusive  |
 
-  @skipOnOcV10 @issue-36064
+  @issue-36064
   Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT/CHILD" setting following properties
@@ -61,19 +92,21 @@ Feature: persistent-locking in case of a public link
     But the content of file "/PARENT/CHILD/child.txt" for user "Alice" should be "ownCloud test text file child" plus end-of-line
     Examples:
       | public-webdav-api-version | lock-scope |
-      | new                       | shared     |
-      | new                       | exclusive  |
-
-  @smokeTest @skipOnOcV10.3
-  Scenario Outline: Public locking is not supported
-    Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    When the public locks "/CHILD" in the last public shared folder using the <public-webdav-api-version> public WebDAV API setting following properties
-      | lockscope | <lock-scope> |
-    Then the HTTP status code should be "405"
-    And the value of the item "//s:message" in the response should be "Locking not allowed from public endpoint"
-    Examples:
-      | public-webdav-api-version | lock-scope |
       | old                       | shared     |
       | old                       | exclusive  |
+
+  @issue-36064
+  #after fixing the issue delete this Scenario and use the one above
+  Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
+    Given user "Alice" has created a public link share of folder "PARENT" with change permission
+    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+      | lockscope | <lock-scope> |
+    When the public uploads file "parent.txt" with content "changed text" using the <public-webdav-api-version> public WebDAV API
+    And the public uploads file "CHILD/child.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/PARENT/parent.txt" for user "Alice" should be "changed text"
+    But the content of file "/PARENT/CHILD/child.txt" for user "Alice" should be "test"
+    Examples:
+      | public-webdav-api-version | lock-scope |
       | new                       | shared     |
       | new                       | exclusive  |

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -54,7 +54,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | shared     |
       | new      | exclusive  |
 
-  @issue-34338 @files_sharing-app-required
+  @skipOnOcV10 @issue-34338 @files_sharing-app-required
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -62,13 +62,9 @@ Feature: actions on a locked item are possible if the token is sent with the req
     And user "Alice" has locked folder "PARENT" setting following properties
       | lockscope | <lock-scope> |
     When user "Brian" moves file "PARENT (2)/parent.txt" to "PARENT (2)/renamed-file.txt" sending the locktoken of file "PARENT" of user "Alice" using the WebDAV API
-    #When the issue is fixed, remove the following steps and replace with the commented-out steps
-    Then the HTTP status code should be "403"
-    And as "Alice" file "/PARENT/parent.txt" should not exist
-    But as "Alice" file "/PARENT/renamed-file.txt" should exist
-    #Then the HTTP status code should be "423"
-    #And as "Alice" file "/PARENT/parent.txt" should exist
-    #But as "Alice" file "/PARENT/renamed-file.txt" should not exist
+    Then the HTTP status code should be "423"
+    And as "Alice" file "/PARENT/parent.txt" should exist
+    But as "Alice" file "/PARENT/renamed-file.txt" should not exist
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |
@@ -92,7 +88,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | shared     |
       | exclusive  |
 
-  @issue-34360 @files_sharing-app-required
+  @skipOnOcV10 @issue-34360 @files_sharing-app-required
   Scenario Outline: two users having both a shared lock can use the resource
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -102,20 +98,13 @@ Feature: actions on a locked item are possible if the token is sent with the req
     And user "Brian" has locked file "textfile0 (2).txt" setting following properties
       | lockscope | shared |
     When user "Alice" uploads file with content "from user 0" to "textfile0.txt" sending the locktoken of file "textfile0.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    And the content of file "textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
-    And the content of file "textfile0 (2).txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+    Then the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "Alice" should be "from user 0"
+    And the content of file "textfile0 (2).txt" for user "Brian" should be "from user 0"
     When user "Brian" uploads file with content "from user 1" to "textfile0 (2).txt" sending the locktoken of file "textfile0 (2).txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    And the content of file "textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
-    And the content of file "textfile0 (2).txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
-    #Then the HTTP status code should be "200"
-    #And the content of file "textfile0.txt" for user "Alice" should be "from user 0"
-    #And the content of file "textfile0 (2).txt" for user "Brian" should be "from user 0"
-    #When user "Brian" uploads file with content "from user 1" to "textfile0 (2).txt" sending the locktoken of file "textfile0 (2).txt" using the WebDAV API
-    #Then the HTTP status code should be "200"
-    #And the content of file "textfile0.txt" for user "Alice" should be "from user 1"
-    #And the content of file "textfile0 (2).txt" for user "Brian" should be "from user 1"
+    Then the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "Alice" should be "from user 1"
+    And the content of file "textfile0 (2).txt" for user "Brian" should be "from user 1"
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
@@ -1,0 +1,21 @@
+@api @notToImplementOnOCIS @issue-ocis-reva-172
+Feature: actions on a locked item are possible if the token is sent with the request
+
+  @issue-34338 @files_sharing-app-required
+  Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
+    Given user "Alice" has been created with default attributes and skeleton files
+    And using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared folder "PARENT" with user "Brian"
+    And user "Alice" has locked folder "PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When user "Brian" moves file "PARENT (2)/parent.txt" to "PARENT (2)/renamed-file.txt" sending the locktoken of file "PARENT" of user "Alice" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Alice" file "/PARENT/parent.txt" should not exist
+    But as "Alice" file "/PARENT/renamed-file.txt" should exist
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
@@ -1,0 +1,25 @@
+@api @notToImplementOnOCIS @issue-ocis-reva-172
+Feature: actions on a locked item are possible if the token is sent with the request
+
+  @issue-34360 @files_sharing-app-required
+  Scenario Outline: two users having both a shared lock can use the resource
+    Given user "Alice" has been created with default attributes and skeleton files
+    And using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has locked file "textfile0.txt" setting following properties
+      | lockscope | shared |
+    And user "Brian" has locked file "textfile0 (2).txt" setting following properties
+      | lockscope | shared |
+    When user "Alice" uploads file with content "from user 0" to "textfile0.txt" sending the locktoken of file "textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "423"
+    And the content of file "textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0 (2).txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+    When user "Brian" uploads file with content "from user 1" to "textfile0 (2).txt" sending the locktoken of file "textfile0 (2).txt" using the WebDAV API
+    Then the HTTP status code should be "423"
+    And the content of file "textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0 (2).txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |


### PR DESCRIPTION
## Description
Refactored some API test scenarios demonstrating the actual behaviors.

Scenarios demonstrating bugs in Oc10 are now in new feature files and tagged `notToImplementOnOCIS`  because they only demonstrate an oC10 bug that needs to be fixed. These feature files have been named with respect to the issue that each one demonstrates.

The main scenarios now demonstrate the expected behavior, which we want to happen on both Oc10 and OCIS. They are tagged `skipOnOcV10` for now, because they would currently fail on Oc10.

## Related Issue
- Part of https://github.com/owncloud/core/issues/37891

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
