### PR TITLE
[tests-only] reword 'switch to the tab' test step

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2246,8 +2246,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the user has switched to :tabName tab in details panel using the webUI
-	 * @When the user switches to :tabName tab in details panel using the webUI
+	 * @Given the user has switched to the :tabName tab in the details panel using the webUI
+	 * @When the user switches to the :tabName tab in the details panel using the webUI
 	 *
 	 * @param string $tabName
 	 *

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -17,11 +17,11 @@ Feature: User can open the details panel for any file or folder
     And the user clicks the details file action on the webUI
     Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
+    When the user switches to the "sharing" tab in the details panel using the webUI
     Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
+    When the user switches to the "comments" tab in the details panel using the webUI
     Then the "comments" details panel should be visible
-    When the user switches to "versions" tab in details panel using the webUI
+    When the user switches to the "versions" tab in the details panel using the webUI
     Then the "versions" details panel should be visible
 
   @comments-app-required @files_versions-app-required @files_sharing-app-required
@@ -34,11 +34,11 @@ Feature: User can open the details panel for any file or folder
     And the user clicks the details file action on the webUI
     Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
+    When the user switches to the "sharing" tab in the details panel using the webUI
     Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
+    When the user switches to the "comments" tab in the details panel using the webUI
     Then the "comments" details panel should be visible
-    When the user switches to "versions" tab in details panel using the webUI
+    When the user switches to the "versions" tab in the details panel using the webUI
     Then the "versions" details panel should be visible
 
   @comments-app-required @public_link_share-feature-required @files_sharing-app-required
@@ -52,9 +52,9 @@ Feature: User can open the details panel for any file or folder
     And the user clicks the details file action on the webUI
     Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
+    When the user switches to the "sharing" tab in the details panel using the webUI
     Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
+    When the user switches to the "comments" tab in the details panel using the webUI
     Then the "comments" details panel should be visible
 
   @comments-app-required @files_sharing-app-required
@@ -69,9 +69,9 @@ Feature: User can open the details panel for any file or folder
     And the user clicks the details file action on the webUI
     Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
+    When the user switches to the "sharing" tab in the details panel using the webUI
     Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
+    When the user switches to the "comments" tab in the details panel using the webUI
     Then the "comments" details panel should be visible
 
   @comments-app-required @files_sharing-app-required
@@ -86,9 +86,9 @@ Feature: User can open the details panel for any file or folder
     And the user clicks the details file action on the webUI
     Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
+    When the user switches to the "sharing" tab in the details panel using the webUI
     Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
+    When the user switches to the "comments" tab in the details panel using the webUI
     Then the "comments" details panel should be visible
 
   @comments-app-required @files_sharing-app-required
@@ -104,9 +104,9 @@ Feature: User can open the details panel for any file or folder
     And the user clicks the details file action on the webUI
     Then the details dialog should be visible on the webUI
     And the thumbnail should be visible in the details panel
-    When the user switches to "sharing" tab in details panel using the webUI
+    When the user switches to the "sharing" tab in the details panel using the webUI
     Then the "sharing" details panel should be visible
-    When the user switches to "comments" tab in details panel using the webUI
+    When the user switches to the "comments" tab in the details panel using the webUI
     Then the "comments" details panel should be visible
 
   Scenario Outline: Breadcrumb through folders

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -13,7 +13,7 @@ Feature: Creation of tags for the files and folders
   Scenario: Create a new tag that does not exist for a file in the root
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user adds a tag "Top Secret" to the file using the webUI
     And the user adds a tag "Confidential" to the file using the webUI
     Then file "/randomfile.txt" should have the following tags for user "Alice"
@@ -25,7 +25,7 @@ Feature: Creation of tags for the files and folders
     Given user "Alice" has created folder "a-folder"
     And user "Alice" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user adds a tag "Top Secret" to the file using the webUI
     And the user adds a tag "Top" to the file using the webUI
     Then file "a-folder/randomfile.txt" should have the following tags for user "Alice"
@@ -40,7 +40,7 @@ Feature: Creation of tags for the files and folders
     And the user has created a "normal" tag with name "randomfile"
     And the user has added tag "randomfile" to file "/a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile-big.txt" in folder "a-folder"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user adds a tag "randomfile" to the file using the webUI
     Then file "a-folder/randomfile.txt" should have the following tags for user "Alice"
       | name       | type   |
