### PR TITLE
Wrong app is used in some calls for translation in javascript

### DIFF
--- a/changelog/unreleased/38119
+++ b/changelog/unreleased/38119
@@ -1,0 +1,3 @@
+Bugfix: Fix translations of some strings in settings
+
+https://github.com/owncloud/core/pull/38119

--- a/core/js/multiselect.js
+++ b/core/js/multiselect.js
@@ -231,7 +231,7 @@
 							$.each(options,function(index, item) {
 								if ($(item).val() == value || $(item).text() == value) {
 									exists = true;
-									OC.Notification.showTemporary(t('settings', "Error adding {addItem}: {addItem} already exists", {addItem: value}));
+									OC.Notification.showTemporary(t('core', "Error adding {addItem}: {addItem} already exists", {addItem: value}));
 									return false;
 								}
 							});

--- a/settings/js/admin-apps.js
+++ b/settings/js/admin-apps.js
@@ -33,7 +33,7 @@ OC.Settings = OC.Settings || {};
 OC.Settings.Apps = OC.Settings.Apps || {
 	setupGroupsSelect: function($elements) {
 		OC.Settings.setupGroupsSelect($elements, {
-			placeholder: t('core', 'All')
+			placeholder: t('settings', 'All')
 		});
 	},
 

--- a/settings/js/certificates.js
+++ b/settings/js/certificates.js
@@ -49,8 +49,8 @@ $(document).ready(function () {
 			row.append($('<td/>').attr('title', data.issuerOrganization).text(data.issuer));
 			row.append($('<td/>').addClass('remove').append(
 				$('<img/>').attr({
-					alt: t('core', 'Delete'),
-					title: t('core', 'Delete'),
+					alt: t('settings', 'Delete'),
+					title: t('settings', 'Delete'),
 					src: OC.imagePath('core', 'actions/delete.svg')
 				}).addClass('action')
 			));

--- a/settings/js/panels/authtoken_view.js
+++ b/settings/js/panels/authtoken_view.js
@@ -30,7 +30,7 @@
 		+ '<td class="has-tooltip" title="{{name}}"><span class="token-name">{{name}}</span></td>'
 		+ '<td><span class="last-activity has-tooltip" title="{{lastActivityTime}}">{{lastActivity}}</span></td>'
 		+ '{{#if canDelete}}'
-		+ '<td><a class="icon-delete has-tooltip" title="' + t('core', 'Disconnect') + '"></a></td>'
+		+ '<td><a class="icon-delete has-tooltip" title="' + t('settings', 'Disconnect') + '"></a></td>'
 		+ '{{else}}'
 		+ '<td></td>'
 		+ '{{/if}}'
@@ -170,7 +170,7 @@
 				_this.render();
 			});
 			$.when(loadingTokens).fail(function() {
-				OC.Notification.showTemporary(t('core', 'Error while loading browser sessions and device tokens'));
+				OC.Notification.showTemporary(t('settings', 'Error while loading browser sessions and device tokens'));
 			});
 		},
 
@@ -179,7 +179,7 @@
 
 			var deviceName = this._tokenName.val();
 			if (!deviceName) {
-				OC.Notification.showTemporary(t('core', 'Empty app name is not allowed.'));
+				OC.Notification.showTemporary(t('settings', 'Empty app name is not allowed.'));
 				return;
 			}
 
