### PR TITLE
Fix settings menu icons theming 

### DIFF
--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -52,7 +52,7 @@ class URLGenerator implements IURLGenerator {
 	private $router;
 	/** @var ITheme */
 	private $theme;
-	
+
 	/** @var EnvironmentHelper */
 	private $environmentHelper;
 
@@ -71,7 +71,6 @@ class URLGenerator implements IURLGenerator {
 		$this->cacheFactory = $cacheFactory;
 		$this->router = $router;
 		$this->environmentHelper = $environmentHelper;
-		$this->theme = \OC_Util::getTheme();
 	}
 
 	/**
@@ -159,7 +158,8 @@ class URLGenerator implements IURLGenerator {
 	 */
 	public function imagePath($app, $image) {
 		$cache = $this->cacheFactory->create('imagePath');
-		$cacheKey = $this->theme->getName().'-'.$app.'-'.$image;
+		$theme = $this->getTheme();
+		$cacheKey = $theme->getName().'-'.$app.'-'.$image;
 		if ($key = $cache->get($cacheKey)) {
 			return $key;
 		}
@@ -184,6 +184,7 @@ class URLGenerator implements IURLGenerator {
 	 * @return string
 	 */
 	private function getImagePath($app, $imageName) {
+		$theme = $this->getTheme();
 		$webRoot = $this->environmentHelper->getWebRoot();
 		if ($app !== '') {
 			$appWebPath = \OC_App::getAppWebPath($app);
@@ -198,15 +199,15 @@ class URLGenerator implements IURLGenerator {
 			\array_unshift($directories, "$appPath", "/$app");
 		}
 
-		$themeDirectory = $this->theme->getDirectory();
+		$themeDirectory = $theme->getDirectory();
 		foreach ($directories as $directory) {
 			$directory = $directory . "/img/";
 			$file = $directory . $imageName;
 
 			if ($themeDirectory !== ''
-				&& $imagePath = $this->getImagePathOrFallback($this->theme->getBaseDirectory() . '/' . $themeDirectory . $file)
+				&& $imagePath = $this->getImagePathOrFallback($theme->getBaseDirectory() . '/' . $themeDirectory . $file)
 			) {
-				return $this->theme->getWebPath() . $file;
+				return $theme->getWebPath() . $file;
 			}
 
 			if ($imagePath = $this->getImagePathOrFallback($this->environmentHelper->getServerRoot() . $file)) {
@@ -258,5 +259,17 @@ class URLGenerator implements IURLGenerator {
 	public function linkToDocs($key) {
 		$theme = new OC_Defaults();
 		return $theme->buildDocLinkToKey($key);
+	}
+
+	/**
+	 * Do not move it to ctor as theme could be not loaded yet
+	 * when the ctor is executed
+	 * @return ITheme
+	 */
+	private function getTheme() {
+		if ($this->theme === null) {
+			$this->theme = \OC_Util::getTheme();
+		}
+		return $this->theme;
 	}
 }


### PR DESCRIPTION
## Description
Firstly URLGenerator is instantiated when user session is loaded and the theme is not available yet on this stage.
So an empty theme is cached into the URLGenerator instance for a while.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4337

## Motivation and Context
Fixes resolution of images added into the settings navigation

## How Has This Been Tested?
1. Enable any app-theme. 
2. Override users icon in the top right menu in your app-theme (`settings/img/users.svg`)

### Expected
users.svg from theme is loaded

### Actual users.svg from core is loaded.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
