### PR TITLE
[Tests-Only]Bug demonstration scenarios added separately for cli tests

### DIFF
--- a/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
@@ -60,19 +60,18 @@ Feature: create local storage from the command line
     And as "Alice" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "Alice" should be "this is a file in local storage"
 
-  @issue-36713
+  @issue-36713 @skipOnOcV10
   Scenario: create local storage that already exists
     Given the administrator has created the local storage mount "local_storage2"
     And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
     When the administrator creates the local storage mount "local_storage2" using the occ command
-    #Then the command should have failed with exit code 1
-    Then the command should have been successful
+    Then the command should have failed with exit code 1
     And as "Alice" folder "/local_storage2" should exist
     And as "Brian" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "Alice" should be "this is a file in local storage"
     And the content of file "/local_storage2/file-in-local-storage.txt" for user "Brian" should be "this is a file in local storage"
 
-  @issue-36719
+  @issue-36719 @skipOnOcV10
   Scenario: create local storage that matches an existing folder of a user
     Given user "Alice" has created folder "reference"
     And user "Alice" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
@@ -86,11 +85,11 @@ Feature: create local storage from the command line
     And the content of file "/reference/file-in-local-storage.txt" for user "Alice" should be "this is a file in local storage"
     And the content of file "/reference/file-in-local-storage.txt" for user "Brian" should be "this is a file in local storage"
     And the content of file "/other/other-file.txt" for user "Alice" should be "this is another file"
-    # Some other behaviour is to be defined here. See discussion in the issue.
-    # How can Alice get access to their own previous folder with file?
-    But as "Alice" file "/reference/reference-file.txt" should not exist
+    And as "Alice" folder "/reference (2)" should exist
+    And as "Alice" file "/reference (2)/reference-file.txt" should exist
+    And the content of file "/reference (2)/reference-file.txt" for user "Alice" should be "this is a reference file"
 
-  @issue-36719
+  @issue-36719 @skipOnOcV10
   Scenario: create local storage that matches an existing shared folder of a user
     Given user "Alice" has created folder "reference"
     And user "Alice" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
@@ -107,12 +106,14 @@ Feature: create local storage from the command line
     And the content of file "/reference/file-in-local-storage.txt" for user "Brian" should be "this is a file in local storage"
     And the content of file "/other/other-file.txt" for user "Alice" should be "this is another file"
     And the content of file "/other/other-file.txt" for user "Brian" should be "this is another file"
-    # Some other behaviour is to be defined here. See discussion in the issue.
-    # How can Alice and Brian get access to their previous shared folder with file?
-    But as "Alice" file "/reference/reference-file.txt" should not exist
-    And as "Brian" file "/reference/reference-file.txt" should not exist
+    And as "Alice" folder "/reference (2)" should exist
+    And as "Alice" file "/reference (2)/reference-file.txt" should exist
+    And the content of file "/reference (2)/reference-file.txt" for user "Alice" should be "this is a reference file"
+    And as "Brian" folder "/reference (2)" should exist
+    And as "Brian" file "/reference (2)/reference-file.txt" should exist
+    And the content of file "/reference (2)/reference-file.txt" for user "Brian" should be "this is a reference file"
 
-  @issue-36719
+  @issue-36719 @skipOnOcV10
   Scenario: create local storage that matches an existing shared folder, and the sharee has renamed the received folder
     Given user "Alice" has created folder "reference"
     And user "Alice" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
@@ -130,8 +131,9 @@ Feature: create local storage from the command line
     And the content of file "/reference/file-in-local-storage.txt" for user "Brian" should be "this is a file in local storage"
     And the content of file "/other/other-file.txt" for user "Alice" should be "this is another file"
     And the content of file "/other/other-file.txt" for user "Brian" should be "this is another file"
