### PR TITLE
[tests-only] Fix test steps for when REPLACE_USERNAMES is in effect

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -385,7 +385,7 @@ Feature: sharing
     #Then user "brian" should see the following elements
     #  | /Shares/randomfile.txt |
     #And the content of file "randomfile.txt" for user "brian" should be "Random data"
-    Then user "brian" should not see the following elements if the upper and lower case username are different
+    Then user "brian" should not see the following elements
       | /Shares/randomfile.txt |
 
   @skipOnLDAP

--- a/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -191,7 +191,7 @@ Feature: sharing
     When user "Alice" deletes the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When user "Brian" requests "/remote.php/dav/files/Brian" with "PROPFIND" using basic auth
+    When user "Brian" requests "/remote.php/dav/files/%username%" with "PROPFIND" using basic auth
     Then the HTTP status code should be "207"
     Examples:
       | ocs_api_version | ocs_status_code |

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -1010,6 +1010,7 @@ class WebDavPropertiesContext implements Context {
 		foreach ($etagTable->getColumnsHash() as $row) {
 			$user = $row["user"];
 			$path = $row["path"];
+			$user = $this->featureContext->getActualUsername($user);
 			$actualEtag = $this->getCurrentEtagOfElement($path, $user);
 			$storedEtag = $this->getStoredEtagOfElement($path, $user, __METHOD__);
 			if ($actualEtag !== $storedEtag) {
@@ -1030,6 +1031,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 */
 	public function etagOfElementOfUserShouldNotHaveChanged(string $path, string $user) {
+		$user = $this->featureContext->getActualUsername($user);
 		$actualEtag = $this->getCurrentEtagOfElement($path, $user);
 		$storedEtag = $this->getStoredEtagOfElement($path, $user, __METHOD__);
 		Assert::assertEquals(
@@ -1056,6 +1058,7 @@ class WebDavPropertiesContext implements Context {
 		foreach ($etagTable->getColumnsHash() as $row) {
 			$user = $row["user"];
 			$path = $row["path"];
+			$user = $this->featureContext->getActualUsername($user);
 			$actualEtag = $this->getCurrentEtagOfElement($path, $user);
 			$storedEtag = $this->getStoredEtagOfElement($path, $user, __METHOD__);
 			if ($actualEtag === $storedEtag) {
@@ -1076,6 +1079,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 */
 	public function etagOfElementOfUserShouldHaveChanged(string $path, string $user) {
+		$user = $this->featureContext->getActualUsername($user);
 		$actualEtag = $this->getCurrentEtagOfElement($path, $user);
 		$storedEtag = $this->getStoredEtagOfElement($path, $user, __METHOD__);
 		Assert::assertNotEquals(


### PR DESCRIPTION
## Description
We have test code that can automagically replace the various usernames `Alice` `Brian` `Carol`... throughout an acceptance test run. That allows us to run the test suite with "unusual" usernames and attributes.

The code of test steps needs to make sure to "translate" the username written in the Gherkin to the actual username being used for the test. Some new etag propagation and other test steps were not doing that.

Add calls to `featureContext->getActualUsername($user)` and other adjustments to tests so that PR #38111 can pass.

## How Has This Been Tested?
PR #38111 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
