### PR TITLE
[tests-only] Use PHP 7.4 for behat acceptance test dependencies

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2026,7 +2026,21 @@ def vendorbinInstall(phpVersion):
 			'COMPOSER_HOME': '/drone/src/.cache/composer'
 		},
 		'commands': [
-			'make vendor-bin-deps'
+			'make vendor-bin-codestyle',
+			'make vendor-bin-codesniffer',
+			'make vendor-bin-phan',
+			'make vendor-bin-phpstan'
+		]
+	},
+	{
+		'name': 'vendorbin-behat',
+		'image': 'owncloudci/php:7.4',
+		'pull': 'always',
+		'environment': {
+			'COMPOSER_HOME': '/drone/src/.cache/composer'
+		},
+		'commands': [
+			'make vendor-bin-behat'
 		]
 	}]
 

--- a/.drone.star
+++ b/.drone.star
@@ -375,7 +375,11 @@ def dependencies(ctx):
 				'steps':
 					cacheRestore() +
 					composerInstall(phpVersion) +
-					vendorbinInstall(phpVersion) +
+					vendorbinCodestyle(phpVersion) +
+					vendorbinCodesniffer(phpVersion) +
+					vendorbinPhan(phpVersion) +
+					vendorbinPhpstan(phpVersion) +
+					vendorbinBehat() +
 					yarnInstall(phpVersion) +
 					cacheRebuildOnEventPush() +
 					cacheFlushOnEventPush(),
@@ -442,7 +446,8 @@ def codestyle():
 				'steps':
 					cacheRestore() +
 					composerInstall(phpVersion) +
