### PR TITLE
[tests-only] Add API test to check shares exists when shared file is restored to previous version

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -233,6 +233,7 @@ default:
         - TrashbinContext:
         - WebDavPropertiesContext:
         - AppConfigurationContext:
+        - FilesVersionsContext:
 
     apiShareManagementToShares:
       paths:
@@ -245,6 +246,7 @@ default:
         - TrashbinContext:
         - WebDavPropertiesContext:
         - AppConfigurationContext:
+        - FilesVersionsContext:
 
     apiShareManagementBasicToRoot:
       paths:

--- a/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
@@ -696,3 +696,12 @@ Feature: accept/decline shares coming from internal users
     And user "David" should not see the following elements
       | /PARENT%20(2)/ |
     And the content of file "/PARENT/abc.txt" for user "David" should be "uploaded content"
+
+  @issue-ocis-765
+  Scenario: shares exist after restoring already shared file to a previous version
+    And user "Alice" has uploaded file with content "Test Content." to "/toShareFile.txt"
+    And user "Alice" has uploaded file with content "Content Test Updated." to "/toShareFile.txt"
+    And user "Alice" has shared file "/toShareFile.txt" with user "Brian"
+    When user "Alice" restores version index "1" of file "/toShareFile.txt" using the WebDAV API
+    Then the content of file "/toShareFile.txt" for user "Alice" should be "Test Content."
+    And the content of file "/toShareFile.txt" for user "Brian" should be "Test Content."

--- a/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
@@ -468,3 +468,13 @@ Feature: accept/decline shares coming from internal users
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  @issue-ocis-765
+  Scenario: shares exist after restoring already shared file to a previous version
+    And user "Alice" has uploaded file with content "Test Content." to "/toShareFile.txt"
+    And user "Alice" has uploaded file with content "Content Test Updated." to "/toShareFile.txt"
+    And user "Alice" has shared file "/toShareFile.txt" with user "Brian"
+    And user "Brian" has accepted share "/toShareFile.txt" offered by user "Alice"
+    When user "Alice" restores version index "1" of file "/toShareFile.txt" using the WebDAV API
+    Then the content of file "/toShareFile.txt" for user "Alice" should be "Test Content."
+    And the content of file "/Shares/toShareFile.txt" for user "Brian" should be "Test Content."


### PR DESCRIPTION
## Description
This PR adds API tests to check shares exists when shared file is restored to previous version
> Note: this scenario is expected to fail with OCIS backend as of the issue mentioned below

## Related Issue
- https://github.com/owncloud/ocis/issues/765

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
