### PR TITLE
[tests-only] Skip new share filter API tests on old oC10

### DIFF
--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesReceivedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingSharesSharedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesPendingFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesPendingFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
 Feature: get the pending shares filtered by type (user, group etc)
   As a user
   I want to be able to know the pending shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesReceivedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)


### PR DESCRIPTION
## Description
PR #38000 added a new API feature - the list of shares can be filtered by share type. The new API acceptance tests for that are not relevant and will not pass on old oC10 versions - skip them.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
