### PR TITLE
[tests-only] Make CI run on various databases

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1463,7 +1463,7 @@ def acceptance(ctx):
 									if (params['scalityS3'] != False):
 										environment['S3_TYPE'] = 'scality'
 
-								federationDbSuffix = '-federated'
+								federationDbSuffix = 'fed'
 
 								result = {
 									'kind': 'pipeline',
@@ -2211,13 +2211,13 @@ def installServer(phpVersion, db, logLevel = '2', ssl = False, federatedServerNe
 		]
 	}]
 
-def installAndConfigureFederated(ctx, federatedServerVersion, phpVersion, logLevel, protocol, db, dbSuffix = '-federated'):
+def installAndConfigureFederated(ctx, federatedServerVersion, phpVersion, logLevel, protocol, db, dbSuffix = 'fed'):
 	return [
 		installFederated(ctx, federatedServerVersion, db, dbSuffix),
 		configureFederated(phpVersion, logLevel, protocol)
 	]
 
-def installFederated(ctx, federatedServerVersion, db, dbSuffix = '-federated'):
+def installFederated(ctx, federatedServerVersion, db, dbSuffix = 'fed'):
 	host = getDbName(db)
 	dbType = host
 

--- a/.drone.star
+++ b/.drone.star
@@ -2167,7 +2167,7 @@ def databaseServiceForFederation(db, suffix):
 		print('Not implemented federated database for ', dbName)
 		return []
 
-	return [{
+	service = {
 		'name': dbName + suffix,
 		'image': db,
 		'pull': 'always',
@@ -2177,7 +2177,10 @@ def databaseServiceForFederation(db, suffix):
 			'MYSQL_DATABASE': getDbDatabase(db) + suffix,
 			'MYSQL_ROOT_PASSWORD': getDbRootPassword()
 		}
-	}]
+	}
+	if (db == 'mysql:8.0'):
+		service['command'] = ['--default-authentication-plugin=mysql_native_password']
+	return [service]
 
 def installServer(phpVersion, db, logLevel = '2', ssl = False, federatedServerNeeded = False, proxyNeeded = False):
 	return [{

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
@@ -9,11 +9,12 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "to delete" to "/textfile0.txt"
 
-  @issue-23151
+  @issue-23151 @skipOnDbOracle
   # This scenario deletes many files as close together in time as the test can run.
   # On a very slow system, the file deletes might all happen in different seconds.
   # But on "reasonable" systems, some of the files will be deleted in the same second,
   # thus testing the required behavior.
+  # Note: skipOnDbOracle because Oracle is slow and so "close together in time" does not really happen
   Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/folderA"
@@ -42,11 +43,12 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  @notToImplementOnOCIS @issue-23151
+  @issue-23151 @skipOnDbOracle
   # This scenario deletes many files as close together in time as the test can run.
   # On a very slow system, the file deletes might all happen in different seconds.
   # But on "reasonable" systems, some of the files will be deleted in the same second,
   # thus testing the required behavior.
+  # Note: skipOnDbOracle because Oracle is slow and so "close together in time" does not really happen
   Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/folderA"

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -100,7 +100,7 @@ Feature: dav-versions
     Then the content of file "/textfile0.txt" for user "Alice" should be "Dav-Test"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-156
-  @issue-ocis-reva-196 @skipOnOracle
+  @issue-ocis-reva-196 @skipOnDbOracle
   Scenario: Restore a file and check, if the content and correct checksum is now in the current file
     Given user "Alice" has uploaded file with content "AAAAABBBBBCCCCC" and checksum "MD5:45a72715acdd5019c5be30bdbb75233e" to "/davtest.txt"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/davtest.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -110,7 +110,9 @@ Feature: Unlock locked files and folders
       | exclusive |
       | shared    |
 
-  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP
+  # This scenario depends on the order of locks displayed on the UI.
+  # Pgsql and Oracle database can have different sorting, so allow this scenario to be skipped on those
+  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql @skipOnDbOracle
   Scenario: deleting the first one of multiple shared locks on the webUI
     Given these users have been created with skeleton files:
       | username  |
@@ -149,7 +151,9 @@ Feature: Unlock locked files and folders
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver1" by the WebDAV API
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver2" by the WebDAV API
 
-  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP
+  # This scenario depends on the order of locks displayed on the UI.
+  # Pgsql and Oracle database can have different sorting, so allow this scenario to be skipped on those
+  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql @skipOnDbOracle
   Scenario: deleting the second one of multiple shared locks on the webUI
     Given these users have been created with skeleton files:
       | username  |
@@ -188,7 +192,9 @@ Feature: Unlock locked files and folders
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver1" by the WebDAV API
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver2" by the WebDAV API
 
-  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP
+  # This scenario depends on the order of locks displayed on the UI.
+  # Pgsql and Oracle database can have different sorting, so allow this scenario to be skipped on those
+  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql @skipOnDbOracle
   Scenario: deleting the last one of multiple shared locks on the webUI
     Given these users have been created with skeleton files:
       | username  |


### PR DESCRIPTION
## Description
Adjust tests so that CI can pass on different databases.
1) add skip tags for test scenarios that are not expected to pass on postgresql and/or Oracle. Notes have been added with the reasons.
2) shorten the suffix of the federated database name in CI, to avoid any possibility of errors on different databases.
3) in the case of mysql:8.0 properly set the federated database settings the same as is done for the local database. That makes the federated tests pass with mysql:8.0 on both the local and federated database

## Related Issue
- #38156 

## Motivation and Context
We want to be able to easily run the full suite of acceptance tests with each supported database.
The adjustments here make it so that CI can pass on each database.

## How Has This Been Tested?
CI run for each database. See issue #38156 for details and links to the test PRs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
