### PR TITLE
[Tests-Only] Remove toImplementOnOcis tags from the scenarios

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -1,4 +1,4 @@
-@api @toImplementOnOCIS @issue-ocis-reva-26 @issue-ocis-reva-27
+@api @issue-ocis-reva-26 @issue-ocis-reva-27
 Feature: CORS headers
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -239,7 +239,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
 
-  @toImplementOnOCIS @issue-ocis-reva-30 @issue-ocis-reva-60
+  @issue-ocis-reva-30 @issue-ocis-reva-60
   Scenario: using OCS with an app password of a normal user
     Given a new browser session for "Alice" has been started
     And the user has generated a new app password named "my-client"

--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
@@ -74,7 +74,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @toImplementOnOCIS @issue-ocis-reva-60
+  @issue-ocis-reva-60
   Scenario: send DELETE requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -88,7 +88,7 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @toImplementOnOCIS @issue-ocis-reva-60
+  @issue-ocis-reva-60
   Scenario: send DELETE requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41
+@api @files_sharing-app-required @issue-ocis-reva-41
 Feature: capabilities
 
   Background:

--- a/tests/acceptance/features/apiFederationToShares1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederationToShares1/etagPropagation.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @toImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: propagation of etags between federated and local server
 
   Background:

--- a/tests/acceptance/features/apiFederationToShares1/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares1/federated.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @toImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: federated
 
   Background:

--- a/tests/acceptance/features/apiFederationToShares2/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares2/federated.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @toImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: federated
 
   Background:

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -1,4 +1,4 @@
-@api @toImplementOnOCIS
+@api
 Feature: caldav
 
   Background:

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -1,4 +1,4 @@
-@api @toImplementOnOCIS
+@api
 Feature: carddav
 
   Background:

--- a/tests/acceptance/features/apiMain/userSync.feature
+++ b/tests/acceptance/features/apiMain/userSync.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.3 @toImplementOnOCIS @issue-ocis-reva-401
+@api @skipOnOcV10.3 @issue-ocis-reva-401
 Feature: Users sync
 
   Background:

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @toImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @toImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @toImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @toImplementOnOCIS
+@api @provisioning_api-app-required @skipOnLDAP
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithInvalidPermissions.feature
@@ -28,7 +28,7 @@ Feature: cannot share resources with invalid permissions
       | 1               | 404             | 200              | PARENT        | 32          |
       | 2               | 404             | 404              | PARENT        | 32          |
 
-  @toImplementOnOCIS @issue-ocis-reva-45 @issue-ocis-reva-243
+  @issue-ocis-reva-45 @issue-ocis-reva-243
   Scenario Outline: Cannot create a share of a file with a user with only create permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -45,7 +45,7 @@ Feature: cannot share resources with invalid permissions
       | 1               | 400             | 200              |
       | 2               | 400             | 400              |
 
-  @toImplementOnOCIS @issue-ocis-reva-45 @issue-ocis-reva-243
+  @issue-ocis-reva-45 @issue-ocis-reva-243
   Scenario Outline: Cannot create a share of a file with a user with only (create,delete) permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243 @issue-ocis-reva-333
+@api @files_sharing-app-required @issue-ocis-reva-41 @issue-ocis-reva-243 @issue-ocis-reva-333
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34
+@api @files_sharing-app-required @issue-ocis-reva-34
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-11 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-11 @issue-ocis-reva-243
 Feature: resources shared with the same name are received with unique names
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareWhenExcludedFromSharing.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41
+@api @files_sharing-app-required @issue-ocis-reva-41
 Feature: cannot share resources when in a group that is excluded from sharing
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-42 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-42 @issue-ocis-reva-243
 Feature: shares are received in the default folder for received shares
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-34 @issue-ocis-reva-243
 Feature: sharing works when a username and group name are the same
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-34 @issue-ocis-reva-243
 Feature: share with groups, group names are case-sensitive
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-41 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-41 @issue-ocis-reva-243
 Feature: cannot share resources outside the group when share with membership groups is enabled
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-243
 Feature: share resources with a disabled user
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature
@@ -32,7 +32,7 @@ Feature: cannot share resources with invalid permissions
       | 1               | 404             | 200              | PARENT        | 32          |
       | 2               | 404             | 404              | PARENT        | 32          |
 
