### PR TITLE
Alternative SMB external storage implementation where all users of on…

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -46,6 +46,8 @@ class SMB extends ExternalBackend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('domain', $l->t('Domain')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('one-storage', $l->t('All users share this storage')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
 		;

--- a/apps/files_external/lib/Lib/Cache/SmbCacheWrapper.php
+++ b/apps/files_external/lib/Lib/Cache/SmbCacheWrapper.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Cache;
+
+use OC\Files\Cache\Wrapper\CacheWrapper;
+use OCA\Files_External\Lib\Storage\SMB;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\ICacheEntry;
+
+/**
+ * Class SmbCacheWrapper
+ *
+ * Reads the cache information from the underlying cache implementation and
+ * verifies if the current user has access by calling stat on the storage.
+ *
+ * In case performance becomes a problem we might want to include a stat cache
+ * per user on e.g. redis or so.
+ *
+ * @package OCA\Files_External\Lib\Cache
+ */
+class SmbCacheWrapper extends CacheWrapper {
+	/**
+	 * @var SMB
+	 */
+	private $smb;
+
+	public function __construct(ICache $cache, SMB $smb) {
+		parent::__construct($cache);
+		$this->smb = $smb;
+	}
+
+	public function get($file) {
+		if ($this->smb->stat($file)) {
+			return parent::get($file);
+		}
+		return null;
+	}
+
+	public function getFolderContents($folder) {
+		$children = parent::getFolderContents($folder);
+		return \array_filter($children, function (ICacheEntry $c) {
+			return $this->smb->stat($c->getPath());
+		});
+	}
+
+	public function getFolderContentsById($fileId) {
+		$children = parent::getFolderContentsById($fileId);
+		return \array_filter($children, function (ICacheEntry $c) {
+			return $this->smb->stat($c->getPath());
+		});
+	}
+}

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -38,6 +38,7 @@ use Icewind\SMB\Exception\ForbiddenException;
 use Icewind\SMB\Exception\NotFoundException;
 use Icewind\SMB\BasicAuth;
 use Icewind\SMB\IFileInfo;
+use Icewind\SMB\IServer;
 use Icewind\SMB\Native\NativeServer;
 use Icewind\SMB\Wrapped\FileInfo;
 use Icewind\SMB\ServerFactory;
@@ -48,17 +49,18 @@ use Icewind\Streams\IteratorDirectory;
 use OC\Cache\CappedMemoryCache;
 use OC\Files\Filesystem;
 use OCA\Files_External\Lib\Cache\SmbCacheWrapper;
+use OCP\Files\Storage\StorageAdapter;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Util;
 
-class SMB extends \OCP\Files\Storage\StorageAdapter {
+class SMB extends StorageAdapter {
 	/**
-	 * @var \Icewind\SMB\IServer
+	 * @var IServer
 	 */
 	protected $server;
 
 	/**
-	 * @var \Icewind\SMB\IShare
+	 * @var IShare
 	 */
 	protected $share;
 
@@ -451,8 +453,12 @@ class SMB extends \OCP\Files\Storage\StorageAdapter {
 	 */
 	public function hasUpdated($path, $time) {
 		$this->log('enter: '.__FUNCTION__."($path, $time)");
-		$actualTime = $this->filemtime($path);
-		$result = $actualTime > $time;
+		if ($this->useSingletonStorage) {
+			$result = true;
+		} else {
+			$actualTime = $this->filemtime($path);
+			$result = $actualTime > $time;
+		}
 		return $this->leave(__FUNCTION__, $result);
 	}
 


### PR DESCRIPTION
…e share use the same storage id. User specific access is filtered in a cache wrapper by stating the files on SMB


## Description
- all users share the same storage id for the smb share (loggin via user credentials)
- fileids are constant over users
- fileid based concepts work (tagging, comments, direct link, file locking, wopi)

## ToDo:
- [x] find a backwards compatible implementation
  - [x] parameter
  - [ ] mount point option
  - [ ] own backend class
- [ ] test performance
- [ ] update detection needs love - different users with different permissions need to retrigger a scan ..... somehow ....

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):

### Same file id is used and as result comments and tags are show properly on both users:
![Screenshot from 2020-11-24 12-12-41](https://user-images.githubusercontent.com/1005065/100089893-b1cb0380-2e52-11eb-857b-144951d9300c.png)

### File ID is the same - see last query parameter in url
![Screenshot from 2020-11-24 12-10-00](https://user-images.githubusercontent.com/1005065/100089899-b394c700-2e52-11eb-88fc-4050bab2ef4e.png)

### Tow users with different permissions see folder content accordingly:
![Screenshot from 2020-11-24 12-08-56](https://user-images.githubusercontent.com/1005065/100089910-b5f72100-2e52-11eb-9b5a-ce2a890a260b.png)

### Setup option
@pmaier1 @hodyroff - happy to take your recommendations in terms of naming this checkbox ;-)

![Screenshot from 2020-11-24 15-20-54](https://user-images.githubusercontent.com/1005065/100111233-2c554c80-2e6e-11eb-9570-caa3948005a4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
