### PR TITLE
Improve text shown when file or pathnames are bad

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -123,7 +123,6 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 	 * @throws ServiceUnavailable
 	 */
 	public function createFile($name, $data = null) {
-
 		try {
 			# the check here is necessary, because createFile uses put covered in sabre/file.php
 			# and not touch covered in files/view.php
@@ -190,7 +189,6 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 	 * @throws SabreServiceUnavailable
 	 */
 	public function createDirectory($name) {
-
 		try {
 			# the check here is necessary, because createDirectory does not use the methods in files/view.php
 			if (Filesystem::isForbiddenFileOrDir($name)) {

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -38,6 +38,7 @@ use OC\Files\Mount\MoveableMount;
 use OC\Lock\Persistent\Lock;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCA\DAV\Connector\Sabre\Exception\ServiceUnavailable;
 use OCP\Files\ForbiddenException;
 use OCP\Files\Storage\IPersistentLockingStorage;
 use OCP\Share\Exceptions\ShareNotFound;
@@ -120,6 +121,7 @@ abstract class Node implements \Sabre\DAV\INode {
 	 * @param string $name The new name
 	 * @throws \Sabre\DAV\Exception\BadRequest
 	 * @throws \Sabre\DAV\Exception\Forbidden
+	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 * @throws InvalidPath
 	 */
 	public function setName($name) {
@@ -137,7 +139,7 @@ abstract class Node implements \Sabre\DAV\INode {
 
 		// verify path of target
 		if (\OC\Files\Filesystem::isForbiddenFileOrDir($parentPath . '/' . $newName)) {
-			throw new \Sabre\DAV\Exception\Forbidden();
+			throw new \Sabre\DAV\Exception\ServiceUnavailable('Excluded or Blacklisted name: ' . $parentPath . '/' . $newName);
 		}
 
 		try {
@@ -354,7 +356,7 @@ abstract class Node implements \Sabre\DAV\INode {
 
 	protected function verifyPath() {
 		if (\OC\Files\Filesystem::isForbiddenFileOrDir($this->info->getPath())) {
-			throw new \Sabre\DAV\Exception\Forbidden();
+			throw new \Sabre\DAV\Exception\ServiceUnavailable('Excluded or Blacklisted name: ' . $this->info->getPath());
 		}
 
 		try {

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -64,9 +64,9 @@ class ObjectTree extends \Sabre\DAV\Tree {
 		\Sabre\DAV\INode $rootNode,
 		\OC\Files\View $view,
 		\OCP\Files\Mount\IMountManager $mountManager) {
-			$this->rootNode = $rootNode;
-			$this->fileView = $view;
-			$this->mountManager = $mountManager;
+		$this->rootNode = $rootNode;
+		$this->fileView = $view;
+		$this->mountManager = $mountManager;
 	}
 
 	/**

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -31,6 +31,7 @@ use OC\Files\FileInfo;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCA\DAV\Connector\Sabre\Exception\ServiceUnavailable;
 use OCP\Files\ForbiddenException;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
@@ -57,12 +58,15 @@ class ObjectTree extends \Sabre\DAV\Tree {
 	/**
 	 * @param \Sabre\DAV\INode $rootNode
 	 * @param \OC\Files\View $view
-	 * @param  \OCP\Files\Mount\IMountManager $mountManager
+	 * @param \OCP\Files\Mount\IMountManager $mountManager
 	 */
-	public function init(\Sabre\DAV\INode $rootNode, \OC\Files\View $view, \OCP\Files\Mount\IMountManager $mountManager) {
-		$this->rootNode = $rootNode;
-		$this->fileView = $view;
-		$this->mountManager = $mountManager;
+	public function init(
+		\Sabre\DAV\INode $rootNode,
+		\OC\Files\View $view,
+		\OCP\Files\Mount\IMountManager $mountManager) {
+			$this->rootNode = $rootNode;
+			$this->fileView = $view;
+			$this->mountManager = $mountManager;
 	}
 
 	/**
@@ -127,7 +131,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 	 */
 	public function getNodeForPath($path) {
 		if (!$this->fileView) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
+			throw new \Sabre\DAV\Exception\ServiceUnavailable('Filesystem Not Setup');
 		}
 
 		$path = \trim($path, '/');
@@ -138,7 +142,7 @@ class ObjectTree extends \Sabre\DAV\Tree {
 
 		// check the path, also called when the path has been entered manually eg via a file explorer
 		if (\OC\Files\Filesystem::isForbiddenFileOrDir($path)) {
-			throw new \Sabre\DAV\Exception\Forbidden();
+			throw new \Sabre\DAV\Exception\ServiceUnavailable('Excluded or Blacklisted name: ' . $path);
 		}
 
 		if ($path !== '') {
@@ -216,12 +220,12 @@ class ObjectTree extends \Sabre\DAV\Tree {
 	 */
 	public function copy($source, $destination) {
 		if (!$this->fileView) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable('filesystem not setup');
+			throw new \Sabre\DAV\Exception\ServiceUnavailable('Filesystem Not Setup');
 		}
 
 		# check the destination path, for source see below
 		if (\OC\Files\Filesystem::isForbiddenFileOrDir($destination)) {
-			throw new \Sabre\DAV\Exception\Forbidden();
+			throw new \Sabre\DAV\Exception\ServiceUnavailable($destination);
 		}
 
 		// at getNodeForPath we also check the path for isForbiddenFileOrDir

--- a/changelog/unreleased/38218
+++ b/changelog/unreleased/38218
@@ -1,0 +1,8 @@
+Enhancement: Improve error messages for invalid file names
+
+When using blacklisted or excluded filenames, you just get a default error
+message that you do not have permissions to write there (basis is 403). This is
+confusing because of the missing reason. Applies when you drag and drop a file
+into the browser. With this change, a proper error message is shown to the user.
+
+https://github.com/owncloud/core/pull/38218

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -139,7 +139,7 @@ class CertificateManager implements ICertificateManager {
 	 */
 	public function addCertificate($certificate, $name) {
 		if (!Filesystem::isValidPath($name) or Filesystem::isForbiddenFileOrDir($name)) {
-			throw new \Exception('Filename is not valid');
+			throw new \Exception('Invalid path or Excluded or Blacklisted name: ' . $sname);
 		}
 
 		$dir = $this->getPathToCertificates() . 'uploads/';


### PR DESCRIPTION
## Description
When using blacklisted or excluded filenames, you just get a default error message that you do not have permissions to write there (basis is 403) when using drag & drop. This is confusing because of the missing reason. Applies when you drag and drop a file into the browser. With this change, a proper error message is shown to the user. In addition, I found that a code fragment was double present, wich I removed. To get a custom error message, I changed the error type thrown.

## Related Issue
No issue related.

## Motivation and Context
I stumbled over that and went nuts while trying to upload a testfile to my dev instance where I have set an excluded name (which I forgot ...)
Now, having a proper error message, this is no longer a issue.

## How Has This Been Tested?
Manually by drag and drop

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
