### PR TITLE
Rename Phoenix to Web

### DIFF
--- a/changelog/unreleased/38199
+++ b/changelog/unreleased/38199
@@ -1,0 +1,9 @@
+Change: Rename phoenix to web
+
+Phoenix has been renamed to Web. You can now set these keys in config.php to control Web:
+
+- web.baseUrl
+- web.icon
+- web.label
+
+https://github.com/owncloud/core/pull/38199

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -472,15 +472,15 @@ $CONFIG = [
 'overwrite.cli.url' => '',
 
 /**
- * Define the Phoenix base URL
- * If phoenix.baseUrl is set, public and private links will be redirected to this url.
- * Phoenix will handle these links accordingly.
+ * Define the Web base URL
+ * If web.baseUrl is set, public and private links will be redirected to this url.
+ * Web will handle these links accordingly.
  *
- * As an example, in case 'phoenix.baseUrl' is set to 'http://phoenix.example.com',
+ * As an example, in case 'web.baseUrl' is set to 'http://web.example.com',
  * the shared link 'http://ocx.example.com/index.php/s/THoQjwYYMJvXMdW' will be redirected
- * by ownCloud to 'http://phoenix.example.com/index.html#/s/THoQjwYYMJvXMdW'.
+ * by ownCloud to 'http://web.example.com/index.html#/s/THoQjwYYMJvXMdW'.
  */
-'phoenix.baseUrl' => '',
+'web.baseUrl' => '',
 
 /**
  * Define clean URLs without `/index.php`

--- a/core/routes.php
+++ b/core/routes.php
@@ -87,10 +87,14 @@ $this->create('core_ajax_update', '/core/ajax/update.php')
 
 // File routes
 $this->create('files.viewcontroller.showFile', '/f/{fileId}')->action(static function ($urlParams) {
-	$phoenixBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
-	if ($phoenixBaseUrl) {
+	$webBaseUrl = \OC::$server->getConfig()->getSystemValue('web.baseUrl', null);
+	if (!$webBaseUrl) {
+		// Check the old phoenix.baseUrl system key to provide compatibility across the name change
+		$webBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
+	}
+	if ($webBaseUrl) {
 		$fileId = $urlParams['fileId'];
-		\OC_Response::redirect("$phoenixBaseUrl/index.html#/f/$fileId");
+		\OC_Response::redirect("$webBaseUrl/index.html#/f/$fileId");
 		return;
 	}
 	$app = new \OCA\Files\AppInfo\Application($urlParams);
@@ -99,10 +103,14 @@ $this->create('files.viewcontroller.showFile', '/f/{fileId}')->action(static fun
 
 // Sharing routes
 $this->create('files_sharing.sharecontroller.showShare', '/s/{token}')->action(static function ($urlParams) {
-	$phoenixBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
-	if ($phoenixBaseUrl) {
+	$webBaseUrl = \OC::$server->getConfig()->getSystemValue('web.baseUrl', null);
+	if (!$webBaseUrl) {
+		// Check the old phoenix.baseUrl system key to provide compatibility across the name change
+		$webBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
+	}
+	if ($webBaseUrl) {
 		$token = $urlParams['token'];
-		\OC_Response::redirect("$phoenixBaseUrl/index.html#/s/$token");
+		\OC_Response::redirect("$webBaseUrl/index.html#/s/$token");
 		return;
 	}
 	$app = new \OCA\Files_Sharing\AppInfo\Application($urlParams);

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -190,15 +190,24 @@ class NavigationManager implements INavigationManager {
 			]);
 		}
 
-		// add phoenix if setup
-		$phoenixBaseUrl = $this->config->getSystemValue('phoenix.baseUrl', null);
-		if ($phoenixBaseUrl) {
-			$iconPath = $this->config->getSystemValue('phoenix.icon', $this->urlGenerator->imagePath('core', 'apps/phoenix.svg'));
+		// add web if setup
+		$webBaseUrl = $this->config->getSystemValue('web.baseUrl', null);
+		$webIconKey = 'web.icon';
+		$webIconLabel = 'web.label';
+		if (!$webBaseUrl) {
+			// Check the old phoenix.baseUrl system key to provide compatibility across
+			// the name change from phoenix to web.
+			$webBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
+			$webIconKey = 'phoenix.icon';
+			$webIconLabel = 'phoenix.label';
+		}
+		if ($webBaseUrl) {
+			$iconPath = $this->config->getSystemValue($webIconKey, $this->urlGenerator->imagePath('core', 'apps/phoenix.svg'));
 			$l = $this->l10nFac->get("core");
-			$label = $this->config->getSystemValue('phoenix.label', $l->t('New Design'));
+			$label = $this->config->getSystemValue($webIconLabel, $l->t('New Design'));
 			$this->add([
-				'id' => 'phoenix',
-				'href' => $phoenixBaseUrl,
+				'id' => 'web',
+				'href' => $webBaseUrl,
 				'name' => $label,
 				'icon' => $iconPath,
 				'order' => 99


### PR DESCRIPTION
## Description
- Change the config.php keys `phoenix.baseUrl` `phoenix.icon` and `phoenix.label` to be `web.baseUrl` `web.icon` and `web.label`

- If the new config.php keys are not set, then check the old keys. This provides backward-compatibility for automated testing and people who are using dev setups etc based on core master. Either key will work while we transition.

Related PR is https://github.com/owncloud/phoenix/pull/4443

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