-    # Brian receives "/reference" from Alice and has renamed it to "/reference1"
-    # it would be helpful if they could still see "/reference1" as well as the local storage called "/reference"
-    And as "Brian" file "/reference1/reference-file.txt" should not exist
-    #And as "Brian" file "/reference1/reference-file.txt" should exist
-    #And the content of file "/reference1/reference-file.txt" for user "Brian" should be "this is a reference file"
+    And as "Alice" folder "/reference (2)" should exist
+    And as "Alice" file "/reference (2)/reference-file.txt" should exist
+    And the content of file "/reference (2)/reference-file.txt" for user "Alice" should be "this is a reference file"
+    And as "Brian" folder "/reference1" should exist
+    And as "Brian" file "/reference1/reference-file.txt" should exist
+    And the content of file "/reference1/reference-file.txt" for user "Brian" should be "this is a reference file"

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageOc10Issue36713.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageOc10Issue36713.feature
@@ -1,0 +1,23 @@
+@cli @local_storage @skipOnLDAP
+Feature: create local storage from the command line
+  As an admin
+  I want to create local storage from the command line
+  So that local folders on my server can be made visible to users of ownCloud
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+
+  @issue-36713 @notToImplementOnOCIS
+  Scenario: create local storage that already exists
+    Given the administrator has created the local storage mount "local_storage2"
+    And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"
+    When the administrator creates the local storage mount "local_storage2" using the occ command
+    #Then the command should have failed with exit code 1
+    Then the command should have been successful
+    And as "Alice" folder "/local_storage2" should exist
+    And as "Brian" folder "/local_storage2" should exist
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "Alice" should be "this is a file in local storage"
+    And the content of file "/local_storage2/file-in-local-storage.txt" for user "Brian" should be "this is a file in local storage"

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageOc10Issue36719.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageOc10Issue36719.feature
@@ -1,0 +1,72 @@
+@cli @local_storage @skipOnLDAP @issue-36719 @notToImplementOnOCIS
+Feature: create local storage from the command line
+  As an admin
+  I want to create local storage from the command line
+  So that local folders on my server can be made visible to users of ownCloud
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+
+  Scenario: create local storage that matches an existing folder of a user
+    Given user "Alice" has created folder "reference"
+    And user "Alice" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
+    And user "Alice" has created folder "other"
+    And user "Alice" has uploaded file with content "this is another file" to "/other/other-file.txt"
+    When the administrator creates the local storage mount "reference" using the occ command
+    And the administrator uploads file with content "this is a file in local storage" to "/reference/file-in-local-storage.txt" using the WebDAV API
+    Then the command should have been successful
+    And as "Alice" folder "/reference" should exist
+    And as "Brian" folder "/reference" should exist
+    And the content of file "/reference/file-in-local-storage.txt" for user "Alice" should be "this is a file in local storage"
+    And the content of file "/reference/file-in-local-storage.txt" for user "Brian" should be "this is a file in local storage"
+    And the content of file "/other/other-file.txt" for user "Alice" should be "this is another file"
+    # Some other behaviour is to be defined here. See discussion in the issue.
+    # How can Alice get access to their own previous folder with file?
+    But as "Alice" file "/reference/reference-file.txt" should not exist
+
+  Scenario: create local storage that matches an existing shared folder of a user
+    Given user "Alice" has created folder "reference"
+    And user "Alice" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
+    And user "Alice" has shared folder "reference" with user "Brian"
+    And user "Alice" has created folder "other"
+    And user "Alice" has uploaded file with content "this is another file" to "/other/other-file.txt"
+    And user "Alice" has shared folder "other" with user "Brian"
+    When the administrator creates the local storage mount "reference" using the occ command
+    And the administrator uploads file with content "this is a file in local storage" to "/reference/file-in-local-storage.txt" using the WebDAV API
+    Then the command should have been successful
+    And as "Alice" folder "/reference" should exist
+    And as "Brian" folder "/reference" should exist
+    And the content of file "/reference/file-in-local-storage.txt" for user "Alice" should be "this is a file in local storage"
+    And the content of file "/reference/file-in-local-storage.txt" for user "Brian" should be "this is a file in local storage"
+    And the content of file "/other/other-file.txt" for user "Alice" should be "this is another file"
+    And the content of file "/other/other-file.txt" for user "Brian" should be "this is another file"
+    # Some other behaviour is to be defined here. See discussion in the issue.
+    # How can Alice and Brian get access to their previous shared folder with file?
+    But as "Alice" file "/reference/reference-file.txt" should not exist
+    And as "Brian" file "/reference/reference-file.txt" should not exist
+
+  Scenario: create local storage that matches an existing shared folder, and the sharee has renamed the received folder
+    Given user "Alice" has created folder "reference"
+    And user "Alice" has uploaded file with content "this is a reference file" to "/reference/reference-file.txt"
+    And user "Alice" has shared folder "reference" with user "Brian"
+    And user "Alice" has created folder "other"
+    And user "Alice" has uploaded file with content "this is another file" to "/other/other-file.txt"
+    And user "Alice" has shared folder "other" with user "Brian"
+    And user "Brian" has moved folder "reference" to "reference1"
+    When the administrator creates the local storage mount "reference" using the occ command
+    And the administrator uploads file with content "this is a file in local storage" to "/reference/file-in-local-storage.txt" using the WebDAV API
+    Then the command should have been successful
+    And as "Alice" folder "/reference" should exist
+    And as "Brian" folder "/reference" should exist
+    And the content of file "/reference/file-in-local-storage.txt" for user "Alice" should be "this is a file in local storage"
+    And the content of file "/reference/file-in-local-storage.txt" for user "Brian" should be "this is a file in local storage"
+    And the content of file "/other/other-file.txt" for user "Alice" should be "this is another file"
+    And the content of file "/other/other-file.txt" for user "Brian" should be "this is another file"
+    # Brian receives "/reference" from Alice and has renamed it to "/reference1"
+    # it would be helpful if they could still see "/reference1" as well as the local storage called "/reference"
+    And as "Brian" file "/reference1/reference-file.txt" should not exist
+    #And as "Brian" file "/reference1/reference-file.txt" should exist
+    #And the content of file "/reference1/reference-file.txt" for user "Brian" should be "this is a reference file"

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
@@ -4,12 +4,11 @@ Feature: Scanning files on local storage
   I want to be able to control the scanning of local storage for changes
   So that I can manage the balance between performance and "up-to-date-ness" of local storage
 
