### PR TITLE
[Tests-Only] Adjust then steps for the unsuccessful sharing scenarios

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
@@ -315,6 +315,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "404"
     And the OCS status message should be "Cannot set expiration date more than 7 days in the future"
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     And user "Brian" should not have any received shares
     Examples:
       | ocs_api_version | http_status_code |
@@ -359,6 +360,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "404"
     And the OCS status message should be "Cannot set expiration date more than 30 days in the future"
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     And user "Brian" should not have any received shares
     Examples:
       | ocs_api_version | http_status_code |
@@ -441,6 +443,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "404"
     And the OCS status message should be "Cannot set expiration date more than 7 days in the future"
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     And user "Brian" should not have any received shares
     Examples:
       | ocs_api_version | http_status_code |
@@ -489,6 +492,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "404"
     And the OCS status message should be "Cannot set expiration date more than 30 days in the future"
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     And user "Brian" should not have any received shares
     Examples:
       | ocs_api_version | http_status_code |
@@ -592,6 +596,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "<ocs_status_code>"
     And the OCS status message should be "Invalid date, date format must be YYYY-MM-DD"
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     And user "Brian" should not have any received shares
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
@@ -673,6 +678,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "<ocs_status_code>"
     And the OCS status message should be "Expiration date is in the past"
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     And user "Brian" should not have any received shares
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | default | enforce |
@@ -698,6 +704,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "<ocs_status_code>"
     And the OCS status message should be "Invalid date, date format must be YYYY-MM-DD"
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     And user "Brian" should not have any received shares
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | default | enforce |
@@ -723,6 +730,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Then the HTTP status code should be "<http_status_code>"
     And the OCS status code should be "<ocs_status_code>"
     And the OCS status message should be "Expiration date is in the past"
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     And user "Brian" should not have any received shares
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -19,6 +19,7 @@ Feature: cannot share resources outside the group when share with membership gro
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" folder "/PARENT (2)" should not exist
     And as "Brian" folder "/Shares/PARENT" should not exist
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |
@@ -76,6 +77,7 @@ Feature: cannot share resources outside the group when share with membership gro
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" file "/textfile0 (2).txt" should not exist
     And as "Brian" file "/Shares/textfile0.txt" should not exist
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature
@@ -20,6 +20,7 @@ Feature: cannot share resources with invalid permissions
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" entry "<item>" should not exist
     And as "Brian" entry "/Shares/<item>" should not exist
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | item          | permissions |
       | 1               | 400             | 200              | textfile0.txt | 0           |
@@ -44,6 +45,7 @@ Feature: cannot share resources with invalid permissions
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" entry "textfile0.txt" should not exist
     And as "Brian" entry "/Shares/textfile0.txt" should not exist
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 400             | 200              |
@@ -62,6 +64,7 @@ Feature: cannot share resources with invalid permissions
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" entry "textfile0.txt" should not exist
     And as "Brian" entry "/Shares/textfile0.txt" should not exist
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | permissions   |
       | 1               | 400             | 200              | delete        |
@@ -84,6 +87,7 @@ Feature: cannot share resources with invalid permissions
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" entry "textfile0.txt" should not exist
     And as "Brian" entry "/Shares/textfile0.txt" should not exist
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 400             | 200              |
@@ -104,6 +108,7 @@ Feature: cannot share resources with invalid permissions
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" entry "textfile0.txt" should not exist
     And as "Brian" entry "/Shares/textfile0.txt" should not exist
+    And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code | permissions   |
       | 1               | 400             | 200              | delete        |

--- a/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
@@ -17,6 +17,7 @@ Feature: sharing
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Carol" file "/Shares/textfile0.txt" should not exist
+    And the sharing API should report to user "Carol" that no shares are in the pending state
     But as "Brian" file "/Shares/textfile0.txt" should exist
     Examples:
       | ocs_api_version | http_status_code |
@@ -31,6 +32,7 @@ Feature: sharing
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Carol" folder "/Shares/FOLDER" should not exist
+    And the sharing API should report to user "Carol" that no shares are in the pending state
     But as "Brian" folder "/Shares/FOLDER" should exist
     Examples:
       | ocs_api_version | http_status_code |
@@ -110,6 +112,7 @@ Feature: sharing
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Carol" file "/Shares/textfile0.txt" should not exist
+    And the sharing API should report to user "Carol" that no shares are in the pending state
     But as "Brian" file "/Shares/textfile0.txt" should exist
     Examples:
       | ocs_api_version | http_status_code | received_permissions | reshare_permissions |
@@ -178,6 +181,7 @@ Feature: sharing
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Carol" folder "/Shares/PARENT" should not exist
+    And the sharing API should report to user "Carol" that no shares are in the pending state
     But as "Brian" folder "/Shares/PARENT" should exist
     Examples:
       | ocs_api_version | http_status_code | received_permissions | reshare_permissions |
@@ -216,6 +220,7 @@ Feature: sharing
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Carol" folder "/Shares/PARENT" should not exist
+    And the sharing API should report to user "Carol" that no shares are in the pending state
     But as "Brian" folder "/Shares/PARENT" should exist
     Examples:
       | ocs_api_version | http_status_code | received_permissions | reshare_permissions |

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
@@ -18,6 +18,7 @@ Feature: resharing can be disabled
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Carol" file "/Shares/textfile0.txt" should not exist
+    And the sharing API should report to user "Carol" that no shares are in the pending state
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
@@ -39,6 +39,7 @@ Feature: a subfolder of a received share can be reshared
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Carol" folder "/Shares/SUB" should not exist
+    And the sharing API should report to user "Carol" that no shares are in the pending state
     And as "Brian" folder "/Shares/TMP/SUB" should exist
     Examples:
       | ocs_api_version | http_status_code | received_permissions | reshare_permissions |


### PR DESCRIPTION
## Description
The `Then` step checks for the unhappy-path sharing scenarios are improved such that no shares are found in the pending state even after the status code is checked.

## Related Issue
- https://github.com/owncloud/core/issues/37942

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
