### PR TITLE
[Tests-only] Adds api tests for renaming received shares

### DIFF
--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -115,23 +115,37 @@ Feature: sharing
     And as "Brian" file "/Shares/newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
 
-  Scenario: receiver renames a received share to different name on the same folder for group sharing
+  Scenario: receiver renames a received file share to different name on the same folder for group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has shared folder "PARENT" with group "grp1"
-    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
-    When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And as "Brian" folder "/Shares/myFolder" should exist
-    But as "Alice" folder "myFolder" should not exist
     When user "Brian" moves file "/Shares/textfile0.txt" to "/Shares/newFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "/Shares/newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
 
-  Scenario: receiver renames a received share with share, read, change permissions in group sharing
+  Scenario: receiver renames a received folder share to different name on the same folder for group sharing
+    Given group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared folder "PARENT" with group "grp1"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "/Shares/myFolder" should exist
+    But as "Alice" folder "myFolder" should not exist
+
+  Scenario: receiver renames a received file share with read,update,share permissions in group sharing
+    Given group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1" with permissions "read,update,share"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/textfile0.txt" to "newFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "newFile.txt" should exist
+    But as "Alice" file "newFile.txt" should not exist
+
+  Scenario: receiver renames a received folder share with share, read, change permissions in group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has shared folder "PARENT" with group "grp1" with permissions "share,read,change"
@@ -140,13 +154,18 @@ Feature: sharing
     Then the HTTP status code should be "201"
     And as "Brian" folder "myFolder" should exist
     But as "Alice" folder "myFolder" should not exist
-    When user "Brian" moves file "/myFolder/parent.txt" to "/myFolder/renamedFile" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And as "Brian" file "/myFolder/renamedFile" should exist
-    And as "Alice" file "/PARENT/renamedFile" should exist
-    But as "Alice" file "/PARENT/parent.txt" should not exist
 
-  Scenario: receiver tries to rename a received share with share, read permissions in group sharing
+  Scenario: receiver tries to rename a received file share with share, read permissions in group sharing
+    Given group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1" with permissions "share,read"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" moves file "/Shares/textfile0.txt" to "/newFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "newFile.txt" should exist
+    But as "Alice" file "newFile.txt" should not exist
+
+  Scenario: receiver tries to rename a received folder share with share, read permissions in group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has shared folder "PARENT" with group "grp1" with permissions "share,read"
@@ -155,14 +174,8 @@ Feature: sharing
     Then the HTTP status code should be "201"
     And as "Brian" folder "myFolder" should exist
     But as "Alice" folder "myFolder" should not exist
-    When user "Brian" moves file "/myFolder/parent.txt" to "/myFolder/renamedFile" using the WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Brian" file "/myFolder/renamedFile" should not exist
-    And as "Brian" file "/myFolder/parent.txt" should exist
-    And as "Alice" file "/PARENT/parent.txt" should exist
-    But as "Alice" file "/PARENT/renamedFile" should not exist
 
-  Scenario Outline: receiver tries to rename a received share to name with special characters in group sharing
+  Scenario Outline: receiver tries to rename a received folder share to name with special characters in group sharing
     Given group "grp1" has been created
     And user "Carol" has been added to group "grp1"
     And user "Alice" has created folder "<sharer_folder>"
@@ -184,7 +197,7 @@ Feature: sharing
       | ?abc=oc #     | ?abc=oc g%rp#   | # oc?test=oc&a  |
       | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d    |
 
-  Scenario Outline: receiver tries to rename a received share to name with special characters with share, read, change permissions in group sharing
+  Scenario Outline: receiver tries to rename a received file share to name with special characters with share, read, change permissions in group sharing
     Given group "grp1" has been created
     And user "Carol" has been added to group "grp1"
     And user "Alice" has created folder "<sharer_folder>"

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -55,9 +55,9 @@ Feature: sharing
     And user "Alice" has created folder "<group_folder>"
     And user "Brian" has created folder "<receiver_folder>"
     And user "Carol" has created folder "<receiver_folder>"
-    When user "Alice" shares folder "<sharer_folder>" with user "Brian" using the sharing API
-    And user "Brian" accepts share "/<sharer_folder>" offered by user "Alice" using the sharing API
-    And user "Brian" moves folder "<receiver_folder>" to "/Shares/<sharer_folder>/<receiver_folder>" using the WebDAV API
+    And user "Alice" has shared folder "<sharer_folder>" with user "Brian"
+    And user "Brian" has accepted share "/<sharer_folder>" offered by user "Alice"
+    When user "Brian" moves folder "<receiver_folder>" to "/Shares/<sharer_folder>/<receiver_folder>" using the WebDAV API
     Then as "Alice" folder "<sharer_folder>/<receiver_folder>" should exist
     And as "Brian" folder "/Shares/<sharer_folder>/<receiver_folder>" should exist
     When user "Alice" shares folder "<group_folder>" with group "grp1" using the sharing API
@@ -99,3 +99,111 @@ Feature: sharing
     And as "Brian" file "/myFolder/renamedFile" should not exist
     But as "Brian" file "/myFolder/fileInside" should exist
 
