### PR TITLE
[Tests-Only] delete users using provisioning api

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -78,18 +78,16 @@ class OcisHelper {
 	 *
 	 * @return void
 	 */
-	public static function deleteRevaUserData($user = "") {
+	public static function deleteRevaUserData($baseUrl, $adminName, $adminPass, $user = "") {
 		$deleteCmd = self::getDeleteUserDataCommand();
-		if ($deleteCmd === false) {
-			self::recurseRmdir(self::getOcisRevaDataRoot() . $user);
+		if ($deleteCmd === false || self::getStorageDriver() === "OCIS" || self::getStorageDriver() === "OWNCLOUD") {
+			HttpRequestHelper::delete($baseUrl . "/ocs/v2.php/cloud/users/" . $user, $adminName, $adminPass);
 			return;
 		}
 		if (self::getStorageDriver() === "EOS") {
 			$deleteCmd = \str_replace(
 				"%s", $user[0] . '/' . $user, $deleteCmd
 			);
-		} else {
-			$deleteCmd = \sprintf($deleteCmd, $user);
 		}
 		\exec($deleteCmd);
 	}

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -4362,7 +4362,7 @@ trait Provisioning {
 		if (OcisHelper::isTestingOnOcis() && $this->someUsersHaveBeenCreated()) {
 			foreach ($this->getCreatedUsers() as $user) {
 				$this->deleteAllSharesForUser($user["actualUsername"]);
-				OcisHelper::deleteRevaUserData($user["actualUsername"]);
+				OcisHelper::deleteRevaUserData($this->baseUrl, $this->adminUsername, $this->adminPassword, $user["actualUsername"]);
 			}
 		} elseif (!OcisHelper::isTestingOnOcis()) {
 			$this->resetAdminUserAttributes();


### PR DESCRIPTION
Implemented a (probably dirty) way to delete the users after a scenario has run. IMO that is required to make the tests in https://github.com/owncloud/ocis/pull/755 pass cause I haven't found any place were the provisioning api was used to delete the user.