### PR TITLE
[tests-only] tests for TUS upload to share 

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
@@ -1,0 +1,54 @@
+@api @files_sharing-app-required @skipOnOcV10
+
+Feature: upload file to shared folder
+
+  Background:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+
+  Scenario Outline: Uploading file to a received share folder
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has shared folder "/FOLDER" with user "Brian"
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
+    Then the HTTP status code should be "200"
+    And as "Alice" file "/FOLDER/textfile.txt" should exist
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: Uploading file to a user read/write share folder works
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "change"
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
+    Then the HTTP status code should be "200"
+    And as "Alice" file "/FOLDER/textfile.txt" should exist
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: Uploading file in a group to received read/write share folder
+    Given using <dav_version> DAV path
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has shared folder "FOLDER" with group "grp1" with permissions "change"
+    When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
+    Then the HTTP status code should be "200"
+    And as "Alice" file "/FOLDER/textfile.txt" should exist
+    And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
@@ -16,8 +16,7 @@ Feature: upload file to shared folder
     And user "Alice" has shared folder "/FOLDER" with user "Brian"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
-    Then the HTTP status code should be "200"
-    And as "Alice" file "/FOLDER/textfile.txt" should exist
+    Then as "Alice" file "/FOLDER/textfile.txt" should exist
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be "uploaded content"
     Examples:
       | dav_version |
@@ -38,7 +37,7 @@ Feature: upload file to shared folder
       | old         |
       | new         |
 
-  Scenario Outline: Uploading file in a group to received read/write share folder
+  Scenario Outline: Uploading a file into a group share as share receiver
     Given using <dav_version> DAV path
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"


### PR DESCRIPTION
## Description
test for TUS uploads to a received share folder

## Related Issue
- part of owncloud/product#153

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/979

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
