### PR TITLE
[tests-only] Use guzzle7 in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -21,9 +21,9 @@
 
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Ring\Exception\ConnectException;
 use GuzzleHttp\Stream\StreamInterface;
-use Guzzle\Http\Exception\BadResponseException;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use TestHelpers\OcsApiHelper;

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -11,7 +11,7 @@
         "sensiolabs/behat-page-object-extension": "^2.3",
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
-        "guzzlehttp/guzzle": "^6.5",
+        "guzzlehttp/guzzle": "^7.2",
         "phpunit/phpunit": "^8.5",
         "laminas/laminas-ldap": "^2.10"
     }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -3,7 +3,6 @@
         "behat/behat": "^3.8",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
-        "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "ciaranmcnulty/behat-stepthroughextension" : "dev-master",
         "jarnaiz/behat-junit-formatter": "^1.3",


### PR DESCRIPTION
## Description
https://github.com/guzzle/guzzle/releases/tag/7.2.0

https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md

We don't use any of the stuff in the linked upgrade guide. So that's nice - the tests pass without messing around.

This PR includes the code in #38129 "Remove behat/mink-goutte-driver from acceptance tests".  It uses https://github.com/FriendsOfPHP/Goutte and that currently causes problems with composer dependencies if we try to use a later guzzle v7. We do not use `behat/mink-goutte-driver` anyway. I guess it was used somewhere in the long-distant past?


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
