### PR TITLE
Remove use of non-existent return value of setDriveFileHelper

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -42,6 +42,7 @@ use Icewind\Streams\RetryWrapper;
 class Google extends \OCP\Files\Storage\StorageAdapter {
 	private $client;
 	private $id;
+	private $root;
 	private $service;
 	private $driveFiles;
 
@@ -129,16 +130,15 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 
 	/**
 	 * Transform an external path to one originating from the virtual root.
-	 * @param $path the path relative to the virtual root directory
-	 * @return a path starting at the real root of Google Drive
+	 * @param $path string the path relative to the virtual root directory
+	 * @return string a path starting at the real root of Google Drive
 	 */
 	private function getAbsolutePath($path) {
 		if ($path === '.') {
 			$path = '';
 		}
 		$path = "{$this->root}/{$path}";
-		$path = \trim($path, '/');
-		return $path;
+		return \trim($path, '/');
 	}
 
 	/**

--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -235,7 +235,7 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 	 * @param \Google_Service_Drive_DriveFile|false $file
 	 */
 	private function setDriveFile($path, $file) {
-		return $this->setDriveFileHelper($this->getAbsolutePath($path), $file);
+		$this->setDriveFileHelper($this->getAbsolutePath($path), $file);
 	}
 
 	/**

--- a/changelog/unreleased/38161
+++ b/changelog/unreleased/38161
@@ -8,3 +8,4 @@ This gives the ability to:
 When using encryption, only the subfolder when used gets encrypted.
 
 https://github.com/owncloud/core/pull/38161
+https://github.com/owncloud/core/pull/38192


### PR DESCRIPTION
## Description
SonarCloud reported that the return value of `setDriveFileHelper` was being used when the function has no return value. Fix this.

The code was only recently added in PR #38184 

https://sonarcloud.io/project/issues?id=owncloud_core&open=AXYeS1IyiEX8BkRfGqkQ&resolved=false&sinceLeakPeriod=true&types=BUG

And adjust a few other things that SonarCloud and/or my editor reported.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
