### PR TITLE
avoid retrieving user root iteratively in share controller

### DIFF
--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -308,7 +308,7 @@ class Share20OcsControllerTest extends TestCase {
 	}
 	*/
 
-	public function createShare($id, $shareType, $sharedWith, $sharedBy, $shareOwner, $path, $permissions,
+	public function createShare($id, $shareType, $sharedWith, $sharedBy, $shareOwner, $file, $permissions,
 								$shareTime, $expiration, $parent, $target, $mail_send, $token=null,
 								$password=null, $name=null, $attributes=null) {
 		$share = $this->createMock(IShare::class);
@@ -317,7 +317,8 @@ class Share20OcsControllerTest extends TestCase {
 		$share->method('getSharedWith')->willReturn($sharedWith);
 		$share->method('getSharedBy')->willReturn($sharedBy);
 		$share->method('getShareOwner')->willReturn($shareOwner);
-		$share->method('getNode')->willReturn($path);
+		$share->method('getNode')->willReturn($file);
+		$share->method('getNodeType')->willReturn($file instanceof Folder ? 'folder' : 'file');
 		$share->method('getPermissions')->willReturn($permissions);
 		$share->method('getAttributes')->willReturn($attributes);
 		$time = new \DateTime();

--- a/changelog/unreleased/38055
+++ b/changelog/unreleased/38055
@@ -1,0 +1,8 @@
+Bugfix: Avoid retrieving user root iteratively in share controller
+
+There was a performance problem that with many shares, the "share tab" was slow
+to display entries. Now the performance of displaying that tab should be better
+as we avoid retrieving the same information for all the shares
+
+https://github.com/owncloud/enterprise/issues/4107
+https://github.com/owncloud/core/pull/38055


### PR DESCRIPTION
Fixes performance problem caused by code that was not refactored for long time.

Prerequisite:
- Create 100 user shares from test1 to test2 root folder
- Listing folders mounted for user test2-> 2s (complexity O(m), m->complexity of propfind, m is small overhead)

Attempt to reduce complexity but reusing available properties from "propfind kind of operation":

- Opening shared with you panel before fix -> 15s complexity O(m+n), n>>m -> O(n)
- Opening shared with you panel after attempt to fix, but due to need to return properties of mount like storage, storage_id it is not possible -> 2s complexity O(m)
- Opening shared with you panel after a fix that just reduced impact of n -> 7s complexity O(m+n), n>m -> O(n)

Finally, I settled on being required on reducing to 7s from 15s, but still not perfect as we need to respond with many mount properties for /shares  .. paging would solve the problem best.

<img width="526" alt="Zrzut ekranu 2020-10-29 o 21 41 11" src="https://user-images.githubusercontent.com/13368647/97630429-e0aab100-1a2f-11eb-97a7-584066a7e921.png">
