### PR TITLE
[tests-only] skip new fileActionsMenu tests on old oC10 versions

### DIFF
--- a/tests/acceptance/features/webUIFileActionsMenu/fileActionsMenu.feature
+++ b/tests/acceptance/features/webUIFileActionsMenu/fileActionsMenu.feature
@@ -9,11 +9,13 @@ Feature: File actions menu
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
+  @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: show the file actions application select menu with both Collabora and the Files Texteditor
     When the user clicks on the file "lorem.txt"
     Then the file actions application select menu should be displayed with these items on the webUI
       | Open in Text Editor | Open in Collabora |
 
+  @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: show the actions for Collabora and the Files Texteditor in the file action menu
     And the user opens the file action menu of file "lorem.txt" on the webUI
     Then the file actions menu should be displayed with these items on the webUI


### PR DESCRIPTION
## Description
These test scenarios were added in #38132 - they will not pass against older versions of ownCloud, so skip in that case.

This fixes failures of nightly CI of various oC10 apps that test against existing and older releases of oC10.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
