### PR TITLE
[tests-only] test favorites related scenarios when shares are recieved in subfolder

### DIFF
--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -176,7 +176,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required
+  @files_sharing-app-required @notToImplementOnOCIS
   Scenario Outline: sharer file favorite state should not change the favorite state of sharee
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -190,7 +190,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required
+  @files_sharing-app-required @notToImplementOnOCIS
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -212,6 +212,43 @@ Feature: favorite
     And user "Alice" should have favorited the following elements
       | /PARENT            |
       | /PARENT/parent.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @files_sharing-app-required @notToImplementOnOCIS
+  Scenario Outline: favorite a file inside of a received share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "/PARENT" with user "Brian"
+    When user "Brian" favorites element "/PARENT/parent.txt" using the WebDAV API
+    Then as user "Brian" file "/PARENT/parent.txt" should be favorited
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @files_sharing-app-required @notToImplementOnOCIS
+  Scenario Outline: favorite a folder inside of a received share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT/sub-folder"
+    And user "Alice" has shared folder "/PARENT" with user "Brian"
+    When user "Brian" favorites element "/PARENT/sub-folder" using the WebDAV API
+    Then as user "Brian" folder "/PARENT/sub-folder" should be favorited
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @files_sharing-app-required @notToImplementOnOCIS
+  Scenario Outline: favorite a received share itself
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "/PARENT" with user "Brian"
+    When user "Brian" favorites element "/PARENT" using the WebDAV API
+    Then as user "Brian" folder "/PARENT" should be favorited
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature
+++ b/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature
@@ -1,0 +1,78 @@
+@api @files_sharing-app-required
+Feature: favorite
+
+  Background:
+    Given the administrator has enabled DAV tech_preview
+    And the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+
+
+  Scenario Outline: favorite a file inside of a received share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "/PARENT" with user "Brian"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" favorites element "/Shares/PARENT/parent.txt" using the WebDAV API
+    Then as user "Brian" file "/Shares/PARENT/parent.txt" should be favorited
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: favorite a folder inside of a received share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT/sub-folder"
+    And user "Alice" has shared folder "/PARENT" with user "Brian"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" favorites element "/Shares/PARENT/sub-folder" using the WebDAV API
+    Then as user "Brian" folder "/Shares/PARENT/sub-folder" should be favorited
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: favorite a received share itself
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "/PARENT" with user "Brian"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" favorites element "/Shares/PARENT" using the WebDAV API
+    Then as user "Brian" folder "/Shares/PARENT" should be favorited
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: moving a favorite file out of a share keeps favorite state
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared folder "/PARENT" with user "Brian"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    And user "Brian" has favorited element "/Shares/PARENT/parent.txt"
+    When user "Brian" moves file "/Shares/PARENT/parent.txt" to "/taken_out.txt" using the WebDAV API
+    Then as user "Brian" file "/taken_out.txt" should be favorited
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @issue-38027 @skipOnOcV10
+  Scenario Outline: sharee file favorite state should not change the favorite state of sharer
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "/PARENT/parent.txt" with user "Brian"
+    And user "Brian" has accepted share "/parent.txt" offered by user "Alice"
+    When user "Brian" favorites element "/Shares/parent.txt" using the WebDAV API
+    Then the HTTP status code should be "207"
+    And as user "Alice" file "/PARENT/parent.txt" should not be favorited
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |


### PR DESCRIPTION
## Description
make sharing related tests be valid also for OCIS

I haven't taken out the existing tests to reduce work that need to be done in the expected failures lists

## Related Issue
part of owncloud/ocis#518
part of #38006

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
