### PR TITLE
[tests-only] Adds API tests to check the file deletion time

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -272,7 +272,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  Scenario Outline: deleted file should have appropriate deletion time information 
+  Scenario Outline: deleted file has appropriate deletion time information 
     Given using <dav-path> DAV path
     And user "Alice" has deleted file "textfile0.txt"
     When user "Alice" tries to list the trashbin content for user "Alice"

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -271,3 +271,15 @@ Feature: files and folders exist in the trashbin after being deleted
       | dav-path |
       | old      |
       | new      |
+
+  Scenario Outline: deleted file should have appropriate deletion time information 
+    Given using <dav-path> DAV path
+    And user "Alice" has deleted file "textfile0.txt"
+    When user "Alice" tries to list the trashbin content for user "Alice"
+    Then the last webdav response should contain the following elements
+      | path           | mtime         |
+      | /textfile0.txt | deleted_mtime |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -260,13 +260,25 @@ class TrashbinContext implements Context {
 		foreach ($elementRows as $expectedElement) {
 			$found = false;
 			$expectedPath = $expectedElement['path'];
-			foreach ($files as $file) {
-				if (\ltrim($expectedPath, "/") === \ltrim($file['original-location'], "/")) {
-					$found = true;
-					break;
+			$expectedMtime = $expectedElement['mtime'] === "deleted_mtime" ? $this->featureContext->getLastUploadDeleteTime() : $expectedElement['mtime'];
+			
+			if (isset($expectedElement['mtime'])) {
+				foreach ($files as $file) {
+					if (\ltrim($expectedPath, "/") === \ltrim($file['original-location'], "/") && \ltrim($expectedMtime, "/") === \ltrim($file['mtime'], "/")) {
+						$found = true;
+						break;
+					}
 				}
+				Assert::assertTrue($found, "$expectedPath with mtime $expectedMtime expected to be listed in response but not found");
+			} else {
+				foreach ($files as $file) {
+					if (\ltrim($expectedPath, "/") === \ltrim($file['original-location'], "/")) {
+						$found = true;
+						break;
+					}
+				}
+				Assert::assertTrue($found, "$expectedPath expected to be listed in response but not found");
 			}
-			Assert::assertTrue($found, "$expectedPath expected to be listed in response but not found");
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -105,6 +105,13 @@ trait WebDav {
 	}
 
 	/**
+	 * @return number
+	 */
+	public function getLastUploadDeleteTime() {
+		return $this->lastUploadDeleteTime;
+	}
+
+	/**
 	 * @return SimpleXMLElement
 	 */
 	public function getResponseXmlObject() {


### PR DESCRIPTION
Co-authored-by: SwikritiT <swikriti808@gmail.com>

## Description
<!--- Describe your changes in detail -->
checks if the files has appropriate deletion time in trashbin api response

## Related Issue
- https://github.com/owncloud/ocis/issues/541

## How Has This Been Tested?
- locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
