### PR TITLE
Improve UI success/error while adding storages

### DIFF
--- a/apps/files_external/css/settings.css
+++ b/apps/files_external/css/settings.css
@@ -5,6 +5,7 @@
 }
 
 #externalStorage td.status > span {
+	cursor: pointer;
 	display: inline-block;
 	height: 16px;
 	width: 16px;

--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1233,12 +1233,24 @@ MountConfigListView.prototype = _.extend({
 					if (_.isFunction(callback)) {
 						callback(storage);
 					}
+
+					if (result.status === StorageConfig.Status.ERROR) {
+						OC.Notification.show(t('files_external', 'An error occured while adding the external storage, please check the logs or contact the administrator'),
+							{ type: "error", timeout: 7 });
+					}
+
+					if (result.status === StorageConfig.Status.SUCCESS) {
+						OC.Notification.show(t('files_external', 'External storage has been added successfully'),
+							{ timeout: 7 });
+					}
 				}
 			},
 			error: function() {
 				if (concurrentTimer === undefined
 					|| $tr.data('save-timer') === concurrentTimer
 				) {
+					OC.Notification.show(t('files_external', 'An error occured while adding the external storage please check the logs'),
+					{ type: "error", timeout: 7 });
 					self.updateStatus($tr, StorageConfig.Status.ERROR);
 				}
 			}

--- a/changelog/unreleased/38288
+++ b/changelog/unreleased/38288
@@ -1,6 +1,6 @@
 Enhancement: Improve the UX in the external storage settings page
 
 When a user adds or edits an external storage, the user will see a notification if the storage has been added or an error occured.
-When a user hovers over the status indicator, the user will see a pointer cursor, this clearifies that a click will result in config (re-)check.
+When a user hovers over the status indicator, the user will see a pointer cursor, this clarifies that a click will result in a config (re-)check.
 
 https://github.com/owncloud/core/pull/38288

--- a/changelog/unreleased/38288
+++ b/changelog/unreleased/38288
@@ -1,0 +1,6 @@
+Enhancement: Improve the UX in the external storage settings page
+
+When a user adds or edits an external storage, the user will see a notification if the storage has been added or an error occured.
+When a user hovers over the status indicator, the user will see a pointer cursor, this clearifies that a click will result in config (re-)check.
+
+https://github.com/owncloud/core/pull/38288


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
* While adding or changing an external storage, a success/error notification will be shown
* Added cursor->pointer to the status item, due a click results in a recheck

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes  https://github.com/owncloud/enterprise/issues/4302

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
