### PR TITLE
[Tests-Only] Oc10 bug demonstration scenarios added separately for webUI tests

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -164,7 +164,7 @@ Feature: admin storage settings
     And the user re-logs in as "Brian" using the webUI
     And folder "local_storage1" should be listed on the webUI
 
-  @issue-36803
+  @issue-36803 @skipOnOcV10
   @issue-files_primary_s3-351 @skipOnStorage:ceph @skipOnStorage:scality
   Scenario: applicable user is not able to share top-level of read-only storage
     Given these users have been created with default attributes and without skeleton files:
@@ -179,7 +179,4 @@ Feature: admin storage settings
     And the administrator has enabled sharing for the last created local storage mount using the webUI
     And the user has re-logged in as "Alice" using the webUI
     When the user shares folder "local_storage1" with user "Brian" using the webUI
-    Then notifications should be displayed on the webUI with the text
-      | Cannot set the requested share permissions for local_storage1 |
-   # And as "Brian" folder "local_storage1" should exist
-    And as "Brian" folder "local_storage1" should not exist
+    And as "Brian" folder "local_storage1" should exist

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
@@ -1,0 +1,25 @@
+@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @notToImplementOnOCIS
+Feature: admin storage settings
+  As an admin
+  I want to be able to manage external storages on the ownCloud server
+  So that owncloud users can link external storages into the owncloud server
+
+  @issue-36803
+  @issue-files_primary_s3-351 @skipOnStorage:ceph @skipOnStorage:scality
+  Scenario: applicable user is not able to share top-level of read-only storage
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And the administrator has enabled the external storage
+    And the administrator has browsed to the admin storage settings page
+    And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
+    And the administrator has added user "Alice" as the applicable user for the last local storage mount from the admin storage settings page
+    And the administrator has enabled read-only for the last created local storage mount using the webUI
+    And the administrator has enabled sharing for the last created local storage mount using the webUI
+    And the user has re-logged in as "Alice" using the webUI
+    When the user shares folder "local_storage1" with user "Brian" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      | Cannot set the requested share permissions for local_storage1 |
+   # And as "Brian" folder "local_storage1" should exist
+    And as "Brian" folder "local_storage1" should not exist

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -121,7 +121,7 @@ Feature: rename folders
     When the user renames folder "a-folder" to "a.part" using the webUI
     Then near folder "a-folder" a tooltip with the text '"a.part" has a forbidden file type/extension.' should be displayed on the webUI
 
-  @issue-30325
+  @issue-30325 @skipOnOcV10
   Scenario: Rename a folder which is received as a share (without change permission)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "RandomFolder"
@@ -129,10 +129,8 @@ Feature: rename folders
     And user "Brian" has shared folder "RandomFolder" with user "Alice" with permissions "read, share"
     And user "Alice" has logged in using the webUI
     When the user renames folder "RandomFolder" to "renamedFolder" using the webUI
-#   Then folder "renamedFolder" should be listed on the webUI
-    Then a notification should be displayed on the webUI with the text 'Could not rename "RandomFolder"'
-    When the user opens folder "/RandomFolder" using the webUI
-#   When the user opens folder "/renamedFolder" using the webUI
+    Then folder "renamedFolder" should be listed on the webUI
+    When the user opens folder "/renamedFolder" using the webUI
     Then the option to rename file "newFile" should not be available on the webUI
 
   Scenario: Rename a folder which is received as a share (with change permission)

--- a/tests/acceptance/features/webUIRenameFolders/renameFoldersOc10Issue30325.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFoldersOc10Issue30325.feature
@@ -1,0 +1,22 @@
+@webUI @insulated @disablePreviews
+Feature: rename folders
+  As a user
+  I want to rename folders
+  So that I can organise my data structure
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  @issue-30325 @notToImplementOnOCIS
+  Scenario: Rename a folder which is received as a share (without change permission)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "RandomFolder"
+    And user "Brian" has uploaded file with content "thisIsFileInsideFolder" to "/RandomFolder/newFile"
+    And user "Brian" has shared folder "RandomFolder" with user "Alice" with permissions "read, share"
+    And user "Alice" has logged in using the webUI
+    When the user renames folder "RandomFolder" to "renamedFolder" using the webUI
+#   Then folder "renamedFolder" should be listed on the webUI
+    Then a notification should be displayed on the webUI with the text 'Could not rename "RandomFolder"'
+    When the user opens folder "/RandomFolder" using the webUI
+#   When the user opens folder "/renamedFolder" using the webUI
+    Then the option to rename file "newFile" should not be available on the webUI