@@ -201,7 +201,7 @@
 				_this._tokenName.val('');
 			});
 			$.when(creatingToken).fail(function() {
-				OC.Notification.showTemporary(t('core', 'Error while creating device token'));
+				OC.Notification.showTemporary(t('settings', 'Error while creating device token'));
 			});
 			$.when(creatingToken).always(function() {
 				_this._toggleAddingToken(false);
@@ -242,7 +242,7 @@
 
 			var _this = this;
 			$.when(destroyingToken).fail(function() {
-				OC.Notification.showTemporary(t('core', 'Error while deleting the token'));
+				OC.Notification.showTemporary(t('settings', 'Error while deleting the token'));
 			});
 			$.when(destroyingToken).always(function() {
 				_this.render();

--- a/settings/js/panels/profile.js
+++ b/settings/js/panels/profile.js
@@ -96,7 +96,7 @@ function showAvatarCropper () {
 			aspectRatio: 1,
 			boxHeight: 500,
 			boxWidth: 500,
-			setSelect: [0, 0, 100000, 100000]  /* set to a very large value since 
+			setSelect: [0, 0, 100000, 100000]  /* set to a very large value since
 			this will automatically take the minimum with width and height of
 			parent image and aspect ratio is already one, ensuring a square cropper */
 		});
@@ -312,11 +312,11 @@ $(document).ready(function () {
 	$('#pass2').strengthify({
 		zxcvbn: OC.linkTo('core','vendor/zxcvbn/dist/zxcvbn.js'),
 		titles: [
-			t('core', 'Very weak password'),
-			t('core', 'Weak password'),
-			t('core', 'So-so password'),
-			t('core', 'Good password'),
-			t('core', 'Strong password')
+			t('settings', 'Very weak password'),
+			t('settings', 'Weak password'),
+			t('settings', 'So-so password'),
+			t('settings', 'Good password'),
+			t('settings', 'Strong password')
 		],
 		drawTitles: true
 	});

--- a/settings/js/setpassword.js
+++ b/settings/js/setpassword.js
@@ -24,7 +24,7 @@
 				retypePasswordObj.val('');
 				passwordObj.parent().addClass('shake');
 				$('#message').addClass('warning');
-				$('#message').text(t('core', 'Passwords do not match'));
+				$('#message').text(t('settings', 'Passwords do not match'));
 				$('#message').show();
 				passwordObj.focus();
 			}
@@ -39,7 +39,7 @@
 			errorMessage = responseObj.message;
 
 			if (!errorMessage) {
-				errorMessage = t('core', 'Failed to set password. Please contact your administrator.');
+				errorMessage = t('settings', 'Failed to set password. Please contact your administrator.');
 			}
 
 			errorObject.text(errorMessage);

--- a/settings/js/settings.js
+++ b/settings/js/settings.js
@@ -27,7 +27,7 @@ OC.Settings = _.extend(OC.Settings, {
 			// note: settings are saved through a "change" event registered
 			// on all input fields
 			$elements.select2(_.extend({
-				placeholder: t('core', 'Groups'),
+				placeholder: t('settings', 'Groups'),
 				allowClear: true,
 				multiple: true,
 				separator: '|',

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -545,7 +545,7 @@ var UserList = {
 		) {
 			// the select component has added the bogus value, delete it again
 			$select.find('option[selected]').remove();
-			OC.Notification.showTemporary(t('core', 'Invalid quota value "{val}"', {val: quota}));
+			OC.Notification.showTemporary(t('settings', 'Invalid quota value "{val}"', {val: quota}));
 			return;
 		}
 		UserList._updateQuota(uid, quota, function(returnedQuota){
@@ -603,14 +603,14 @@ var UserList = {
                         {username: uid, enabled: enabled},
                         function (result) {
                                	if(result.status == 'success') {
-                                        OC.Notification.showTemporary(t('admin', 'User {uid} has been {state}!',
+                                        OC.Notification.showTemporary(t('settings', 'User {uid} has been {state}!',
                                                                         {uid: uid,
                                                                         state: result.data.enabled === 'true' ?
-                                                                        t('admin', 'enabled') :
-                                                                        t('admin', 'disabled')}
+                                                                        t('settings', 'enabled') :
+                                                                        t('settings', 'disabled')}
                                                                      ));
 				} else {
-                                        OC.Notification.showTemporary(t('admin', result.data.message));
+                                        OC.Notification.showTemporary(t('settings', result.data.message));
 				}
                         }
                );
@@ -750,9 +750,9 @@ $(document).ready(function () {
 							{username: uid, password: $(this).val(), recoveryPassword: recoveryPasswordVal},
 							function (result) {
 								if(result.status == 'success') {
-									OC.Notification.showTemporary(t('admin', 'Password successfully changed'));
+									OC.Notification.showTemporary(t('settings', 'Password successfully changed'));
 								} else {
-									OC.Notification.showTemporary(t('admin', result.data.message));
+									OC.Notification.showTemporary(t('settings', result.data.message));
 								}
 							}
 						);


### PR DESCRIPTION
## Description
If case the wrong app name is used in javascript - e.g. t('core',..) in settings the translations are simply not found.
Rules for core repo:
- each app uses it's app name - files app -> t('files')
- in folder core -> use t('core')
- in folder settings -> use t('settings')

## How Has This Been Tested?
- manually checked a few of the pages, for example changing password, setting an app to be limited to a particular group,... and the translation to `de` now happens @phil-davis 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
