### PR TITLE
[Tests-Only] add tests for downloading file with range request

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -883,11 +883,45 @@ trait WebDav {
 		// But if the content is wrong (e.g. empty) then it is useful to
 		// report the HTTP status to give some clue what might be the problem.
 		$actualStatus = $this->response->getStatusCode();
+		$pattern = ["/--\w*/", "/\s*/m"];
+		$actualContent = \preg_replace($pattern, "", $actualContent);
+		$content = \preg_replace("/\s*/m", '', $content);
 		Assert::assertEquals(
 			$content,
 			$actualContent,
 			"The downloaded content was expected to be '$content', but actually is '$actualContent'. HTTP status was $actualStatus"
 		);
+	}
+
+	/**
+	 * @Then /^if the HTTP status code was "([^"]*)" then the downloaded content for multipart byterange should be:$/
+	 *
+	 * @param int|string $statusCode
+	 * @param PyStringNode $content
+	 *
+	 * @return void
+	 *
+	 */
+	public function theDownloadedContentForMultipartByterangeShouldBe($statusCode, PyStringNode $content) {
+		$actualStatusCode = $this->response->getStatusCode();
+		if ($actualStatusCode === $statusCode) {
+			$this->downloadedContentShouldBe($content->getRaw());
+		}
+	}
+
+	/**
+	 * @Then /^if the HTTP status code was "([^"]*)" then the downloaded content should be "([^"]*)"$/
+	 *
+	 * @param int|string $statusCode
+	 * @param string $content
+	 *
+	 * @return void
+	 */
+	public function checkStatusCodeForDownloadedContentShouldBe($statusCode, $content) {
+		$actualStatusCode = $this->response->getStatusCode();
+		if ($actualStatusCode === $statusCode) {
+			$this->downloadedContentShouldBe($content);
+		}
 	}
 
 	/**
@@ -3285,6 +3319,22 @@ trait WebDav {
 				(bool) \preg_match($expectedHeaderValue, $returnedHeader),
 				"'$expectedHeaderValue' does not match '$returnedHeader'"
 			);
+		}
+	}
+
+	/**
+	 * @Then /^if the HTTP status code was "([^"]*)" then the following headers should match these regular expressions$/
+	 *
+	 * @param int|string $statusCode
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function statusCodeShouldMatchTheseRegularExpressions($statusCode, TableNode $table) {
+		$actualStatusCode = $this->response->getStatusCode();
+		if ($actualStatusCode === $statusCode) {
+			$this->headersShouldMatchRegularExpressions($table);
 		}
 	}
 


### PR DESCRIPTION
## Description
This PR adds tests for downloading file with range request

## Related Issue
- https://github.com/owncloud/ocis/issues/1026

## How Has This Been Tested?
- locally


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
