### PR TITLE
determine unencrypted block size after begin operation

### DIFF
--- a/changelog/unreleased/38249
+++ b/changelog/unreleased/38249
@@ -1,0 +1,7 @@
+Bugfix: Determine unencrypted block size after begin operation
+
+Unencrypted block size of encrypted file can change with different encoding types.
+Unencrypted block size determination has been moved after begin operation in stream opening.
+In this way, EncryptionModule can decide block size after reading the header of the file.
+
+https://github.com/owncloud/core/pull/38249

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -234,7 +234,6 @@ class Encryption extends Wrapper {
 		$this->position = 0;
 		$this->cache = '';
 		$this->writeFlag = false;
-		$this->unencryptedBlockSize = $this->encryptionModule->getUnencryptedBlockSize($this->signed);
 
 		if (
 			$mode === 'w'
@@ -256,7 +255,8 @@ class Encryption extends Wrapper {
 
 		$accessList = $this->file->getAccessList($sharePath);
 		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $mode, $this->header, $accessList, $context['sourceFileOfRename']);
-
+		$this->unencryptedBlockSize = $this->encryptionModule->getUnencryptedBlockSize($this->signed);
+		
 		if (
 			$mode === 'w'
 			|| $mode === 'w+'


### PR DESCRIPTION
## Description
Unencrypted block size of encrypted file can change with different encoding types. Determine unencrypted block size after begin operation. In this way, EncryptionModule can decide block size after reading the header of the file.

## Related Issue
https://github.com/owncloud/encryption/issues/210
https://github.com/owncloud/core/issues/10831

## How Has This Been Tested?
https://github.com/owncloud/encryption/pull/224 is able to support both base64 and binary encoding after this change.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
