### PR TITLE
[tests-only] relax expected Location regex

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/lowLevelCreationExtension.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/lowLevelCreationExtension.feature
@@ -12,8 +12,8 @@ Feature: low level tests of the creation extension see https://tus.io/protocols/
       | Tus-Resumable   | 1.0.0                                         |
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
-      | Tus-Resumable | /1\.0\.0/                             |
-      | Location      | /%base_url%\/[a-zA-Z0-9_\-\.]{1,300}/ |
+      | Tus-Resumable | /1\.0\.0/                       |
+      | Location      | /http[s]?:\/\/.*:\d+\/data\/.*/ |
     Examples:
       | dav_version |
       | old         |


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
make the regex broader to also match reva location urls e.g. `http://revad-services:12001/data/tus/e4d65ee9-f7c0-4ef5-ab68-92753552560e`

## Related Issue
part of https://github.com/owncloud/product/issues/153

## How Has This Been Tested?
https://github.com/cs3org/reva/pull/1353

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
