### PR TITLE
Properly handle StorageNotAvailableException in share external

### DIFF
--- a/apps/files/js/files.js
+++ b/apps/files/js/files.js
@@ -29,6 +29,11 @@
 				state.dir = null;
 				state.call = null;
 				Files.updateMaxUploadFilesize(response);
+			}).fail(function() {
+				OC.Notification.show(
+					t('files', 'Encountered problem accessing the folder {name}', {name: currentDir}),
+					{type : 'error'}
+				);
 			});
 		},
 		/**

--- a/apps/files_sharing/lib/External/Watcher.php
+++ b/apps/files_sharing/lib/External/Watcher.php
@@ -21,6 +21,8 @@
 
 namespace OCA\Files_Sharing\External;
 
+use OCP\Files\StorageNotAvailableException;
+
 class Watcher extends \OC\Files\Cache\Watcher {
 	/**
 	 * remove deleted files in $path from the cache
@@ -29,5 +31,13 @@ class Watcher extends \OC\Files\Cache\Watcher {
 	 */
 	public function cleanFolder($path) {
 		// not needed, the scanner takes care of this
+	}
+
+	public function needsUpdate($path, $cachedData) {
+		try {
+			return parent::needsUpdate($path, $cachedData);
+		} catch (StorageNotAvailableException $e) {
+			return false;
+		}
 	}
 }

--- a/changelog/unreleased/38042
+++ b/changelog/unreleased/38042
@@ -1,6 +1,6 @@
 Bugfix: Properly handle StorageNotAvailableException in share external
 
-Users with Federates Shares of which storage was unavailable, were encountering
+Users with Federated Shares of which storage was unavailable, were encountering
 issues when working with the shares (e.g. unsharing or listing). It was caused by
 unhandled exception.
 

--- a/changelog/unreleased/38042
+++ b/changelog/unreleased/38042
@@ -1,0 +1,10 @@
+Bugfix: Properly handle StorageNotAvailableException in share external
+
+Users with Federates Shares of which storage was unavailable, were encountering
+issues when working with the shares (e.g. unsharing or listing). It was caused by
+unhandled exception.
+
+https://github.com/owncloud/core/pull/38042
+https://github.com/owncloud/enterprise/issues/4217
+https://github.com/owncloud/enterprise/issues/4117
+https://github.com/owncloud/enterprise/issues/2721


### PR DESCRIPTION
This fixes following problems when federates share storage is unavailable:
- now we can see the share in "Shared with me" 
- list the files structure that has been available before storage got unavailable. 
- unshare the share
- check share info

Additionaly, warning is properly displayed

<img width="1134" alt="Zrzut ekranu 2020-10-27 o 21 25 49" src="https://user-images.githubusercontent.com/13368647/97358514-a3adb580-189b-11eb-9026-e9cd1d40beb0.png">

<img width="723" alt="Zrzut ekranu 2020-10-27 o 21 25 19" src="https://user-images.githubusercontent.com/13368647/97358522-a6a8a600-189b-11eb-81a1-3bb8387f5651.png">
