### PR TITLE
[tests-only] change the expectation of TUS OPTIONS tests to match reva behaviour

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/optionsRequest.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/optionsRequest.feature
@@ -31,11 +31,11 @@ Feature: OPTIONS request
       | endpoint                          |
       | /remote.php/webdav/               |
       | /remote.php/dav/files/%username%/ |
-    Then the following headers should not be set
-      | header        |
-      | Tus-Resumable |
-      | Tus-Version   |
-      | Tus-Extension |
+    Then the following headers should be set
+      | header        | value                         |
+      | Tus-Resumable | 1.0.0                         |
+      | Tus-Version   | 1.0.0                         |
+      | Tus-Extension | creation,creation-with-upload |
 
   Scenario: send OPTIONS requests to webDav endpoints using valid password and username of different user
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -43,8 +43,8 @@ Feature: OPTIONS request
       | endpoint                          |
       | /remote.php/webdav/               |
       | /remote.php/dav/files/%username%/ |
-    Then the following headers should not be set
-      | header        |
-      | Tus-Resumable |
-      | Tus-Version   |
-      | Tus-Extension |
+    Then the following headers should be set
+      | header        | value                         |
+      | Tus-Resumable | 1.0.0                         |
+      | Tus-Version   | 1.0.0                         |
+      | Tus-Extension | creation,creation-with-upload |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
change the expectations of the tests so that the behaviour of cs3org/reva is reflected, that seems to be more consinstent to the ocis behaviour
see https://github.com/owncloud/ocis/issues/1012
I will make a PR to ocis to put these tests into expected failures file

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- see https://github.com/owncloud/ocis/issues/1012

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
