### PR TITLE
[tests-only] pin minio/mc docker to work-around broken 'latest'

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1560,7 +1560,7 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 		[
 			{
 				'name': 'sync-from-cache',
-				'image': 'minio/mc',
+				'image': 'minio/mc:RELEASE.2020-12-10T01-26-17Z',
 				'pull': 'always',
 				'environment': {
 					'MC_HOST_cache': {
@@ -1611,7 +1611,7 @@ def sonarAnalysis(ctx, phpVersion = '7.4'):
 			},
 			{
 				'name': 'purge-cache',
-				'image': 'minio/mc',
+				'image': 'minio/mc:RELEASE.2020-12-10T01-26-17Z',
 				'environment': {
 					'MC_HOST_cache': {
 						'from_secret': 'cache_s3_connection_url'


### PR DESCRIPTION
## Description
See issue. Pin `minio/mc` to the previous working docker tag.

## Related Issue
#38232 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
