### PR TITLE
User should be able to see their own subadmin groups

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -53,7 +53,7 @@ API::register('post', '/cloud/users/{userid}/groups', [$users, 'addToGroup'], 'p
 API::register('delete', '/cloud/users/{userid}/groups', [$users, 'removeFromGroup'], 'provisioning_api', API::SUBADMIN_AUTH);
 API::register('post', '/cloud/users/{userid}/subadmins', [$users, 'addSubAdmin'], 'provisioning_api', API::ADMIN_AUTH);
 API::register('delete', '/cloud/users/{userid}/subadmins', [$users, 'removeSubAdmin'], 'provisioning_api', API::ADMIN_AUTH);
-API::register('get', '/cloud/users/{userid}/subadmins', [$users, 'getUserSubAdminGroups'], 'provisioning_api', API::ADMIN_AUTH);
+API::register('get', '/cloud/users/{userid}/subadmins', [$users, 'getUserSubAdminGroups'], 'provisioning_api', API::USER_AUTH);
 
 // Groups
 $groups = new Groups(

--- a/changelog/unreleased/38281
+++ b/changelog/unreleased/38281
@@ -1,0 +1,3 @@
+Bugfix: Allow all users to see which groups they manage
+
+https://github.com/owncloud/core/pull/38281

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -26,7 +26,7 @@ Feature: get subadmin groups
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
     When the administrator gets all the groups where user "nonexistentuser" is subadmin using the provisioning API
-    Then the OCS status code should be "101"
+    Then the OCS status code should be "998"
     And the HTTP status code should be "200"
     And the API should not return any data
 
@@ -38,15 +38,11 @@ Feature: get subadmin groups
     And user "Alice" has been made a subadmin of group "brand-new-group"
     And user "Alice" has been made a subadmin of group "😅 😆"
     When user "Alice" gets all the groups where user "Alice" is subadmin using the provisioning API
-    # Then the OCS status code should be "100"
-    # And the HTTP status code should be "200"
-    # Then the subadmin groups returned by the API should be
-    #   | brand-new-group |
-    #   | 😅 😆           |
-    Then the OCS status code should be "997"
-    And the HTTP status code should be "401"
-    And the API should not return any data
-
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then the subadmin groups returned by the API should be
+      | brand-new-group |
+      | 😅 😆          |
 
   Scenario: subadmin of a group should not be able to get subadmin groups of another subadmin user
     Given these users have been created with default attributes and small skeleton files:

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -26,8 +26,8 @@ Feature: get subadmin groups
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
     When the administrator gets all the groups where user "nonexistentuser" is subadmin using the provisioning API
-    Then the OCS status code should be "400"
-    And the HTTP status code should be "400"
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "404"
     And the API should not return any data
 
   @issue-owncloud-sdk-658
@@ -38,15 +38,11 @@ Feature: get subadmin groups
     And user "Alice" has been made a subadmin of group "brand-new-group"
     And user "Alice" has been made a subadmin of group "😅 😆"
     When user "Alice" gets all the groups where user "Alice" is subadmin using the provisioning API
-    # Then the OCS status code should be "200"
-    # And the HTTP status code should be "200"
-    # Then the subadmin groups returned by the API should be
-    #   | brand-new-group |
-    #   | 😅 😆           |
-    Then the OCS status code should be "997"
-    And the HTTP status code should be "401"
-    And the API should not return any data
-
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    Then the subadmin groups returned by the API should be
+      | brand-new-group |
+      | 😅 😆          |
 
   Scenario: subadmin of a group should not be able to get subadmin groups of another subadmin user
     Given these users have been created with default attributes and small skeleton files:


### PR DESCRIPTION
## Description
See related issue below.

## Related Issue
- Fixes https://github.com/owncloud/owncloud-sdk/issues/658

## Motivation and Context
When logging in, we want to check what groups a user is a subadmin of, so we know what UI to present them with if they can manage specific groups.

## Changes to Functionality
Before, you had to be an admin to call this API call.  Now, it is implemented in different ways as follows:

a) If you are a regular user and are requesting your own subadmin groups, it will be successful.
b) If you are a regular user and are requesting someone else subadmin groups, it will fail (401).
c) If you are a subadmin and are requesting yourself, or a user who you manage (via groups) it will be successful.
d) If you are a subadmin and are requesting someone else, it will fail (401).
e) If you are an admin and are requesting anyone, it will be successful.


## How Has This Been Tested?
Works as expected, normal users can call the **owncloud-sdk** without an error response (even if they have are not a subadmin of the group) as per the above use cases.  There are now unit and acceptance tests in the PR.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
