### PR TITLE
[tests-only] Adjust skipOnOcis-OC-Storage for etag test scenarios

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -7,6 +7,7 @@ Feature: propagation of etags when deleting a file or folder
     And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "Alice" has created folder "/upload"
 
+
   Scenario Outline: deleting a file changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"
@@ -44,6 +45,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
+
   Scenario Outline: deleting a folder with content changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"
@@ -62,6 +64,7 @@ Feature: propagation of etags when deleting a file or folder
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: as share receiver deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -92,6 +95,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
+
   Scenario Outline: as sharer deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -121,6 +125,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
+  @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: as share receiver deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -152,6 +157,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
+  @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: as sharer deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
@@ -4,6 +4,7 @@ Feature: propagation of etags when moving files or folders
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
+
   Scenario Outline: renaming a file inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
@@ -19,6 +20,7 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: moving a file from one folder to an other changes the etags of both folders
     Given using <dav_version> DAV path
@@ -39,6 +41,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+
   Scenario Outline: moving a file into a subfolder changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
@@ -58,6 +61,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+
   Scenario Outline: renaming a folder inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
@@ -73,6 +77,7 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: moving a folder from one folder to an other changes the etags of both folders
     Given using <dav_version> DAV path
@@ -113,6 +118,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+
   Scenario Outline: as share receiver renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -139,6 +145,7 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: as sharer renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -201,6 +208,7 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: as share receiver moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -271,6 +279,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+
   Scenario Outline: as share receiver moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -305,6 +314,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+
   Scenario: renaming a file in a publicly shared folder changes its etag for the sharer
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "/upload"
@@ -319,6 +329,7 @@ Feature: propagation of etags when moving files or folders
       | user  | path    |
       | Alice | /       |
       | Alice | /upload |
+
 
   Scenario: renaming a folder in a publicly shared folder changes its etag for the sharer
     Given the administrator has enabled DAV tech_preview

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -120,6 +120,7 @@ Feature: propagation of etags when copying files or folders
       | old         |
       | new         |
 
+
   Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -156,6 +157,7 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -158,7 +158,7 @@ Feature: propagation of etags when copying files or folders
       | old         |
       | new         |
 
-
+  @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
@@ -22,6 +22,7 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
+
   Scenario Outline: creating an invalid folder inside a folder should not change any etags
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/folder"
@@ -40,6 +41,7 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
+  @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: as share receiver creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -64,6 +66,7 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
+  @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: as sharer creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
@@ -6,6 +6,7 @@ Feature: propagation of etags when restoring a file or folder from trash
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/upload"
 
+
   Scenario Outline: restoring a file to its original location changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"
@@ -24,6 +25,7 @@ Feature: propagation of etags when restoring a file or folder from trash
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: restoring a file to an other location changes the etags of all parents
     Given using <dav_version> DAV path
@@ -46,6 +48,7 @@ Feature: propagation of etags when restoring a file or folder from trash
       | old         |
       | new         |
 
+
   Scenario Outline: restoring a folder to its original location changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"
@@ -64,6 +67,7 @@ Feature: propagation of etags when restoring a file or folder from trash
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: restoring a folder to an other location changes the etags of all parents
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
@@ -23,6 +23,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
+
   Scenario Outline: overwriting a file inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
@@ -41,6 +42,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
+  @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: as share receiver uploading a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -64,6 +66,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
+  @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: as sharer uploading a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -86,6 +89,7 @@ Feature: propagation of etags when uploading data
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: as share receiver overwriting a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -110,6 +114,7 @@ Feature: propagation of etags when uploading data
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: as sharer overwriting a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files


### PR DESCRIPTION
## Description
When running CI for https://github.com/cs3org/reva/pull/1299 there are some more etag test scenarios that are failing intermittently on `owncloud` storage.

- skip those for now on `owncloud` storage.
- add an extra blank line between all etag scenarios, so that in future we can add tags without forcing the line numbers of scenarios to change

## How Has This Been Tested?
https://github.com/cs3org/reva/pull/1299 with these skips

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