-  @toImplementOnOCIS @issue-ocis-reva-45 @issue-ocis-reva-243
+  @issue-ocis-reva-45 @issue-ocis-reva-243
   Scenario Outline: Cannot create a share of a file with a user with only create permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -51,7 +51,7 @@ Feature: cannot share resources with invalid permissions
       | 1               | 400             | 200              |
       | 2               | 400             | 400              |
 
-  @toImplementOnOCIS @issue-ocis-reva-45 @issue-ocis-reva-243
+  @issue-ocis-reva-45 @issue-ocis-reva-243
   Scenario Outline: Cannot create a share of a file with a user with only (create,delete) permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -406,7 +406,7 @@ Feature: sharing
       | /Shares/randomfile.txt |
     And the content of file "/Shares/randomfile.txt" for user "Brian" should be "Random data"
 
-  @issue-ocis-reva-34 @toImplementOnOCIS
+  @issue-ocis-reva-34
   Scenario Outline: Share of folder to a group with emoji in the name
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-34 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-34 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-14 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-14 @issue-ocis-reva-243
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature
@@ -55,7 +55,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @issue-ocis-reva-34 @issue-ocis-reva-194 @toImplementOnOCIS
+  @smokeTest @issue-ocis-reva-34 @issue-ocis-reva-194
   Scenario Outline: Sharee can see the group share
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareOperationsToShares/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/getWebDAVSharePermissions.feature
@@ -23,7 +23,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received file with edit and reshare permissions
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -38,7 +38,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared file with edit and reshare permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -59,7 +59,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -73,7 +73,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared file with edit permissions but no reshare permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -94,7 +94,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "foo" to "/tmp.txt"
@@ -108,7 +108,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared file with reshare permissions but no edit permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -142,7 +142,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -157,7 +157,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -177,7 +177,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but edit
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -191,7 +191,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but edit
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -212,7 +212,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but create
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -226,7 +226,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but create
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -247,7 +247,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but delete
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -261,7 +261,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but delete
     Given using <dav-path> DAV path
     And group "grp1" has been created
@@ -282,7 +282,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but share
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
@@ -296,7 +296,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but share
     Given using <dav-path> DAV path
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature
@@ -60,7 +60,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @toImplementOnOCIS @issue-ocis-reva-243
+  @smokeTest @issue-ocis-reva-243
   Scenario Outline: getting all shares of a file with reshares
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and skeleton files:
@@ -82,7 +82,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-194
+  @smokeTest @issue-ocis-reva-243 @issue-ocis-reva-194
   Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -180,7 +180,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnLDAP @issue-ocis-reva-194 @toImplementOnOCIS
+  @skipOnLDAP @issue-ocis-reva-194
   Scenario: Share of folder to a group, remove user from that group
     Given using OCS API version "1"
     And user "Carol" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -7,7 +7,7 @@ Feature: sharing
     And using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @smokeTest @toImplementOnOCIS @issue-ocis-reva-243
+  @smokeTest @issue-ocis-reva-243
   Scenario Outline: Allow modification of reshare
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -29,7 +29,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: keep group permissions in sync
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and skeleton files
@@ -61,7 +61,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: Cannot set permissions to zero
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -75,7 +75,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 400              |
 
-  @toImplementOnOCIS @issue-ocis-reva-243
+  @issue-ocis-reva-243
   Scenario Outline: Cannot update a share of a file with a user to have only create and/or delete permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -96,7 +96,7 @@ Feature: sharing
       | 1               | 200              | create,delete |
       | 2               | 400              | create,delete |
 
-  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: Cannot update a share of a file with a group to have only create and/or delete permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -119,7 +119,7 @@ Feature: sharing
       | 1               | 200              | create,delete |
       | 2               | 400              | create,delete |
 
-  @skipOnFilesClassifier @issue-files-classifier-291 @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
+  @skipOnFilesClassifier @issue-files-classifier-291 @toFixOnOCIS @issue-ocis-reva-243
   Scenario: Share ownership change after moving a shared file outside of an outer share
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -151,7 +151,7 @@ Feature: sharing
     And as "Alice" folder "/Shares/folder1/folder2" should not exist
     And as "Carol" folder "/Shares/folder2" should exist
 
