### PR TITLE
[tests-only] Only use user 'moss' when isTestingOnOcis

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2606,15 +2606,17 @@ trait Provisioning {
 		// the URL see https://github.com/owncloud/core/issues/36822
 		$user = $this->getActualUsername($user);
 		if (OcisHelper::isTestingOnOcisOrReva()) {
-			// In OCIS an intermittend issue restricts users to list their own account
+			// In OCIS an intermittent issue restricts users to list their own account
 			// So use admin account to list the user
 			// https://github.com/owncloud/ocis/issues/820
-			// Uncomment these lines once the issue is fixed
-
-			// $requestingUser = $this->getActualUsername($user);
-			// $requestingPassword = $this->getPasswordForUser($requestingUser);
-			$requestingUser = 'moss';
-			$requestingPassword = 'vista';
+			// The special code can be reverted once the issue is fixed
+			if (OcisHelper::isTestingOnOcis()) {
+				$requestingUser = 'moss';
+				$requestingPassword = 'vista';
+			} else {
+				$requestingUser = $this->getActualUsername($user);
+				$requestingPassword = $this->getPasswordForUser($requestingUser);
+			}
 		} else {
 			$requestingUser = $this->getAdminUsername();
 			$requestingPassword = $this->getAdminPassword();


### PR DESCRIPTION
## Description
PR #38093 adjusted some code to use the "admin" user called "moss" on OCIS. But that code also accidentally ran for `cs3org/reva`, which breaks.

Adjust the changes so that `moss` is only used on OCIS, and the previous `admin` user is used in `cs3org/reva`

## How Has This Been Tested?
CI - https://cloud.drone.io/cs3org/reva/3111 is passing

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
