### PR TITLE
[tests-only] Drop laminas-ldap from behat acceptance test dependencies

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -12,7 +12,6 @@
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^7.2",
         "phpunit/phpunit": "^9.4",
-        "laminas/laminas-ldap": "^2.10",
         "ankitpokhrel/tus-php": "^2.1"
     }
 }


### PR DESCRIPTION
## Description
IMO we do not use this in core CI. But it is probably used when the core tests are run from `user_ldap` and also if the core API tests are run from `owncloud/ocis` with an LDAP as the back-end auth behind OIDC...

So I am not so sure that deleting this is a good idea!

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
