### PR TITLE
[tests-only] Use phpunit9 in acceptance tests

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -28,7 +28,8 @@ return [
 		'lib',
 		'ocs',
 		'ocs-provider',
-		'settings'
+		'settings',
+		'tests'
 	],
 
 	'exclude_file_list' => [

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -11,7 +11,7 @@
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^7.2",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^9.4",
         "laminas/laminas-ldap": "^2.10"
     }
 }


### PR DESCRIPTION
## Description
1) The behat acceptance test runner is always being run with PHP 7.4 these days. So use the latest phpunit major version 9 also. In practice the acceptance tests just use the `Assert` functions from phpunit, so the new major version should run quite easily.

2) Add the `tests` dir to the things checked by `phan`. This will help find any "obvious" code problems in the test code.

## Motivation
Be as up-to-date as we can be with test dependencies, so that we get the best available code of dependencies.

## How Has This Been Tested?
1) CI will tell us if all the phpunit `Assert::*` calls run OK.

2) `make test-php-phan` locally. It uses to analyse about 1500MB, now it analyses about 1900MB. So it is analysing more stuff.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
