### PR TITLE
[tests-only] tests for TUS uploads with mtime

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtime.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtime.feature
@@ -1,0 +1,50 @@
+@api @skipOnOcV10
+Feature: upload file
+  As a user
+  I want the mtime of an uploaded file to be the creation date on upload source not the upload date
+  So that I can find files by their real creation date
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+
+  Scenario Outline: upload file with mtime
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: upload file with future mtime
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2129 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2129 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: upload a file with mtime in a folder
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "testFolder"
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testFolder/file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "/testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: overwriting a file changes its mtime
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "first time upload content" to "file.txt"
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtimeShares.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtimeShares.feature
@@ -1,0 +1,71 @@
+@api @files_sharing-app-required @skipOnOcV10
+Feature: upload file
+  As a user
+  I want the mtime of an uploaded file to be the creation date on upload source not the upload date
+  So that I can find files by their real creation date
+
+  Background:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+
+
+  Scenario Outline: upload file with mtime to a received share
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/toShare"
+    And user "Alice" has shared folder "/toShare" with user "Brian"
+    And user "Brian" has accepted share "/toShare" offered by user "Alice"
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/toShare/file.txt" with mtime "Thu, 08 Aug 2012 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
+    And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: upload file with mtime to a send share
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/toShare"
+    And user "Alice" has shared folder "/toShare" with user "Brian"
+    And user "Brian" has accepted share "/toShare" offered by user "Alice"
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/toShare/file.txt" with mtime "Thu, 08 Aug 2012 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
+    And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: overwriting a file with mtime in a received share
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/toShare"
+    And user "Alice" has shared folder "/toShare" with user "Brian"
+    And user "Brian" has accepted share "/toShare" offered by user "Alice"
+    And user "Alice" has uploaded file with content "uploaded content" to "/toShare/file.txt"
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/toShare/file.txt" with mtime "Thu, 08 Aug 2012 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
+    And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: overwriting a file with mtime in a send share
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/toShare"
+    And user "Alice" has shared folder "/toShare" with user "Brian"
+    And user "Brian" has accepted share "/toShare" offered by user "Alice"
+    And user "Brian" has uploaded file with content "uploaded content" to "/Shares/toShare/file.txt"
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/toShare/file.txt" with mtime "Thu, 08 Aug 2012 04:18:13 GMT" using the TUS protocol on the WebDAV API
+    Then as "Alice" the mtime of the file "/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
+    And as "Brian" the mtime of the file "/Shares/toShare/file.txt" should be "Thu, 08 Aug 2012 04:18:13 GMT"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |


### PR DESCRIPTION
## Description
test if the TUS uploads work correctly when the mtime is send in the `Upload-Metadata` header

## Related Issue
part of https://github.com/owncloud/product/issues/153

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
