### PR TITLE
Context menu for files in case multiple (default-)actions apply

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -216,6 +216,16 @@ config = {
 				'notifications': 'composer install'
 			},
 		},
+		'webUIFileActionsMenu': {
+			'suites': {
+				'webUIFileActionsMenu': '',
+			},
+			'useHttps': False,
+			'extraApps': {
+				'files_texteditor': 'make vendor',
+				'richdocuments': 'make vendor',
+			},
+		},
 		'webUIFederation': {
 			'suites': {
 				'webUISharingExternal1': 'webUISharingExt1',

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -991,3 +991,13 @@ html.ie8 #controls .button.new {
 	position: inherit;
 	right: inherit;
 }
+
+.fileActionsApplicationSelectMenu.bubble{
+	right: initial;
+	left: 45px !important;
+}
+
+.fileActionsApplicationSelectMenu.bubble:after{
+	right: initial;
+	left: 15px !important;
+}

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -215,34 +215,24 @@
 		 * @param {string} type "dir" or "file"
 		 * @param {int} permissions permissions
 		 *
-		 * @return {Array.<OCA.Files.FileAction>} array of action specs
+		 * @return {Object.<OCA.Files.FileAction>} array of action specs
 		 */
 		getActions: function (mime, type, permissions) {
-			var actions = {};
-			if (this.actions.all) {
-				actions = $.extend(actions, this.actions.all);
-			}
-			if (type) {//type is 'dir' or 'file'
-				if (this.actions[type]) {
-					actions = $.extend(actions, this.actions[type]);
-				}
-			}
-			if (mime) {
-				var mimePart = mime.substr(0, mime.indexOf('/'));
-				if (this.actions[mimePart]) {
-					actions = $.extend(actions, this.actions[mimePart]);
-				}
-				if (this.actions[mime]) {
-					actions = $.extend(actions, this.actions[mime]);
-				}
-			}
-			var filteredActions = {};
-			$.each(actions, function (name, action) {
-				if (action.permissions & permissions) {
-					filteredActions[name] = action;
-				}
-			});
-			return filteredActions;
+			return this._getActions(mime, type, permissions, false);
+		},
+
+		/**
+		 * Returns an array of file actions matching the given conditions while
+		 * omitting the actions which apply to all mime types ("Rename", "Download" etc.)
+		 *
+		 * @param {string} mime mime type
+		 * @param {string} type "dir" or "file"
+		 * @param {int} permissions permissions
+		 *
+		 * @return {Object.<OCA.Files.FileAction>} array of action specs
+		 */
+		getActionsWithoutAll: function (mime, type, permissions) {
+			return this._getActions(mime, type, permissions, true);
 		},
 
 		/**
@@ -291,6 +281,45 @@
 			}
 			var actions = this.getActions(mime, type, permissions);
 			return actions[name];
+		},
+
+		/**
+		 * Returns an array of file actions matching the given conditions
+		 *
+		 * @param {string} mime mime type
+		 * @param {string} type "dir" or "file"
+		 * @param {int} permissions permissions
+		 * @param {boolean} excludeAll excludeAll
+		 *
+		 * @return {Object.<OCA.Files.FileAction>} array of action specs
+		 */
+		_getActions: function (mime, type, permissions, excludeAll) {
+			var actions = {};
+
+			if (this.actions.all && excludeAll !== true) {
+				actions = $.extend(actions, this.actions.all);
+			}
+			if (type) {//type is 'dir' or 'file'
+				if (this.actions[type]) {
+					actions = $.extend(actions, this.actions[type]);
+				}
+			}
+			if (mime) {
+				var mimePart = mime.substr(0, mime.indexOf('/'));
+				if (this.actions[mimePart]) {
+					actions = $.extend(actions, this.actions[mimePart]);
+				}
+				if (this.actions[mime]) {
+					actions = $.extend(actions, this.actions[mime]);
+				}
+			}
+			var filteredActions = {};
+			$.each(actions, function (name, action) {
+				if (action.permissions & permissions) {
+					filteredActions[name] = action;
+				}
+			});
+			return filteredActions;
 		},
 
 		/**
@@ -736,6 +765,7 @@
 	 * @property {Object} $file jQuery file row element
 	 * @property {OCA.Files.FileActions} fileActions file actions object
 	 * @property {OCA.Files.FileList} fileList file list object
+	 * @property {String} dir file dir
 	 */
 
 	/**

--- a/apps/files/js/fileactionsapplicationselectmenu.js
+++ b/apps/files/js/fileactionsapplicationselectmenu.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2014
+ *
+ * This file is licensed under the Affero General Public License version 3
+ * or later.
+ *
+ * See the COPYING-README file.
+ *
+ */
+
+(function() {
+
+	var TEMPLATE_MENU =
+		'<ul>' +
+		'<li>'+ t('files', 'How do you want to open this file?')+'</li>' +
+		'{{#each items}}' +
+		'<li>' +
+			'<a href="#" class="menuitem action action-{{nameLowerCase}} permanent" data-action="{{name}}">' +
+				'{{#if icon}}<img class="icon" src="{{icon}}"/>' +
+				'{{else}}'+
+					'{{#if iconClass}}' +
+						'<span class="icon {{iconClass}}"></span>' +
+					'{{else}}' +
+						'<span class="no-icon"></span>' +
+					'{{/if}}' +
+				'{{/if}}' +
+				'<span>{{displayName}}</span>' +
+		'	</a>' +
+		'</li>' +
+		'{{/each}}' +
+		'</ul>';
+
+	/**
+	 * Construct a new FileActionsApplicationSelectMenu instance
+	 * @constructs FileActionsApplicationSelectMenu
+	 * @memberof OCA.Files
+	 */
+	var FileActionsApplicationSelectMenu = OC.Backbone.View.extend({
+		tagName: 'div',
+		className: 'fileActionsApplicationSelectMenu popovermenu bubble hidden open menu',
+
+		/**
+		 * Current context
+		 *
+		 * @type OCA.Files.FileActionContext
+		 */
+		_context: null,
+
+		events: {
+			'click a.action': '_onClickAction'
+		},
+
+		template: function(data) {
+			if (!OCA.Files.FileActionsApplicationSelectMenu._TEMPLATE) {
+				OCA.Files.FileActionsApplicationSelectMenu._TEMPLATE = Handlebars.compile(TEMPLATE_MENU);
+			}
+			return OCA.Files.FileActionsApplicationSelectMenu._TEMPLATE(data);
+		},
+
+		/**
+		 * Event handler whenever an action has been clicked within the App Drawer
+		 *
+		 * @param {Object} event event object
+		 */
+		_onClickAction: function(event) {
+			var $target = $(event.target);
+			if (!$target.is('a')) {
+				$target = $target.closest('a');
+			}
+			var fileActions = this._context.fileActions;
+			var actionName = $target.attr('data-action');
+			var actions = fileActions.getActions(
+				fileActions.getCurrentMimeType(),
+				fileActions.getCurrentType(),
+				fileActions.getCurrentPermissions()
+			);
+			var actionSpec = actions[actionName];
+			var fileName = this._context.$file.attr('data-file');
+
+			event.stopPropagation();
+			event.preventDefault();
+
+			OC.hideMenus();
+
+			actionSpec.action(
+				fileName,
+				this._context
+			);
+		},
+
+		render: function() {
+			var fileActions = this._context.fileActions;
+			var actions = fileActions.getActionsWithoutAll(
+				fileActions.getCurrentMimeType(),
+				fileActions.getCurrentType(),
+				fileActions.getCurrentPermissions()
+			);
+
+			var items = [];
+
+			Object.keys(actions).forEach(function (actionKey) {
+				items.push(actions[actionKey]);
+			});
+
+			this.$el.html(this.template({
+				items: items
+			}));
+		},
+
+		/**
+		 * Displays the App Drawer menu.
+		 *
+		 * @param {OCA.Files.FileActionContext} context context
+		 * @param {jQuery} target target element to append menu
+		 */
+		show: function(context, target) {
+			this._context = context;
+
+			target.append(this.$el);
+			this.$el.on('afterHide', function() {
+				this.remove();
+			});
+
+			this.render();
+			this.$el.removeClass('hidden');
+			OC.Util.scrollIntoView(this.$el, null);
+			OC.showMenu(null, this.$el);
+		}
+	});
+
+	OCA.Files.FileActionsApplicationSelectMenu = FileActionsApplicationSelectMenu;
+
+})();
+

--- a/apps/files/js/fileactionsmenu.js
+++ b/apps/files/js/fileactionsmenu.js
@@ -106,10 +106,15 @@
 
 			actions = fileActions._advancedFilter(actions, this._context);
 
+			// always show default actions for files but not for directories
 			var items = _.filter(actions, function(actionSpec) {
 				return (
 					actionSpec.type === OCA.Files.FileActions.TYPE_DROPDOWN &&
-					(!defaultAction || actionSpec.name !== defaultAction.name)
+					(
+						!defaultAction ||
+						actionSpec.name !== defaultAction.name ||
+						fileActions.getCurrentType() !== 'dir'
+					)
 				);
 			});
 			items = _.map(items, function(item) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -665,17 +665,28 @@
 						var mime = this.fileActions.getCurrentMimeType();
 						var type = this.fileActions.getCurrentType();
 						var permissions = this.fileActions.getCurrentPermissions();
+						var actionsWithoutAll = this.fileActions.getActionsWithoutAll(mime,type, permissions);
+						var context = {
+							$file: $tr,
+							fileList: this,
+							fileActions: this.fileActions,
+							dir: $tr.attr('data-path') || this.getCurrentDirectory()
+						};
+
+						// don't show app drawer for directories as we want to open them per default
+						if (Object.keys(actionsWithoutAll).length > 1 && type !== 'dir') {
+							var appSelectMenu = new OCA.Files.FileActionsApplicationSelectMenu();
+							appSelectMenu.show(context, $tr.find('td.filename'));
+							event.preventDefault();
+							return;
+						}
+
 						var action = this.fileActions.getDefault(mime,type, permissions);
 						if (action) {
 							event.preventDefault();
 							// also set on global object for legacy apps
 							window.FileActions.currentFile = this.fileActions.currentFile;
-							action(filename, {
-								$file: $tr,
-								fileList: this,
-								fileActions: this.fileActions,
-								dir: $tr.attr('data-path') || this.getCurrentDirectory()
-							});
+							action(filename, context);
 						}
 						// deselect row
 						$(event.target).closest('a').blur();

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -186,6 +186,7 @@ class ViewController extends Controller {
 
 		\OCP\Util::addScript('files', 'fileactions');
 		\OCP\Util::addScript('files', 'fileactionsmenu');
+		\OCP\Util::addScript('files', 'fileactionsapplicationselectmenu');
 		\OCP\Util::addScript('files', 'files');
 		\OCP\Util::addScript('files', 'keyboardshortcuts');
 		\OCP\Util::addScript('files', 'navigation');

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -278,6 +278,52 @@ describe('OCA.Files.FileActions tests', function() {
 			expect($tr.find('.action.action-iconnoalttext').find('.icon').length).toEqual(1);
 			expect($tr.find('.action.action-iconnoalttext').find('.hidden-visually').length).toEqual(0);
 		});
+		it('get all file actions for a specific mime type', function() {
+			fileActions.registerAction({
+				mime: 'application/pdf',
+				name: 'View PDF file',
+				type: OCA.Files.FileActions.TYPE_INLINE,
+				permissions: OC.PERMISSION_READ,
+				icon: OC.imagePath('core', 'actions/test')
+			});
+
+			fileActions.registerAction({
+				mime: 'application/pdf',
+				name: 'Edit PDF file',
+				type: OCA.Files.FileActions.TYPE_INLINE,
+				permissions: OC.PERMISSION_UPDATE,
+				icon: OC.imagePath('core', 'actions/test')
+			});
+
+			var actions = fileActions.getActions(
+				'application/pdf',
+				OCA.Files.FileActions.TYPE_INLINE,
+				OC.PERMISSION_READ
+			);
+
+			expect(Object.keys(actions).length).toEqual(3);
+			expect(Object.keys(actions).indexOf('View PDF file') >= 0).toEqual(true);
+			expect(Object.keys(actions).indexOf('Edit PDF file') <= 0).toEqual(true);
+		});
+		it('get file actions for a specific mime type omitting the ones which apply to all mime types', function() {
+			fileActions.registerAction({
+				mime: 'application/pdf',
+				name: 'View PDF file',
+				type: OCA.Files.FileActions.TYPE_INLINE,
+				permissions: OC.PERMISSION_READ,
+				icon: OC.imagePath('core', 'actions/test')
+			});
+
+			var actions = fileActions.getActionsWithoutAll(
+				'application/pdf',
+				OCA.Files.FileActions.TYPE_INLINE,
+				OC.PERMISSION_READ
+			);
+
+			expect(Object.keys(actions).length).toEqual(1);
+			expect(Object.keys(actions).indexOf('View PDF file') >= 0).toEqual(true);
+			expect(Object.keys(actions).indexOf('Testdefault') <= 0).toEqual(true);
+		});
 	});
 	describe('action handler', function() {
 		var actionStub, $tr, clock;

--- a/apps/files/tests/js/fileactionsmenuSpec.js
+++ b/apps/files/tests/js/fileactionsmenuSpec.js
@@ -110,8 +110,8 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 			expect($action.find('img').length).toEqual(0);
 			expect($action.find('.no-icon').length).toEqual(1);
 		});
-		it('does not render default actions', function() {
-			expect(menu.$el.find('a[data-action=Testdefault]').length).toEqual(0);
+		it('does render default actions', function() {
+			expect(menu.$el.find('a[data-action=Testdefault]').length).toEqual(1);
 		});
 		it('does not render inline actions', function() {
 			expect(menu.$el.find('a[data-action=Testinline]').length).toEqual(0);

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2351,6 +2351,67 @@ describe('OCA.Files.FileList tests', function() {
 			expect(context.fileActions).toBeDefined();
 			expect(context.dir).toEqual('/subdir');
 		});
+		it('clicking on a file name will render the app drawer context menu if more than one action applies for this mime type', function() {
+			var actionStub = sinon.stub();
+			fileList.setFiles(testFiles);
+			fileList.fileActions.registerAction({
+				mime: 'text/plain',
+				name: 'View file',
+				type: OCA.Files.FileActions.TYPE_INLINE,
+				permissions: OC.PERMISSION_ALL,
+				icon: function() {
+					return OC.imagePath('core','actions/history');
+				},
+				actionHandler: actionStub,
+			});
+			fileList.fileActions.registerAction({
+				mime: 'text/plain',
+				name: 'Edit file',
+				type: OCA.Files.FileActions.TYPE_INLINE,
+				permissions: OC.PERMISSION_ALL,
+				icon: function() {
+					return OC.imagePath('core','actions/history');
+				},
+			});
+
+			fileList.fileActions.setDefault('text/plain', 'View file');
+			var $tr = fileList.findFileEl('One.txt');
+			$tr.find('td.filename .nametext').click();
+			expect(actionStub.calledOnce).toEqual(false);
+			expect($tr.find('td.filename .fileActionsApplicationSelectMenu').length).toEqual(1);
+			expect($tr.find('td.filename .fileActionsApplicationSelectMenu a').length).toEqual(2);
+			var firstAction = $tr.find('td.filename .fileActionsApplicationSelectMenu a')[0];
+			firstAction.click();
+			expect(actionStub.calledOnce).toEqual(true);
+		});
+		it('clicking on a directory name will never render the app drawer context menu', function() {
+			var actionStub = sinon.stub();
+			fileList.setFiles(testFiles);
+			fileList.fileActions.registerAction({
+				mime: 'httpd/unix-directory',
+				name: 'View dir',
+				type: 'dir',
+				permissions: OC.PERMISSION_ALL,
+				icon: function() {
+					return OC.imagePath('core','actions/history');
+				},
+				actionHandler: actionStub,
+			});
+			fileList.fileActions.registerAction({
+				mime: 'httpd/unix-directory',
+				name: 'Edit dir',
+				type: 'dir',
+				permissions: OC.PERMISSION_ALL,
+				icon: function() {
+					return OC.imagePath('core','actions/history');
+				},
+			});
+
+			fileList.fileActions.setDefault('httpd/unix-directory', 'View dir');
+			var $tr = fileList.findFileEl('somedir');
+			$tr.find('td.filename .nametext').click();
+			expect(actionStub.calledOnce).toEqual(true);
+		});
 		it('redisplays actions when new actions have been registered', function() {
 			var actionStub = sinon.stub();
 			var readyHandler = sinon.stub();

--- a/changelog/unreleased/38132
+++ b/changelog/unreleased/38132
@@ -1,0 +1,11 @@
+Enhancement: Context menu for files in case multiple actions apply
+
+When triggering the default action for a file which can be opened or edited
+with more than one app, a new context menu is displayed. This menu will
+ask the user with which app the corresponding file should be opened.
+
+This also solves the problem with some apps which set themselves as
+default without asking or even informing the user.
+
+https://github.com/owncloud/core/pull/38132
+https://github.com/owncloud/enterprise/issues/4261

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -1142,6 +1142,17 @@ default:
         - OccContext:
         - PublicWebDavContext:
 
+    webUIFileActionsMenu:
+      paths:
+        - '%paths.base%/../features/webUIFileActionsMenu'
+      context: *common_ldap_suite_context
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIFileActionsMenuContext:
+
   extensions:
     jarnaiz\JUnitFormatter\JUnitFormatterExtension:
       filename: report.xml

--- a/tests/acceptance/features/bootstrap/WebUIFileActionsMenuContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFileActionsMenuContext.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2019 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+require_once 'bootstrap.php';
+
+use Behat\Behat\Context\Context;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Page\FilesPage;
+
+/**
+ * Context for file actions menu
+ */
+class WebUIFileActionsMenuContext extends RawMinkContext implements Context {
+	/**
+	 *
+	 * @var FilesPage
+	 */
+	private $filesPage;
+
+	/**
+	 * WebUIFileActionsMenuContext constructor.
+	 *
+	 * @param FilesPage $filesPage
+	 *
+	 * @return void
+	 */
+	public function __construct(FilesPage $filesPage) {
+		$this->filesPage = $filesPage;
+	}
+
+	/**
+	 * @When the user clicks on the file :filename
+	 *
+	 * @param string $filename
+	 *
+	 * @return void
+	 */
+	public function theUserClicksOnTheFile(string $filename) {
+		$this->filesPage->openFile($filename, $this->getSession());
+	}
+
+	/**
+	 * @Then the file actions application select menu should be displayed with these items on the webUI
+	 *
+	 * @param \Behat\Gherkin\Node\TableNode $menuItems
+	 *
+	 * @return void
+	 */
+	public function theFileActionsApplicationSelectMenuShouldBeDisplayed(
+		\Behat\Gherkin\Node\TableNode $menuItems
+	) {
+		$menuContent = $this->filesPage->getFileActionsApplicationSelectMenu();
+		foreach ($menuItems->getRows()[0] as $item) {
+			PHPUnit\Framework\Assert::assertStringContainsString(
+				$item,
+				$menuContent,
+				__METHOD__ . " Item '$item' was not found."
+			);
+		}
+	}
+
+	/**
+	 * @Then the file actions menu should be displayed with these items on the webUI
+	 *
+	 * @param \Behat\Gherkin\Node\TableNode $menuItems
+	 *
+	 * @return void
+	 */
+	public function theFileActionsMenuShouldBeDisplayed(\Behat\Gherkin\Node\TableNode $menuItems) {
+		$menuContent = $this->filesPage->getFileActionsMenu();
+		foreach ($menuItems->getRows()[0] as $item) {
+			PHPUnit\Framework\Assert::assertStringContainsString(
+				$item,
+				$menuContent,
+				__METHOD__ . " Item '$item' was not found."
+			);
+		}
+	}
+}

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -52,6 +52,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	protected $styleOfCheckboxWhenVisible = "display: block;";
 	protected $detailsDialogXpath = "//*[contains(@id, 'app-sidebar') and not(contains(@class, 'disappear'))]";
 	protected $newFileFolderButtonXpath = './/*[@id="controls"]//a[@class="button new"]';
+	protected $fileActionsApplicationSelectMenuXpath = ".//div[contains(@class, 'fileActionsApplicationSelectMenu')]";
 
 	/**
 	 * @return string
@@ -662,5 +663,39 @@ abstract class FilesPageBasic extends OwncloudPage {
 			return false;
 		}
 		return $btn->isVisible();
+	}
+
+	/**
+	 * get file actions application select menu
+	 *
+	 * @return string
+	 */
+	public function getFileActionsApplicationSelectMenu() {
+		$menu = $this->find("xpath", $this->fileActionsApplicationSelectMenuXpath);
+
+		if ($menu === null) {
+			throw new ElementNotFoundException(
+				"could not find file actions application select menu"
+			);
+		}
+
+		return $menu->getText();
+	}
+
+	/**
+	 * get file actions menu
+	 *
+	 * @return string
+	 */
+	public function getFileActionsMenu() {
+		$menu = $this->find("xpath", $this->fileActionMenuXpath);
+
+		if ($menu === null) {
+			throw new ElementNotFoundException(
+				"could not find file actions menu"
+			);
+		}
+
+		return $menu->getText();
 	}
 }

--- a/tests/acceptance/features/webUIFileActionsMenu/fileActionsMenu.feature
+++ b/tests/acceptance/features/webUIFileActionsMenu/fileActionsMenu.feature
@@ -1,0 +1,20 @@
+@webUI @insulated @disablePreviews @richdocuments-app-required @files_texteditor-app-required
+Feature: File actions menu
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+
+  Scenario: show the file actions application select menu with both Collabora and the Files Texteditor
+    When the user clicks on the file "lorem.txt"
+    Then the file actions application select menu should be displayed with these items on the webUI
+      | Open in Text Editor | Open in Collabora |
+
+  Scenario: show the actions for Collabora and the Files Texteditor in the file action menu
+    And the user opens the file action menu of file "lorem.txt" on the webUI
+    Then the file actions menu should be displayed with these items on the webUI
+      | Open in Text Editor | Open in Collabora |


### PR DESCRIPTION
## Description
Show app drawer when requesting the default action for a file to which more than 1 action applies. The user can then select with which app the file should be opened (or edited).

## Related Issue
- Partly fixes https://github.com/owncloud/enterprise/issues/4261

## Screenshots
![Screenshot_20201211_111046](https://user-images.githubusercontent.com/26169327/101890940-afcaa980-3ba1-11eb-8597-784bae9cc1dc.png)
![Screenshot_20201211_111110](https://user-images.githubusercontent.com/26169327/101890948-b1946d00-3ba1-11eb-89be-a5ae378e8a91.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
