### PR TITLE
[tests-only] Use assertStringContainsString in PublicWebDavContext test code

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -1030,7 +1030,7 @@ class PublicWebDavContext implements Context {
 			$mtime = \explode(" ", $mtime);
 			\array_pop($mtime);
 			$mtime = \implode(" ", $mtime);
-			Assert::assertContains(
+			Assert::assertStringContainsString(
 				$mtime,
 				\TestHelpers\WebDavHelper::getMtimeOfFileinPublicLinkShare($baseUrl, $fileName, $token)
 			);


### PR DESCRIPTION
## Description
`PublicWebDavContext` uses `assertContains` to compare 2 strings. That is no longer correct in phpunit9. We need to use `assertStringContainsString`
`
This was not noticed when running CI in oC10 core, because that code is inside OcisHelper::isTestingOnOcisOrReva()`

The test fails happened in https://github.com/owncloud/ocis/pull/907 and https://github.com/cs3org/reva/pull/1327
https://drone.owncloud.com/owncloud/ocis/1561/26/7
```
runsh: Total unexpected failed scenarios throughout the test run:
apiSharePublicLink1/createPublicLinkShare.feature:775
apiSharePublicLink1/createPublicLinkShare.feature:776
apiSharePublicLink1/createPublicLinkShare.feature:789
apiSharePublicLink1/createPublicLinkShare.feature:790
apiSharePublicLink1/createPublicLinkShare.feature:793
apiSharePublicLink1/createPublicLinkShare.feature:804
```

I also examined each remaining use of `assertContains` and they are all correctly checking for a needle in a haystack that is an array.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
