### PR TITLE
[tests-only] skip on old oCV10 for scenarios that were added or changed by issue 38089

### DIFF
--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -34,7 +34,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @issue-ocis-reva-9
+  @issue-ocis-reva-9 @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: send LOCK requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
       | endpoint                                       |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -34,7 +34,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @issue-ocis-reva-9 @issue-ocis-reva-197
+  @issue-ocis-reva-9 @issue-ocis-reva-197 @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: send PUT requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" about user "Alice"
       | endpoint                                       |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -26,6 +26,7 @@ Feature: upload file
       | old         | /s,a,m,p,l,e.txt  |
       | new         | /s,a,m,p,l,e.txt  |
 
+
   Scenario Outline: upload a file and check download content
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to <file_name> using the WebDAV API
@@ -52,6 +53,7 @@ Feature: upload file
       | new         | " ?fi=le&%#2 . txt" |
       | new         | " # %ab ab?=ed "    |
 
+
   Scenario Outline: upload a file with comma in the filename and check download content
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "file with comma" to <file_name> using the WebDAV API
@@ -64,6 +66,7 @@ Feature: upload file
       | new         | "sample,1.txt" |
       | new         | ",,,.txt"      |
       | new         | ",,,.,"        |
+
 
   Scenario Outline: upload a file into a folder and check download content
     Given using <dav_version> DAV path
@@ -97,6 +100,7 @@ Feature: upload file
       | new         | /folder ?2.txt    | file ?2.txt  |
       | new         | /?fi=le&%#2 . txt | # %ab ab?=ed |
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: attempt to upload a file into a non-existent folder
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "non-existent-folder/new-file.txt" using the WebDAV API
@@ -122,6 +126,7 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: upload a file into a folder with dots in the path and check download content
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -9,6 +9,7 @@ Feature: upload file using new chunking
     And using new DAV path
     And user "Alice" has been created with default attributes and skeleton files
 
+
   Scenario: Upload chunked file asc with new chunking
     Given the owncloud log level has been set to debug
     And the owncloud log has been cleared
@@ -26,6 +27,7 @@ Feature: upload file using new chunking
       | app |
       | dav |
 
+
   Scenario: Upload chunked file desc with new chunking
     Given the owncloud log level has been set to debug
     And the owncloud log has been cleared
@@ -40,6 +42,7 @@ Feature: upload file using new chunking
       | app |
       | dav |
 
+
   Scenario: Upload chunked file random with new chunking
     Given the owncloud log level has been set to debug
     And the owncloud log has been cleared
@@ -53,6 +56,7 @@ Feature: upload file using new chunking
     And the log file should not contain any log-entries containing these attributes:
       | app |
       | dav |
+
 
   Scenario: Checking file id after a move overwrite using new chunking endpoint
     Given the owncloud log level has been set to debug
@@ -71,16 +75,19 @@ Feature: upload file using new chunking
       | app |
       | dav |
 
+
   Scenario: New chunked upload MKDIR using old DAV path should fail
     Given using old DAV path
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
     Then the HTTP status code should be "409"
 
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: New chunked upload PUT using old DAV path should fail
     Given user "Alice" has created a new chunking upload with id "chunking-42"
     When using old DAV path
     And user "Alice" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API
     Then the HTTP status code should be "409"
+
 
   Scenario: New chunked upload MOVE using old DAV path should fail
     Given user "Alice" has created a new chunking upload with id "chunking-42"
@@ -91,9 +98,11 @@ Feature: upload file using new chunking
     And user "Alice" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" using the WebDAV API
     Then the HTTP status code should be "404"
 
+
   Scenario: Upload to new dav path using old way should fail
     When user "Alice" uploads chunk file "1" of "3" with "AAAAA" to "/myChunkedFile.txt" using the WebDAV API
     Then the HTTP status code should be "503"
+
 
   Scenario: Upload file via new chunking endpoint with wrong size header
     Given user "Alice" has created a new chunking upload with id "chunking-42"
@@ -102,6 +111,7 @@ Feature: upload file using new chunking
     And user "Alice" has uploaded new chunk file "3" with "CCCCC" to id "chunking-42"
     When user "Alice" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with size 5 using the WebDAV API
     Then the HTTP status code should be "400"
+
 
   Scenario: Upload file via new chunking endpoint with correct size header
     Given the owncloud log level has been set to debug
@@ -135,6 +145,7 @@ Feature: upload file using new chunking
       | 0         |
       | &#?       |
       | TIÄFÜ     |
+
 
   # This scenario does extra checks with the log level set to debug.
   # It does not run in smoke test runs. (see comments in scenario above)


### PR DESCRIPTION
## Description
PR #38092 added and changed some test scenarios. These will only pass on current master oC10.6 onwards.
Skip them on older oCV10.

In feature files where I had to add a line, I also spaced out the other scenarios. We get over the pain of the line numbers changing, and they will not have to change again just to add tags.

## Related Issue

#38089 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
