### PR TITLE
Do not prepended share_folder to file_target for public link shares

### DIFF
--- a/changelog/unreleased/38291
+++ b/changelog/unreleased/38291
@@ -1,0 +1,8 @@
+Bugfix: Fix file_target in response when creating a public link share
+
+The value of share_folder (if set in config.php) was being prepended to the
+file_target field in the response to a request to create a public link share.
+share_folder is not relevant to public link shares. It is no longer prepended.
+
+https://github.com/owncloud/core/issues/38291
+https://github.com/owncloud/core/pull/38295

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -748,7 +748,10 @@ class Manager implements IManager {
 		}
 
 		// Generate the target
-		$target = $this->config->getSystemValue('share_folder', '/') .'/'. $share->getNode()->getName();
+		$target = $share->getNode()->getName();
+		if ($share->getShareType() !== \OCP\Share::SHARE_TYPE_LINK) {
+			$target = $this->config->getSystemValue('share_folder', '/') .'/'. $target;
+		}
 		$target = \OC\Files\Filesystem::normalizePath($target);
 		$share->setTarget($target);
 

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
@@ -66,8 +66,8 @@ Feature: get shares filtered by type (user, group etc)
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And exactly 2 files or folders should be included in the response
-    And folder "/Shares/folderToShareWithPublic" should be included in the response
-    And folder "/Shares/fileToShareWithPublic.txt" should be included in the response
+    And folder "/folderToShareWithPublic" should be included in the response
+    And folder "/fileToShareWithPublic.txt" should be included in the response
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
@@ -1,0 +1,33 @@
+@api @files_sharing-app-required @public_link_share-feature-required
+Feature: create a public link share when share_folder is set to Shares
+
+  Background:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Alice" has been created with default attributes and skeleton files
+
+
+  Scenario Outline: Creating a new public link share of a file gives the correct response
+    Given using OCS API version "<ocs_api_version>"
+    And the administrator has enabled DAV tech_preview
+    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | randomfile.txt |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | item_type              | file            |
+      | mimetype               | text/plain      |
+      | file_target            | /randomfile.txt |
+      | path                   | /randomfile.txt |
+      | permissions            | read            |
+      | share_type             | public_link     |
+      | displayname_file_owner | %displayname%   |
+      | displayname_owner      | %displayname%   |
+      | uid_file_owner         | %username%      |
+      | uid_owner              | %username%      |
+      | name                   |                 |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |


### PR DESCRIPTION
## Description

When a user or group share is created and `share_folder` is set in the config, then the value of `share_folder` is prepended to `file_target` in the response to the share create API request. That is because the shared resource is "delivered" to the share receiver(s) inside that `share_folder` - so `file_target` is a helpful "pointer" to the shared resource .

But for public link shares that does not make sense. A public link share is not "delivered" into any user's "file system". It is a "standalone" thing. So in the case of `SHARE_TYPE_LINK`, do not prepended the `share_folder` value.

Note: I did not add any more unit tests. I could not see any unit tests that check what happens to share responses when `share_folder` is set. It could be a separate job to add a range of tests that check the use of `share_folder`

(I did add an acceptance test, which fails before this code changes, and passes when the code change is applied.)

## Related Issue
- Fixes #38291 

## How Has This Been Tested?
Local acceptance test run plus CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
