### PR TITLE
Fix subadmin group validation for addToGroup function

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -484,7 +484,7 @@ class Users {
 			return new Result(null, 102);
 		}
 
-		if (!$this->groupManager->isAdmin($user->getUID())) {
+		if (!$this->canUserManageGroup($user, $group)) {
 			return new Result(null, 104);
 		}
 

--- a/changelog/unreleased/38280
+++ b/changelog/unreleased/38280
@@ -1,0 +1,3 @@
+Change: Allow subadministrators to add users to groups they manage
+
+https://github.com/owncloud/core/pull/38280


### PR DESCRIPTION
## Description
This change aligns the provisioning API (and by extension, the **owncloud-sdk**) to allow subadministrators of groups (not just admins) to add users to groups they are a subadministrator of.  This is already permitted via the OC10 UI (which uses the PHP API directly).  The method `removeFromGroup` in this same file already had this check, but it seems the `addToGroup` method was changed and became inconsistent.  This PR makes it consistent across all 3 approaches.

I have re-opened the issue again here:
- Fixes https://github.com/owncloud/core/issues/38279

## Motivation and Context
As detailed above.

## How Has This Been Tested?
Locally it has been tested and works as expected.

There are related acceptances here
https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature#L132-L143

https://github.com/rpocklin/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature#L103-L114


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
