### PR TITLE
[Tests-Only] added api test for share shared to deleted user

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
@@ -503,3 +503,22 @@ Feature: sharing
     Then the HTTP status code should be "200"
 #    Then the HTTP status code should be "405"
     And as "Carol" folder "userOneFolder" should not exist
+
+  Scenario Outline: shares to a deleted user should not be listed as shares for the sharer
+    Given using OCS API version "<ocs_api_version>"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+      | Carol    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has shared file "textfile0.txt" with user "Carol"
+    And the administrator has deleted user "Brian" using the provisioning API
+    When user "Alice" gets all the shares from the file "textfile0.txt" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "Carol" should be included in the response
+    But user "Brian" should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -610,3 +610,24 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  Scenario Outline: shares to a deleted user should not be listed as shares for the sharer
+    Given using OCS API version "<ocs_api_version>"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+      | Carol    |
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has shared file "textfile0.txt" with user "Carol"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    And user "Carol" has accepted share "/textfile0.txt" offered by user "Alice"
+    And the administrator has deleted user "Brian" using the provisioning API
+    When user "Alice" gets all the shares from the file "textfile0.txt" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And user "Carol" should be included in the response
+    But user "Brian" should not be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1525,6 +1525,19 @@ trait Provisioning {
 		);
 		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
+	/**
+	 * @Given /^the administrator has deleted user "([^"]*)" using the provisioning API$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theAdministratorHasDeletedUserUsingTheProvisioningApi($user) {
+		$user = $this->getActualUsername($user);
+		$this->deleteTheUserUsingTheProvisioningApi($user);
+		$this->userShouldNotExist($user);
+	}
 
 	/**
 	 * @When /^the administrator deletes user "([^"]*)" using the provisioning API$/


### PR DESCRIPTION
Co-authored-by: Saw-jan <saw.jan.grg3e@gmail.com>

## Description
Added api test for share shared to deleted user

## Related Issue
- https://github.com/owncloud/ocis/issues/903

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/1063

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
