### PR TITLE
[tests-only] remove unused folder parameter from Favorites test-functions

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -84,6 +84,8 @@ default:
         - FeatureContext: *common_feature_context_params
         - FavoritesContext:
         - WebDavPropertiesContext:
+        - AppConfigurationContext:
+        - OccContext:
 
     apiFederationToRoot1:
       paths:

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -82,7 +82,7 @@ Feature: favorite
     And user "Alice" favorites element "/textfile0.txt" using the WebDAV API
     And user "Alice" favorites element "/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "207"
-    And user "Alice" in folder "/" should have favorited the following elements
+    And user "Alice" should have favorited the following elements
       | /FOLDER        |
       | /textfile0.txt |
       | /textfile1.txt |
@@ -102,10 +102,10 @@ Feature: favorite
     And user "Alice" favorites element "/subfolder/textfile2.txt" using the WebDAV API
     And user "Alice" unfavorites element "/subfolder/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "207"
-    And user "Alice" in folder "/subfolder" should have favorited the following elements
+    And user "Alice" should have favorited the following elements
       | /subfolder/textfile0.txt |
       | /subfolder/textfile2.txt |
-    And user "Alice" in folder "/subfolder" should not have favorited the following elements
+    And user "Alice" should not have favorited the following elements
       | /subfolder/textfile1.txt |
     Examples:
       | dav_version |
@@ -121,7 +121,7 @@ Feature: favorite
     And user "Alice" has shared folder "/shared" with user "Brian"
     And user "Brian" has favorited element "/shared/shared_file.txt"
     When user "Brian" moves file "/shared/shared_file.txt" to "/taken_out.txt" using the WebDAV API
-    Then user "Brian" in folder "/" should have favorited the following elements
+    Then user "Brian" should have favorited the following elements
       | /taken_out.txt |
     Examples:
       | dav_version |
@@ -136,7 +136,7 @@ Feature: favorite
     And user "Alice" has favorited element "/textfile2.txt"
     And user "Alice" has favorited element "/textfile3.txt"
     And user "Alice" has favorited element "/textfile4.txt"
-    When user "Alice" lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
+    When user "Alice" lists the favorites and limits the result to 3 elements using the WebDAV API
     Then the search result should contain any "3" of these entries:
       | /textfile0.txt |
       | /textfile1.txt |
@@ -164,7 +164,7 @@ Feature: favorite
     And user "Alice" has favorited element "/subfolder/textfile3.txt"
     And user "Alice" has favorited element "/subfolder/textfile4.txt"
     And user "Alice" has favorited element "/subfolder/textfile5.txt"
-    When user "Alice" lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
+    When user "Alice" lists the favorites and limits the result to 3 elements using the WebDAV API
     Then the search result should contain any "3" of these entries:
       | /subfolder/textfile0.txt |
       | /subfolder/textfile1.txt |
@@ -209,7 +209,7 @@ Feature: favorite
     When user "Alice" favorites element "/PARENT/parent.txt" using the WebDAV API
     And user "Alice" favorites element "/PARENT" using the WebDAV API
     Then the HTTP status code should be "207"
-    And user "Alice" in folder "/" should have favorited the following elements
+    And user "Alice" should have favorited the following elements
       | /PARENT            |
       | /PARENT/parent.txt |
     Examples:

--- a/tests/acceptance/features/apiFavorites/favoritesOc10Issue33840.feature
+++ b/tests/acceptance/features/apiFavorites/favoritesOc10Issue33840.feature
@@ -21,7 +21,7 @@ Feature: current oC10 behavior for issue-33840
     And user "Alice" has favorited element "/textfile2.txt"
     And user "Alice" has favorited element "/textfile3.txt"
     And user "Alice" has favorited element "/textfile4.txt"
-    When user "Alice" lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
+    When user "Alice" lists the favorites and limits the result to 3 elements using the WebDAV API
     #Then the search result should contain any "3" of these entries:
     Then the search result should contain any "0" of these entries:
       | /textfile0.txt |
@@ -50,7 +50,7 @@ Feature: current oC10 behavior for issue-33840
     And user "Alice" has favorited element "/subfolder/textfile3.txt"
     And user "Alice" has favorited element "/subfolder/textfile4.txt"
     And user "Alice" has favorited element "/subfolder/textfile5.txt"
-    When user "Alice" lists the favorites of folder "/" and limits the result to 3 elements using the WebDAV API
+    When user "Alice" lists the favorites and limits the result to 3 elements using the WebDAV API
     #Then the search result should contain any "3" of these entries:
     Then the search result should contain any "0" of these entries:
       | /subfolder/textfile0.txt |

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -156,53 +156,33 @@ class FavoritesContext implements Context {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" in folder "([^"]*)" should (not|)\s?have favorited the following elements$/
+	 * @Then /^user "([^"]*)" should (not|)\s?have favorited the following elements$/
 	 *
 	 * @param string $user
-	 * @param string $folder
 	 * @param string $shouldOrNot (not|)
 	 * @param TableNode $expectedElements
 	 *
 	 * @return void
 	 */
 	public function checkFavoritedElements(
-		$user, $folder, $shouldOrNot, $expectedElements
+		$user, $shouldOrNot, $expectedElements
 	) {
 		$user = $this->featureContext->getActualUsername($user);
-		$this->userListsFavoriteOfFolder($user, $folder, null);
+		$this->userListsFavorites($user, null);
 		$this->featureContext->propfindResultShouldContainEntries(
 			$shouldOrNot, $expectedElements, $user
 		);
 	}
 
 	/**
-	 * @Then /^the user in folder "([^"]*)" should (not|)\s?have favorited the following elements$/
-	 *
-	 * @param string $folder
-	 * @param string $shouldOrNot (not|)
-	 * @param TableNode $expectedElements
-	 *
-	 * @return void
-	 */
-	public function checkFavoritedElementsForCurrentUser(
-		$folder, $shouldOrNot, $expectedElements
-	) {
-		$this->checkFavoritedElements(
-			$this->featureContext->getCurrentUser(),
-			$folder, $shouldOrNot, $expectedElements
-		);
-	}
-
-	/**
-	 * @When /^user "([^"]*)" lists the favorites of folder "([^"]*)" and limits the result to ([\d*]) elements using the WebDAV API$/
+	 * @When /^user "([^"]*)" lists the favorites and limits the result to ([\d*]) elements using the WebDAV API$/
 	 *
 	 * @param string $user
-	 * @param string $folder
 	 * @param int $limit
 	 *
 	 * @return void
 	 */
-	public function userListsFavoriteOfFolder($user, $folder, $limit = null) {
+	public function userListsFavorites($user, $limit = null) {
 		$renamedUser = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();
 		$password = $this->featureContext->getPasswordForUser($user);
@@ -224,20 +204,6 @@ class FavoritesContext implements Context {
 			$this->featureContext->getDavPathVersion()
 		);
 		$this->featureContext->setResponse($response);
-	}
-
-	/**
-	 * @When /^the user lists the favorites of folder "([^"]*)" and limits the result to ([\d*]) elements using the WebDAV API$/
-	 *
-	 * @param string $folder
-	 * @param int $limit
-	 *
-	 * @return void
-	 */
-	public function listFavoriteOfFolder($folder, $limit = null) {
-		$this->userListsFavoriteOfFolder(
-			$this->featureContext->getCurrentUser(), $folder, $limit
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
the folder parameter was not really used and in the table anyway the full path of the item needs to be given, so lets get rid of that code

## Motivation and Context
deleted code is debugged code

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
