### PR TITLE
Refactor getSharesInDir method and allow new interaction in params

### DIFF
--- a/changelog/unreleased/38053
+++ b/changelog/unreleased/38053
@@ -1,0 +1,10 @@
+Enhancement: getShare API request's "subfiles" parameter allows new interactions
+
+Previously, the "subfiles" parameter required only the "path" parameter, and
+the rest of the parameters were ignored.
+
+Now, the "subfiles" parameter still requires the "path" parameter, but it also
+interacts with the "reshares" parameter as well as the "share_types" parameter
+to provide additional filtering capabilities
+
+https://github.com/owncloud/core/pull/38053


### PR DESCRIPTION
"subfiles" param in the getShares request can interact with "reshares"
and the new "share_types" params. The "path" param is still required if
"subfiles" is present.
There are no changes regarding the "shared_with_me" param

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The "subfiles" parameter in the getShares request had some additional restrictions which weren't documented. This PR remove those restrictions and allows interaction with the rest of the parameters (except the "share_with_me", which remain the same

## Related Issue
No opened issue.
Follow up of https://github.com/owncloud/core/pull/38000

## Motivation and Context
there is no reason to limit the interaction of the "reshares" and "share_types" parameters with the "subfiles" one.

## How Has This Been Tested?
Checked manually via API

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