+  @issue-33670 @skipOnOcV10
   Scenario: Adding a file to local storage and running scan should add files.
     Given user "Alice" has been created with default attributes and skeleton files
     And using new DAV path
     And the administrator has set the external storage "local_storage" to be never scanned automatically
-    # issue-33670: Need to re-scan. Config change doesn't come into effect until once scanned
-    And the administrator has scanned the filesystem for all users
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage using the testing API
     And user "Alice" requests "/remote.php/dav/files/%username%/local_storage" with "PROPFIND" using basic auth
     Then the propfind result of user "Alice" should not contain these entries:
@@ -22,6 +21,7 @@ Feature: Scanning files on local storage
     But the propfind result of user "Alice" should not contain these entries:
       | /local_storage/hello2.txt |
 
+  @issue-33670 @skipOnOcV10
   Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
     Given user "Alice" has been created with default attributes and skeleton files
     And using new DAV path
@@ -29,8 +29,6 @@ Feature: Scanning files on local storage
     And user "Alice" has created folder "/local_storage/folder1"
     And user "Alice" has created folder "/local_storage/folder2"
     And the administrator has set the external storage "local_storage" to be never scanned automatically
-    # issue-33670: Need to re-scan. Config change doesn't come into effect until once scanned
-    And the administrator has scanned the filesystem for all users
     When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
     And the administrator creates file "folder2/hello2.txt" with content "<? php :(" in local storage using the testing API
     And user "Alice" requests "/remote.php/dav/files/%username%/local_storage/folder1" with "PROPFIND" using basic auth

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorageOc10Issue33670.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorageOc10Issue33670.feature
@@ -1,0 +1,48 @@
+@cli @local_storage @issue-33670 @notToImplementOnOCIS
+Feature: Scanning files on local storage
+  As an admin
+  I want to be able to control the scanning of local storage for changes
+  So that I can manage the balance between performance and "up-to-date-ness" of local storage
+
+  Scenario: Adding a file to local storage and running scan should add files.
+    Given user "Alice" has been created with default attributes and skeleton files
+    And using new DAV path
+    And the administrator has set the external storage "local_storage" to be never scanned automatically
+    # Need to re-scan. Config change doesn't come into effect until once scanned
+    And the administrator has scanned the filesystem for all users
+    When the administrator creates file "hello1.txt" with content "<? php :)" in local storage using the testing API
+    And user "Alice" requests "/remote.php/dav/files/%username%/local_storage" with "PROPFIND" using basic auth
+    Then the propfind result of user "Alice" should not contain these entries:
+      | /local_storage/hello1.txt |
+    When the administrator scans the filesystem for all users using the occ command
+    And the administrator creates file "hello2.txt" with content "<? php :(" in local storage using the testing API
+    And user "Alice" requests "/remote.php/dav/files/%username%/local_storage" with "PROPFIND" using basic auth
+    Then the propfind result of user "Alice" should contain these entries:
+      | /local_storage/hello1.txt |
+    But the propfind result of user "Alice" should not contain these entries:
+      | /local_storage/hello2.txt |
+
+  Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
+    Given user "Alice" has been created with default attributes and skeleton files
+    And using new DAV path
+    And the administrator has set the external storage "local_storage" to be never scanned automatically
+    And user "Alice" has created folder "/local_storage/folder1"
+    And user "Alice" has created folder "/local_storage/folder2"
+    And the administrator has set the external storage "local_storage" to be never scanned automatically
+    # Need to re-scan. Config change doesn't come into effect until once scanned
+    And the administrator has scanned the filesystem for all users
+    When the administrator creates file "folder1/hello1.txt" with content "<? php :)" in local storage using the testing API
+    And the administrator creates file "folder2/hello2.txt" with content "<? php :(" in local storage using the testing API
+    And user "Alice" requests "/remote.php/dav/files/%username%/local_storage/folder1" with "PROPFIND" using basic auth
+    Then the propfind result of user "Alice" should not contain these entries:
+      | /local_storage/folder1/hello1.txt |
+    When user "Alice" requests "/remote.php/dav/files/%username%/local_storage/folder2" with "PROPFIND" using basic auth
+    Then the propfind result of user "Alice" should not contain these entries:
+      | /local_storage/folder2/hello2.txt |
+    When the administrator scans the filesystem in path "/%username%/files/local_storage/folder1" of user "Alice" using the occ command
+    And user "Alice" requests "/remote.php/dav/files/%username%/local_storage/folder1" with "PROPFIND" using basic auth
+    Then the propfind result of user "Alice" should contain these entries:
+      | /local_storage/folder1/hello1.txt |
+    When user "Alice" requests "/remote.php/dav/files/%username%/local_storage/folder2" with "PROPFIND" using basic auth
+    Then the propfind result of user "Alice" should not contain these entries:
+      | /local_storage/folder2/hello2.txt |

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -44,19 +44,15 @@ Feature: edit users
     And the user attributes returned by the API should include
       | displayname | brand-new-user |
 
