### PR TITLE
[tests-only] test trashbin related scenarios when shares are recieved in subfolder

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -74,36 +74,6 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  @smokeTest @files_sharing-app-required
-  Scenario Outline: deleting a received folder doesn't move it to trashbin
-    Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/shared"
-    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-    And user "Alice" has shared folder "/shared" with user "Brian"
-    And user "Brian" has moved folder "/shared" to "/renamed_shared"
-    When user "Brian" deletes folder "/renamed_shared" using the WebDAV API
-    Then as "Brian" the folder with original path "/renamed_shared" should not exist in the trashbin
-    Examples:
-      | dav-path |
-      | old      |
-      | new      |
-
-  @files_sharing-app-required
-  Scenario Outline: deleting a file in a received folder moves it to trashbin
-    Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/shared"
-    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-    And user "Alice" has shared folder "/shared" with user "Brian"
-    And user "Brian" has moved file "/shared" to "/renamed_shared"
-    When user "Brian" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
-    Then as "Brian" the file with original path "/renamed_shared/shared_file.txt" should exist in the trashbin
-    Examples:
-      | dav-path |
-      | old      |
-      | new      |
-
   @skipOnOcV10 @issue-23151
   # This scenario deletes many files as close together in time as the test can run.
   # On a very slow system, the file deletes might all happen in different seconds.

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -9,28 +9,6 @@ Feature: Restore deleted files/folders
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "file to delete" to "/textfile0.txt"
 
-  @files_sharing-app-required
-  Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
-    Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Alice" has created folder "/shared"
-    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
-    And user "Alice" has shared folder "/shared" with user "Brian"
-    And user "Brian" has moved file "/shared" to "/renamed_shared"
-    And user "Brian" has deleted file "/renamed_shared/shared_file.txt"
-    When user "Brian" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
-    Then the HTTP status code should be "201"
-    And the following headers should match these regular expressions for user "Brian"
-      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And as "Brian" the file with original path "/renamed_shared/shared_file.txt" should not exist in the trashbin
-    And user "Brian" should see the following elements
-      | /renamed_shared/                |
-      | /renamed_shared/shared_file.txt |
-    Examples:
-      | dav-path |
-      | old      |
-      | new      |
-
   @smokeTest
   Scenario Outline: A deleted file can be restored
     Given using <dav-path> DAV path
@@ -141,43 +119,6 @@ Feature: Restore deleted files/folders
       | new      | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
       | old      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
       | new      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
