### PR TITLE
[tests-only] Skip changed webUITags tests on old oC10 versions

### DIFF
--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required
+@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
 Feature: Creation of tags for the files and folders
   As a user
   I want to create tags for the files/folders

--- a/tests/acceptance/features/webUITags/deleteTags.feature
+++ b/tests/acceptance/features/webUITags/deleteTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required
+@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
 Feature: Deletion of existing tags from files and folders
   As a user
   I want to delete tags from files and folders

--- a/tests/acceptance/features/webUITags/editTags.feature
+++ b/tests/acceptance/features/webUITags/editTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required
+@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
 Feature: Edit tags for files and folders
   As a user
   I want to edit tags for files/folders

--- a/tests/acceptance/features/webUITags/removeTags.feature
+++ b/tests/acceptance/features/webUITags/removeTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required
+@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
 Feature: Removal of already existing tags from files and folders
   As a user
   I want to remove tags from files and folders

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required
+@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
 Feature: Suggestion for matching tag names
   As a user
   I want to get suggestions for adding tags from already existing tags


### PR DESCRIPTION
## Description
The UI for tags was changed by PR #38197 which was merged to master and will be in the next oC10 release.

The tests also had to change, and ` tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php` had to have different code to find the tags panel of the details dialog. So the test code in master no longer works against other older oC10 versions.

Add skip tags. This will allow apps that run the webUI tests against other older oC10 versions to pass - for example encryption: https://drone.owncloud.com/owncloud/encryption/1572/186/17

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
