### PR TITLE
[tests-only] tus test for file with invalid-name

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
@@ -119,3 +119,23 @@ Feature: upload file
       | old         |
       | new         |
 
+  Scenario Outline: upload a file with invalid-name
+    Given using <dav_version> DAV path
+    When user "Alice" creates a new TUS resource on the WebDAV API with these headers:
+      | Upload-Length   | 100                 |
+      | Upload-Metadata | filename <metadata> |
+      | Tus-Resumable   | 1.0.0               |
+    And user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "123" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And user "Alice" downloads file <file_name> using the WebDAV API
+    And the HTTP status code should be "404"
+    Examples:
+      | dav_version | file_name               | metadata                     |
+      | old         | " "                     | IA==                         |
+      | old         | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
+      | old         | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
+      | old         | "my\\file"              | bXkMaWxl                     |
+      | new         | " "                     | IA==                         |
+      | new         | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
+      | new         | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
+      | new         | "my\\file"              | bXkMaWxl                     |

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
@@ -125,17 +125,17 @@ Feature: upload file
       | Upload-Length   | 100                 |
       | Upload-Metadata | filename <metadata> |
       | Tus-Resumable   | 1.0.0               |
-    And user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "123" using the WebDAV API
-    Then the HTTP status code should be "204"
-    And user "Alice" downloads file <file_name> using the WebDAV API
-    And the HTTP status code should be "404"
+    Then the HTTP status code should be "412"
+    And the following headers should not be set
+      | header   |
+      | Location |
     Examples:
-      | dav_version | file_name               | metadata                     |
-      | old         | " "                     | IA==                         |
-      | old         | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
-      | old         | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
-      | old         | "my\\file"              | bXkMaWxl                     |
-      | new         | " "                     | IA==                         |
-      | new         | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
-      | new         | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
-      | new         | "my\\file"              | bXkMaWxl                     |
+      | dav_version | metadata                     |
+      | old         | IA==                         |
+      | old         | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
+      | old         | Zm9sZGVyL2ZpbGU=             |
+      | old         | bXkMaWxl                     |
+      | new         | IA==                         |
+      | new         | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
+      | new         | Zm9sZGVyL2ZpbGU=             |
+      | new         | bXkMaWxl                     |


### PR DESCRIPTION
## Description
Test for TUS to upload a file with invalid-name

## Related Issue
- part of owncloud/product#153

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/1111

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
