### PR TITLE
Integrity locks fixes

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -169,7 +169,12 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 
 			$node = new File($this->fileView, $info);
 			$node->acquireLock(ILockingProvider::LOCK_SHARED);
-			return $node->put($data);
+			try {
+				$result = $node->put($data);
+			} finally {
+				$node->releaseLock(ILockingProvider::LOCK_SHARED);
+			}
+			return $result;
 		} catch (StorageNotAvailableException $e) {
 			throw new SabreServiceUnavailable($e->getMessage());
 		} catch (InvalidPathException $ex) {

--- a/apps/dav/tests/unit/DAV/LockPluginTest.php
+++ b/apps/dav/tests/unit/DAV/LockPluginTest.php
@@ -68,9 +68,9 @@ class LockPluginTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		parent::tearDown();
 		$this->restoreService('UserSession');
 		$this->restoreService(LockMapper::class);
+		parent::tearDown();
 	}
 
 	/**

--- a/lib/private/Lock/AbstractLockingProvider.php
+++ b/lib/private/Lock/AbstractLockingProvider.php
@@ -110,12 +110,14 @@ abstract class AbstractLockingProvider implements ILockingProvider {
 	 */
 	public function releaseAll() {
 		foreach ($this->acquiredLocks['shared'] as $path => $count) {
+			\OCP\Util::writeLog('core', "cleaning $count stray shared locks for $path", \OCP\Util::WARN);
 			for ($i = 0; $i < $count; $i++) {
 				$this->releaseLock($path, self::LOCK_SHARED);
 			}
 		}
 
 		foreach ($this->acquiredLocks['exclusive'] as $path => $hasLock) {
+			\OCP\Util::writeLog('core', "cleaning stray exclusive locks for $path", \OCP\Util::WARN);
 			$this->releaseLock($path, self::LOCK_EXCLUSIVE);
 		}
 	}

--- a/lib/private/Lock/AbstractLockingProvider.php
+++ b/lib/private/Lock/AbstractLockingProvider.php
@@ -113,14 +113,14 @@ abstract class AbstractLockingProvider implements ILockingProvider {
 	 */
 	public function releaseAll() {
 		foreach ($this->acquiredLocks['shared'] as $path => $count) {
-			\OCP\Util::writeLog('core', "cleaning $count stray shared locks for $path", \OCP\Util::WARN);
+			\OCP\Util::writeLog('core', "cleaning $count stray shared locks for $path", \OCP\Util::INFO);
 			for ($i = 0; $i < $count; $i++) {
 				$this->releaseLock($path, self::LOCK_SHARED);
 			}
 		}
 
 		foreach ($this->acquiredLocks['exclusive'] as $path => $hasLock) {
-			\OCP\Util::writeLog('core', "cleaning stray exclusive locks for $path", \OCP\Util::WARN);
+			\OCP\Util::writeLog('core', "cleaning stray exclusive locks for $path", \OCP\Util::INFO);
 			$this->releaseLock($path, self::LOCK_EXCLUSIVE);
 		}
 	}

--- a/lib/private/Lock/AbstractLockingProvider.php
+++ b/lib/private/Lock/AbstractLockingProvider.php
@@ -102,6 +102,9 @@ abstract class AbstractLockingProvider implements ILockingProvider {
 		} elseif ($targetType === self::LOCK_EXCLUSIVE) {
 			$this->acquiredLocks['exclusive'][$path] = true;
 			$this->acquiredLocks['shared'][$path]--;
+			if ($this->acquiredLocks['shared'][$path] === 0) {
+				unset($this->acquiredLocks['shared'][$path]);
+			}
 		}
 	}
 

