### PR TITLE
check public link already authenticated before checking password of link

### DIFF
--- a/apps/dav/lib/Connector/PublicAuth.php
+++ b/apps/dav/lib/Connector/PublicAuth.php
@@ -95,10 +95,10 @@ class PublicAuth extends AbstractBasic {
 		// check if the share is password protected
 		if ($share->getPassword() !== null) {
 			if ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
-				if ($this->shareManager->checkPassword($share, $password)) {
-					return true;
-				} elseif ($this->session->exists('public_link_authenticated')
+				if ($this->session->exists('public_link_authenticated')
 					&& $this->session->get('public_link_authenticated') === (string)$share->getId()) {
+					return true;
+				} elseif ($this->shareManager->checkPassword($share, $password)) {
 					return true;
 				} else {
 					if (\in_array('XMLHttpRequest', \explode(',', $this->request->getHeader('X-Requested-With')))) {

--- a/changelog/unreleased/38016
+++ b/changelog/unreleased/38016
@@ -1,0 +1,8 @@
+Bugfix: Do not emit "share.failedpasswordcheck" events for authenticated links
+
+ShareManager was checking password of already authenticated public links.
+This situation led to wrong "share.failedpasswordcheck" events emitting in already authenticated links.
+This problem has been resolved by first checking link already authenticated.
+
+https://github.com/owncloud/brute_force_protection/issues/138
+https://github.com/owncloud/core/pull/38016


### PR DESCRIPTION
## Description
ShareManager was checking password of already authenticated public links.
This situation has been led to wrong "share.failedpasswordcheck" events emitting in already authenticated links and led to the related issue on brute force protection app. This problem has been resolved by first checking link already authenticated.

@micbar I would like to add this PR to 10.6 if it is possible.

## Related Issue
- Fixes https://github.com/owncloud/brute_force_protection/issues/138


## How Has This Been Tested?
- https://github.com/owncloud/brute_force_protection/issues/138 is resolved after the fix.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
