### PR TITLE
[Tests-Only] Refactor GET request to a pending remote share 

### DIFF
--- a/tests/acceptance/features/apiFederationToRoot1/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federated.feature
@@ -132,9 +132,9 @@ Feature: federated
     Then the HTTP status code should be "405"
     And the body of the response should be empty
     Examples:
-      | ocs-api-version | ocs-status |
-      | 1               | 100        |
-      | 2               | 200        |
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
   Scenario Outline: sending a GET request to a not existing remote share
     Given using OCS API version "<ocs-api-version>"

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
@@ -60,10 +60,10 @@ Feature: sharing works when a username and group name are the same
       | username |
       | Brian    |
       | Carol    |
-    And group "Brian" has been created
-    And user "Carol" has been added to group "Brian"
+    And group "brian" has been created
+    And user "Carol" has been added to group "brian"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
-    And user "Alice" has shared file "randomfile.txt" with group "Brian"
+    And user "Alice" has shared file "randomfile.txt" with group "brian"
     And user "Carol" has accepted share "/randomfile.txt" offered by user "Alice"
     When user "Alice" shares file "randomfile.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "100"
@@ -84,12 +84,12 @@ Feature: sharing works when a username and group name are the same
       | username |
       | Brian    |
       | Carol    |
-    And group "Brian" has been created
-    And user "Carol" has been added to group "Brian"
+    And group "brian" has been created
+    And user "Carol" has been added to group "brian"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     And user "Alice" has shared file "randomfile.txt" with user "Brian"
     And user "Brian" has accepted share "/randomfile.txt" offered by user "Alice"
-    When user "Alice" shares file "randomfile.txt" with group "Brian" using the sharing API
+    When user "Alice" shares file "randomfile.txt" with group "brian" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     When user "Carol" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API


### PR DESCRIPTION
## Description
Scenario to "send GET request to a pending remote share" has `ocs-status` in the examples table which is not used. This PR removed `ocs-status` from example table.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/37978

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