--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -122,18 +122,18 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 	public function changeLock($path, $targetType) {
 		if ($targetType === self::LOCK_SHARED) {
 			if (!$this->hasAcquiredLock($path, self::LOCK_EXCLUSIVE)) {
-				// trying to change a lock that we haven't acquired -> ignore
-				\OCP\Util::writeLog('core', "ignoring lock change to type $targetType for $path. Lock hasn't been acquired before", \OCP\Util::WARN);
-				return;
+				// trying to change a lock that we haven't acquired -> throw exception
+				\OCP\Util::writeLog('core', "trying lock change to type $targetType for $path, but the lock hasn't been acquired before!!", \OCP\Util::WARN);
+				throw new LockedException($path);
 			}
 			if (!$this->memcache->cas($path, 'exclusive', 1)) {
 				throw new LockedException($path);
 			}
 		} elseif ($targetType === self::LOCK_EXCLUSIVE) {
 			if (!$this->hasAcquiredLock($path, self::LOCK_SHARED)) {
-				// trying to change a lock that we haven't acquired -> ignore
-				\OCP\Util::writeLog('core', "ignoring lock change to type $targetType for $path. Lock hasn't been acquired before", \OCP\Util::WARN);
-				return;
+				// trying to change a lock that we haven't acquired -> throw exception
+				\OCP\Util::writeLog('core', "trying lock change to type $targetType for $path, but the lock hasn't been acquired before!!", \OCP\Util::WARN);
+				throw new LockedException($path);
 			}
 			// we can only change a shared lock to an exclusive if there's only a single owner of the shared lock
 			if (!$this->memcache->cas($path, 1, 'exclusive')) {

--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -120,16 +120,21 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function changeLock($path, $targetType) {
-		if (!$this->hasAcquiredLock($path, $targetType)) {
-			\OCP\Util::writeLog('core', "ignoring lock change to type $targetType for $path. Lock hasn't been acquired before", \OCP\Util::WARN);
-			return;
-		}
-
 		if ($targetType === self::LOCK_SHARED) {
+			if (!$this->hasAcquiredLock($path, self::LOCK_EXCLUSIVE)) {
+				// trying to change a lock that we haven't acquired -> ignore
+				\OCP\Util::writeLog('core', "ignoring lock change to type $targetType for $path. Lock hasn't been acquired before", \OCP\Util::WARN);
+				return;
+			}
 			if (!$this->memcache->cas($path, 'exclusive', 1)) {
 				throw new LockedException($path);
 			}
 		} elseif ($targetType === self::LOCK_EXCLUSIVE) {
+			if (!$this->hasAcquiredLock($path, self::LOCK_SHARED)) {
+				// trying to change a lock that we haven't acquired -> ignore
+				\OCP\Util::writeLog('core', "ignoring lock change to type $targetType for $path. Lock hasn't been acquired before", \OCP\Util::WARN);
+				return;
+			}
 			// we can only change a shared lock to an exclusive if there's only a single owner of the shared lock
 			if (!$this->memcache->cas($path, 1, 'exclusive')) {
 				throw new LockedException($path);

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -333,8 +333,7 @@ class OC_Files {
 	 */
 	public static function lockFiles($view, $dir, $files) {
 		if (!\is_array($files)) {
-			$file = $dir . '/' . $files;
-			$files = [$file];
+			$files = [$files];
 		}
 		foreach ($files as $file) {
 			$file = $dir . '/' . $file;

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -290,7 +290,7 @@ class OC_Files {
 			} else {
 				$msg = 'Access denied';
 			}
-			\OC_Template::printErrorPage('Access denied', $message, 403);
+			\OC_Template::printErrorPage('Access denied', $msg, 403);
 			return;
 		}
 

--- a/lib/public/IMemcache.php
+++ b/lib/public/IMemcache.php
@@ -70,10 +70,13 @@ interface IMemcache extends ICache {
 	/**
 	 * Compare and set
 	 *
-	 * @param string $key
-	 * @param mixed $old
-	 * @param mixed $new
-	 * @return bool
+	 * @param string $key the key to check
+	 * @param mixed $old the expected value to compare against what is currently set.
+	 * If the "old" value matches, the "new" value will be set. If it doesn't match,
+	 * the "new" value will be ignored.
+	 * @param mixed $new the "new" value we want to set if the comparison matches
+	 * @return bool true if the "new" value is effectively set by this client. Note that
+	 * if the value is set by other clients, this method will return false.
 	 * @since 8.1.0
 	 */
 	public function cas($key, $old, $new);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
List of changes in this PR:
* Fix possible race condition in the `MemcacheLockingProvider` causing problems during the lock release
* Ensure `releaseLock` and `changeLock` methods of the `MemcacheLockingProvider` only happen if you have acquire a lock previously, otherwise log a warning and ignore the action.
* Added warning log in the `AbstractLockingProvider` to check whether we're releasing locks during shutdown. Locks should be released as early as possible, so the log should never happen.
* Refactor `OC_Files::get()` method to ensure the locks are properly released.

## Related Issue
https://github.com/owncloud/enterprise/issues/4319

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Create a folder structure such as "/big share/batches/b1/file.jpg" with multiple big files in the "b1" folder
2. Share the "/big share" folder via link
3. Run the following script to download the shared folder by multiple clients at the same time (it should match the request made by the browser)
    ```
    #!/bin/bash
    for i in {1..50}
    do
      curl -k -o /tmp/down$i 'https://<server>:<port>/s/<shareToken>/download?path=%2Fbatches%2Fb1&files=' &
    done
    ```

No stray locks are reported. The locks are properly cleanup in redis
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

@DeepDiver1975 I've taken a quick look at the `DBLockingProvider` and it seems might flood the logs. Locks are always released during shutdown, the new "stray lock removal" warning implemented here will complain a lot.

We shouldn't rely on auto-removing the lock during shutdown, and think about it as a safety measure. The warning is intended to rise awareness and fix the problem.
Note that we want to release the locks as early as possible to prevent locking exceptions in other clients if we aren't doing anything with the file.