### PR TITLE
[tests-only] Make findLines a static function in SetupHelper

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -934,7 +934,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 	 *
 	 * @return array array of lines that matched
 	 */
-	public function findLines($input, $text) {
+	public static function findLines($input, $text) {
 		$results = [];
 		foreach (\explode("\n", $input) as $line) {
 			if (\strpos($line, $text) !== false) {


### PR DESCRIPTION
## Description
All other functions in `tests/TestHelpers/*Helper.php` are already static. `findLines` is called statically everywhere. It should also be declared `static`. Make it so.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
