### PR TITLE
[tests-only] Bump test tool dependencies

### DIFF
--- a/apps/dav/lib/CalDAV/BirthdayService.php
+++ b/apps/dav/lib/CalDAV/BirthdayService.php
@@ -184,12 +184,14 @@ class BirthdayService {
 		$vCal->VERSION = '2.0';
 		$vEvent = $vCal->createComponent('VEVENT');
 		$vEvent->add('DTSTART');
+		/* @phan-suppress-next-line PhanUndeclaredMethod */
 		$vEvent->DTSTART->setDateTime(
 			$date
 		);
 		$vEvent->DTSTART['VALUE'] = 'DATE';
 		$vEvent->add('DTEND');
 		$date->add(new \DateInterval('P1D'));
+		/* @phan-suppress-next-line PhanUndeclaredMethod */
 		$vEvent->DTEND->setDateTime(
 			$date
 		);

--- a/apps/dav/lib/CalDAV/CalendarObject.php
+++ b/apps/dav/lib/CalDAV/CalendarObject.php
@@ -61,6 +61,7 @@ class CalendarObject extends \Sabre\CalDAV\CalendarObject {
 			$vElement = $vObject->VTODO;
 		}
 		if ($vElement !== null) {
+			/* @phan-suppress-next-line PhanUndeclaredMethod */
 			foreach ($vElement->children() as &$property) {
 				/** @var Property $property */
 				switch ($property->name) {
@@ -76,13 +77,14 @@ class CalendarObject extends \Sabre\CalDAV\CalendarObject {
 						$property->setValue('Busy');
 						break;
 					default:
+						/* @phan-suppress-next-line PhanUndeclaredMethod */
 						$vElement->__unset($property->name);
 						unset($property);
 						break;
 				}
 			}
 		}
-		
+
 		return $vObject->serialize();
 	}
 }

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -317,10 +317,14 @@ class SFTP extends \OCP\Files\Storage\StorageAdapter {
 	public function filetype($path) {
 		try {
 			$stat = $this->getConnection()->stat($this->absPath($path));
+			/* ToDo: Investigate if NET_SFTP_TYPE_REGULAR is an available constant */
+			/* @phan-suppress-next-line PhanUndeclaredConstant */
 			if ($stat['type'] == NET_SFTP_TYPE_REGULAR) {
 				return 'file';
 			}
 
+			/* ToDo: Investigate if NET_SFTP_TYPE_DIRECTORY is an available constant */
+			/* @phan-suppress-next-line PhanUndeclaredConstant */
 			if ($stat['type'] == NET_SFTP_TYPE_DIRECTORY) {
 				return 'dir';
 			}
@@ -419,6 +423,8 @@ class SFTP extends \OCP\Files\Storage\StorageAdapter {
 	 * @throws \Exception
 	 */
 	public function uploadFile($path, $target) {
+		/* ToDo: Investigate if NET_SFTP_LOCAL_FILE is an available constant */
+		/* @phan-suppress-next-line PhanUndeclaredConstant */
 		$this->getConnection()->put($target, $path, NET_SFTP_LOCAL_FILE);
 	}
 

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "behat/behat": "^3.7",
+        "behat/behat": "^3.8",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
         "behat/mink-goutte-driver": "^1.2",

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^2.7"
+        "phan/phan": "^3.2"
     }
 }


### PR DESCRIPTION
## Description
1) Set behat to minimum of 3.8, which is the current minor version that happens in practice anyway.
2) Bump phan from 2.7 to new major version 3.2. And suppress some PhanUndeclaredMethod in CalDAV code. That uses properties accessed by "magic methods" and phan cannot be sure if the property will turn out to be a class that has the `setDateTime` ... method.
3) Suppress NET_SFTP PhanUndeclaredConstant messages for now
phan reports:
```
apps/files_external/lib/Lib/Storage/SFTP.php:320 PhanUndeclaredConstant Reference to undeclared constant \NET_SFTP_TYPE_REGULAR. This will cause a thrown Error in php 8.0+.
apps/files_external/lib/Lib/Storage/SFTP.php:324 PhanUndeclaredConstant Reference to undeclared constant \NET_SFTP_TYPE_DIRECTORY. This will cause a thrown Error in php 8.0+.
apps/files_external/lib/Lib/Storage/SFTP.php:422 PhanUndeclaredConstant Reference to undeclared constant \NET_SFTP_LOCAL_FILE. This will cause a thrown Error in php 8.0+.
```
It needs to be investigated if these really are undeclared constants, or if they somehow become available via phpseclib or?
I raised issue #38123 


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