-
-  @skipOnOcV10 @issue-35900 @files_sharing-app-required
-  Scenario Outline: restoring a file to a read-only folder
-    Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Brian" has created folder "shareFolderParent"
-    And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
-    And as "Alice" folder "/shareFolderParent" should exist
-    And user "Alice" has deleted file "/textfile0.txt"
-    When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
-    Then the HTTP status code should be "403"
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" file "/shareFolderParent/textfile0.txt" should not exist
-    And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
-    Examples:
-      | dav-path |
-      | old      |
-      | new      |
-
-  @skipOnOcV10 @issue-35900 @files_sharing-app-required
-  Scenario Outline: restoring a file to a read-only sub-folder
-    Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Brian" has created folder "shareFolderParent"
-    And user "Brian" has created folder "shareFolderParent/shareFolderChild"
-    And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
-    And as "Alice" folder "/shareFolderParent/shareFolderChild" should exist
-    And user "Alice" has deleted file "/textfile0.txt"
-    When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
-    Then the HTTP status code should be "403"
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
-    And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
-    Examples:
-      | dav-path |
-      | old      |
-      | new      |
 
   Scenario Outline: A file deleted from a folder is restored to the original folder if the original folder was deleted and recreated
     Given using <dav-path> DAV path

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -1,0 +1,96 @@
+@api @files_trashbin-app-required @files_sharing-app-required @notToImplementOnOCIS
+Feature: using trashbin together with sharing
+
+  Background:
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "to delete" to "/textfile0.txt"
+
+  @smokeTest
+  Scenario Outline: deleting a received folder doesn't move it to trashbin
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with user "Brian"
+    And user "Brian" has moved folder "/shared" to "/renamed_shared"
+    When user "Brian" deletes folder "/renamed_shared" using the WebDAV API
+    Then as "Brian" the folder with original path "/renamed_shared" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: deleting a file in a received folder moves it to trashbin
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with user "Brian"
+    And user "Brian" has moved file "/shared" to "/renamed_shared"
+    When user "Brian" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
+    Then as "Brian" the file with original path "/renamed_shared/shared_file.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with user "Brian"
+    And user "Brian" has moved file "/shared" to "/renamed_shared"
+    And user "Brian" has deleted file "/renamed_shared/shared_file.txt"
+    When user "Brian" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Brian"
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And as "Brian" the file with original path "/renamed_shared/shared_file.txt" should not exist in the trashbin
+    And user "Brian" should see the following elements
+      | /renamed_shared/                |
+      | /renamed_shared/shared_file.txt |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @skipOnOcV10 @issue-35900
+  Scenario Outline: restoring a file to a read-only folder
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "shareFolderParent"
+    And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
+    And as "Alice" folder "/shareFolderParent" should exist
+    And user "Alice" has deleted file "/textfile0.txt"
+    When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
+    Then the HTTP status code should be "403"
+    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" file "/shareFolderParent/textfile0.txt" should not exist
+    And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @skipOnOcV10 @issue-35900
+  Scenario Outline: restoring a file to a read-only sub-folder
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "shareFolderParent"
+    And user "Brian" has created folder "shareFolderParent/shareFolderChild"
+    And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
+    And as "Alice" folder "/shareFolderParent/shareFolderChild" should exist
+    And user "Alice" has deleted file "/textfile0.txt"
+    When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
+    Then the HTTP status code should be "403"
+    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -1,0 +1,103 @@
+@api @files_trashbin-app-required @files_sharing-app-required
+Feature: using trashbin together with sharing
+
+  Background:
+    Given the administrator has enabled DAV tech_preview
+    And the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "file to delete" to "/textfile0.txt"
+
+  @smokeTest
+  Scenario Outline: deleting a received folder doesn't move it to trashbin
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with user "Brian"
+    And user "Brian" has accepted share "/shared" offered by user "Alice"
+    And user "Brian" has moved folder "/Shares/shared" to "/Shares/renamed_shared"
+    When user "Brian" deletes folder "/Shares/renamed_shared" using the WebDAV API
+    Then as "Brian" the folder with original path "/Shares/renamed_shared" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: deleting a file in a received folder moves it to trashbin
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with user "Brian"
+    And user "Brian" has accepted share "/shared" offered by user "Alice"
+    And user "Brian" has moved file "/Shares/shared" to "/Shares/renamed_shared"
+    When user "Brian" deletes file "/Shares/renamed_shared/shared_file.txt" using the WebDAV API
+    Then as "Brian" the file with original path "/Shares/renamed_shared/shared_file.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with user "Brian"
+    And user "Brian" has accepted share "/shared" offered by user "Alice"
+    And user "Brian" has moved folder "/Shares/shared" to "/Shares/renamed_shared"
+    And user "Brian" has deleted file "/Shares/renamed_shared/shared_file.txt"
+    When user "Brian" restores the file with original path "/Shares/renamed_shared/shared_file.txt" using the trashbin API
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Brian"
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And as "Brian" the file with original path "/Shares/renamed_shared/shared_file.txt" should not exist in the trashbin
+    And user "Brian" should see the following elements
+      | /Shares/renamed_shared/                |
+      | /Shares/renamed_shared/shared_file.txt |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @skipOnOcV10 @issue-35900
+  Scenario Outline: restoring a file to a read-only folder
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "shareFolderParent"
+    And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
+    And user "Alice" has accepted share "/shareFolderParent" offered by user "Brian"
+    And as "Alice" folder "/Shares/shareFolderParent" should exist
+    And user "Alice" has deleted file "/textfile0.txt"
+    When user "Alice" restores the file with original path "/textfile0.txt" to "/Shares/shareFolderParent/textfile0.txt" using the trashbin API
+    Then the HTTP status code should be "403"
+    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" file "/Shares/shareFolderParent/textfile0.txt" should not exist
+    And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @skipOnOcV10 @issue-35900
+  Scenario Outline: restoring a file to a read-only sub-folder
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "shareFolderParent"
+    And user "Brian" has created folder "shareFolderParent/shareFolderChild"
+    And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
+    And user "Alice" has accepted share "/shareFolderParent" offered by user "Brian"
+    And as "Alice" folder "/Shares/shareFolderParent/shareFolderChild" should exist
+    And user "Alice" has deleted file "/textfile0.txt"
+    When user "Alice" restores the file with original path "/textfile0.txt" to "/Shares/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
+    Then the HTTP status code should be "403"
+    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" file "/Shares/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |


### PR DESCRIPTION
## Description
make sharing related tests be valid also for OCIS

## Related Issue
part of owncloud/ocis#518
part of #38006

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