-  @issue-23603
+  @issue-23603 @skipOnOcV10
   Scenario: the administrator can edit a user quota
     Given user "brand-new-user" has been created with default attributes and skeleton files
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the occ command
-    Then the command should have failed with exit code 1
-    #Then the command should have been successful
-    And the command output should contain the text 'Supported keys are email, displayname'
-    #And the command output should contain the text 'The quota of brand-new-user updated to 12 MB'
+    Then the command should have been successful
+    And the command output should contain the text 'The quota of brand-new-user updated to 12 MB'
     And user "brand-new-user" should exist
     And the user attributes returned by the API should include
-      | quota definition | default |
-    #And the user attributes returned by the API should include
-    #  | quota definition | 12 MB |
+      | quota definition | 12 MB |
 
   Scenario Outline: Admin resets user password with special characters
     Given user "brand-new-user" has been deleted

--- a/tests/acceptance/features/cliProvisioning/editUserOc10Issue23603.feature
+++ b/tests/acceptance/features/cliProvisioning/editUserOc10Issue23603.feature
@@ -1,0 +1,19 @@
+@cli @skipOnLDAP @notToImplementOnOCIS
+Feature: edit users
+  As an admin
+  I want to be able to edit user information
+  So that I can keep the user information up-to-date
+
+  @issue-23603
+  Scenario: the administrator can edit a user quota
+    Given user "brand-new-user" has been created with default attributes and skeleton files
+    When the administrator changes the quota of user "brand-new-user" to "12MB" using the occ command
+    Then the command should have failed with exit code 1
+    #Then the command should have been successful
+    And the command output should contain the text 'Supported keys are email, displayname'
+    #And the command output should contain the text 'The quota of brand-new-user updated to 12 MB'
+    And user "brand-new-user" should exist
+    And the user attributes returned by the API should include
+      | quota definition | default |
+    #And the user attributes returned by the API should include
+    #  | quota definition | 12 MB |

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -39,7 +39,7 @@ Feature: get group
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Group nonexistentgroup does not exist'
 
