### PR TITLE
[tests-only] Fix: new trashbinFilesFolders.feature test failing in oC10 app testing

### DIFF
--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -260,16 +260,23 @@ class TrashbinContext implements Context {
 		foreach ($elementRows as $expectedElement) {
 			$found = false;
 			$expectedPath = $expectedElement['path'];
-			$expectedMtime = $expectedElement['mtime'] === "deleted_mtime" ? $this->featureContext->getLastUploadDeleteTime() : $expectedElement['mtime'];
+			$expectedMtime = $this->featureContext->getLastUploadDeleteTime();
+			$responseMtime = '';
 			
 			if (isset($expectedElement['mtime'])) {
 				foreach ($files as $file) {
-					if (\ltrim($expectedPath, "/") === \ltrim($file['original-location'], "/") && \ltrim($expectedMtime, "/") === \ltrim($file['mtime'], "/")) {
-						$found = true;
-						break;
+					$responseMtime = $file['mtime'];
+
+					if (\ltrim($expectedPath, "/") === \ltrim($file['original-location'], "/")) {
+						$mtime_difference = \abs((int)\trim($expectedMtime) - (int)\trim($file['mtime']));
+
+						if ($mtime_difference <= 2) {
+							$found = true;
+							break;
+						}
 					}
 				}
-				Assert::assertTrue($found, "$expectedPath with mtime $expectedMtime expected to be listed in response but not found");
+				Assert::assertTrue($found, "$expectedPath expected to be listed in response with mtime $responseMtime but found $expectedMtime");
 			} else {
 				foreach ($files as $file) {
 					if (\ltrim($expectedPath, "/") === \ltrim($file['original-location'], "/")) {

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -275,7 +275,7 @@ class TrashbinContext implements Context {
 						}
 					}
 				}
-				Assert::assertTrue($found, "$expectedPath expected to be listed in response with mtime '$responseMtime' but found '$expectedMtime'");
+				Assert::assertTrue($found, "$expectedPath expected to be listed in response with mtime '$expectedMtime' but found '$responseMtime'");
 			} else {
 				foreach ($files as $file) {
 					if (\ltrim($expectedPath, "/") === \ltrim($file['original-location'], "/")) {

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -265,10 +265,9 @@ class TrashbinContext implements Context {
 			
 			if (isset($expectedElement['mtime'])) {
 				foreach ($files as $file) {
-					$responseMtime = $file['mtime'];
-
 					if (\ltrim($expectedPath, "/") === \ltrim($file['original-location'], "/")) {
-						$mtime_difference = \abs((int)\trim($expectedMtime) - (int)\trim($file['mtime']));
+						$responseMtime = $file['mtime'];
+						$mtime_difference = \abs((int)\trim($expectedMtime) - (int)\trim($responseMtime));
 
 						if ($mtime_difference <= 2) {
 							$found = true;
@@ -276,7 +275,7 @@ class TrashbinContext implements Context {
 						}
 					}
 				}
-				Assert::assertTrue($found, "$expectedPath expected to be listed in response with mtime $responseMtime but found $expectedMtime");
+				Assert::assertTrue($found, "$expectedPath expected to be listed in response with mtime '$responseMtime' but found '$expectedMtime'");
 			} else {
 				foreach ($files as $file) {
 					if (\ltrim($expectedPath, "/") === \ltrim($file['original-location'], "/")) {


### PR DESCRIPTION
Co-authored-by: SwikritiT <swikriti808@gmail.com>

## Description
`trashbinFilesFolders.feature:285` test was failing sometime due to the time difference between `mtime` in response and `mtime` saved in `lastUploadDeleteTime`

## Related Issue
https://github.com/owncloud/QA/issues/650

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- local environment

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
