### PR TITLE
Fix a regression with theming of settings menu icons 

### DIFF
--- a/changelog/unreleased/38246
+++ b/changelog/unreleased/38246
@@ -1,0 +1,6 @@
+Bugfix: Fix a regression with theming of settings menu icons
+
+Default icons were loaded instead of the overrides from the enabled app-theme
+in the settings menu.
+
+https://github.com/owncloud/core/pull/38246

--- a/lib/base.php
+++ b/lib/base.php
@@ -582,11 +582,11 @@ class OC {
 		\stream_wrapper_register('quota', 'OC\Files\Stream\Quota');
 
 		\OC::$server->getEventLogger()->start('init_session', 'Initialize session');
-		OC_App::loadApps(['session']);
+		OC_App::loadApps(['session', 'theme']);
 		if (!self::$CLI) {
 			self::initSession();
 		}
-		OC_App::loadApps(['license', 'theme']);
+		OC_App::loadApps(['license']);
 
 		\OC::$server->getEventLogger()->end('init_session');
 


### PR DESCRIPTION
## Description
Firstly URLGenerator is instantiated when user session is loaded and the theme is not available yet on this stage.
So an empty theme is cached into the URLGenerator instance for a while.
Partially reverts https://github.com/owncloud/core/pull/37867

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4337

## Motivation and Context
Fixes resolution of images added into the settings navigation by app-themes

## How Has This Been Tested?
1. Enable any app-theme. 
2. Override users icon in the top right menu in your app-theme (`settings/img/users.svg`)

### Expected
users.svg from theme is loaded

### Actual 
users.svg from core is loaded.

![Screenshot_20201222_182622](https://user-images.githubusercontent.com/991300/102904773-3e350a00-4483-11eb-8cca-8dd7bc8dab33.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
