### PR TITLE
Use the right l10n object if the template is loaded from another app

### DIFF
--- a/changelog/unreleased/38072
+++ b/changelog/unreleased/38072
@@ -1,0 +1,15 @@
+Bugfix: Pick the translations from templates included from other apps
+
+Some apps can include template parts from a different app, normally from core.
+From example, the activity app can include content from the core templates to
+be used in the activity email.
+
+The translated strings were picked from the original app even though the
+template was within core space. As a result, some string weren't translated
+because of the missing translation for those strings in the original app.
+Note that core had the strings correctly translated.
+
+Now the translations are picked from the requested app template as intended,
+instead of looking for them in the original app.
+
+https://github.com/owncloud/core/pull/38072

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -207,7 +207,14 @@ class Base {
 	protected function load($file, $additionalParams = null) {
 		// This variables will be used inside templates, they are not unused!
 		$_ = $this->vars;
-		$l = $this->l10n;
+		if (isset($additionalParams['app'])) {
+			// in case a template wants to include content from another app (usually from core)
+			// we need to change the l10n object and adjust it to use the new app instead of
+			// the one currently set, so the translation are picked from the correct app.
+			$l = \OC::$server->getL10N($additionalParams['app'], $this->l10n->getLanguageCode());
+		} else {
+			$l = $this->l10n;
+		}
 		$theme = $this->themeDefaults;
 
 		if ($additionalParams !== null) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Some apps can include template parts from a different app, normally from core. From example, the activity app can include content from the core templates to be used in the activity email.
The translated strings where picked from the original app even though the template was loaded from core. As a result, some string weren't translated because the missing translation for those strings in the original app. Note that core had the string correctly translated.

## Related Issue
https://github.com/owncloud/enterprise/issues/4249

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested with a custom theme, which loads some core content in the activity app.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
