### PR TITLE
Update sabre/dav (4.1.2 => 4.1.3)

### DIFF
--- a/changelog/unreleased/38092
+++ b/changelog/unreleased/38092
@@ -1,0 +1,3 @@
+Change: Update sabre/dav (4.1.2 => 4.1.3)
+
+https://github.com/owncloud/core/pull/38092

--- a/composer.lock
+++ b/composer.lock
@@ -2476,16 +2476,16 @@
         },
         {
             "name": "sabre/dav",
-            "version": "4.1.2",
+            "version": "4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/dav.git",
-                "reference": "e1f617a4112da461bfc31aa4e87e0e6ac0bd6ed0"
+                "reference": "b903eeedfbdcd6cab7935661ec6dc2d90cdf8a1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/dav/zipball/e1f617a4112da461bfc31aa4e87e0e6ac0bd6ed0",
-                "reference": "e1f617a4112da461bfc31aa4e87e0e6ac0bd6ed0",
+                "url": "https://api.github.com/repos/sabre-io/dav/zipball/b903eeedfbdcd6cab7935661ec6dc2d90cdf8a1e",
+                "reference": "b903eeedfbdcd6cab7935661ec6dc2d90cdf8a1e",
                 "shasum": ""
             },
             "require": {
@@ -2509,7 +2509,7 @@
             },
             "require-dev": {
                 "evert/phpdoc-md": "~0.1.0",
-                "friendsofphp/php-cs-fixer": "^2.16.3",
+                "friendsofphp/php-cs-fixer": "^2.16.7",
                 "monolog/monolog": "^1.18",
                 "phpstan/phpstan": "^0.12",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.0"
@@ -2558,7 +2558,7 @@
                 "issues": "https://github.com/sabre-io/dav/issues",
                 "source": "https://github.com/fruux/sabre-dav"
             },
-            "time": "2020-10-04T07:21:47+00:00"
+            "time": "2020-11-09T07:48:35+00:00"
         },
         {
             "name": "sabre/event",

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -44,7 +44,7 @@ Feature: LOCK file/folder
     When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
       | endpoint                                           |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "404"
+    Then the HTTP status code of responses on all endpoints should be "409"
 
   Scenario: send LOCK requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "LOCK" including body "doesnotmatter" using the password of user "Alice"

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -44,7 +44,7 @@ Feature: get file info using PUT
     When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" about user "Alice"
       | endpoint                                            |
       | /remote.php/dav/files/%username%/PARENTS/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "404"
+    Then the HTTP status code of responses on all endpoints should be "409"
 
   Scenario: send PUT requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "PUT" including body "doesnotmatter" using the password of user "Alice"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -97,6 +97,17 @@ Feature: upload file
       | new         | /folder ?2.txt    | file ?2.txt  |
       | new         | /?fi=le&%#2 . txt | # %ab ab?=ed |
 
+  Scenario Outline: attempt to upload a file into a non-existent folder
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file with content "uploaded content" to "non-existent-folder/new-file.txt" using the WebDAV API
+    Then the HTTP status code should be "409"
+    And as "Alice" folder "non-existent-folder" should not exist
+    And as "Alice" file "non-existent-folder/new-file.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
   @issue-ocis-reva-15
   Scenario Outline: Uploading file to path with extension .part should not be possible
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -80,7 +80,7 @@ Feature: upload file using new chunking
     Given user "Alice" has created a new chunking upload with id "chunking-42"
     When using old DAV path
     And user "Alice" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "409"
 
   Scenario: New chunked upload MOVE using old DAV path should fail
     Given user "Alice" has created a new chunking upload with id "chunking-42"


### PR DESCRIPTION
## Description
https://github.com/sabre-io/dav/releases/tag/4.1.3

and add an API acceptance test to check the HTTP status when trying to do a Webdav PUT of a file into a non-existent folder.

## Related Issue
Fixes #38089 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
