### PR TITLE
[Tests-Only]Added test for requesting remote.php/dav/files with depth headers

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/apiWebdavOperations/propfind.feature
@@ -6,3 +6,10 @@ Feature: PROPFIND
     Given user "Alice" has been created with default attributes and without skeleton files
     When user "Alice" requests "/remote.php/dav/files" with "PROPFIND" using basic auth
     Then the HTTP status code should be "405"
+
+  Scenario: PROPFIND to "/remote.php/dav/files" with depth header
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When user "Alice" requests "/remote.php/dav/files" with "PROPFIND" using basic auth and with headers
+      | header | value |
+      | depth  | 0     |
+    Then the HTTP status code should be "207"

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -603,11 +603,12 @@ class AuthContext implements Context {
 	 * @param string|null $authHeader
 	 * @param bool $useCookies
 	 * @param string $body
+	 * @param array $headers
 	 *
 	 * @return void
 	 */
 	public function sendRequest(
-		$url, $method, $authHeader = null, $useCookies = false, $body = null, $headers = null
+		$url, $method, $authHeader = null, $useCookies = false, $body = null, $headers = []
 	) {
 		// reset responseXml
 		$this->featureContext->setResponseXml([]);

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -607,7 +607,7 @@ class AuthContext implements Context {
 	 * @return void
 	 */
 	public function sendRequest(
-		$url, $method, $authHeader = null, $useCookies = false, $body = null
+		$url, $method, $authHeader = null, $useCookies = false, $body = null, $headers = null
 	) {
 		// reset responseXml
 		$this->featureContext->setResponseXml([]);
@@ -619,7 +619,6 @@ class AuthContext implements Context {
 			$cookies = $this->featureContext->getCookieJar();
 		}
 
-		$headers = [];
 		if ($authHeader) {
 			$headers['Authorization'] = $authHeader;
 		}
@@ -766,6 +765,36 @@ class AuthContext implements Context {
 		}
 		$this->sendRequest(
 			$url, $method, 'basic ' . \base64_encode($authString), false, $body
+		);
+	}
+
+	/**
+	 * @When user :user requests :url with :method using basic auth and with headers
+	 *
+	 * @param string $user
+	 * @param string $url
+	 * @param string $method
+	 * @param TableNode $headersTable
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userRequestsURLWithUsingBasicAuthAndDepthHeader($user, $url, $method, TableNode $headersTable) {
+		$user = $this->featureContext->getActualUsername($user);
+		$authString = "$user:" . $this->featureContext->getPasswordForUser($user);
+		$url = $this->featureContext->substituteInLineCodes(
+			$url, $user
+		);
+		$this->featureContext->verifyTableNodeColumns(
+			$headersTable,
+			['header', 'value']
+		);
+		$headers = [];
+		foreach ($headersTable as $row) {
+			$headers[$row['header']] = $row ['value'];
+		}
+		$this->sendRequest(
+			$url, $method, 'basic ' . \base64_encode($authString), false, null, $headers
 		);
 	}
 


### PR DESCRIPTION
## Description
Writing test that demonstrates that an authorized request to the endpoint `remote.php/dav/files` will return 207

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/ocis/issues/974

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- https://github.com/owncloud/ocis/pull/1099

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
