### PR TITLE
Add Oracle to web wizard

### DIFF
--- a/changelog/unreleased/38062
+++ b/changelog/unreleased/38062
@@ -1,0 +1,7 @@
+Change: Add Oracle to web ui installation wizard
+
+Interactive web UI installation wizard now allows to setup Oracle as database
+backend
+
+https://github.com/owncloud/core/pull/38062
+https://github.com/owncloud/enterprise/issues/4018

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -150,7 +150,7 @@ class Setup {
 			$configuredDatabases = \array_keys($availableDatabases);
 		} else {
 			$configuredDatabases = $this->config->getSystemValue('supportedDatabases',
-				['sqlite', 'mysql', 'pgsql']);
+				['sqlite', 'mysql', 'pgsql', 'oci']);
 		}
 		if (!\is_array($configuredDatabases)) {
 			throw new Exception('Supported databases are not properly configured.');

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -46,6 +46,8 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
+			->with('supportedDatabases',
+				['sqlite', 'mysql', 'pgsql', 'oci'])
 			->will($this->returnValue(
 				['sqlite', 'mysql', 'oci']
 			));
@@ -73,6 +75,8 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
+			->with('supportedDatabases',
+				['sqlite', 'mysql', 'pgsql', 'oci'])
 			->will($this->returnValue(
 				['sqlite', 'mysql', 'oci', 'pgsql']
 			));
@@ -97,6 +101,8 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
+			->with('supportedDatabases',
+				['sqlite', 'mysql', 'pgsql', 'oci'])
 			->will($this->returnValue(
 				['sqlite', 'mysql', 'pgsql', 'oci']
 			));
@@ -131,6 +137,8 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
+			->with('supportedDatabases',
+				['sqlite', 'mysql', 'pgsql', 'oci'])
 			->will($this->returnValue('NotAnArray'));
 		$this->setupClass->getSupportedDatabases();
 	}


### PR DESCRIPTION
When adding Oracle to available dbs in owncloud, it was overlooked to add it also to web wizard (at least from what I inspected in Blame).

This PR adds support for Oracle in web wizard

Steps: 
- setup docker-compose for oracle, good example is https://github.com/owncloud/core/blob/master/.drone.star#L1687-L1696, but needs to be applied to docker-compose
- install Oracle driver on OC server, good example is https://github.com/owncloud-ci/php/tree/master/latest/overlay-amd64/etc/php/7.2
- check oracle installed (php -m | grep oci)
- install owncloud with oracle
<img width="1084" alt="Zrzut ekranu 2020-11-1 o 20 35 07" src="https://user-images.githubusercontent.com/13368647/97812602-9a995b80-1c82-11eb-823e-efa1fd6c101f.png">
<img width="692" alt="Zrzut ekranu 2020-11-1 o 20 35 35" src="https://user-images.githubusercontent.com/13368647/97812601-9a995b80-1c82-11eb-9d6e-ca48a6be04be.png">
<img width="812" alt="Zrzut ekranu 2020-11-1 o 20 35 54" src="https://user-images.githubusercontent.com/13368647/97812599-99682e80-1c82-11eb-87c2-31798e3b0f64.png">
