### PR TITLE
Catch StorageNotAvailableException while formatting the share

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -31,6 +31,7 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -289,6 +290,11 @@ class Share20OcsController extends OCSController {
 				return new Result([$share]);
 			} catch (NotFoundException $e) {
 				//Fall trough
+			} catch (StorageNotAvailableException $e) {
+				// could happen if the share node points to a storage which isn't available
+				// TODO: This should go through an injected logger instance
+				\OCP\Util::logException('core', $e, \OCP\Util::ERROR);
+				return new Result(null, 404, $this->l->t('Share points to a node not available'));
 			}
 		}
 
@@ -612,6 +618,10 @@ class Share20OcsController extends OCSController {
 					$formatted[] = $this->formatShare($share, true);
 				} catch (NotFoundException $e) {
 					// Ignore this share
+				} catch (StorageNotAvailableException $e) {
+					// could happen if the share node points to a storage which isn't available
+					// TODO: This should go through an injected logger instance
+					\OCP\Util::logException('core', $e, \OCP\Util::ERROR);
 				}
 			}
 		}
@@ -753,6 +763,10 @@ class Share20OcsController extends OCSController {
 				$formatted[] = $this->formatShare($share);
 			} catch (NotFoundException $e) {
 				//Ignore share
+			} catch (StorageNotAvailableException $e) {
+				// could happen if the share node points to a storage which isn't available
+				// TODO: This should go through an injected logger instance
+				\OCP\Util::logException('core', $e, \OCP\Util::ERROR);
 			}
 		}
 

--- a/changelog/unreleased/38190
+++ b/changelog/unreleased/38190
@@ -1,0 +1,17 @@
+Bugfix: Show the share list even if some shares point to unavailable storages
+
+Previously, if some shares pointed to file nodes that belonged to unavailable
+storages, the share list wouldn't show any share due to the exception not being
+handled correctly.
+
+Now, the exception is handled. The affected shares will be ignored (an error
+message will appear in the log with the exception), and the rest of the shares
+will show in the web UI.
+
+Note that the steps to reproduce the problem are still unclear, and it might
+be impossible to reproduce the issue using recent ownCloud versions. So far,
+not only it seems required to have a share pointing to an unavailable storage,
+but also there has to be a pending modification for ownCloud to scan the file.
+Such conditions shouldn't be possible at the same time.
+
+https://github.com/owncloud/core/pull/38190


### PR DESCRIPTION
The getById method called while formatting could go down to the storage
if somehow the node needs to be updated. If so, the storage where the
node is could not be available, causing the exception to pop up.
Such exception causes the list of shares to be broken since it wasn't
being caught.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Catch a possible StorageNotAvailableException that could be thrown while formatting the shares.
This specially affects to the share listing, which could be broken and the UI might not show any local share if such exception happens.

So far, this has been detected only while listing the shares, and the steps to reproduce aren't fully clear. There are some other locations for the `formatShare` method being called, although it's expected to behave better since other similar exception that could happen such as `NotFoundException` aren't being handled in those places.

## Related Issue
Related to https://github.com/owncloud/enterprise/issues/4250

## Motivation and Context
Could lead to an empty list of shares

## How Has This Been Tested?
Not tested yet

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
