### PR TITLE
[tests-only] sync at end of tests to get all test log output

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1327,8 +1327,8 @@ sync
 # drone agent send all the output to the drone server.
 if [ -n "${CI_REPO}" ]
 then
-  echo "sleeping for 10 seconds at end of test run"
-  sleep 10
+  echo "sleeping for 30 seconds at end of test run"
+  sleep 30
 fi
 
 exit ${FINAL_EXIT_STATUS}

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1323,4 +1323,12 @@ fi
 # drone log.
 sync
 
+# If we are running in drone CI, then sleep for a bit to (hopefully) let the
+# drone agent send all the output to the drone server.
+if [ -n "${CI_REPO}" ]
+then
+  echo "sleeping for 10 seconds at end of test run"
+  sleep 10
+fi
+
 exit ${FINAL_EXIT_STATUS}

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1318,4 +1318,9 @@ then
   tput setaf 1; printf "%s\n" "${UNEXPECTED_BEHAT_EXIT_STATUSES[@]}"
 fi
 
+# sync the file-system so all output will be flushed to storage.
+# In drone we sometimes see that the last lines of output are missing from the
+# drone log.
+sync
+
 exit ${FINAL_EXIT_STATUS}


### PR DESCRIPTION
## Description
drone output is sometimes truncated at the end of an acceptance test run. That is annoying when we do not get to see the details of the unexpected failures and passes.

sync the file-system at the end of a test run so that (hopefully) all the output finds its way to the drone server t be reported.

## How Has This Been Tested?
CI - the acceptance test pipelines do have all the output
https://github.com/owncloud/ocis/pull/1161 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
