### PR TITLE
[tests-only] Remove unused use statements in test code

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -22,8 +22,6 @@
 
 namespace TestHelpers;
 
-use PHPUnit\Framework\Assert;
-
 /**
  * Class OcisHelper
  *

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -26,7 +26,6 @@ use GuzzleHttp\Client;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
-use SimpleXMLElement;
 use DateTime;
 
 /**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -28,7 +28,6 @@ use TestHelpers\SetupHelper;
 use TestHelpers\UserHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\OcisHelper;
-use TestHelpers\FileHandlingHelper;
 use Zend\Ldap\Exception\LdapException;
 use Zend\Ldap\Ldap;
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -118,6 +118,13 @@ trait Provisioning {
 	}
 
 	/**
+	 * @return boolean
+	 */
+	public function someUsersHaveBeenCreated() {
+		return (\count($this->createdUsers) > 0);
+	}
+
+	/**
 	 * @return array
 	 */
 	public function getCreatedGroups() {
@@ -4294,7 +4301,9 @@ trait Provisioning {
 		$this->cleanupDatabaseGroups();
 
 		if (OcisHelper::isTestingOnOcis()) {
-			OcisHelper::deleteRevaUserData("");
+			if ($this->someUsersHaveBeenCreated()) {
+				OcisHelper::deleteRevaUserData("");
+			}
 		} else {
 			$this->resetAdminUserAttributes();
 		}


### PR DESCRIPTION
## Description
1) Some `use` statements are not used by the test code - delete them.
2) On OCIS, in scenarios that do not create any users, the `AfterScenario` code calls `OcisHelper::deleteRevaUserData("")`
In that situation the reva data root folder will not exist and a warning appears:
https://cloud.drone.io/cs3org/reva/2795/6/7
```
WARNING: reva data root folder (/drone/src/tmp/reva/data/) does not exist
```
That is a bit worrying when reading the test output. So avoid calling that in the case where no users were created.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
