### PR TITLE
[tests-only] let more sharing tests run on ocis

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -455,6 +455,8 @@ default:
         - ChecksumContext:
         - FilesVersionsContext:
         - WebDavPropertiesContext:
+        - OccContext:
+        - AppConfigurationContext:
 
     apiWebdavLocks:
       paths:

--- a/tests/acceptance/features/apiShareOperationsToRoot/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/uploadToShare.feature
@@ -13,6 +13,7 @@ Feature: sharing
       | shareWith   | Brian  |
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
+    And as "Alice" file "/FOLDER/textfile.txt" should not exist
 
   Scenario Outline: Uploading file to a group read-only share folder does not work
     Given using <dav-path> DAV path
@@ -26,6 +27,7 @@ Feature: sharing
       | shareWith   | grp1   |
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
+    And as "Alice" file "/FOLDER/textfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -43,6 +45,12 @@ Feature: sharing
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -62,6 +70,12 @@ Feature: sharing
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -78,6 +92,12 @@ Feature: sharing
       | shareWith   | Brian  |
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -95,6 +115,12 @@ Feature: sharing
       | shareWith   | grp1   |
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -111,6 +137,12 @@ Feature: sharing
     Then the HTTP status code should be "204"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "/myfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -127,6 +159,7 @@ Feature: sharing
     And the quota of user "Alice" has been set to "0"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -145,6 +178,7 @@ Feature: sharing
     And the quota of user "Alice" has been set to "0"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -161,6 +195,7 @@ Feature: sharing
     And the quota of user "Alice" has been set to "0"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -179,6 +214,7 @@ Feature: sharing
     And the quota of user "Alice" has been set to "0"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -198,3 +234,4 @@ Feature: sharing
       | 1      | hallo   |
       | 2      | welt    |
     Then the HTTP status code should be "403"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist

--- a/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-14 @issue-ocis-reva-243
 Feature: sharing
 
   Background:
@@ -59,6 +59,7 @@ Feature: sharing
       | old              |
       | new              |
 
+
   Scenario: Move files between shares by same user
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "share1"
@@ -74,6 +75,7 @@ Feature: sharing
     And as "Alice" file "share1/welcome.txt" should not exist
     But as "Alice" file "share2/welcome.txt" should exist
 
+
   Scenario: Move files between shares by same user added by sharee
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "share1"
@@ -88,6 +90,7 @@ Feature: sharing
     When user "Brian" moves file "/Shares/share1/welcome.txt" to "/Shares/share2/welcome.txt" using the WebDAV API
     Then as "Brian" file "/Shares/share2/welcome.txt" should exist
     And as "Alice" file "share2/welcome.txt" should exist
+
 
   Scenario: Move files between shares by different users
     Given the administrator has enabled DAV tech_preview

--- a/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature
@@ -1,10 +1,11 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: sharing
 
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and skeleton files
+
 
   Scenario: Uploading file to a user read-only share folder does not work
     Given user "Brian" has been created with default attributes and skeleton files
@@ -16,6 +17,7 @@ Feature: sharing
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
+
 
   Scenario Outline: Uploading file to a group read-only share folder does not work
     Given using <dav-path> DAV path
@@ -35,6 +37,7 @@ Feature: sharing
       | old      |
       | new      |
 
+
   Scenario Outline: Uploading file to a user upload-only share folder works
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -52,6 +55,7 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
+
 
   Scenario Outline: Uploading file to a group upload-only share folder works
     Given using <dav-path> DAV path
@@ -90,6 +94,7 @@ Feature: sharing
       | old      |
       | new      |
 
+
   Scenario Outline: Uploading file to a group read/write share folder works
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -125,6 +130,7 @@ Feature: sharing
       | old      |
       | new      |
 
+
   Scenario Outline: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -141,6 +147,7 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
+
 
   Scenario Outline: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
@@ -161,6 +168,7 @@ Feature: sharing
       | old      |
       | new      |
 
+
   Scenario Outline: Uploading to a user shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
@@ -177,6 +185,7 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
+
 
   Scenario Outline: Uploading to a group shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
@@ -196,6 +205,7 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
+
 
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path

--- a/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature
@@ -17,6 +17,7 @@ Feature: sharing
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
+    And as "Alice" file "/FOLDER/textfile.txt" should not exist
 
 
   Scenario Outline: Uploading file to a group read-only share folder does not work
@@ -32,6 +33,7 @@ Feature: sharing
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
+    And as "Alice" file "/FOLDER/textfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -51,6 +53,12 @@ Feature: sharing
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -72,6 +80,12 @@ Feature: sharing
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -89,6 +103,12 @@ Feature: sharing
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -108,6 +128,12 @@ Feature: sharing
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -125,6 +151,12 @@ Feature: sharing
     Then the HTTP status code should be "204"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "/myfile.txt" for user "Alice" should be:
+    """
+    This is a testfile.
+
+    Cheers.
+    """
     Examples:
       | dav-path |
       | old      |
@@ -143,6 +175,7 @@ Feature: sharing
     And the quota of user "Alice" has been set to "0"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -163,6 +196,7 @@ Feature: sharing
     And the quota of user "Alice" has been set to "0"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -181,6 +215,7 @@ Feature: sharing
     And the quota of user "Alice" has been set to "0"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -201,6 +236,7 @@ Feature: sharing
     And the quota of user "Alice" has been set to "0"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
       | dav-path |
       | old      |
@@ -222,3 +258,4 @@ Feature: sharing
       | 1      | hallo   |
       | 2      | welt    |
     Then the HTTP status code should be "403"
+    And as "Alice" file "/FOLDER/myfile.txt" should not exist


### PR DESCRIPTION
## Description
remove the `toImplementOnOCIS` tag, to make the tests run in ocis & reva, actually some of them do pass

## How Has This Been Tested?
:robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
