### PR TITLE
when adding public link to owncloud, check for ssl for both with and without redirects

### DIFF
--- a/changelog/unreleased/38104
+++ b/changelog/unreleased/38104
@@ -1,7 +1,7 @@
 Bugfix: adding public link - check for ssl for both with and without redirects
 
 When adding public link to owncloud, checking of SSL certificate is performed.
-However when remote servers cannot handle redirects ToManyRedirects
+However when remote servers cannot handle redirects TooManyRedirects
 error was thrown in this case. Now, we check SSL certificate with and without
 redirects allowed.
 

--- a/changelog/unreleased/38104
+++ b/changelog/unreleased/38104
@@ -1,0 +1,9 @@
+Bugfix: adding public link - check for ssl for both with and without redirects
+
+When adding public link to owncloud, checking of SSL certificate is performed.
+However when remote servers cannot handle redirects ToManyRedirects
+error was thrown in this case. Now, we check SSL certificate with and without
+redirects allowed.
+
+https://github.com/owncloud/enterprise/issues/4241
+https://github.com/owncloud/core/pull/38104


### PR DESCRIPTION
This solves the issue, that when adding public link to owncloud, when checking SSL certificate and servers does not follow redirects, we should also try with "allow_redirects=>false` so redirects are not allowed.