### PR TITLE
[tests-only] first TUS upload tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -574,6 +574,16 @@ default:
         - OccContext:
         - PublicWebDavContext:
 
+    apiWebdavUploadTUS:
+      paths:
+        - '%paths.base%/../features/apiWebdavUploadTUS'
+      context: *common_ldap_suite_context
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - LoggingContext:
+        - OccContext:
+        - PublicWebDavContext:
+
     apiWebdavEtagPropagation1:
       paths:
         - '%paths.base%/../features/apiWebdavEtagPropagation1'

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
@@ -1,0 +1,51 @@
+@api @skipOnOcV10
+Feature: upload file
+  As a user
+  I want to be able to upload files
+  So that I can store and share files between multiple client systems
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  Scenario Outline: upload a file and check download content
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file with content "uploaded content" to "<file_name>" using the TUS protocol on the WebDAV API
+    Then the content of file "<file_name>" for user "Alice" should be "uploaded content"
+    Examples:
+      | dav_version | file_name         |
+      | old         | /upload.txt       |
+      | old         | /नेपाली.txt       |
+      | old         | /strängé file.txt |
+      | old         | /s,a,m,p,l,e.txt  |
+      | old         | /C++ file.cpp     |
+      | old         | /?fi=le&%#2 . txt |
+      | old         | /# %ab ab?=ed     |
+      | new         | /upload.txt       |
+      | new         | /strängé file.txt |
+      | new         | /नेपाली.txt       |
+      | new         | /s,a,m,p,l,e.txt  |
+      | new         | /C++ file.cpp     |
+      | new         | /?fi=le&%#2 . txt |
+      | new         | /# %ab ab?=ed     |
+
+  Scenario Outline: upload a file into a folder and check download content
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "<folder_name>"
+    When user "Alice" uploads file with content "uploaded content" to "<folder_name>/<file_name>" using the TUS protocol on the WebDAV API
+    Then the content of file "<folder_name>/<file_name>" for user "Alice" should be "uploaded content"
+    Examples:
+      | dav_version | folder_name                      | file_name                     |
+      | old         | /upload                          | abc.txt                       |
+      | old         | /strängé folder                  | strängé file.txt              |
+      | old         | /C++ folder                      | C++ file.cpp                  |
+      | old         | /नेपाली                          | नेपाली                        |
+      | old         | /folder #2.txt                   | file #2.txt                   |
+      | old         | /folder ?2.txt                   | file ?2.txt                   |
+      | old         | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
+      | new         | /upload                          | abc.txt                       |
+      | new         | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
+      | new         | /C++ folder                      | C++ file.cpp                  |
+      | new         | /नेपाली                          | नेपाली                        |
+      | new         | /folder #2.txt                   | file #2.txt                   |
+      | new         | /folder ?2.txt                   | file ?2.txt                   |
+      | new         | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |


### PR DESCRIPTION
## Description
some happy-path test for uploading files using the TUS protocol
this is not implemented in oc 10 but in OCIS

## Related Issue
part of https://github.com/owncloud/product/issues/153

## Motivation and Context
make sure TUS upload works as expected in ocis

## How Has This Been Tested?
https://github.com/owncloud/ocis/pull/948

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
