### PR TITLE
[tests-only] [full-ci] Try PHP 8.0 for acceptance test runner

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1708,7 +1708,7 @@ def acceptance(ctx):
                                              [
                                                  ({
                                                      "name": "acceptance-tests",
-                                                     "image": "owncloudci/php:%s" % phpVersion,
+                                                     "image": "owncloudci/php:8.0",
                                                      "pull": "always",
                                                      "environment": environment,
                                                      "commands": params["extraCommandsBeforeTestRun"] + [
@@ -1723,6 +1723,7 @@ def acceptance(ctx):
                                                  }),
                                              ] + buildGithubCommentForBuildStopped(name, params["earlyFail"]) + githubComment(params["earlyFail"]) + stopBuild(params["earlyFail"]),
                                     "services": databaseService(db) +
+                                                occUpgradeService(isCLI) +
                                                 browserService(browser) +
                                                 emailService(params["emailNeeded"]) +
                                                 ldapService(params["ldapNeeded"]) +
@@ -2106,6 +2107,19 @@ def proxyService(proxyNeeded):
 
     return []
 
+def occUpgradeService(needed):
+    if not needed:
+        return []
+
+    return [{
+        "name": "occupgrade",
+        "image": "owncloudci/php:7.4",
+        "pull": "always",
+        "command": [
+            "php -S occupgrade:8123 tests/acceptance/occUpgrade.php",
+        ],
+    }]
+
 def webdavService(needed):
     if not needed:
         return []
@@ -2445,7 +2459,7 @@ def vendorbinPhpstan(phpVersion):
 def vendorbinBehat():
     return [{
         "name": "vendorbin-behat",
-        "image": "owncloudci/php:7.4",
+        "image": "owncloudci/php:8.0",
         "pull": "always",
         "environment": {
             "COMPOSER_HOME": "%s/.cache/composer" % dir["server"],

--- a/.drone.star
+++ b/.drone.star
@@ -1702,6 +1702,7 @@ def acceptance(ctx):
                                              setupScality(phpVersion, params["scalityS3"]) +
                                              params["extraSetup"] +
                                              waitForServer(phpVersion, params["federatedServerNeeded"]) +
+                                             waitForOccUpgrade(phpVersion, isCLI) +
                                              waitForBrowserService(phpVersion, isWebUI) +
                                              fixPermissions(phpVersion, params["federatedServerNeeded"], params["selUserNeeded"], pathOfServerUnderTest) +
                                              owncloudLog("server", pathOfServerUnderTest) +
@@ -2744,6 +2745,19 @@ def waitForServer(phpVersion, federatedServerNeeded):
         ] + ([
             "wait-for-it -t 600 federated:80",
         ] if federatedServerNeeded else []),
+    }]
+
+def waitForOccUpgrade(phpVersion, needed):
+    if not needed:
+        return []
+
+    return [{
+        "name": "wait-for-occupgrade",
+        "image": "owncloudci/php:%s" % phpVersion,
+        "pull": "always",
+        "commands": [
+            "wait-for-it -t 600 occupgrade:8123",
+        ],
     }]
 
 def owncloudLog(server, folder):

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
+use TestHelpers\HttpRequestHelper;
 use TestHelpers\OcisHelper;
 use TestHelpers\SetupHelper;
 use Behat\Gherkin\Node\PyStringNode;
@@ -496,7 +497,7 @@ class OccContext implements Context {
 	public function deleteExpiredVersionsForMultipleUsersUsingOccCommand(string $users): void {
 		$this->deleteExpiredVersionsForUserUsingOccCommand($users);
 	}
-	
+
 	/**
 	 * @return void
 	 * @throws Exception
@@ -768,6 +769,35 @@ class OccContext implements Context {
 			// if the above command fails make sure to turn off maintenance mode
 			\system("./occ maintenance:mode --off");
 		}
+	}
+
+	/**
+	 * @When the administrator runs an upgrade using the occ command
+	 *
+	 * @return void
+	 */
+	public function theAdministratorRunsAnUpgradeUsingTheOccCommand() {
+		//$this->invokingTheCommand("upgrade");
+		// Send a "ping" to an endpoint that is (hopefully) ready and waiting
+		// to "php occ upgrade". That endpoint should be served by a PHP
+		// process that is:
+		// - running a version of PHP that is supported by the system-under-test
+		// - not processing the incoming request through oC10 code
+		//   (because oC10 code might reject because "the system is waiting for upgrade")
+		HttpRequestHelper::sendRequest('occupgrade:8123');
+		//if (!$this->theOccCommandExitStatusWasSuccess()) {
+		// If the above command fails make sure to turn off maintenance mode.
+		// This uses the testing app to run the command for us. So it might
+		// fail if the testing app refuses to work, because maintenance mode
+		// is on.
+		//$this->invokingTheCommand("maintenance:mode --off");
+		//if (!$this->theOccCommandExitStatusWasSuccess()) {
+		// As a last resort, try a local occ command.
+		// If the test-runner happens to be on the same file-system as
+		// the system-under-test, then this might be a way to recover.
+		//\system("./occ maintenance:mode --off");
+		//}
+		//}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -784,7 +784,10 @@ class OccContext implements Context {
 		// - running a version of PHP that is supported by the system-under-test
 		// - not processing the incoming request through oC10 code
 		//   (because oC10 code might reject because "the system is waiting for upgrade")
-		HttpRequestHelper::sendRequest('occupgrade:8123');
+		HttpRequestHelper::sendRequest(
+			'occupgrade:8123',
+			$this->featureContext->getStepLineRef()
+		);
 		//if (!$this->theOccCommandExitStatusWasSuccess()) {
 		// If the above command fails make sure to turn off maintenance mode.
 		// This uses the testing app to run the command for us. So it might

--- a/tests/acceptance/features/cliAppManagement/appUpgrade.feature
+++ b/tests/acceptance/features/cliAppManagement/appUpgrade.feature
@@ -13,7 +13,7 @@ Feature: App upgrade
     And app "updatetest" has been disabled
     When the administrator puts app "updatetest" with version "2.1.0" in dir "apps"
     And the administrator enables app "updatetest"
-    And the administrator runs upgrade routines on local server using the occ command
+    And the administrator runs an upgrade using the occ command
     Then the installed version of "updatetest" should be "2.1.0"
 
   Scenario: Update of major version of an app
@@ -22,5 +22,5 @@ Feature: App upgrade
     And app "updatetest" has been disabled
     When the administrator puts app "updatetest" with version "3.0.0" in dir "apps"
     And the administrator enables app "updatetest"
-    And the administrator runs upgrade routines on local server using the occ command
+    And the administrator runs an upgrade using the occ command
     Then the installed version of "updatetest" should be "3.0.0"

--- a/tests/acceptance/occUpgrade.php
+++ b/tests/acceptance/occUpgrade.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @author Phil Davis <phil@jankaritech.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+$descriptor = [
+	0 => ['pipe', 'r'],
+	1 => ['pipe', 'w'],
+	2 => ['pipe', 'w'],
+];
+
+$process = \proc_open(
+	'php console.php upgrade',
+	$descriptor,
+	$pipes
+);
+$lastStdOut = \stream_get_contents($pipes[1]);
+$lastStdErr = \stream_get_contents($pipes[2]);
+$lastCode = \proc_close($process);
+echo "StdOut: $lastStdOut\n";
+echo "StdErr: $lastStdErr\n";
+echo "  Code: $lastCode\n";

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -13,7 +13,7 @@
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^7.2",
         "phpunit/phpunit": "^9.4",
-        "laminas/laminas-ldap": "^2.10",
+        "laminas/laminas-ldap": "^2.11",
         "ankitpokhrel/tus-php": "^2.1"
     }
 }


### PR DESCRIPTION
## Description
Use PHP 8.0 for the Behat PHP acceptance test runner.

Note: ownCloud 10 does not yet support PHP 8.0. So this test combination still requires ownCloud10 running in a PHP 7.4 environment.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