-  @skipOnLDAP @issue-499
+  @skipOnLDAP @issue-user_ldap-499
   Scenario Outline: admin tries to get users in a group but using wrong case of the group name
     Given group "<group_id1>" has been created
     When the administrator gets the users in group "<group_id2>" in JSON format using the occ command

--- a/tests/acceptance/features/cliProvisioning/getUserGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getUserGroups.feature
@@ -4,7 +4,7 @@ Feature: get user groups
   I want to be able to get group membership information
   So that I can manage group membership
 
-  @issue-ldap-500
+  @issue-user_ldap-500
   Scenario: admin gets groups of an user
     Given user "brand-new-user" has been created with default attributes and skeleton files
     And group "unused-group" has been created

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -27,20 +27,13 @@ Feature: reset user password
       Use the following link to reset your password: <a href=
       """
 
-  @skipOnEncryption @issue-36985
+  @skipOnOcV10 @skipOnEncryption @issue-36985
   Scenario: user should get email when the administrator changes their password and specifies to also send email
     Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
-    Then the command should have been successful
-    And the command output should contain the text "Successfully reset password for %username%" about user "brand-new-user"
-    And the email address "brand.new.user@oc.com.np" should have received an email with the body containing
-      """
-      Password changed successfully
-      """
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
+    Then the command should have failed with exit code 1
 
   Scenario: administrator gets error message while trying to reset user password with send email when the email address of the user is not setup
     Given these users have been created with skeleton files:

--- a/tests/acceptance/features/cliProvisioning/resetUserPasswordOc10Issue36985.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPasswordOc10Issue36985.feature
@@ -1,0 +1,13 @@
+@cli @mailhog @skipOnLDAP @notToImplementOnOCIS
+Feature: reset user password
+  As an admin
+  I want to be able to reset a user's password
+  So that I can secure individual access to resources on the ownCloud server
+
+  @issue-36985
+  Scenario: user should get email when the administrator changes their password and specifies to also send email
+    Given these users have been created with skeleton files:
+      | username       | password  | displayname | email                    |
+      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
+    When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
+    Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliProvisioning/resetUserPasswordOc10Issue36985.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPasswordOc10Issue36985.feature
@@ -4,10 +4,17 @@ Feature: reset user password
   I want to be able to reset a user's password
   So that I can secure individual access to resources on the ownCloud server
 
-  @issue-36985
+  @skipOnEncryption @issue-36985
   Scenario: user should get email when the administrator changes their password and specifies to also send email
     Given these users have been created with skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
-    Then the command should have failed with exit code 1
+    Then the command should have been successful
+    And the command output should contain the text "Successfully reset password for %username%" about user "brand-new-user"
+    And the email address "brand.new.user@oc.com.np" should have received an email with the body containing
+      """
+      Password changed successfully
+      """
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"


### PR DESCRIPTION
## Description
Refactored some CLI test scenarios demonstrating the actual behaviors.

Scenarios demonstrating bugs in Oc10 are now in new feature files and tagged notToImplementOnOCIS because they only demonstrate an oC10 bug that needs to be fixed. These feature files have been named with respect to the issue that each one demonstrates.

The main scenarios now demonstrate the expected behavior, which we want to happen on both Oc10 and OCIS. They are tagged skipOnOcV10 for now, because they would currently fail on Oc10.

## Related Issue
- Part of #37891

## How Has This Been Tested?
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