+  Scenario: receiver renames a received folder share to a different name on the same folder
+    Given user "Alice" has shared folder "PARENT" with user "Brian"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "/Shares/myFolder" should exist
+    But as "Alice" folder "myFolder" should not exist
+
+  Scenario: receiver renames a received file share to different name on the same folder
+    Given user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" moves file "/Shares/textfile0.txt" to "/Shares/newFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/Shares/newFile.txt" should exist
+    But as "Alice" file "newFile.txt" should not exist
+
+  Scenario: receiver renames a received share to different name on the same folder for group sharing
+    Given group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared folder "PARENT" with group "grp1"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "/Shares/myFolder" should exist
+    But as "Alice" folder "myFolder" should not exist
+    When user "Brian" moves file "/Shares/textfile0.txt" to "/Shares/newFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/Shares/newFile.txt" should exist
+    But as "Alice" file "newFile.txt" should not exist
+
+  Scenario: receiver renames a received share with share, read, change permissions in group sharing
+    Given group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared folder "PARENT" with group "grp1" with permissions "share,read,change"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/PARENT" to "myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "myFolder" should exist
+    But as "Alice" folder "myFolder" should not exist
+    When user "Brian" moves file "/myFolder/parent.txt" to "/myFolder/renamedFile" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/myFolder/renamedFile" should exist
+    And as "Alice" file "/PARENT/renamedFile" should exist
+    But as "Alice" file "/PARENT/parent.txt" should not exist
+
+  Scenario: receiver tries to rename a received share with share, read permissions in group sharing
+    Given group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared folder "PARENT" with group "grp1" with permissions "share,read"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/PARENT" to "/myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "myFolder" should exist
+    But as "Alice" folder "myFolder" should not exist
+    When user "Brian" moves file "/myFolder/parent.txt" to "/myFolder/renamedFile" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Brian" file "/myFolder/renamedFile" should not exist
+    And as "Brian" file "/myFolder/parent.txt" should exist
+    And as "Alice" file "/PARENT/parent.txt" should exist
+    But as "Alice" file "/PARENT/renamedFile" should not exist
+
+  Scenario Outline: receiver tries to rename a received share to name with special characters in group sharing
+    Given group "grp1" has been created
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "<sharer_folder>"
+    And user "Alice" has created folder "<group_folder>"
+    And user "Alice" has shared folder "<sharer_folder>" with user "Brian"
+    And user "Brian" has accepted share "/<sharer_folder>" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/<sharer_folder>" to "/Shares/<receiver_folder>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" folder "<receiver_folder>" should not exist
+    And as "Brian" folder "/Shares/<receiver_folder>" should exist
+    When user "Alice" shares folder "<group_folder>" with group "grp1" using the sharing API
+    And user "Carol" accepts share "/<group_folder>" offered by user "Alice" using the sharing API
+    And user "Carol" moves folder "/Shares/<group_folder>" to "/Shares/<receiver_folder>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" folder "<receiver_folder>" should not exist
+    But as "Carol" folder "/Shares/<receiver_folder>" should exist
+    Examples:
+      | sharer_folder | group_folder    | receiver_folder |
+      | ?abc=oc #     | ?abc=oc g%rp#   | # oc?test=oc&a  |
+      | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d    |
+
+  Scenario Outline: receiver tries to rename a received share to name with special characters with share, read, change permissions in group sharing
+    Given group "grp1" has been created
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "<sharer_folder>"
+    And user "Alice" has created folder "<group_folder>"
+    And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/<sharer_folder>/fileInside"
+    And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/<group_folder>/fileInside"
+    And user "Alice" has shared folder "<sharer_folder>" with user "Brian" with permissions "share,read,change"
+    And user "Brian" has accepted share "/<sharer_folder>" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/<sharer_folder>/fileInside" to "/Shares/<sharer_folder>/<receiver_file>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "<sharer_folder>/<receiver_file>" should exist
+    And as "Brian" file "/Shares/<sharer_folder>/<receiver_file>" should exist
+    When user "Alice" shares folder "<group_folder>" with group "grp1" with permissions "share,read,change" using the sharing API
+    And user "Carol" accepts share "/<group_folder>" offered by user "Alice" using the sharing API
+    And user "Carol" moves folder "/Shares/<group_folder>/fileInside" to "/Shares/<group_folder>/<reciever_file>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "<group_folder>/<reciever_file>" should exist
+    And as "Carol" file "/Shares/<group_folder>/<reciever_file>" should exist
+    Examples:
+      | sharer_folder | group_folder    | receiver_file  |
+      | ?abc=oc #     | ?abc=oc g%rp#   | # oc?test=oc&a |
+      | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d   |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1216,7 +1216,7 @@ trait Sharing {
 		$user1Actual = $this->getActualUsername($user1);
 		$user2Actual = $this->getActualUsername($user2);
 
-		$path = $this->getSharesEndpointPath("?path=$filepath");
+		$path = $this->getSharesEndpointPath("?path=" . \urlencode($filepath));
 		$this->response = OcsApiHelper::sendRequest(
 			$this->getBaseUrl(),
 			$user1Actual,


### PR DESCRIPTION
## Description

 Adds tests for renaming received shares

## Related Issue
-  https://github.com/owncloud/core/issues/36364

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog