### PR TITLE
[Tests-Only]TUS upload to non existing folder

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToNonExistingFolder.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToNonExistingFolder.feature
@@ -1,0 +1,58 @@
+@api @skipOnOcV10
+Feature: upload file
+  As a user
+  I want to try uploading files to a non-existent folder
+  So that I can check if the uploading works in such case
+
+  Background:
+    Given using OCS API version "1"
+    And the administrator has set the default folder for received shares to "Shares"
+    And user "Alice" has been created with default attributes and without skeleton files
+
+  Scenario Outline: attempt to upload a file into a non-existent folder inside shares
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
+    Then as "Alice" folder "/Shares/FOLDER/" should not exist
+    And as "Alice" file "/Shares/FOLDER/textfile.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: attempt to upload a file into a non-existent folder
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file with content "uploaded content" to "/nonExistentFolder/textfile.txt" using the TUS protocol on the WebDAV API
+    Then as "Alice" folder "/nonExistentFolder" should not exist
+    And as "Alice" file "/nonExistentFolder/textfile.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: attempt to upload a file into a non-existent folder within correctly received share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has shared folder "/FOLDER" with user "Brian"
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/nonExistentFolder/textfile.txt" using the TUS protocol on the WebDAV API
+    Then as "Brian" folder "/Shares/FOLDER/nonExistentFolder" should not exist
+    And as "Brian" file "/Shares/FOLDER/nonExistentFolder/textfile.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: attempt to upload a file into a non-existent folder within correctly received read only share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read"
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/nonExistentFolder/textfile.txt" using the TUS protocol on the WebDAV API
+    Then as "Brian" folder "/Shares/FOLDER/nonExistentFolder" should not exist
+    And as "Brian" file "/Shares/FOLDER/nonExistentFolder/textfile.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
@@ -65,3 +65,15 @@ Feature: upload file to shared folder
       | dav_version |
       | old         |
       | new         |
+
+  Scenario Outline: attempt to upload a file into a folder within correctly received read only share
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read"
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    When user "Brian" uploads file with content "uploaded content" to "/Shares/FOLDER/textfile.txt" using the TUS protocol on the WebDAV API
+    Then as "Brian" file "/Shares/FOLDER/textfile.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -185,9 +185,13 @@ class TUSContext implements Context {
 		string $user, string $content, string $destination
 	) {
 		$tmpfname = $this->writeDataToTempFile($content);
-		$this->userUploadsUsingTusAFileTo(
-			$user, \basename($tmpfname), $destination
-		);
+		try {
+			$this->userUploadsUsingTusAFileTo(
+				$user, \basename($tmpfname), $destination
+			);
+		} catch (Exception $e) {
+			Assert::assertStringContainsString('TusPhp\Exception\FileException: Unable to create resource', $e);
+		}
 		\unlink($tmpfname);
 	}
 


### PR DESCRIPTION
## Description
Tests for TUS upload to a non existing folder

## Related Issue
- Part of https://github.com/owncloud/product/issues/153

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/1023


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
