### PR TITLE
[tests-only] Do not cleanup user data under-the-hood when testing on OCIS

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -4646,7 +4646,7 @@ trait Provisioning {
 	public function afterScenario() {
 		$this->restoreParametersAfterScenario();
 
-		if (OcisHelper::isTestingOnOcisOrReva() && $this->someUsersHaveBeenCreated()) {
+		if (OcisHelper::isTestingOnReva() && $this->someUsersHaveBeenCreated()) {
 			foreach ($this->getCreatedUsers() as $user) {
 				$this->deleteAllSharesForUser($user["actualUsername"]);
 				OcisHelper::deleteRevaUserData($user["actualUsername"]);


### PR DESCRIPTION
## Description
OCIS PR https://github.com/owncloud/ocis/pull/755 is implementing proper user cleanup when a user is deleted using the Provisioning API. When that is working, there will be no need for the acceptance test code to try to "manually" delete the shares and the user's files.

This branch `do-not-cleanup-under-the-hood-on-ocis` can be used for testing from OCIS. Do not merge this PR to core until there is a known-good implementation of OCIS PR https://github.com/owncloud/ocis/pull/755


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
