### PR TITLE
[tests-only] Add API tests for sharing of renamed folder when another share exists

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
@@ -530,7 +530,6 @@ Feature: sharing
     And user "Alice" has created folder "/Folder1"
     And user "Alice" has created folder "/Folder2"
     And user "Alice" has shared folder "/Folder1" with user "Brian"
-    And user "Brian" has accepted share "/Folder1" offered by user "Alice"
     When user "Alice" moves folder "/Folder2" to "/renamedFolder2" using the WebDAV API
     And user "Alice" shares folder "/renamedFolder2" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -547,9 +546,7 @@ Feature: sharing
       | mimetype               | httpd/unix-directory   |
       | storage_id             | ANY_VALUE              |
       | share_type             | user                   |
-    When user "Brian" accepts share "/renamedFolder2" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
+    And as "Brian" folder "/renamedFolder2" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
@@ -522,3 +522,35 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  @issue-ocis-719
+  Scenario Outline: Creating a share of a renamed file when another share exists
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/Folder1"
+    And user "Alice" has created folder "/Folder2"
+    And user "Alice" has shared folder "/Folder1" with user "Brian"
+    And user "Brian" has accepted share "/Folder1" offered by user "Alice"
+    When user "Alice" moves folder "/Folder2" to "/renamedFolder2" using the WebDAV API
+    And user "Alice" shares folder "/renamedFolder2" with user "Brian" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_with             | %username%             |
+      | share_with_displayname | %displayname%          |
+      | file_target            | /renamedFolder2        |
+      | path                   | /renamedFolder2        |
+      | permissions            | all                    |
+      | uid_owner              | %username%             |
+      | displayname_owner      | %displayname%          |
+      | item_type              | folder                 |
+      | mimetype               | httpd/unix-directory   |
+      | storage_id             | ANY_VALUE              |
+      | share_type             | user                   |
+    When user "Brian" accepts share "/renamedFolder2" offered by user "Alice" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -659,6 +659,7 @@ Feature: sharing
     When user "Brian" accepts share "/renamedFolder2" offered by user "Alice" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
+    And as "Brian" folder "/Shares/renamedFolder2" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -631,3 +631,35 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  @issue-ocis-719
+  Scenario Outline: Creating a share of a renamed file when another share exists
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/Folder1"
+    And user "Alice" has created folder "/Folder2"
+    And user "Alice" has shared folder "/Folder1" with user "Brian"
+    And user "Brian" has accepted share "/Folder1" offered by user "Alice"
+    When user "Alice" moves folder "/Folder2" to "/renamedFolder2" using the WebDAV API
+    And user "Alice" shares folder "/renamedFolder2" with user "Brian" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+      | share_with             | %username%             |
+      | share_with_displayname | %displayname%          |
+      | file_target            | /Shares/renamedFolder2 |
+      | path                   | /renamedFolder2        |
+      | permissions            | all                    |
+      | uid_owner              | %username%             |
+      | displayname_owner      | %displayname%          |
+      | item_type              | folder                 |
+      | mimetype               | httpd/unix-directory   |
+      | storage_id             | ANY_VALUE              |
+      | share_type             | user                   |
+    When user "Brian" accepts share "/renamedFolder2" offered by user "Alice" using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |


### PR DESCRIPTION
## Description
Add API tests for sharing of the renamed folder when another share exists

## Related Issue
- Closes https://github.com/owncloud/ocis/issues/719

## How Has This Been Tested?
- test environment: CI/drone

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
