### PR TITLE
[tests-only] Fix acceptance test exit status when running a single scenario

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -491,7 +491,7 @@ function run_behat_tests() {
 				echo "${FAILED_SCENARIO_PATHS}" | grep ${SUITE_SCENARIO}$ > /dev/null
 				if [ $? -ne 0 ]
 				then
-					echo "Error: Scenario ${SUITE_SCENARIO} was expected to fail but did not fail."
+					echo "Info: Scenario ${SUITE_SCENARIO} was expected to fail but did not fail."
 					UNEXPECTED_PASSED_SCENARIOS+=("${SUITE_SCENARIO}")
 				fi
 			done < ${EXPECTED_FAILURES_FILE}
@@ -1249,25 +1249,10 @@ else
 	UNEXPECTED_BEHAT_EXIT_STATUS=false
 fi
 
-if [ "${UNEXPECTED_FAILURE}" = false ] && [ "${UNEXPECTED_SUCCESS}" = false ] && [ "${UNEXPECTED_BEHAT_EXIT_STATUS}" = false ]
-then
-	FINAL_EXIT_STATUS=0
-else
-	FINAL_EXIT_STATUS=1
-fi
-
-if [ -n "${EXPECTED_FAILURES_FILE}" ]
-then
-	echo "runsh: Exit code after checking expected failures: ${FINAL_EXIT_STATUS}"
-fi
-
-if [ "${UNEXPECTED_FAILURE}" = true ]
-then
-  tput setaf 3; echo "runsh: Total unexpected failed scenarios throughout the test run:"
-  tput setaf 1; printf "%s\n" "${UNEXPECTED_FAILED_SCENARIOS[@]}"
-else
-  tput setaf 2; echo "runsh: There were no unexpected failures."
-fi
+# If we got some unexpected success, and we only ran a single feature or scenario
+# then the fact that some expected failures did not happen might be because those
+# scenarios were never even run.
+# Filter the UNEXPECTED_PASSED_SCENARIOS to remove scenarios that were not run.
 if [ "${UNEXPECTED_SUCCESS}" = true ]
 then
   ACTUAL_UNEXPECTED_PASS=()
@@ -1297,6 +1282,26 @@ then
   then
     UNEXPECTED_SUCCESS=false
   fi
+fi
+
+if [ "${UNEXPECTED_FAILURE}" = false ] && [ "${UNEXPECTED_SUCCESS}" = false ] && [ "${UNEXPECTED_BEHAT_EXIT_STATUS}" = false ]
+then
+	FINAL_EXIT_STATUS=0
+else
+	FINAL_EXIT_STATUS=1
+fi
+
+if [ -n "${EXPECTED_FAILURES_FILE}" ]
+then
+	echo "runsh: Exit code after checking expected failures: ${FINAL_EXIT_STATUS}"
+fi
+
+if [ "${UNEXPECTED_FAILURE}" = true ]
+then
+  tput setaf 3; echo "runsh: Total unexpected failed scenarios throughout the test run:"
+  tput setaf 1; printf "%s\n" "${UNEXPECTED_FAILED_SCENARIOS[@]}"
+else
+  tput setaf 2; echo "runsh: There were no unexpected failures."
 fi
 
 if [ "${UNEXPECTED_SUCCESS}" = true ]


### PR DESCRIPTION
## Description
When running a single acceptance test scenario, the acceptance test `run.sh` script correctly filters out "unexpected passed scenarios" to not report scenarios that were not actually run. But the exit status was still set to `1` (fail). This is a problem when trying to run acceptance tests to reproduce problems - a wrapper script around the acceptance test script needs an accurate exit status.

Move the code that sets the final exit status to be after the code that filters out the scenarios that were not actually run. This will make it determine the correct exit status in the case when there really were no "unexpected passed scenarios".

During earlier processing, a message "Error: Scenario ${SUITE_SCENARIO} was expected to fail but did not fail." is emitted. That message is handy to see when debugging what happened in a test run, so keep it. But it is not an error - the code is just in the process of accumulating "unexpected passed scenarios". Change the text to "Info:"

## How Has This Been Tested?
Create a temporary expected-failures file with:
```
#
apiComments/comments.feature:24
apiComments/comments.feature:52
```

Run some local API tests:
```
export EXPECTED_FAILURES_FILE='tests/acceptance/expected-failures.txt'
make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiComments/comments.feature
make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiComments/comments.feature:24
make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiComments/comments.feature:38
```

And check that the appropriate unexpected failures and passed scenarios are reported, with exit status 0 when everything is good.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
