### PR TITLE
[tests-only] Adjust logic for testing on OCIS or REVA

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1445,7 +1445,7 @@ def acceptance(ctx):
 									environment['MAILHOG_HOST'] = 'email'
 
 								if params['ldapNeeded']:
-									environment['TEST_EXTERNAL_USER_BACKENDS'] = True
+									environment['TEST_WITH_LDAP'] = True
 
 								if params['testingRemoteSystem']:
 									environment['TESTING_REMOTE_SYSTEM'] = True

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ TEST_PHP_SUITE=
 # Acceptance test flags (for shells supporting autocompletion of makefiles, eg: zsh)
 TEST_SERVER_URL?=
 TEST_SERVER_FED_URL?=
-TEST_EXTERNAL_USER_BACKENDS?=
+TEST_WITH_LDAP?=
 BEHAT_FEATURE?=
 NORERUN?=
 BEHAT_RERUN_TIMES?=

--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -100,7 +100,7 @@ class LoggingHelper {
 	 * @return string
 	 */
 	public static function getLogLevel() {
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			return "debug";
 		}
 		$result = SetupHelper::runOcc(["log:manage"]);
@@ -144,7 +144,7 @@ class LoggingHelper {
 	 * @return string
 	 */
 	public static function getLogBackend() {
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			return "errorlog";
 		}
 		$result = SetupHelper::runOcc(["log:manage"]);
@@ -192,7 +192,7 @@ class LoggingHelper {
 	 * @return string
 	 */
 	public static function getLogTimezone() {
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			return "UTC";
 		}
 		$result = SetupHelper::runOcc(["log:manage"]);

--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -45,6 +45,20 @@ class OcisHelper {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public static function isTestingOnOcisOrReva() {
+		return (self::isTestingOnOcis() || self::isTestingOnReva());
+	}
+
+	/**
+	 * @return bool
+	 */
+	public static function isTestingOnOc10() {
+		return (!self::isTestingOnOcisOrReva());
+	}
+
+	/**
 	 * @return bool|string false if no command given or the command as string
 	 */
 	public static function getDeleteUserDataCommand() {
@@ -224,7 +238,7 @@ class OcisHelper {
 	 */
 	private static function getOcisRevaDataRoot() {
 		$root = \getenv("OCIS_REVA_DATA_ROOT");
-		if (($root === false || $root === "") && self::isTestingOnOcis()) {
+		if (($root === false || $root === "") && self::isTestingOnOcisOrReva()) {
 			$root = "/var/tmp/ocis/owncloud/";
 		}
 		if (!\file_exists($root)) {

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -639,7 +639,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		$ocPath = null,
 		$envVariables = null
 	) {
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			return ['code' => '', 'stdOut' => '', 'stdErr' => '' ];
 		}
 		$baseUrl = self::checkBaseUrl($baseUrl, "runOcc");

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -66,7 +66,7 @@ class AppConfigurationContext implements Context {
 	public function serverParameterHasBeenSetTo($parameter, $app, $value) {
 		// The capturing group of the regex always includes the quotes at each
 		// end of the captured string, so trim them.
-		if (\TestHelpers\OcisHelper::isTestingOnOcis()) {
+		if (\TestHelpers\OcisHelper::isTestingOnOcisOrReva()) {
 			return;
 		}
 		$value = \trim($value, $value[0]);

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1316,7 +1316,7 @@ class FeatureContext extends BehatVariablesContext {
 			$urlEnding = \substr($url, \strlen($this->getBaseUrl() . '/'));
 		}
 
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			return \preg_match("%^(#/)?s/([a-zA-Z0-9]{15})$%", $urlEnding);
 		} else {
 			return \preg_match("%^(index.php/)?s/([a-zA-Z0-9]{15})$%", $urlEnding);
@@ -3162,7 +3162,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @return void
 	 */
 	public function clearFileLocks() {
-		if (!OcisHelper::isTestingOnOcis()) {
+		if (!OcisHelper::isTestingOnOcisOrReva()) {
 			$this->authContext->deleteTokenAuthEnforcedAfterScenario();
 			$this->clearFileLocksForServer($this->getBaseUrl());
 			if ($this->remoteBaseUrl !== $this->localBaseUrl) {
@@ -3180,7 +3180,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @throws \Exception
 	 */
 	public static function useBigFileIDs(BeforeSuiteScope $scope) {
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			return;
 		}
 		$fullUrl = \getenv('TEST_SERVER_URL');
@@ -3596,7 +3596,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @return void
 	 */
 	public function restoreParametersAfterScenario() {
-		if (!OcisHelper::isTestingOnOcis()) {
+		if (!OcisHelper::isTestingOnOcisOrReva()) {
 			$this->authContext->deleteTokenAuthEnforcedAfterScenario();
 			$user = $this->getCurrentUser();
 			$this->setCurrentUser($this->getAdminUsername());
@@ -3686,7 +3686,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @return void
 	 */
 	public function prepareParametersBeforeScenario() {
-		if (!OcisHelper::isTestingOnOcis()) {
+		if (!OcisHelper::isTestingOnOcisOrReva()) {
 			$user = $this->getCurrentUser();
 			$this->setCurrentUser($this->getAdminUsername());
 			$previousServer = $this->getCurrentServer();

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -431,7 +431,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @return bool
 	 */
 	public function isTestingWithLdap() {
-		return (\getenv("TEST_EXTERNAL_USER_BACKENDS") === "true");
+		return (\getenv("TEST_WITH_LDAP") === "true");
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -852,8 +852,8 @@ class OccContext implements Context {
 	 * @throws Exception
 	 */
 	public function theAdministratorHasSetTheDefaultFolderForReceivedSharesTo($folder) {
-		if (OcisHelper::isTestingOnOcis()) {
-			// The default folder for received shares is already "Shares" on OCIS.
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// The default folder for received shares is already "Shares" on OCIS and REVA.
 			// If the step is asking for a different folder, then fail.
 			// Otherwise just return - the setting is already done by default.
 			Assert::assertEquals(

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -541,7 +541,7 @@ trait Provisioning {
 	 */
 	public function connectToLdap($suiteParameters) {
 		$useSsl = false;
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$this->ldapBaseDN = OcisHelper::getBaseDN();
 			$this->ldapHost = OcisHelper::getHostname();
 			$this->ldapPort = OcisHelper::getLdapPort();
@@ -603,7 +603,7 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function theLdapUsersHaveBeenReSynced() {
-		if (!OcisHelper::isTestingOnOcis()) {
+		if (!OcisHelper::isTestingOnOcisOrReva()) {
 			$occResult = SetupHelper::runOcc(
 				['user:sync', 'OCA\User_LDAP\User_Proxy', '-m', 'remove']
 			);
@@ -939,7 +939,7 @@ trait Provisioning {
 			} else {
 				$attributesToCreateUser['userid'] = $userAttributes['userid'];
 				$attributesToCreateUser['password'] = $userAttributes['password'];
-				if (OcisHelper::isTestingOnOcis()) {
+				if (OcisHelper::isTestingOnOcisOrReva()) {
 					$attributesToCreateUser['username'] = $userAttributes['userid'];
 					if ($userAttributes['email'] === null) {
 						Assert::assertArrayHasKey(
@@ -988,7 +988,7 @@ trait Provisioning {
 		$users = [];
 		$editData = [];
 		foreach ($usersAttributes as $userAttributes) {
-			if (OcisHelper::isTestingOnOcis()) {
+			if (OcisHelper::isTestingOnOcisOrReva()) {
 				OcisHelper::createEOSStorageHome(
 					$this->getBaseUrl(),
 					$userAttributes['userid'],
@@ -1018,7 +1018,7 @@ trait Provisioning {
 		// then do some work to "manually" put the skeleton files in place.
 		// When testing on ownCloud 10 the user is already getting whatever
 		// skeleton dir is defined in the server-under-test.
-		if ($skeleton && OcisHelper::isTestingOnOcis()) {
+		if ($skeleton && OcisHelper::isTestingOnOcisOrReva()) {
 			$this->manuallyAddSkeletonFiles($usersAttributes);
 		}
 
@@ -1266,7 +1266,7 @@ trait Provisioning {
 			"email" => $email
 		];
 
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			if ($email === null) {
 				$email = $username . '@owncloud.org';
 			}
@@ -1289,7 +1289,7 @@ trait Provisioning {
 			$email,
 			$this->theHTTPStatusCodeWasSuccess()
 		);
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$this->manuallyAddSkeletonFilesForUser($username, $password);
 		}
 	}
@@ -1306,7 +1306,7 @@ trait Provisioning {
 	public function adminSendsUserCreationRequestUsingTheProvisioningApi($user, $password) {
 		$user = $this->getActualUsername($user);
 		$password = $this->getActualPassword($password);
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$email = $user . '@owncloud.org';
 			$bodyTable = new TableNode(
 				[
@@ -1335,7 +1335,7 @@ trait Provisioning {
 			$email,
 			$this->theHTTPStatusCodeWasSuccess()
 		);
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			OcisHelper::createEOSStorageHome($this->getBaseUrl(), $user, $password);
 			$this->manuallyAddSkeletonFilesForUser($user, $password);
 		}
@@ -1356,7 +1356,7 @@ trait Provisioning {
 	) {
 		$user = $this->getActualUsername($user);
 		$password = $this->getActualPassword($password);
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$email = $user . '@owncloud.org';
 			$bodyTable = new TableNode(
 				[
@@ -1388,7 +1388,7 @@ trait Provisioning {
 			$email,
 			$this->theHTTPStatusCodeWasSuccess()
 		);
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$this->manuallyAddSkeletonFilesForUser($user, $password);
 		}
 	}
@@ -2605,7 +2605,7 @@ trait Provisioning {
 		// sending the username in lowercase in the auth but in uppercase in
 		// the URL see https://github.com/owncloud/core/issues/36822
 		$user = $this->getActualUsername($user);
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$requestingUser = $this->getActualUsername($user);
 			$requestingPassword = $this->getPasswordForUser($requestingUser);
 		} else {
@@ -3431,7 +3431,7 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function groupExists($group) {
-		if ($this->isTestingWithLdap() && OcisHelper::isTestingOnOcis()) {
+		if ($this->isTestingWithLdap() && OcisHelper::isTestingOnOcisOrReva()) {
 			$baseDN = $this->getLdapBaseDN();
 			$newDN = 'cn=' . $group . ',ou=' . $this->ou . ',' . $baseDN;
 			if ($this->ldap->getEntry($newDN) !== null) {
@@ -4359,12 +4359,12 @@ trait Provisioning {
 	public function afterScenario() {
 		$this->restoreParametersAfterScenario();
 
-		if (OcisHelper::isTestingOnOcis() && $this->someUsersHaveBeenCreated()) {
+		if (OcisHelper::isTestingOnOcisOrReva() && $this->someUsersHaveBeenCreated()) {
 			foreach ($this->getCreatedUsers() as $user) {
 				$this->deleteAllSharesForUser($user["actualUsername"]);
 				OcisHelper::deleteRevaUserData($user["actualUsername"]);
 			}
-		} elseif (!OcisHelper::isTestingOnOcis()) {
+		} elseif (OcisHelper::isTestingOnOc10()) {
 			$this->resetAdminUserAttributes();
 		}
 		if ($this->isTestingWithLdap()) {
@@ -4437,7 +4437,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function rememberAppEnabledDisabledState() {
-		if (!OcisHelper::isTestingOnOcis()) {
+		if (!OcisHelper::isTestingOnOcisOrReva()) {
 			SetupHelper::init(
 				$this->getAdminUsername(),
 				$this->getAdminPassword(),
@@ -4457,7 +4457,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function restoreAppEnabledDisabledState() {
-		if (!OcisHelper::isTestingOnOcis()) {
+		if (!OcisHelper::isTestingOnOcisOrReva()) {
 			$this->runOcc(['app:list', '--output json']);
 			$apps = \json_decode($this->getStdOutOfOccCommand(), true);
 			$currentlyEnabledApps = \array_keys($apps["enabled"]);

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -1026,7 +1026,7 @@ class PublicWebDavContext implements Context {
 		$tokenArray = $this->featureContext->getLastShareData()->data->token;
 		$token = (string)$tokenArray[0];
 		$baseUrl = $this->featureContext->getBaseUrl();
-		if (\TestHelpers\OcisHelper::isTestingOnOcis()) {
+		if (\TestHelpers\OcisHelper::isTestingOnOcisOrReva()) {
 			$mtime = \explode(" ", $mtime);
 			\array_pop($mtime);
 			$mtime = \implode(" ", $mtime);

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -290,7 +290,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function autoAcceptSharesHasBeenDisabled() {
-		if (OcisHelper::isTestingOnOcis()) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
 			// auto-accept shares is disabled by default on OCIS.
 			// so there is nothing to do, just return
 			return;

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -183,7 +183,7 @@ export LANG=C
 # sets $REMOTE_OCC_STDOUT and $REMOTE_OCC_STDERR from returned xml data
 # @return occ return code given in the xml data
 function remote_occ() {
-	if [ "${TEST_OCIS}" == "true" ]
+	if [ "${TEST_OCIS}" == "true" ] || [ "${TEST_REVA}" == "true" ]
 	then
 		return 0
 	fi
@@ -295,7 +295,7 @@ function assert_testing_app_enabled() {
 # $4 text description of the server being checked, e.g. "local", "remote"
 # return 0 if given module is enabled, else return with 1
 function check_apache_module_enabled() {
-	if [ "${TEST_OCIS}" == "true" ]
+	if [ "${TEST_OCIS}" == "true" ] || [ "${TEST_REVA}" == "true" ]
 	then
 		return 0
 	fi
@@ -695,9 +695,9 @@ then
 	DIR_URL="${TESTING_APP_URL}dir"
 	# test that server is up and running, and testing app is enabled.
 	assert_server_up ${TEST_SERVER_URL}
-	if [ "${TEST_OCIS}" != "true" ]
+	if [ "${TEST_OCIS}" != "true" ] && [ "${TEST_REVA}" != "true" ]
 	then
-			assert_testing_app_enabled ${TEST_SERVER_URL}
+		assert_testing_app_enabled ${TEST_SERVER_URL}
 	fi
 
 	if [ -n "${TEST_SERVER_FED_URL}" ]
@@ -706,7 +706,7 @@ then
 		OCC_FED_URL="${TESTING_APP_FED_URL}occ"
 		# test that fed server is up and running, and testing app is enabled.
 		assert_server_up ${TEST_SERVER_FED_URL}
-		if [ "${TEST_OCIS}" != "true" ]
+		if [ "${TEST_OCIS}" != "true" ] && [ "${TEST_REVA}" != "true" ]
 		then
 			assert_testing_app_enabled ${TEST_SERVER_URL}
 		fi


### PR DESCRIPTION
## Description
Before this PR, when testing on REVA you have to define bothe environment variables `TEST_OCIS` and `TEST_REVA` - that is not such an obvious thing.

1) adjust the test logic so that if just `TEST_REVA` is defined, then all the appropriate test setup and teardown happens.

2) change the environment variable `TEST_EXTERNAL_USER_BACKENDS` to `TEST_WITH_LDAP` to better reflect what it does. The test suite uses this environment variable to know to create/delete users and groups on LDAP... (rather than with the provisioning API)

Note: `TEST_OCIS` is only documented in `owncloud/ocis` repo. And the use of that does not change. 
`TEST_REVA` and `TEST_EXTERNAL_USER_BACKENDS` are only documented in `cs3org/reva` repo. That will be changed in the PR that bumps the core commit.
None of these are mentioned in `owncloud/docs` so there is nothing to change there! 

I will make a PR in `user_ldap` repo to change `TEST_EXTERNAL_USER_BACKENDS` after this PR is merged.

After this PR, we want to adjust the logic in a separate PR so that user data and shares are not cleaned up "under-the-hood" when running on OCIS. There is an OCIS PR in development that will cleanup user files, shares and other metadata correctly when the user is deleted using the provisioning API.

## How Has This Been Tested?
CI

PR https://github.com/cs3org/reva/pull/1295 demonstrates that this works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
