### PR TITLE
adapted solution for 5xx error on i10n vsprintf

### DIFF
--- a/changelog/unreleased/38103
+++ b/changelog/unreleased/38103
@@ -1,0 +1,8 @@
+Bugfix: Prevent server error when loading invalid/corrupt translations
+
+This fix prevents server errors when loading invalid or corrupt translations
+from Transifex. This is critical as every user is able to contribute to
+the ownCloud translations.
+
+https://github.com/owncloud/core/issues/37799
+https://github.com/owncloud/core/pull/38103

--- a/lib/private/legacy/l10n/string.php
+++ b/lib/private/legacy/l10n/string.php
@@ -66,7 +66,10 @@ class OC_L10N_String implements JsonSerializable {
 
 		// Replace %n first (won't interfere with vsprintf)
 		$text = \str_replace('%n', $this->count, $text);
-		return \vsprintf($text, $this->parameters);
+		$text = @\vsprintf($text, $this->parameters);
+
+		// If vsprintf fails, return untranslated string
+		return $text === false ? $this->text : $text;
 	}
 
 	public function jsonSerialize() {

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -46,6 +46,14 @@ class L10nTest extends TestCase {
 		$this->assertEquals('2 Dateien', (string) $l->n('%n file', '%n files', 2));
 	}
 
+	public function testMalformedTranslations() {
+		$lMock = $this->createMock('OC\L10N\L10N');
+		$lMock->method('getTranslations')->willReturn(['malformed' => 'malformed %']);
+
+		$lString = new \OC_L10N_String($lMock, "malformed", []);
+		self::assertEquals('malformed', $lString->__toString());
+	}
+
 	public function testRussianPluralTranslations() {
 		$transFile = \OC::$SERVERROOT.'/tests/data/l10n/ru.json';
 		$l = new L10N($this->getFactory(), 'test', 'ru', [$transFile]);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
As we using the vsprintf links in the i10n translation provider and also translations provided via the community, there is always the possibility, that there might be an error in the translation string.

Especially if there is an unescaped % char in the text, without any parameter, this will provoke an error in the WebUi (Error Page).

Instead of showing a 5xx Error, the original text will be displayed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/37799
- Patch of https://github.com/math221e/core/commit/965636c84987be32fd9aaeb09d4ec26e18645f51

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
