### PR TITLE
Do not redirect if browser asks for a .properties file

### DIFF
--- a/changelog/unreleased/38181
+++ b/changelog/unreleased/38181
@@ -1,0 +1,10 @@
+Bugfix: Don't redirect if the browser ask for a .properties file
+
+In order to provide translations, the files_pdfviewer app requested a
+.properties file. This request failed because the server redirected it to
+the default page (the files view), so the app couldn't get the translations
+
+This redirection doesn't happen any longer, and the app can translate the
+UI elements now.
+
+https://github.com/owncloud/core/pull/38181

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -489,7 +489,7 @@ class Setup {
 			$content .= "\n  RewriteRule ^favicon.ico$ core/img/favicon.ico [L]";
 			$content .= "\n  RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]";
-			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !\\.(css|js|svg|gif|png|html|ttf|woff|ico|jpg|jpeg|json)$";
+			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !\\.(css|js|svg|gif|png|html|ttf|woff|ico|jpg|jpeg|json|properties)$";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !core/img/favicon.ico$";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/robots.txt";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/remote.php";


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
files_pdfviewer app asks for a locale.properties file in order to handle the translations. In some setups, this request gets redirected to the files view, so the app can't get the translations.
This change makes possible to get the file so the files_pdfviewer can translate the pdf viewer content according to the language set by the user.

## Related Issue
No issue related. Found in https://github.com/owncloud/files_pdfviewer/pull/228#issuecomment-736578183

## Motivation and Context
The whole UI should be shown in the same language.

## How Has This Been Tested?
1. Install OC via docker setup (used official docker setup for 10.5)
2. Install files_pdfviewer app
3. As user1, change the ownCloud language settings for the user to anything other than English
4. As user1, upload a pdf file
5. As user1, access to that pdf file. The pdf viewer should open the file. The UI related to the pdf viewer should be translated

## Screenshots (if appropriate):
![Screenshot from 2020-12-02 10-50-15](https://user-images.githubusercontent.com/1477829/100856891-45708580-348c-11eb-89d9-a62388581c46.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
