### PR TITLE
Feature/pre signed url ajax download

### DIFF
--- a/apps/files/ajax/download.php
+++ b/apps/files/ajax/download.php
@@ -29,7 +29,7 @@
  */
 
 // Check if we are a user
-OCP\User::checkLoggedIn();
+OCP\User::checkLoggedIn(true);
 \OC::$server->getSession()->close();
 
 // files can be an array with multiple "files[]=one.txt&files[]=two.txt" or a single file with "files=filename.txt"

--- a/changelog/unreleased/37634
+++ b/changelog/unreleased/37634
@@ -7,6 +7,8 @@ This means that we can only fetch data using XHR or the fetch API but cannot use
 To solve this, we now support pre-signed URLs. This means that before creating an image tag or starting a download, we send an authenticated request to the server (OC 10 or OCIS) to ask for a pre-signed URL pointing at a specific resource. Then said URL can be forwarded either to an image tag (for thumbnails) or to another browser window to trigger a download.
 
 https://github.com/owncloud/core/pull/37634
+https://github.com/owncloud/core/pull/38029
 https://github.com/owncloud/phoenix/pull/3797
 https://github.com/owncloud/owncloud-sdk/pull/504
+https://github.com/owncloud/owncloud-sdk/pull/616
 https://github.com/owncloud/ocis-proxy/pull/75

--- a/lib/public/User.php
+++ b/lib/public/User.php
@@ -150,7 +150,7 @@ class User {
 	 * redirect URL parameter to the request URI.
 	 * @since 5.0.0
 	 */
-	public static function checkLoggedIn() {
-		\OC_Util::checkLoggedIn();
+	public static function checkLoggedIn($allowPreSigned = false) {
+		\OC_Util::checkLoggedIn($allowPreSigned);
 	}
 }

--- a/tests/lib/Security/SignedUrl/VerifierTest.php
+++ b/tests/lib/Security/SignedUrl/VerifierTest.php
@@ -42,11 +42,11 @@ class VerifierTest extends TestCase {
 		$config->method('getUserValue')->willReturn('1234567890');
 		$v = new Verifier($r, $config, new \DateTime('2019-05-14T11:01:58.135Z', null));
 		if ($isSignedUrl) {
-			$this->assertTrue($v->isSignedRequest());
-			$this->assertEquals('alice', $v->getUrlCredential());
-			$this->assertEquals($isUrlValid, $v->signedRequestIsValid());
+			self::assertTrue($v->isSignedRequest());
+			self::assertEquals('alice', $v->getUrlCredential());
+			self::assertEquals($isUrlValid, $v->signedRequestIsValid());
 		} else {
-			$this->assertFalse($v->isSignedRequest());
+			self::assertFalse($v->isSignedRequest());
 		}
 	}
 
@@ -56,6 +56,8 @@ class VerifierTest extends TestCase {
 			'no signature' => [false, false, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET'],
 			'wrong method' => [true, false, 'post', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
 			'invalid signature' => [true, false, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b'],
+			'different algo' => [true, false, 'post', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Algo=PBKDF2/5-SHA512&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
+			'unsupported algo' => [true, false, 'post', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Algo=PBKDF2/x-SHA512&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
 		];
 	}
 }


### PR DESCRIPTION
## Description
- ajax/download can now be used with pre-signed urls
- OC-Algo was added to give the client a chance to use less computaion effort (bloody ie11 as example)


## How Has This Been Tested?
- :hand: 
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
