### PR TITLE
Add missing event emitters for Symfony EventDispatcher

### DIFF
--- a/changelog/unreleased/38195
+++ b/changelog/unreleased/38195
@@ -1,0 +1,7 @@
+Change: Add missing event emitters for Symfony EventDispatcher
+
+Prior to this fix we were missing emitters for the events postUserCreate and
+postSetPassword. This change adds those calls as we need them when working
+with the Symfony EventDispatcher.
+
+https://github.com/owncloud/core/issues/38195

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -339,6 +339,9 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			$userSession->listen('\OC\User', 'postCreateUser', function ($user, $password) {
 				/** @var $user \OC\User\User */
 				\OC_Hook::emit('OC_User', 'post_createUser', ['uid' => $user->getUID(), 'password' => $password]);
+				$this->emittingCall(function () {
+					return true;
+				}, ['before' => [], 'after' => ['uid' => $user->getUID(), 'password' => $password]], 'user', 'create');
 			});
 			$userSession->listen('\OC\User', 'preDelete', function ($user) {
 				/** @var $user \OC\User\User */
@@ -358,6 +361,9 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			$userSession->listen('\OC\User', 'postSetPassword', function ($user, $password, $recoveryPassword) {
 				/** @var $user \OC\User\User */
 				\OC_Hook::emit('OC_User', 'post_setPassword', ['run' => true, 'uid' => $user->getUID(), 'password' => $password, 'recoveryPassword' => $recoveryPassword]);
+				$this->emittingCall(function () {
+					return true;
+				}, ['before' => [], 'after' => ['run' => true, 'uid' => $user->getUID(), 'password' => $password, 'recoveryPassword' => $recoveryPassword]], 'user', 'setpassphrase');
 			});
 			$userSession->listen('\OC\User', 'preLogin', function ($uid, $password) {
 				\OC_Hook::emit('OC_User', 'pre_login', ['run' => true, 'uid' => $uid, 'password' => $password]);


### PR DESCRIPTION
## Description
Right now we are missing emitters for the events postUserCreate and postSetPassword. This change adds those calls as we need them when working with the Symfony EventDispatcher.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/38195

## Motivation and Context
This issue came up as we changed the event dispatchers in the Encryption app: https://github.com/owncloud/encryption/pull/25/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
