### PR TITLE
Coerce occ config:app:set boolish value to 0 or 1

### DIFF
--- a/changelog/unreleased/37697
+++ b/changelog/unreleased/37697
@@ -1,0 +1,10 @@
+Enhancement: Fix expiring a wrong share entry problem
+
+Setting an app value via the occ config:app:set command to false may not result to a negation evaluation due the value will be stored in the database as 'false' type string.
+As this is a non-zero value it may evaluate to true.
+To come over this problem we will coerce the value:
+true => 1
+false => 0
+
+https://github.com/owncloud/core/issues/37697
+https://github.com/owncloud/core/pull/38099

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -80,10 +80,27 @@ class SetConfig extends Base {
 			return 1;
 		}
 
-		$configValue = $input->getOption('value');
+		$configValue = $this->coerceValue($input->getOption('value'));
 		$this->config->setAppValue($appName, $configName, $configValue);
 
 		$output->writeln('<info>Config value ' . $configName . ' for app ' . $appName . ' set to ' . $configValue . '</info>');
 		return 0;
+	}
+
+	/**
+	 * @param $value string
+	 *
+	 * @return int|string
+	 */
+	protected function coerceValue(string $value) {
+		if ($value === 'false') {
+			return 0;
+		}
+
+		if ($value === 'true') {
+			return 1;
+		}
+
+		return $value;
 	}
 }

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -15,6 +15,16 @@ Feature: add and delete app configs using occ command
     And the command output should contain the text 'Config value con of app core deleted'
     And app "core" should not have config key "con"
 
+  Scenario: admin adds a config boolean-like string value for an app using the occ command
+    When the administrator adds config key "con" with value "true" in app "core" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'Config value con for app core set to 1'
+    And the config key "con" of app "core" should have value "1"
+    When the administrator adds config key "con" with value "false" in app "core" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'Config value con for app core set to 0'
+    And the config key "con" of app "core" should have value "0"
+
   Scenario: admin adds and deletes a system config
     When the administrator adds system config key "con" with value "conkey" using the occ command
     Then the command should have been successful


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Setting an app value via the occ config:app:set command to false may not result to a negation evaluation due the value will be stored in the database as 'false' type string. 
As this is a non-zero value it may evaluate to true.
To come over this problem we will coerce the value: 
true => 1
false => 0

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <https://github.com/owncloud/core/issues/37697>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
