### PR TITLE
[tests-only] Add app-required tag to fileActionsMenu.feature

### DIFF
--- a/tests/acceptance/features/webUIFileActionsMenu/fileActionsMenu.feature
+++ b/tests/acceptance/features/webUIFileActionsMenu/fileActionsMenu.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @richdocuments-app-required @files_texteditor-app-required
+@webUI @insulated @disablePreviews @app-required @richdocuments-app-required @files_texteditor-app-required
 Feature: File actions menu
 
   Background:


### PR DESCRIPTION
## Description
If a scenario requires a non-core app, then that scenario needs to be run in a CI environment that has that "extra" app installed and enabled. So the scenario is "special" and cannot be run in a normal run of "all scenarios together". When that is the case, we tag the scenario `@app-required`, as well as tagging it with the specific apps that are required, for example `@richdocuments-app-required` `@files_texteditor-app-required`. 

This is already done in, for example, `apiSharingNotificationsToShares/sharingNotifications.feature` and `webUISharingNotifications/notificationLink.feature`. Doing this makes it easy to exclude these in nightly runs of "all core scenarios".

Do that in `fileActionsMenu.feature`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
