### PR TITLE
[tests-only] regression tests for ocis/issues/720

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -182,3 +182,18 @@ Feature: sharing
       | /shared/shared_file.txt | 2               | 404              | /Shares/shared_file.txt |
       | /shared                 | 1               | 200              | /Shares/shared          |
       | /shared                 | 2               | 404              | /Shares/shared          |
+
+  @issue-ocis-720
+  Scenario Outline: delete a share
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Alice" deletes the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    When user "Brian" requests "/remote.php/dav/files/Brian" with "PROPFIND" using basic auth
+    Then the HTTP status code should be "207"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |


### PR DESCRIPTION
## Description
Test to make sure owncloud/ocis/issues/720 is really fixed and does not come back
please note: test added in https://github.com/owncloud/ocis/pull/722 still return `500` but there seems to be a different bug, I will open a new issue and update the corresponding file

## Related Issue
https://github.com/owncloud/ocis/issues/720

## Motivation and Context
avoid regressions

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
