### PR TITLE
Alternative SMB external storage implementation where all users of on…

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -909,7 +909,7 @@ MountConfigListView.prototype = _.extend({
 		var selectAuthMechanism = $('<select class="selectAuthMechanism"></select>');
 		var neededVisibility = (this._isPersonal) ? StorageConfig.Visibility.PERSONAL : StorageConfig.Visibility.ADMIN;
 		$.each(this._allAuthMechanisms, function(authIdentifier, authMechanism) {
-			if (backend.authSchemes[authMechanism.scheme] && (authMechanism.visibility & neededVisibility)) {
+			if ((backend.authSchemes[authMechanism.scheme] || backend.authSchemes[authMechanism.identifier]) && (authMechanism.visibility & neededVisibility)) {
 				selectAuthMechanism.append(
 					$('<option value="'+authMechanism.identifier+'" data-scheme="'+authMechanism.scheme+'">'+authMechanism.name+'</option>')
 				);
@@ -1589,8 +1589,8 @@ OCA.External.Settings.OAuth2.verifyCode = function (backendUrl, data) {
 		}, function (result) {
 			if (result && result.status == 'success') {
 				$(token).val(result.data.token);
-				$(configured).val('true');	
-				
+				$(configured).val('true');
+
 				OCA.External.Settings.mountConfig.saveStorageConfig($tr, function(status) {
 					if (status) {
 						$tr.find('.configuration input.auth-param')

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -29,6 +29,7 @@
 
 namespace OCA\Files_External\AppInfo;
 
+use OCA\Files_External\Lib\Backend\SMB2;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
 use OCP\Files\External\Config\IAuthMechanismProvider;
@@ -77,6 +78,7 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 			$container->query('OCA\Files_External\Lib\Backend\Google'),
 			$container->query('OCA\Files_External\Lib\Backend\SFTP_Key'),
 			$container->query('OCA\Files_External\Lib\Backend\SMB'),
+			$container->query(SMB2::class),
 			$container->query('OCA\Files_External\Lib\Backend\SMB_OC'),
 		];
 

--- a/apps/files_external/lib/Lib/Backend/SMB2.php
+++ b/apps/files_external/lib/Lib/Backend/SMB2.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * @author Robin McCorkell <robin@mccorkell.me.uk>
- * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2020, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
@@ -27,18 +26,18 @@ use OCP\Files\External\Auth\AuthMechanism;
 use OCP\Files\External\Backend\Backend as ExternalBackend;
 use OCP\Files\External\DefinitionParameter;
 use OCP\Files\External\IStorageConfig;
+use OCP\Files\External\IStoragesBackendService;
 use OCP\IL10N;
 use OCP\IUser;
 
-class SMB extends ExternalBackend {
+class SMB2 extends ExternalBackend {
 	use LegacyDependencyCheckPolyfill;
 
 	public function __construct(IL10N $l) {
 		$this
-			->setIdentifier('smb')
-			->addIdentifierAlias('\OC\Files\Storage\SMB') // legacy compat
-			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB')
-			->setText($l->t('SMB Personal (unique file IDs)'))
+			->setIdentifier('smb-coll')
+			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB2')
+			->setText($l->t('SMB Collaborative (shared file IDs)'))
 			->addParameters([
 				(new DefinitionParameter('host', $l->t('Host'))),
 				(new DefinitionParameter('share', $l->t('Share'))),
@@ -46,15 +45,17 @@ class SMB extends ExternalBackend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('domain', $l->t('Domain')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('service-account', $l->t('Service Account'))),
+				(new DefinitionParameter('service-account-password', $l->t('Service Account Password')))
+					->setType(DefinitionParameter::VALUE_PASSWORD),
 			])
-			->addAuthScheme(AuthMechanism::SCHEME_PASSWORD)
+			// only password::sessioncredentials is reasonable
+			->addAuthScheme('password::sessioncredentials')
+			->setVisibility(IStoragesBackendService::VISIBILITY_ADMIN)
+			->setAllowedVisibility(IStoragesBackendService::VISIBILITY_ADMIN)
 		;
 	}
 
-	/**
-	 * @param StorageConfig $storage
-	 * @param IUser $user
-	 */
 	public function manipulateStorageConfig(IStorageConfig &$storage, IUser $user = null) {
 		$userFromBackendOption = $storage->getBackendOption('user');
 		if ($domain = $storage->getBackendOption('domain')) {

--- a/apps/files_external/lib/Lib/Cache/SmbCacheWrapper.php
+++ b/apps/files_external/lib/Lib/Cache/SmbCacheWrapper.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Cache;
+
+use OC\Files\Cache\Wrapper\CacheWrapper;
+use OCA\Files_External\Lib\Storage\SMB;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\ICacheEntry;
+
+/**
+ * Class SmbCacheWrapper
+ *
+ * Reads the cache information from the underlying cache implementation and
+ * verifies if the current user has access by calling stat on the storage.
+ *
+ * In case performance becomes a problem we might want to include a stat cache
+ * per user on e.g. redis or so.
+ *
+ * @package OCA\Files_External\Lib\Cache
+ */
+class SmbCacheWrapper extends CacheWrapper {
+	/**
+	 * @var SMB
+	 */
+	private $smb;
+
+	public function __construct(ICache $cache, SMB $smb) {
+		parent::__construct($cache);
+		$this->smb = $smb;
+	}
+
+	public function get($file) {
+		if ($this->canAccess($file)) {
+			return parent::get($file);
+		}
+		return null;
+	}
+
+	public function getFolderContents($folder) {
+		$children = parent::getFolderContents($folder);
+		return \array_filter($children, function (ICacheEntry $c) {
+			return $this->canAccess($c->getPath());
+		});
+	}
+
+	public function getFolderContentsById($fileId) {
+		$children = parent::getFolderContentsById($fileId);
+		return \array_filter($children, function (ICacheEntry $c) {
+			return $this->canAccess($c->getPath());
+		});
+	}
+
+	private function canAccess($file): bool {
+		try {
+			if (\is_integer($file)) {
+				$fileInfo = parent::get($file);
+				if ($fileInfo === null) {
+					return false;
+				}
+				$file = $fileInfo['path'];
+			}
+			return $this->smb->stat($file) !== false;
+		} catch (\Exception $ex) {
+			\OC::$server->getLogger()->logException($ex);
+			return false;
+		}
+	}
+}

--- a/apps/files_external/lib/Lib/Storage/SMB2.php
+++ b/apps/files_external/lib/Lib/Storage/SMB2.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib\Storage;
+
+use Icewind\SMB\Exception\AlreadyExistsException;
+use Icewind\SMB\Exception\ConnectException;
+use Icewind\SMB\Exception\Exception;
+use Icewind\SMB\Exception\ForbiddenException;
+use Icewind\SMB\Exception\NotFoundException;
+use Icewind\SMB\BasicAuth;
+use Icewind\SMB\IFileInfo;
+use Icewind\SMB\IServer;
+use Icewind\SMB\Native\NativeServer;
+use Icewind\SMB\Wrapped\FileInfo;
+use Icewind\SMB\ServerFactory;
+use Icewind\SMB\System;
+use Icewind\SMB\IShare;
+use Icewind\Streams\CallbackWrapper;
+use Icewind\Streams\IteratorDirectory;
+use OC\Cache\CappedMemoryCache;
+use OC\Files\Filesystem;
+use OCA\Files_External\Lib\Cache\SmbCacheWrapper;
+use OCP\Files\Storage\StorageAdapter;
+use OCP\Files\StorageNotAvailableException;
+use OCP\Util;
+
+class SMB2 extends SMB {
+	/**
+	 * @var SMB
+	 */
+	private $userSpecificSmb;
+
+	public function __construct($params) {
+		$this->userSpecificSmb = new SMB($params);
+
+		$params2 = $params;
+		$params2['user'] = $params['service-account'];
+		$params2['password'] = $params['service-account-password'];
+
+		parent::__construct($params2);
+	}
+
+	public function getId(): string {
+		return 'smb2::' . $this->server->getHost() . '//' . $this->share->getName() . '/' . $this->root;
+	}
+
+	public function getCache($path = '', $storage = null) {
+		$parentCache = parent::getCache($path, $storage);
+		return new SmbCacheWrapper($parentCache, $this->userSpecificSmb);
+	}
+}

--- a/changelog/unreleased/38151
+++ b/changelog/unreleased/38151
@@ -1,0 +1,9 @@
+Enhancement: New external storage: SMB Collaborative (shared file IDs))
+
+This new external storage allows the shared use of SMB/CIFS shares among users.
+Independent of the use all files and folders will have the same file id.
+This allows better collaboration especially in the area of tagging, comments,
+private links and any document collaboration like Office Online Server,
+Collabora and OnlyOffice.
+
+https://github.com/owncloud/core/pull/38151

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -291,9 +291,11 @@ class Folder extends Node implements \OCP\Files\Folder {
 				if (\is_string($internalPath)) {
 					$fullPath = $mount->getMountPoint() . $internalPath;
 					if (($path = $this->getRelativePath($fullPath)) !== null) {
-						$nodes[] = $this->get($path);
-						if ($first) {
-							break;
+						if ($this->nodeExists($path)) {
+							$nodes[] = $this->get($path);
+							if ($first) {
+								break;
+							}
 						}
 					}
 				}

--- a/lib/public/Files/External/Auth/AuthMechanism.php
+++ b/lib/public/Files/External/Auth/AuthMechanism.php
@@ -54,13 +54,13 @@ use OCP\Files\External\IStorageConfig;
 abstract class AuthMechanism implements \JsonSerializable {
 
 	/** Standard authentication schemes */
-	const SCHEME_NULL = 'null';
-	const SCHEME_BUILTIN = 'builtin';
-	const SCHEME_PASSWORD = 'password';
-	const SCHEME_OAUTH1 = 'oauth1';
-	const SCHEME_OAUTH2 = 'oauth2';
-	const SCHEME_PUBLICKEY = 'publickey';
-	const SCHEME_OPENSTACK = 'openstack';
+	public const SCHEME_NULL = 'null';
+	public const SCHEME_BUILTIN = 'builtin';
+	public const SCHEME_PASSWORD = 'password';
+	public const SCHEME_OAUTH1 = 'oauth1';
+	public const SCHEME_OAUTH2 = 'oauth2';
+	public const SCHEME_PUBLICKEY = 'publickey';
+	public const SCHEME_OPENSTACK = 'openstack';
 
 	use VisibilityTrait;
 	use FrontendDefinitionTrait;
@@ -117,7 +117,8 @@ abstract class AuthMechanism implements \JsonSerializable {
 	public function validateStorage(IStorageConfig $storage) {
 		// does the backend actually support this scheme
 		$supportedSchemes = $storage->getBackend()->getAuthSchemes();
-		if (!isset($supportedSchemes[$this->getScheme()])) {
+		if (!isset($supportedSchemes[$this->getScheme()]) &&
+			!isset($supportedSchemes[$this->getIdentifier()])) {
 			return false;
 		}
 

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -13,8 +13,13 @@ use OC\Files\FileInfo;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Node\Folder;
 use OC\Files\Node\Node;
+use OC\Files\View;
 use OCP\Constants;
 use OCP\Files\NotFoundException;
+use OC\Files\Mount\Manager;
+use PHPUnit\Framework\MockObject\MockObject;
+use OC\Files\Node\Root;
+use OC\Files\Storage\Storage;
 
 /**
  * Class FolderTest
@@ -35,7 +40,7 @@ class FolderTest extends NodeTest {
 	public function testGetDirectoryContent() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -67,7 +72,7 @@ class FolderTest extends NodeTest {
 	public function testGet() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -88,7 +93,7 @@ class FolderTest extends NodeTest {
 	public function testNodeExists() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -112,7 +117,7 @@ class FolderTest extends NodeTest {
 	public function testNodeExistsNotExists() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -134,7 +139,7 @@ class FolderTest extends NodeTest {
 	public function testNewFolder() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -167,7 +172,7 @@ class FolderTest extends NodeTest {
 
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -189,7 +194,7 @@ class FolderTest extends NodeTest {
 	public function testNewFile() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -222,7 +227,7 @@ class FolderTest extends NodeTest {
 
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -244,7 +249,7 @@ class FolderTest extends NodeTest {
 	public function testGetFreeSpace() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -266,7 +271,7 @@ class FolderTest extends NodeTest {
 	public function testSearch() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -318,7 +323,7 @@ class FolderTest extends NodeTest {
 	public function testSearchInRoot() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -372,7 +377,7 @@ class FolderTest extends NodeTest {
 	public function testSearchInStorageRoot() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -422,7 +427,7 @@ class FolderTest extends NodeTest {
 	public function testSearchByTag() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -473,7 +478,7 @@ class FolderTest extends NodeTest {
 	public function testSearchSubStorages() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -552,57 +557,58 @@ class FolderTest extends NodeTest {
 		$this->assertFalse($folder->isSubNode($file));
 	}
 
-	public function testGetById() {
-		$manager = $this->createMock('\OC\Files\Mount\Manager');
+	public function testGetById(): void {
+		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
-		$view = $this->createMock('\OC\Files\View');
-		$root = $this->getMockBuilder('\OC\Files\Node\Root')
+		$view = $this->createMock(View::class);
+		$root = $this->getMockBuilder(Root::class)
 			->setMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user])
 			->getMock();
 
-		$root->expects($this->any())
+		$root->expects(self::any())
 			->method('getUser')
-			->will($this->returnValue($this->user));
-		$storage = $this->createMock('\OC\Files\Storage\Storage');
+			->willReturn($this->user);
+		$storage = $this->createMock(Storage::class);
 		$mount = new MountPoint($storage, '/bar');
 		$cache = $this->createMock(Cache::class);
 
-		$view->expects($this->once())
+		// called twice because of Folder::nodeExists and Folder::get
+		$view->expects(self::exactly(2))
 			->method('getFileInfo')
-			->will($this->returnValue(new FileInfo('/bar/foo/qwerty', null, 'qwerty', ['mimetype' => 'text/plain'], null)));
+			->willReturn(new FileInfo('/bar/foo/qwerty', null, 'qwerty', ['mimetype' => 'text/plain'], null));
 
-		$storage->expects($this->once())
+		$storage->expects(self::once())
 			->method('getCache')
-			->will($this->returnValue($cache));
+			->willReturn($cache);
 
-		$cache->expects($this->once())
+		$cache->expects(self::once())
 			->method('getPathById')
 			->with('1')
-			->will($this->returnValue('foo/qwerty'));
+			->willReturn('foo/qwerty');
 
-		$root->expects($this->once())
+		$root->expects(self::once())
 			->method('getMountsIn')
 			->with('/bar/foo')
-			->will($this->returnValue([]));
+			->willReturn([]);
 
-		$root->expects($this->once())
+		$root->expects(self::once())
 			->method('getMount')
 			->with('/bar/foo')
-			->will($this->returnValue($mount));
+			->willReturn($mount);
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$result = $node->getById(1);
-		$this->assertCount(1, $result);
-		$this->assertEquals('/bar/foo/qwerty', $result[0]->getPath());
+		self::assertCount(1, $result);
+		self::assertEquals('/bar/foo/qwerty', $result[0]->getPath());
 	}
 
 	public function testGetByIdOutsideFolder() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -643,7 +649,7 @@ class FolderTest extends NodeTest {
 	public function testGetByIdMultipleStorages() {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')
@@ -704,7 +710,7 @@ class FolderTest extends NodeTest {
 		$manager = $this->createMock('\OC\Files\Mount\Manager');
 		$folderPath = '/bar/foo';
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View | MockObject $view
 		 */
 		$view = $this->createMock('\OC\Files\View');
 		$root = $this->getMockBuilder('\OC\Files\Node\Root')


### PR DESCRIPTION
…e share use the same storage id. User specific access is filtered in a cache wrapper by stating the files on SMB

## Description
- all users share the same storage id for the smb share (loggin via user credentials)
- fileids are constant over users
- fileid based concepts work (tagging, comments, direct link, file locking, wopi)

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):

### Setup of SMB version 2
![Screenshot from 2020-11-30 09-54-55](https://user-images.githubusercontent.com/1005065/100588477-2f2ec200-32f2-11eb-9453-53c9f10dcae7.png)

### Same file id is used and as result comments and tags are show properly on both users:
![Screenshot from 2020-11-24 12-12-41](https://user-images.githubusercontent.com/1005065/100089893-b1cb0380-2e52-11eb-857b-144951d9300c.png)

### File ID is the same - see last query parameter in url
![Screenshot from 2020-11-24 12-10-00](https://user-images.githubusercontent.com/1005065/100089899-b394c700-2e52-11eb-88fc-4050bab2ef4e.png)

### Tow users with different permissions see folder content accordingly:
![Screenshot from 2020-11-24 12-08-56](https://user-images.githubusercontent.com/1005065/100089910-b5f72100-2e52-11eb-9b5a-ce2a890a260b.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
