### PR TITLE
[tests-only] split public link tests into separate files for new/old dav

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -25,6 +25,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 404              |
 
+
   Scenario Outline: creating a public link from a share with share+read only permissions is allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -36,16 +37,14 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
-    And the downloaded content should be "some content"
     And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API
     And the downloaded content should be "some content"
-    But uploading a file should not work using the old public WebDAV API
-    And uploading a file should not work using the new public WebDAV API
+    But uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
 
   Scenario Outline: creating an upload public link from a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
@@ -78,6 +77,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 404              |
 
+
   Scenario Outline: creating a public link from a share with share+read+write permissions is allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -89,16 +89,14 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
-    And the downloaded content should be "some content"
     And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API
     And the downloaded content should be "some content"
-    But uploading a file should not work using the old public WebDAV API
-    And uploading a file should not work using the new public WebDAV API
+    But uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
 
   Scenario Outline: creating an upload public link from a share with share+read+write permissions is allowed
     Given using OCS API version "<ocs_api_version>"
@@ -112,16 +110,14 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
-    And the downloaded content should be "some content"
     And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API
     And the downloaded content should be "some content"
-    And uploading a file should work using the old public WebDAV API
     And uploading a file should work using the new public WebDAV API
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
 
   Scenario Outline: creating an upload public link from a sub-folder of a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
@@ -140,6 +136,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 404              |
 
+
   Scenario Outline: increasing permissions of a public link of a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -154,12 +151,12 @@ Feature: reshare as public link
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the old public WebDAV API
     And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
+
 
   Scenario Outline: increasing permissions of a public link from a sub-folder of a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
@@ -171,13 +168,11 @@ Feature: reshare as public link
       | path         | /Shares/test/sub |
       | permissions  | read             |
       | publicUpload | false            |
-    And uploading a file should not work using the old public WebDAV API
     And uploading a file should not work using the new public WebDAV API
     When user "Brian" updates the last share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the old public WebDAV API
     And uploading a file should not work using the new public WebDAV API
     Examples:
       | ocs_api_version | http_status_code |

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
@@ -1,0 +1,115 @@
+@api @files_sharing-app-required @public_link_share-feature-required
+Feature: reshare as public link
+  As a user
+  I want to create public link shares from files/folders shared with me
+  So that I can give controlled access to others
+
+  Background:
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+
+
+  Scenario Outline: creating a public link from a share with share+read only permissions is allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/test"
+    And user "Alice" has uploaded file with content "some content" to "/test/file.txt"
+    And user "Alice" has shared folder "/test" with user "Brian" with permissions "share,read"
+    And user "Brian" has accepted share "/test" offered by user "Alice"
+    When user "Brian" creates a public link share using the sharing API with settings
+      | path         | /Shares/test |
+      | publicUpload | false        |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
+    And the downloaded content should be "some content"
+    But uploading a file should not work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+
+  Scenario Outline: creating a public link from a share with share+read+write permissions is allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/test"
+    And user "Alice" has uploaded file with content "some content" to "/test/file.txt"
+    And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
+    And user "Brian" has accepted share "/test" offered by user "Alice"
+    When user "Brian" creates a public link share using the sharing API with settings
+      | path         | /Shares/test |
+      | publicUpload | false        |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
+    And the downloaded content should be "some content"
+    But uploading a file should not work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+
+  Scenario Outline: creating an upload public link from a share with share+read+write permissions is allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/test"
+    And user "Alice" has uploaded file with content "some content" to "/test/file.txt"
+    And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
+    And user "Brian" has accepted share "/test" offered by user "Alice"
+    When user "Brian" creates a public link share using the sharing API with settings
+      | path         | /Shares/test              |
+      | permissions  | read,update,create,delete |
+      | publicUpload | true                      |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
+    And the downloaded content should be "some content"
+    And uploading a file should work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+
+  Scenario Outline: increasing permissions of a public link of a share with share+read only permissions is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/test"
+    And user "Alice" has created folder "/test/sub"
+    And user "Alice" has shared folder "/test" with user "Brian" with permissions "share,read"
+    And user "Brian" has accepted share "/test" offered by user "Alice"
+    And user "Brian" has created a public link share with settings
+      | path         | /Shares/test |
+      | permissions  | read         |
+      | publicUpload | false        |
+    When user "Brian" updates the last share using the sharing API with
+      | permissions | read,update,create,delete |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And uploading a file should not work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+
+  Scenario Outline: increasing permissions of a public link from a sub-folder of a share with share+read only permissions is not allowed
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/test"
+    And user "Alice" has created folder "/test/sub"
+    And user "Alice" has shared folder "/test" with user "Brian" with permissions "share,read"
+    And user "Brian" has accepted share "/test" offered by user "Alice"
+    And user "Brian" has created a public link share with settings
+      | path         | /Shares/test/sub |
+      | permissions  | read             |
+      | publicUpload | false            |
+    And uploading a file should not work using the old public WebDAV API
+    When user "Brian" updates the last share using the sharing API with
+      | permissions | read,update,create,delete |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    And uploading a file should not work using the old public WebDAV API
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |


### PR DESCRIPTION
## Description
splitting of parts of the tests that check the old public link webdav API into seperate scenarios

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes owncloud/ocis-reva/issues/282 (that should be the last places)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