-  @toImplementOnOCIS @toFixOnOCIS @issue-ocis-reva-243
+  @toFixOnOCIS @issue-ocis-reva-243
   Scenario: Share ownership change after moving a shared file to another share
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -183,7 +183,7 @@ Feature: sharing
     And as "Alice" folder "/Alice-folder/folder2" should not exist
     And as "Carol" folder "/Carol-folder/folder2" should exist
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @toImplementOnOCIS @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
+  @skipOnOcV10.3 @skipOnOcV10.4 @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
   #after fixing all the issues merge this scenario with the one below
   Scenario Outline: API responds with a full set of parameters when owner changes the permission of a share
     Given using OCS API version "<ocs_api_version>"
@@ -230,7 +230,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -252,7 +252,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+  @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: Forbid sharing with groups
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -265,7 +265,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
-  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: Editing share permission of existing share is forbidden when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -290,7 +290,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 400              |
 
-  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: Deleting group share is allowed when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -306,7 +306,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: user can update the role in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -334,7 +334,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10 @issue-37217 @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-41
+  @skipOnOcV10 @issue-37217 @issue-ocis-reva-194 @issue-ocis-reva-41
   Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-194 @issue-ocis-reva-243
+@api @files_sharing-app-required @issue-ocis-reva-194 @issue-ocis-reva-243
 Feature: updating shares to users and groups that have the same name
 
   Background:

--- a/tests/acceptance/features/apiTranslation/translation.feature
+++ b/tests/acceptance/features/apiTranslation/translation.feature
@@ -1,4 +1,4 @@
-@api @skipOnLDAP @toImplementOnOCIS
+@api @skipOnLDAP
 Feature: translate messages in api response to preferred language
   As a user
   I want response messages to be translated in preferred language

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -1,4 +1,4 @@
-@api @toImplementOnOCIS @issue-ocis-reva-172
+@api @issue-ocis-reva-172
 Feature: there can be only one exclusive lock on a resource
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -1,4 +1,4 @@
-@api @toImplementOnOCIS @issue-ocis-reva-172
+@api @issue-ocis-reva-172
 Feature: lock folders
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
 Feature: persistent-locking in case of a public link
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
 Feature: LOCKDISCOVERY for public links
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -1,4 +1,4 @@
-@api @toImplementOnOCIS @issue-ocis-reva-172
+@api @issue-ocis-reva-172
 Feature: actions on a locked item are possible if the token is sent with the request
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172 @issue-ocis-reva-11
+@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11
 Feature: lock should propagate correctly if a share is reshared
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172 @issue-ocis-reva-11
+@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11
 Feature: lock should propagate correctly if a share is reshared
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @issue-ocis-reva-172
 Feature: set timeouts of LOCKS
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
 Feature: set timeouts of LOCKS on shares
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @toImplementOnOCIS @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
 Feature: set timeouts of LOCKS on shares
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
@@ -1,4 +1,4 @@
-@api @toImplementOnOCIS @issue-ocis-reva-172
+@api @issue-ocis-reva-172
 Feature: UNLOCK locked items
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
@@ -1,4 +1,4 @@
-@api @toImplementOnOCIS @issue-ocis-reva-172 @files_sharing-app-required
+@api @issue-ocis-reva-172 @files_sharing-app-required
 Feature: UNLOCK locked items (sharing)
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -1,4 +1,4 @@
-@api @toImplementOnOCIS @issue-ocis-reva-172 @files_sharing-app-required
+@api @issue-ocis-reva-172 @files_sharing-app-required
 Feature: UNLOCK locked items (sharing)
 
   Background:

--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -202,7 +202,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a file over the top of an existing folder received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -220,7 +220,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a folder over the top of an existing file received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -237,7 +237,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a folder into another folder at different level which is received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -259,7 +259,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a file into a folder at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -283,7 +283,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a file into a file at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -306,7 +306,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @toImplementOnOCIS @issue-ocis-reva-243 @issue-ocis-reva-387
+  @issue-ocis-reva-243 @issue-ocis-reva-387
   Scenario Outline: copy a folder into a file at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files


### PR DESCRIPTION
## Description
In this PR, the `toImplementOnOcis` tags are removed from core to run all the tests in ocis.

## Related Issue
- Part of: https://github.com/owncloud/ocis/issues/796

## How Has This Been Tested?
- CI : https://github.com/owncloud/ocis/pull/798

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
