### PR TITLE
[tests-only] Add API test to check accessibility of public link shared by disabled user

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -137,7 +137,7 @@ Feature: disable user
     And user "Alice" has been disabled
     When user "Alice" downloads file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
-  
+
   Scenario: Disabled user tries to upload file
     Given user "Alice" has been created with default attributes and skeleton files
     And user "Alice" has been disabled
@@ -206,3 +206,15 @@ Feature: disable user
     When user "Alice" creates a public link share using the sharing API with settings
       | path | textfile0.txt |
     Then the HTTP status code should be "401"
+
+  Scenario Outline: getting public link share shared by disabled user using the new public WebDAV API
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has created a public link share with settings
+      | path        | /textfile0.txt |
+      | permissions | read           |
+    When the administrator disables user "Alice" using the provisioning API
+    Then the public should be able to download the last publicly shared file using the <dav_version> public WebDAV API without a password and the content should be "ownCloud test text file 0"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -138,7 +138,7 @@ Feature: disable user
     And user "Alice" has been disabled
     When user "Alice" downloads file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
-  
+
   Scenario: Disabled user tries to upload file
     Given user "Alice" has been created with default attributes and skeleton files
     And user "Alice" has been disabled
@@ -207,3 +207,15 @@ Feature: disable user
     When user "Alice" creates a public link share using the sharing API with settings
       | path | textfile0.txt |
     Then the HTTP status code should be "401"
+
+  Scenario Outline: getting public link share shared by disabled user using the new public WebDAV API
+    Given user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has created a public link share with settings
+      | path        | /textfile0.txt |
+      | permissions | read           |
+    When the administrator disables user "Alice" using the provisioning API
+    Then the public should be able to download the last publicly shared file using the <dav_version> public WebDAV API without a password and the content should be "ownCloud test text file 0"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |


### PR DESCRIPTION
## Description
added API tests testing the public can access the public links shared by the disabled user.

## Related Issue
- Closes https://github.com/owncloud/core/issues/38284

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
