### PR TITLE
[tests-only] make mtime upload step upload data

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -764,7 +764,7 @@ Feature: create a public link share
 
   Scenario Outline: Get the mtime of a file shared by public link
     Given using <dav_version> DAV path
-    And user "Alice" has uploaded a file to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | file.txt |
       | permissions | read     |
@@ -778,7 +778,7 @@ Feature: create a public link share
   Scenario Outline: Get the mtime of a file inside a folder shared by public link
     Given using <dav_version> DAV path
     And user "Alice" has created folder "testFolder"
-    And user "Alice" has uploaded a file to "testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | /testFolder |
       | permissions | read        |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -151,9 +151,9 @@ Feature: upload file
   @issue-ocis-reva-174
   Scenario Outline: upload file with mtime
     Given using <dav_version> DAV path
-    When user "Alice" uploads file to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
-    Then as "Alice" file "file.txt" should exist
-    And the HTTP status code should be "201"
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "file.txt" should exist
     And as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
       | dav_version |
@@ -164,9 +164,9 @@ Feature: upload file
   Scenario Outline: upload a file with mtime in a folder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "testFolder"
-    When user "Alice" uploads file to "/testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
-    Then as "Alice" file "/testFolder/file.txt" should exist
-    And the HTTP status code should be "201"
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "/testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "/testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     Examples:
       | dav_version |
@@ -177,7 +177,7 @@ Feature: upload file
   Scenario Outline: moving a file does not changes its mtime
     Given using <dav_version> DAV path
     And user "Alice" has created folder "testFolder"
-    When user "Alice" uploads file to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     And user "Alice" moves file "file.txt" to "/testFolder/file.txt" using the WebDAV API
     Then as "Alice" file "/testFolder/file.txt" should exist
     And the HTTP status code should be "201"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2217,23 +2217,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @param $user
-	 * @param $destination
-	 * @param $mtime
-	 *
-	 * @return void
-	 */
-	public function uploadFileWithMtime(
-		$user, $destination, $mtime
-	) {
-		$user = $this->getActualUsername($user);
-
-		$this->response = $this->makeDavRequest(
-			$user, "PUT", $destination, ["X-OC-Mtime" => $mtime]
-		);
-	}
-
-	/**
 	 * @When the administrator uploads file with content :content to :destination using the WebDAV API
 	 *
 	 * @param string $content
@@ -2306,21 +2289,27 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user uploads file to :destination with mtime :mtime using the WebDAV API
-	 * @Given user :user has uploaded a file to :destination with mtime :mtime using the WebDAV API
+	 * @When user :user uploads file :source to :destination with mtime :mtime using the WebDAV API
+	 * @Given user :user has uploaded file :source to :destination with mtime :mtime using the WebDAV API
 	 *
 	 * @param string $user
+	 * @param string $source
 	 * @param string $destination
 	 * @param string $mtime Time in human readable format is taken as input which is converted into milliseconds that is used by API
 	 *
 	 * @return void
 	 */
-	public function userUploadsFileWithContentToWithMtimeUsingTheWebdavApi(
-		$user, $destination, $mtime
+	public function userUploadsFileToWithMtimeUsingTheWebdavApi(
+		$user, $source, $destination, $mtime
 	) {
 		$mtime = new DateTime($mtime);
 		$mtime = $mtime->format('U');
-		return $this->uploadFileWithMtime($user, $destination, $mtime);
+		$user = $this->getActualUsername($user);
+		$this->response = UploadHelper::upload(
+			$this->getBaseUrl(), $user, $this->getPasswordForUser($user),
+			$this->acceptanceTestsDirLocation() . $source, $destination,
+			["X-OC-Mtime" => $mtime]
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
make the tests that check upload with mtime actually also upload data into the file not only create an empty file

## Motivation and Context
more realistic test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
