### PR TITLE
[tests-only] Add step to check failing download from inside a public link folder

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -737,18 +737,20 @@ class PublicWebDavContext implements Context {
 
 	/**
 	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
+	 * @Then /^the public download of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $publicWebDAVAPIVersion
 	 * @param string $password
+	 * @param string $expectedHttpCode
 	 *
 	 * @return void
 	 */
 	public function shouldNotBeAbleToDownloadFileInsidePublicSharedFolderWithPassword(
-		$path, $publicWebDAVAPIVersion, $password
+		$path, $publicWebDAVAPIVersion, $password, $expectedHttpCode = "401"
 	) {
 		$this->shouldNotBeAbleToDownloadRangeOfFileInsidePublicSharedFolderWithPassword(
-			"", $path, $publicWebDAVAPIVersion, $password
+			"", $path, $publicWebDAVAPIVersion, $password, $expectedHttpCode
 		);
 	}
 


### PR DESCRIPTION
## Description
1) Add step to check failing download from inside a public link folder

There is already a test step for checking that a download of a file shared by public link with password fails with a given status. That is used by the brute_force_protection app tests:
```
Then the public download of the last publicly shared file using the new public WebDAV API with password "abcdef" should fail with HTTP status code "401"
```
We also need to be able to do this sort of check on a file that is in a publicly shared folder:
```
Then the public download of file "randomfile.txt" from inside the last public shared folder using the new public WebDAV API with password "abcdef" should fail with HTTP status code "401"
```

This PR adds the above step format. It makes it possible to refactor an existing test scenario in the brute_force_protection app so that it does a more realistic test.

2) Add test steps for upload and MKCOL to public link folders - this allows adding `Then` steps to scenarios to confirm that "the public" can or cannot create a folder inside an existing public shared folder. For example, in brute_force_protection we want to try creating the folder a few times using a wrong password, and then with the correct password, and confirm that even the correct password is now locked out.

## Related Issue
https://github.com/owncloud/brute_force_protection/issues/146

The existing tests did not cover the folder-creation case in the issue.

## How Has This Been Tested?
Local run of a scenarios in brute_force_protection app. I have a PR coming for that.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
