### PR TITLE
[tests-only] Improve skeleton upload error message

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -149,24 +149,30 @@ class OcisHelper {
 		$dir = \opendir($source);
 		while (($file = \readdir($dir)) !== false) {
 			if (($file != '.') && ($file != '..')) {
-				if (\is_dir($source . '/' . $file)) {
+				$sourcePath = $source . '/' . $file;
+				$destinationPath = $destination . '/' . $file;
+				if (\is_dir($sourcePath)) {
 					self::recurseUpload(
 						$baseUrl,
-						$source . '/' . $file,
+						$sourcePath,
 						$userId,
 						$password,
-						$destination . '/' . $file
+						$destinationPath
 					);
 				} else {
 					$response = UploadHelper::upload(
 						$baseUrl,
 						$userId,
 						$password,
-						$source . '/' . $file,
-						$destination . '/' . $file
+						$sourcePath,
+						$destinationPath
 					);
-					if ($response->getStatusCode() !== 201) {
-						throw new \Exception("Could not upload skeleton file" . $response->getBody()->getContents());
+					$responseStatus = $response->getStatusCode();
+					if ($responseStatus !== 201) {
+						throw new \Exception(
+							"Could not upload skeleton file $sourcePath to $destinationPath for user '$userId' status '$responseStatus' response body: '"
+							. $response->getBody()->getContents() . "'"
+						);
 					}
 				}
 			}

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2624,9 +2624,15 @@ trait Sharing {
 	 */
 	public function userHasReactedToShareOfferedBy($user, $action, $share, $offeredBy) {
 		$this->userReactsToShareOfferedBy($user, $action, $share, $offeredBy);
+		if ($action === 'declined') {
+			$actionText = 'decline';
+		}
+		if ($action === 'accepted') {
+			$actionText = 'accept';
+		}
 		$this->theHTTPStatusCodeShouldBe(
 			200,
-			__METHOD__ . " could not $action share to $user by $offeredBy"
+			__METHOD__ . " could not $actionText share $share to $user by $offeredBy"
 		);
 	}
 


### PR DESCRIPTION
## Description
1) When a test run uses the "upload" method to create skeleton files for a user and something goes wrong, all we get is a message:
https://drone.owncloud.com/owncloud/ocis/1076/21/7
```
  Background:                                                                          # /srv/app/testrunner/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature:7
    Given the administrator has set the default folder for received shares to "Shares" # OccContext::theAdministratorHasSetTheDefaultFolderForReceivedSharesTo()
    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"      # AppConfigurationContext::serverParameterHasBeenSetTo()
    And using OCS API version "1"                                                      # FeatureContext::usingOcsApiVersion()
    And using new DAV path                                                             # FeatureContext::usingOldOrNewDavPath()
    And these users have been created with default attributes and skeleton files:      # FeatureContext::theseUsersHaveBeenCreated()
      | username |
      | Alice    |
      | Brian    |
      Could not upload skeleton file (Exception)
```

"Could not upload skeleton file" is not so helpful. We do not even know which user it was.

Add information about the user, file, status to the exception message.

2) When a share could not be accepted, we get a message like `Sharing::userHasReactedToShareOfferedBy could not accepted share to Brian by Alice`

Fix it so it says "could not accept". Add the path of the share to the message, so it will be obvious exactly which share could not be accepted.

These were noticed while investigated test fails on OCIS.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