-					vendorbinInstall(phpVersion) +
+					vendorbinCodestyle(phpVersion) +
+					vendorbinCodesniffer(phpVersion) +
 					yarnInstall(phpVersion) +
 					[
 						{
@@ -618,7 +623,7 @@ def phpstan():
 				'steps':
 					cacheRestore() +
 					composerInstall(phpVersion) +
-					vendorbinInstall(phpVersion) +
+					vendorbinPhpstan(phpVersion) +
 					yarnInstall(phpVersion) +
 					installServer(phpVersion, 'sqlite', params['logLevel']) +
 				[
@@ -692,7 +697,7 @@ def phan():
 				'steps':
 					cacheRestore() +
 					composerInstall(phpVersion) +
-					vendorbinInstall(phpVersion) +
+					vendorbinPhan(phpVersion) +
 					yarnInstall(phpVersion) +
 					installServer(phpVersion, 'sqlite', params['logLevel']) +
 				[
@@ -775,7 +780,6 @@ def litmus():
 				'steps':
 					cacheRestore() +
 					composerInstall(phpVersion) +
-					vendorbinInstall(phpVersion) +
 					yarnInstall(phpVersion) +
 					installServer(phpVersion, db, params['logLevel'], params['useHttps']) +
 					setupLocalStorage(phpVersion) +
@@ -943,7 +947,6 @@ def dav():
 					'steps':
 						cacheRestore() +
 						composerInstall(phpVersion) +
-						vendorbinInstall(phpVersion) +
 						yarnInstall(phpVersion) +
 						installServer(phpVersion, db, params['logLevel']) +
 						davInstall(phpVersion, scriptPath) +
@@ -1015,7 +1018,6 @@ def javascript(ctx):
 		'steps':
 			cacheRestore() +
 			composerInstall(params['phpVersion']) +
-			vendorbinInstall(params['phpVersion']) +
 			yarnInstall(params['phpVersion']) +
 		[
 			{
@@ -1190,7 +1192,6 @@ def phptests(ctx, testType):
 						'steps':
 							cacheRestore() +
 							composerInstall(phpVersion) +
-							vendorbinInstall(phpVersion) +
 							yarnInstall(phpVersion) +
 							installServer(phpVersion, db, params['logLevel']) +
 							installExtraApps(phpVersion, extraAppsDict) +
@@ -1475,7 +1476,7 @@ def acceptance(ctx):
 									'steps':
 										cacheRestore() +
 										composerInstall(phpVersion) +
-										vendorbinInstall(phpVersion) +
+										vendorbinBehat() +
 										yarnInstall(phpVersion) +
 										installServer(phpVersion, db, params['logLevel'], params['useHttps'], params['federatedServerNeeded'], params['proxyNeeded']) +
 										(
@@ -1544,7 +1545,6 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 		'steps':
 			cacheRestore() +
 			composerInstall(phpVersion) +
-			vendorbinInstall(phpVersion) +
 			yarnInstall(phpVersion) +
 			installServer(phpVersion, 'sqlite') +
 		[
@@ -2017,22 +2017,60 @@ def composerInstall(phpVersion):
 		]
 	}]
 
-def vendorbinInstall(phpVersion):
+def vendorbinCodestyle(phpVersion):
 	return [{
-		'name': 'vendorbin-install',
+		'name': 'vendorbin-codestyle',
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'environment': {
 			'COMPOSER_HOME': '/drone/src/.cache/composer'
 		},
 		'commands': [
-			'make vendor-bin-codestyle',
-			'make vendor-bin-codesniffer',
-			'make vendor-bin-phan',
+			'make vendor-bin-codestyle'
+		]
+	}]
+
+def vendorbinCodesniffer(phpVersion):
+	return [{
+		'name': 'vendorbin-codesniffer',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'environment': {
+			'COMPOSER_HOME': '/drone/src/.cache/composer'
+		},
+		'commands': [
+			'make vendor-bin-codesniffer'
+		]
+	}]
+
+def vendorbinPhan(phpVersion):
+	return [{
+		'name': 'vendorbin-phan',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'environment': {
+			'COMPOSER_HOME': '/drone/src/.cache/composer'
+		},
+		'commands': [
+			'make vendor-bin-phan'
+		]
+	}]
+
+def vendorbinPhpstan(phpVersion):
+	return [{
+		'name': 'vendorbin-phpstan',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'environment': {
+			'COMPOSER_HOME': '/drone/src/.cache/composer'
+		},
+		'commands': [
 			'make vendor-bin-phpstan'
 		]
-	},
-	{
+	}]
+
+def vendorbinBehat():
+	return [{
 		'name': 'vendorbin-behat',
 		'image': 'owncloudci/php:7.4',
 		'pull': 'always',

--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,21 @@ vendor/bamarni/composer-bin-plugin: composer.lock
 .PHONY: vendor-bin-deps
 vendor-bin-deps: vendor-bin/owncloud-codestyle/vendor vendor-bin/php_codesniffer/vendor vendor-bin/phan/vendor vendor-bin/phpstan/vendor vendor-bin/behat/vendor
 
+.PHONY: vendor-bin-codestyle
+vendor-bin-codestyle: vendor-bin/owncloud-codestyle/vendor
+
+.PHONY: vendor-bin-codesniffer
+vendor-bin-codesniffer: vendor-bin/php_codesniffer/vendor
+
+.PHONY: vendor-bin-phan
+vendor-bin-phan: vendor-bin/phan/vendor
+
+.PHONY: vendor-bin-phpstan
+vendor-bin-phpstan: vendor-bin/phpstan/vendor
+
+.PHONY: vendor-bin-behat
+vendor-bin-behat: vendor-bin/behat/vendor
+
 vendor-bin/owncloud-codestyle/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/owncloud-codestyle/composer.lock
 	composer bin owncloud-codestyle install --no-progress
 


### PR DESCRIPTION
## Description
See the issue for details of the problem. Summary:  with composer 2.0, behat gets errors when trying to load its dependencies with PHP 7.2 and 7.3. It works OK  with PHP  7.4

1) make separate make-file targets for each vendor-bin tool
2) just install the needed vendor-bin tool(s) for each pipeline - this reduces the amount of crud that keeps getting installed
3) lock behat to PHP 7.4 - that is fine because we are happy to run the behat testrunner only on PHP 7.4. There is no need to "test the test runner" on older  PHP versions

This works-around the problem. There is likely some dependency of behat that needs to have something sorted out for composer 2.0 and PHP 7.2/7.3. But actually we don't really care about that!

## Related Issue

Fixes #38067 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