@@ -54,12 +54,12 @@ Feature: Creation of tags for the files and folders
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     And the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    When the user switches to "tags" tab in details panel using the webUI
+    When the user switches to the "tags" tab in the details panel using the webUI
     And the user adds a tag "tag1" to the file using the webUI
     And the user shares file "randomfile.txt" with user "Brian" using the webUI
     And the user re-logs in with username "Brian" using the webUI
     And the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user adds a tag "tag2" to the file using the webUI
     Then file "randomfile.txt" should have the following tags for user "Alice"
       | name | type   |
@@ -78,7 +78,7 @@ Feature: Creation of tags for the files and folders
       | Carol    |
     And the user re-logs in as "Brian" using the webUI
     And the user browses directly to display the details of file "lorem.txt" in folder "/"
-    When the user switches to "tags" tab in details panel using the webUI
+    When the user switches to the "tags" tab in the details panel using the webUI
     And the user adds a tag "skeleton" to the file using the webUI
     And the user shares file "lorem.txt" with user "Carol" using the webUI
     Then file "lorem (2).txt" should have the following tags for user "Carol"
@@ -90,7 +90,7 @@ Feature: Creation of tags for the files and folders
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user adds a tag "Confidential" to the file using the webUI
     And the user shares file "randomfile.txt" with user "Brian" using the webUI
     Then file "/randomfile.txt" should have the following tags for user "Brian"

--- a/tests/acceptance/features/webUITags/deleteTags.feature
+++ b/tests/acceptance/features/webUITags/deleteTags.feature
@@ -15,7 +15,7 @@ Feature: Deletion of existing tags from files and folders
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     And the user browses directly to display the details of file "randomfile.txt" in folder ""
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user has switched to the "tags" tab in the details panel using the webUI
     When the user adds a tag "tag1" to the file using the webUI
     And the user shares file "randomfile.txt" with user "Brian" using the webUI
     And the user re-logs in with username "Brian" using the webUI
@@ -23,7 +23,7 @@ Feature: Deletion of existing tags from files and folders
       | name | type   |
       | tag1 | normal |
     When the user browses directly to display the details of file "randomfile.txt" in folder ""
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user deletes tag with name "tag1" using the webUI
     Then tag "tag1" should not exist for user "Alice"
     And tag "tag1" should not exist for user "Brian"
@@ -33,7 +33,7 @@ Feature: Deletion of existing tags from files and folders
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     Then file "randomfile.txt" should have the following tags for user "Alice"
       | name   | type   |
       | random | normal |
@@ -46,7 +46,7 @@ Feature: Deletion of existing tags from files and folders
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     Then file "a-folder/randomfile.txt" should have the following tags for user "Alice"
       | name   | type   |
       | random | normal |
@@ -62,7 +62,7 @@ Feature: Deletion of existing tags from files and folders
     And the user has added tag "random" to file "randomfile.txt"
     And the user has added tag "random" to file "randomfile-big.txt"
     And the user has browsed directly to display the details of file "randomfile.txt" in folder "a-folder"
-    And the user has switched to "tags" tab in details panel using the webUI
+    And the user has switched to the "tags" tab in the details panel using the webUI
     When the user deletes tag with name "random" using the webUI
     Then tag "random" should not exist for user "Alice"
 
@@ -73,7 +73,7 @@ Feature: Deletion of existing tags from files and folders
     And the user has added tag "random" to file "randomfile.txt"
     And the user has added tag "Confidential" to file "randomfile.txt"
     And the user has browsed directly to display the details of file "randomfile.txt" in folder "/"
-    And the user has switched to "tags" tab in details panel using the webUI
+    And the user has switched to the "tags" tab in the details panel using the webUI
     When the user deletes tag with name "random" using the webUI
     And the user deletes tag with name "Confidential" using the webUI
     Then file "randomfile.txt" should have no tags for user "Alice"
@@ -87,7 +87,7 @@ Feature: Deletion of existing tags from files and folders
     And the user has added tag "Confidential" to file "randomfile.txt"
     And the user has added tag "some-tag" to file "randomfile.txt"
     And the user has browsed directly to display the details of file "randomfile.txt" in folder "/"
-    And the user has switched to "tags" tab in details panel using the webUI
+    And the user has switched to the "tags" tab in the details panel using the webUI
     When the user deletes tag with name "random" using the webUI
     And the user deletes tag with name "Confidential" using the webUI
     Then tag "random" should not exist for user "Alice"

