### PR TITLE
Allow subfolders for Google Drive mounts

### DIFF
--- a/apps/files_external/lib/Lib/Backend/Google.php
+++ b/apps/files_external/lib/Lib/Backend/Google.php
@@ -2,6 +2,7 @@
 /**
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Martin Mattel <github@diemattels.at>
  *
  * @copyright Copyright (c) 2017, ownCloud GmbH
  * @license AGPL-3.0
@@ -39,6 +40,7 @@ class Google extends ExternalBackend {
 			->setText($l->t('Google Drive'))
 			->addParameters([
 				// all parameters handled in OAuth2 mechanism
+				(new DefinitionParameter('root', $l->t('SubFolder')))->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 			])
 			->addAuthScheme(AuthMechanism::SCHEME_OAUTH2)
 			->addCustomJs('gdrive')

--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -14,6 +14,7 @@
  * @author Robin McCorkell <robin@mccorkell.me.uk>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Vincent Petry <pvince81@owncloud.com>
+ * @author Martin Mattel <github@diemattels.at>
  *
  * @copyright Copyright (c) 2017, ownCloud GmbH
  * @license AGPL-3.0
@@ -77,6 +78,7 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 			$this->service = new \Google_Service_Drive($this->client);
 			$token = \json_decode($params['token'], true);
 			$this->id = 'google::'.\substr($params['client_id'], 0, 30).$token['created'];
+			$this->root = isset($params['root']) ? $params['root'] : '';
 		} else {
 			throw new \Exception('Creating Google storage failed');
 		}
@@ -90,7 +92,11 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 	}
 
 	public function getId() {
-		return $this->id;
+		if ($this->root === '') {
+			return $this->id;
+		} else {
+			return "{$this->id}/{$this->root}";
+		}
 	}
 
 	private function getDefaultFieldsForFile() {
@@ -122,12 +128,37 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 	}
 
 	/**
-	 * Get the Google_Service_Drive_DriveFile object for the specified path.
+	 * Transform an external path to one originating from the virtual root.
+	 * @param $path the path relative to the virtual root directory
+	 * @return a path starting at the real root of Google Drive
+	 */
+	private function getAbsolutePath($path) {
+		if ($path === '.') {
+			$path = '';
+		}
+		$path = "{$this->root}/{$path}";
+		$path = \trim($path, '/');
+		return $path;
+	}
+
+	/**
+	 * Get elements of the relative path given.
+	 * The path is relative, in case a subfolder is used.
 	 * Returns false on failure.
 	 * @param string $path
 	 * @return \Google_Service_Drive_DriveFile|false
 	 */
 	private function getDriveFile($path) {
+		return $this->getInternalDriveFile($this->getAbsolutePath($path));
+	}
+
+	/**
+	 * Get the elements of the absolute path in case a subfolder is used.
+	 * Returns false on failure.
+	 * @param string $path
+	 * @return \Google_Service_Drive_DriveFile|false
+	 */
+	private function getInternalDriveFile($path) {
 		// Remove leading and trailing slashes
 		$path = \trim($path, '/');
 		if ($path === '.') {
@@ -144,7 +175,7 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 		} else {
 			// Google Drive SDK does not have methods for retrieving files by path
 			// Instead we must find the id of the parent folder of the file
-			$parentId = $this->getDriveFile('')->getId();
+			$parentId = $this->getInternalDriveFile('')->getId();
 			$folderNames = \explode('/', $path);
 			$path = '';
 			// Loop through each folder of this path to get to the file
@@ -179,7 +210,7 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 						$pos = \strrpos($path, '.');
 						if ($pos !== false) {
 							$pathWithoutExt = \substr($path, 0, $pos);
-							$file = $this->getDriveFile($pathWithoutExt);
+							$file = $this->getInternalDriveFile($pathWithoutExt);
 							if ($file && $this->isGoogleDocFile($file)) {
 								// Switch cached Google_Service_Drive_DriveFile to the correct index
 								unset($this->driveFiles[$pathWithoutExt]);
@@ -204,6 +235,15 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 	 * @param \Google_Service_Drive_DriveFile|false $file
 	 */
 	private function setDriveFile($path, $file) {
+		return $this->setDriveFileHelper($this->getAbsolutePath($path), $file);
+	}
+
+	/**
+	 * Set the Google_Service_Drive_DriveFile object in the cache
+	 * @param string $path
+	 * @param \Google_Service_Drive_DriveFile|false $file
+	 */
+	private function setDriveFileHelper($path, $file) {
 		$path = \trim($path, '/');
 		$this->driveFiles[$path] = $file;
 		if ($file === false) {
@@ -381,7 +421,7 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 	}
 
 	public function filetype($path) {
-		if ($path === '') {
+		if ($this->getAbsolutePath($path) === '') {
 			return 'dir';
 		} else {
 			$file = $this->getDriveFile($path);

--- a/changelog/unreleased/38161
+++ b/changelog/unreleased/38161
@@ -1,0 +1,10 @@
+Enhancement: Allow mounting a subfolder from Google Drive
+
+You can now define a subfolder from your Google Drive when mounting.
+This gives the ability to:
+ subfolder = empty (like you have it without this enhancment)
+ subfolder = name
+ subfolder = name/$user
+When using encryption, only the subfolder when used gets encrypted.
+
+https://github.com/owncloud/core/pull/38161


### PR DESCRIPTION
## Description
This adds the ability to add a Google Drive mount from a GD subfolder.
Similar when you eg mount form SMB.

## Related Issue
No issue related.
Based on the work of: https://github.com/owncloud/files_external_gdrive/pull/9 (added support for changing root folder in google drive)

## Motivation and Context
One can now mount from a GD subfolder. This has big benefits:
- only a fraction of your GD is mounted and seen
- it is now possibe to use the `$user` variable to have a mount based on a subfolder structure like:
`sub_folder/$user` !
- when using encryption, only the subfolder gets encrypted

## How Has This Been Tested?
Manually having:
- subfolder = empty (like you have it without this PR)
- subfolder = name
- subfolder = name/$user

In case name or name/$user does not exist in GD, the mount does not show up without error.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3321281/100548712-868b4e80-326e-11eb-92fa-1ac11b853a55.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

Adding a doc ticket when merged
