### PR TITLE
Override browser locales with OC locale in ajax requests

### DIFF
--- a/changelog/unreleased/38073
+++ b/changelog/unreleased/38073
@@ -1,0 +1,7 @@
+Bugfix: Override browser Accept-Language header in ajax requests
+
+A default Accept-Language header sent by browser in Ajax requests made 
+OCS API to respond in a wrong language sometimes. Now this header is set
+globally to match the current user language.
+
+https://github.com/owncloud/core/pull/38073

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1451,6 +1451,15 @@ function initCore() {
 	 */
 	moment.locale(OC.getLocale());
 
+	/*
+	 * Override browser locales with OC locale in ajax requests
+	 */
+	$.ajaxSetup({
+		beforeSend: function(xhr) {
+			xhr.setRequestHeader('Accept-Language', OC.getLocale());
+		}
+	});
+
 	var userAgent = window.navigator.userAgent;
 	var msie = userAgent.indexOf('MSIE ');
 	var trident = userAgent.indexOf('Trident/');


### PR DESCRIPTION
## Description
Send  `Accept-Language` header based on the current OC user locale 

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4159

## Motivation and Context
owncloud API uses Accept-Language header to set the response locale. This PR overrides  a default `Accept-Language` sent  by browser  with the current user locale


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