--- a/tests/acceptance/features/webUITags/editTags.feature
+++ b/tests/acceptance/features/webUITags/editTags.feature
@@ -17,7 +17,7 @@ Feature: Edit tags for files and folders
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user edits the tag with name "random" and sets its name to "random-big" using the webUI
     Then file "randomfile.txt" should have the following tags for user "Alice"
       | name       | type   |
@@ -32,7 +32,7 @@ Feature: Edit tags for files and folders
     And the user has added tag "random" to file "randomfile.txt"
     And the user has added tag "some-tag" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user edits the tag with name "random" and sets its name to "random-big" using the webUI
     And the user edits the tag with name "some-tag" and sets its name to "another-tag" using the webUI
     Then file "randomfile.txt" should have the following tags for user "Alice"

--- a/tests/acceptance/features/webUITags/removeTags.feature
+++ b/tests/acceptance/features/webUITags/removeTags.feature
@@ -16,7 +16,7 @@ Feature: Removal of already existing tags from files and folders
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user toggles a tag "random" on the file using the webUI
     Then file "a-folder/randomfile.txt" should have no tags for user "Alice"
 
@@ -25,7 +25,7 @@ Feature: Removal of already existing tags from files and folders
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user toggles a tag "random" on the file using the webUI
     Then file "randomfile.txt" should have no tags for user "Alice"
 
@@ -36,7 +36,7 @@ Feature: Removal of already existing tags from files and folders
     And the user has added tag "random" to file "randomfile.txt"
     And the user has added tag "Confidential" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user toggles a tag "random" on the file using the webUI
     And the user toggles a tag "Confidential" on the file using the webUI
     Then file "randomfile.txt" should have no tags for user "Alice"
@@ -53,7 +53,7 @@ Feature: Removal of already existing tags from files and folders
       | name | type   |
       | tag1 | normal |
     When the user browses directly to display the details of file "coolnewfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user toggles a tag "tag1" on the file using the webUI
     Then file "coolnewfile.txt" should have no tags for user "Brian"
     And file "coolnewfile.txt" should have no tags for user "Alice"
@@ -71,7 +71,7 @@ Feature: Removal of already existing tags from files and folders
       | tag1 | normal |
     When the user re-logs in with username "Alice" using the webUI
     And the user browses directly to display the details of file "coolnewfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user toggles a tag "tag1" on the file using the webUI
     Then file "coolnewfile.txt" should have no tags for user "Brian"
     And file "coolnewfile.txt" should have no tags for user "Alice"
@@ -85,7 +85,7 @@ Feature: Removal of already existing tags from files and folders
     And the user has added tag "Confidential" to file "randomfile.txt"
     And the user has added tag "some-tag" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user toggles a tag "random" on the file using the webUI
     And the user toggles a tag "Confidential" on the file using the webUI
     Then file "randomfile.txt" should have the following tags for user "Alice"
@@ -97,7 +97,7 @@ Feature: Removal of already existing tags from files and folders
     And the user has created a "normal" tag with name "random"
     And the user has added tag "random" to file "randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "/"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user toggles a tag "random" on the file using the webUI
     And the user adds a tag "some-tag" to the file using the webUI
     Then file "randomfile.txt" should have the following tags for user "Alice"

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -24,7 +24,7 @@ Feature: Suggestion for matching tag names
     Given user "Alice" has created folder "a-folder"
     And user "Alice" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the user types "sp" in the collaborative tags field using the webUI
     Then all the tags starting with "sp" in their name should be listed in the dropdown list on the webUI
     But tag "gham" should not be listed in the dropdown list on the webUI
@@ -36,7 +36,7 @@ Feature: Suggestion for matching tag names
     Given user "Alice" has created folder "a-folder"
     And user "Alice" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
     When the user browses directly to display the details of file "randomfile.txt" in folder "a-folder"
-    And the user switches to "tags" tab in details panel using the webUI
+    And the user switches to the "tags" tab in the details panel using the webUI
     And the administrator has created a "static" tag with name "StaticTagName" and groups "group1"
     And the user types "St" in the collaborative tags field using the webUI
     Then all the tags starting with "St" in their name should be listed in the dropdown list on the webUI


### PR DESCRIPTION
## Description
I noticed that in PR #38197 this existing test step was used quite a lot:
`When the user switches to "tags" tab in details panel using the webUI`

The English will be a bit more readable with some `the` added:

`When the user switches to the "tags" tab in the details panel using the webUI`

Make that change to the step text.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
