### PR TITLE
[tests-only] Purge cache after sonar analysis

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1598,7 +1598,19 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 						'drone.owncloud.com'
 					],
 				}
-			}
+			},
+			{
+				'name': 'purge-cache',
+				'image': 'minio/mc',
+				'environment': {
+					'MC_HOST_cache': {
+						'from_secret': 'cache_s3_connection_url'
+					}
+				},
+				'commands': [
+					'mc rm --recursive --force cache/cache/%s/%s' % (ctx.repo.slug, ctx.build.commit + '-${DRONE_BUILD_NUMBER}'),
+				]
+			},
 		],
 		'depends_on': [],
 		'trigger': {


### PR DESCRIPTION
## Description
Be nice and delete the cached coverage reports after doing SonarCloud analysis. That will reduce the crud left behind on the S3 cache storage.

Note: the coverage reports are in a `coverage` folder in the cache. But I delete the whole folder above that, because we can cleanup the whole of the cache for the current PR at this point. There are no other pipelines that are using the cache for anything else. 

Similar to PR https://github.com/owncloud/activity/pull/906 and PR https://github.com/owncloud/ocis/pull/961

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
