### PR TITLE
[Tests-Only] Refactored Oc10 bug demonstration scenarios that were tagged issue-core-nnnn

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature
@@ -56,7 +56,7 @@ Feature: copying from public link share
     And as "Alice" file "/PARENT/copy1.txt" should exist
     And the content of file "/PARENT/copy1.txt" for user "Alice" should be "some data 0"
 
-  @issue-ocis-reva-373 @issue-core-37683
+  @skipOnOcV10 @issue-ocis-reva-373 @issue-37683
   Scenario: Copy folder within a public link folder to the same folder name as an already existing file
     Given user "Alice" has created folder "/PARENT/testFolder"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/testFolder/testfile.txt"
@@ -65,12 +65,11 @@ Feature: copying from public link share
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     When the public copies folder "/testFolder" to "/copy1.txt" using the new public WebDAV API
-    Then the HTTP status code should be "204"
+    Then the HTTP status code should be "403"
     And as "Alice" folder "/PARENT/testFolder" should exist
     And as "Alice" folder "/PARENT/copy1.txt" should exist
-    And as "Alice" file "/PARENT/copy1.txt/testfile.txt" should exist
+    And as "Alice" file "/PARENT/copy1.txt/testfile.txt" should not exist
     And the content of file "/PARENT/testFolder/testfile.txt" for user "Alice" should be "some data"
-    And the content of file "/PARENT/copy1.txt/testfile.txt" for user "Alice" should be "some data"
 
   Scenario: Copy file within a public link folder and delete file
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"
@@ -82,7 +81,7 @@ Feature: copying from public link share
     Then the HTTP status code should be "204"
     And as "Alice" file "/PARENT/copy1.txt" should not exist
 
-  @issue-ocis-reva-373 @issue-core-37683
+  @skipOnOcV10 @issue-ocis-reva-373 @issue-37683
   Scenario: Copy file within a public link folder to a file with name same as an existing folder
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"
     And user "Alice" has created folder "/PARENT/new-folder"
@@ -91,11 +90,11 @@ Feature: copying from public link share
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     When the public copies file "/testfile.txt" to "/new-folder" using the new public WebDAV API
-    Then the HTTP status code should be "204"
+    Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/testfile.txt" should exist
-    And as "Alice" file "/PARENT/new-folder" should exist
+    And as "Alice" folder "/PARENT/new-folder" should exist
     And the content of file "/PARENT/testfile.txt" for user "Alice" should be "some data"
-    And the content of file "/PARENT/new-folder" for user "Alice" should be "some data"
+    And the content of file "/PARENT/new-folder/testfile.txt" for user "Alice" should be "some data"
 
   Scenario Outline: Copy file with special characters in it's name within a public link folder
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/<file-name>"

--- a/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLinkOc10Issue37683.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLinkOc10Issue37683.feature
@@ -1,0 +1,38 @@
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-310 @notToImplementOnOCIS
+Feature: copying from public link share
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And the administrator has enabled DAV tech_preview
+
+  @issue-ocis-reva-373 @issue-37683
+  Scenario: Copy folder within a public link folder to the same folder name as an already existing file
+    Given user "Alice" has created folder "/PARENT/testFolder"
+    And user "Alice" has uploaded file with content "some data" to "/PARENT/testFolder/testfile.txt"
+    And user "Alice" has uploaded file with content "some data 1" to "/PARENT/copy1.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public copies folder "/testFolder" to "/copy1.txt" using the new public WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" folder "/PARENT/testFolder" should exist
+    And as "Alice" folder "/PARENT/copy1.txt" should exist
+    And as "Alice" file "/PARENT/copy1.txt/testfile.txt" should exist
+    And the content of file "/PARENT/testFolder/testfile.txt" for user "Alice" should be "some data"
+    And the content of file "/PARENT/copy1.txt/testfile.txt" for user "Alice" should be "some data"
+
+  @issue-ocis-reva-373 @issue-37683
+  Scenario: Copy file within a public link folder to a file with name same as an existing folder
+    Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"
+    And user "Alice" has created folder "/PARENT/new-folder"
+    And user "Alice" has uploaded file with content "some data 1" to "/PARENT/new-folder/testfile1.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When the public copies file "/testfile.txt" to "/new-folder" using the new public WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "/PARENT/testfile.txt" should exist
+    And as "Alice" file "/PARENT/new-folder" should exist
+    And the content of file "/PARENT/testfile.txt" for user "Alice" should be "some data"
+    And the content of file "/PARENT/new-folder" for user "Alice" should be "some data"


### PR DESCRIPTION
## Description
Refactored core test scenarios that were tagged `@issue-core-nnnn` demonstrating the actual behaviors.

Scenarios demonstrating bugs in Oc10 are now in new feature files and tagged `notToImplementOnOCIS`  because they only demonstrate an oC10 bug that needs to be fixed. These feature files have been named with respect to the issue that each one demonstrates.

The main scenarios now demonstrate the expected behavior, which we want to happen on both Oc10 and OCIS. They are tagged `skipOnOcV10` for now, because they would currently fail on Oc10.

## Related Issue
- fixes https://github.com/owncloud/core/issues/37891

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
