### PR TITLE
[tests-only] Zend to laminas

### DIFF
--- a/tests/Core/Command/Db/ConvertTypeTest.php
+++ b/tests/Core/Command/Db/ConvertTypeTest.php
@@ -25,8 +25,6 @@ use OC\App\AppManager;
 use OC\Core\Command\Db\ConvertType;
 use OC\DB\ConnectionFactory;
 use OCP\IConfig;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 

--- a/tests/Core/Command/User/DeleteTest.php
+++ b/tests/Core/Command/User/DeleteTest.php
@@ -25,7 +25,6 @@ namespace Tests\Core\Command\User;
 use OC\Core\Command\User\Delete;
 use OCP\IUser;
 use OCP\IUserManager;
-use OCP\Files\Node;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -34,7 +34,6 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Mail\IMailer;
 use OCP\Security\ISecureRandom;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Core/Controller/UserSyncControllerTest.php
+++ b/tests/Core/Controller/UserSyncControllerTest.php
@@ -23,7 +23,6 @@ declare(strict_types = 1);
 namespace Tests\Core\Controller;
 
 use OC\Core\Controller\UserSyncController;
-use OC\OCS\Result;
 use OC\User\SyncService;
 use OCP\IRequest;
 use OCP\IUser;

--- a/tests/Settings/Controller/CorsControllerTest.php
+++ b/tests/Settings/Controller/CorsControllerTest.php
@@ -23,7 +23,6 @@ namespace Tests\Settings\Controller;
 
 use OC\Settings\Controller\CorsController;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\Http\RedirectResponse;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\ILogger;

--- a/tests/Settings/Panels/Admin/LicenseTest.php
+++ b/tests/Settings/Panels/Admin/LicenseTest.php
@@ -22,8 +22,6 @@ namespace Tests\Settings\Panels\Admin;
 
 use OC\Settings\Panels\Admin\License;
 use OC\License\ILicense;
-use OC\License\LicenseFetcher;
-use OC\License\MessageService;
 use OCP\License\ILicenseManager;
 
 /**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -35,7 +35,7 @@ use TestHelpers\SetupHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\UploadHelper;
 use TestHelpers\OcisHelper;
-use Zend\Ldap\Ldap;
+use Laminas\Ldap\Ldap;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -24,7 +24,6 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
-use TestHelpers\OcsApiHelper;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -28,8 +28,8 @@ use TestHelpers\SetupHelper;
 use TestHelpers\UserHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\OcisHelper;
-use Zend\Ldap\Exception\LdapException;
-use Zend\Ldap\Ldap;
+use Laminas\Ldap\Exception\LdapException;
+use Laminas\Ldap\Ldap;
 
 /**
  * Functions for provisioning of users and groups
@@ -497,7 +497,7 @@ trait Provisioning {
 	 * @return void
 	 */
 	public function importLdifData($ldifData) {
-		$items = Zend\Ldap\Ldif\Encoder::decode($ldifData);
+		$items = Laminas\Ldap\Ldif\Encoder::decode($ldifData);
 		if (isset($items['dn'])) {
 			//only one item in the ldif data
 			$this->ldap->add($items['dn'], $items);
@@ -3117,7 +3117,7 @@ trait Provisioning {
 		$attribute, $entry, $value, $append=false
 	) {
 		$ldapEntry = $this->ldap->getEntry($entry . "," . $this->ldapBaseDN);
-		Zend\Ldap\Attribute::setAttribute($ldapEntry, $attribute, $value, $append);
+		Laminas\Ldap\Attribute::setAttribute($ldapEntry, $attribute, $value, $append);
 		$this->ldap->update($entry . "," . $this->ldapBaseDN, $ldapEntry);
 		$this->theLdapUsersHaveBeenReSynced();
 	}

--- a/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
+++ b/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
@@ -22,7 +22,6 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Psr\Http\Message\ResponseInterface;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -32,8 +32,6 @@ use TestHelpers\UploadHelper;
 use TestHelpers\WebDavHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\Asserts\WebDav as WebDavAssert;
-use TusPhp\Exception\ConnectionException;
-use TusPhp\Exception\TusException;
 
 /**
  * WebDav functions

--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -12,7 +12,6 @@ namespace Test\DB;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use OC\DB\MDB2SchemaManager;
 use OCP\DB\QueryBuilder\IQueryBuilder;
-use PHPUnit\Framework\Constraint\IsType as IsType;
 
 /**
  * Class Connection

--- a/tests/lib/Files/MetaVersionCollectionTest.php
+++ b/tests/lib/Files/MetaVersionCollectionTest.php
@@ -26,8 +26,6 @@ use Test\TestCase;
 use OCP\Files\Node;
 use OC\Files\Meta\MetaVersionCollection;
 use OCP\Files\IRootFolder;
-use OCP\Files\Storage\IStorage;
-use OCP\Files\Storage;
 use OCP\Files\Storage\IVersionedStorage;
 use OC\Files\Meta\MetaFileVersionNode;
 

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -23,7 +23,6 @@
 namespace Test\Files\Storage;
 
 use OC\Files\Storage\Local;
-use PHPUnit\Framework\Constraint\IsType as IsType;
 
 /**
  * Class LocalTest

--- a/tests/lib/Files/Storage/Wrapper/JailTest.php
+++ b/tests/lib/Files/Storage/Wrapper/JailTest.php
@@ -9,8 +9,6 @@
 namespace Test\Files\Storage\Wrapper;
 
 use OC\Files\Storage\Common;
-use OCP\Files\Storage\IStorage;
-use OCP\Files\Storage\IVersionedStorage;
 
 class JailTest extends \Test\Files\Storage\Storage {
 

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -21,7 +21,6 @@ use OCP\Util\UserSearch;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Zend\EventManager\Event;
 
 class LoggerTest extends TestCase {
 	/** @var \OCP\ILogger */

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -11,7 +11,6 @@ namespace Test;
 use OC\Log;
 use OC\User\AccountMapper;
 use OC\User\Manager;
-use OC\User\Session;
 use OC\User\SyncService;
 use OCP\IConfig;
 use OCP\ILogger;

--- a/tests/lib/LoggerWithoutWriteExtraTest.php
+++ b/tests/lib/LoggerWithoutWriteExtraTest.php
@@ -10,7 +10,6 @@ namespace Test;
 
 use OC\Log;
 use OCP\IConfig;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class LoggerWithoutWriteExtraTest extends TestCase {

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -24,7 +24,6 @@ namespace Test\Share20;
 use OC\Authentication\Token\DefaultTokenMapper;
 use OC\Share20\DefaultShareProvider;
 use OC\Share20\ShareAttributes;
-use OCP\Share\IAttributes as IShareAttributes;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\File;
 use OCP\Files\Folder;


### PR DESCRIPTION
## Description
`Zend` became `Laminas` quite a while ago. `vendor-bin/behat/composer.json` already requires `laminas/laminas-ldap`

1) Change Zend to Laminas in acceptance test code
2) Remove unused Zend in unit tests 
3) Remove unused imports in tests (I let the IDE tell me about other unused `use` statements - we may as well remove them)


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
