### PR TITLE
[tests-only] Remove behat/mink-goutte-driver from acceptance tests

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -3,7 +3,6 @@
         "behat/behat": "^3.8",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
-        "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
         "ciaranmcnulty/behat-stepthroughextension" : "dev-master",
         "jarnaiz/behat-junit-formatter": "^1.3",


### PR DESCRIPTION
## Description
Remove `behat/mink-goutte-driver` from acceptance tests dependencies. It uses https://github.com/FriendsOfPHP/Goutte and that currently causes problems with composer dependencies if we try to use a later guzzle v7.

We do not use `behat/mink-goutte-driver` anyway. I guess it was used somewhere in the long-distant past?

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
