### PR TITLE
Fix position of the user afterLogin-event

### DIFF
--- a/changelog/unreleased/38289
+++ b/changelog/unreleased/38289
@@ -1,0 +1,7 @@
+Bugfix: Fix the position of the user afterLogin-event
+
+Move the emitting event "user.afterlogin" in the method loginWithPassword.
+Previously it was placed after the prepareUserLogin-call which caused
+some issues with the encryption app using Symfony event listeners.
+
+https://github.com/owncloud/core/pull/38289

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -535,12 +535,11 @@ class Session implements IUserSession, Emitter {
 			$this->setLoginName($login);
 			$firstTimeLogin = $user->updateLastLoginTimestamp();
 			$this->manager->emit('\OC\User', 'postLogin', [$user, $password]);
+			$afterEvent = new GenericEvent(null, ['loginType' => 'password', 'user' => $user, 'uid' => $user->getUID(), 'password' => $password]);
+			$this->eventDispatcher->dispatch($afterEvent, 'user.afterlogin');
+
 			if ($this->isLoggedIn()) {
 				$this->prepareUserLogin($firstTimeLogin);
-
-				$afterEvent = new GenericEvent(null, ['loginType' => 'password', 'user' => $user, 'uid' => $user->getUID(), 'password' => $password]);
-				$this->eventDispatcher->dispatch($afterEvent, 'user.afterlogin');
-
 				return true;
 			}
 


### PR DESCRIPTION
## Description
Move the emitting event `user.afterlogin` in the method `loginWithPassword()`. For some reason it was placed after the `prepareUserLogin()`-call. This behavior causes trouble in combination with the Symfony event emitters of the encryption app. See https://github.com/owncloud/encryption/pull/25#issuecomment-751726680 for a more detailed explanation.

Similar methods like `loginWithToken()` and `loginWithApache()` already have the event at the right position. 

## Related Issue
- https://github.com/owncloud/encryption/pull/25

## How has this been tested

- Unit tests in core
- Unit tests in possibly affected apps (those who listen to the event)
- Manual tests if the events in possibly affected apps still listen and behave correctly

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
