### PR TITLE
[tests-only] Add ankitpokhrel/tus-php for acceptance tests

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -12,6 +12,7 @@
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^7.2",
         "phpunit/phpunit": "^9.4",
-        "laminas/laminas-ldap": "^2.10"
+        "laminas/laminas-ldap": "^2.10",
+        "ankitpokhrel/tus-php": "^2.1"
     }
 }


### PR DESCRIPTION
## Description

PR #38142 added the first TUS upload tests. The scenarios are actually only run on OCIS at present (oC10 does not support TUS upload). The needed PHP dependency did not get added. When running the core API tests the dependencies used are the ones in core `vendor-bin/behat` - so add the dependency here in the core test infrastructure.

## How Has This Been Tested?
OCIS CI

Fixes errors in https://drone.owncloud.com/owncloud/ocis/1724/36/7 
```
Fatal error: Class 'TusPhp\Tus\Client' not found (Behat\Testwork\Call\Exception\FatalThrowableError)
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