--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
@@ -76,7 +76,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user has browsed to the personal sharing settings page
     Then User-based auto accepting from trusted servers checkbox should not be displayed on the personal sharing settings page on the webUI
 
-  @skip @issue-34742
+  @issue-34742 @skipOnOcV10
   Scenario: User-based & global auto accepting is enabled but remote server is not trusted
     Given parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     And parameter "autoAddServers" of app "federation" has been set to "0"
@@ -84,7 +84,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user disables automatically accepting remote shares from trusted servers
     And the user enables automatically accepting remote shares from trusted servers
     And user "Alice" from server "REMOTE" shares "/lorem.txt" with user "Alice" from server "LOCAL" using the sharing API
-    Then user "Alice" should not see the following elements
+    Then user "Alice" should see the following elements
       | /lorem%20(2).txt |
 
   @skipOnOcV10.3 @skipOnOcV10.4.0

--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedSharesOc10Issue34742.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedSharesOc10Issue34742.feature
@@ -1,0 +1,32 @@
+@webUI @federation-app-required @insulated @disablePreviews @files_sharing-app-required
+Feature: Federation Sharing - sharing with users on other cloud storages
+  As a user
+  I want to share files with any users on other cloud storages
+  So that other users have access to these files
+
+  Background:
+    Given using server "REMOTE"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-empty-folder"
+    And user "Alice" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And using server "LOCAL"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-empty-folder"
+    And user "Alice" has uploaded file with content "I am lorem.txt inside simple-folder" to "/simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
+
+  @issue-34742 @notToImplementOnOCIS
+  Scenario: User-based & global auto accepting is enabled but remote server is not trusted
+    Given parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
+    And parameter "autoAddServers" of app "federation" has been set to "0"
+    And the user has browsed to the personal sharing settings page
+    When the user disables automatically accepting remote shares from trusted servers
+    And the user enables automatically accepting remote shares from trusted servers
+    And user "Alice" from server "REMOTE" shares "/lorem.txt" with user "Alice" from server "LOCAL" using the sharing API
+    Then user "Alice" should not see the following elements
+      | /lorem%20(2).txt |

--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
@@ -292,7 +292,7 @@ Feature: misc scenarios on sharing with internal users
       just letting you know that %username% shared simple-folder with you.
       """
 
-  @issue-35787
+  @issue-35787 @skipOnOcV10
   Scenario: share a skeleton file after changing its content to a user before the user has logged in
     Given these users have been created with default attributes and skeleton files:
       | username |
@@ -303,8 +303,7 @@ Feature: misc scenarios on sharing with internal users
     When the user shares file "lorem.txt" with user "Alice" using the webUI
     Then the content of file "lorem.txt" for user "Brian" should be "edited original content"
     When the user re-logs in as "Alice" using the webUI
-    Then the content of "lorem.txt" should be the same as the original "lorem.txt"
-#   And the content of file "lorem.txt" for user "Alice" should be "edited original content"
+    And the content of file "lorem.txt" for user "Alice" should be "edited original content"
 
   @skipOnOcV10.3
   Scenario: share with two users having same display name

--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsersOc10Issue35787.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsersOc10Issue35787.feature
@@ -1,0 +1,16 @@
+@webUI @insulated @disablePreviews @files_sharing-app-required
+Feature: misc scenarios on sharing with internal users
+
+  @issue-35787 @notToImplementOnOCIS
+  Scenario: share a skeleton file after changing its content to a user before the user has logged in
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Brian" has logged in using the webUI
+    And user "Brian" has uploaded file with content "edited original content" to "/lorem.txt"
+    When the user shares file "lorem.txt" with user "Alice" using the webUI
+    Then the content of file "lorem.txt" for user "Brian" should be "edited original content"
+    When the user re-logs in as "Alice" using the webUI
+    Then the content of "lorem.txt" should be the same as the original "lorem.txt"
+#   And the content of file "lorem.txt" for user "Alice" should be "edited original content"


### PR DESCRIPTION
## Description
Refactored some webUI test scenarios demonstrating the actual behaviors.

Scenarios demonstrating bugs in Oc10 are now in new feature files and tagged `notToImplementOnOCIS`  because they only demonstrate an oC10 bug that needs to be fixed. These feature files have been named with respect to the issue that each one demonstrates.

The main scenarios now demonstrate the expected behavior, which we want to happen on both Oc10 and OCIS. They are tagged `skipOnOcV10` for now, because they would currently fail on Oc10.

## Related Issue
- Part of https://github.com/owncloud/core/issues/37891

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
