### PR TITLE
fix rendering of multiple checksums

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ChecksumList.php
+++ b/apps/dav/lib/Connector/Sabre/ChecksumList.php
@@ -39,7 +39,7 @@ class ChecksumList implements XmlSerializable {
 	 * @param string $checksum
 	 */
 	public function __construct($checksum) {
-		$this->checksums = \explode(',', $checksum);
+		$this->checksums = \explode(' ', $checksum);
 	}
 
 	/**


### PR DESCRIPTION
Hey OC10, long time no see...

I am implementing checksum support in ocis and wondered why oc10 is not rendiring multiple checksums as descriped in the original pr: https://github.com/owncloud/core/pull/22199
```xml
<oc:checksums>
  <oc:checksum>TYPE1:CHECKSUM1</oc:checksum>
  <oc:checksum>TYPE2:CHECKSUM2</oc:checksum>
</oc:checksum>
```

The root cause is that at the time there was only a single checksum and it was expected to be comma seperated as can be read in https://github.com/owncloud/core/pull/21997#issuecomment-181230285

When [multiple checksums got implemented](https://github.com/owncloud/core/commit/b9852612698b047b29371191831ef73f846bf88a) they were seperated by `' '` in the database. leading to this output, which was however untested:
```xml
<oc:checksums>
  <oc:checksum>TYPE1:CHECKSUM1 TYPE2:CHECKSUM2 TYPE3:CHECKSUM3</oc:checksum>
</oc:checksum>
```

😭 

https://github.com/owncloud/core/commit/b9852612698b047b29371191831ef73f846bf88a#diff-c76e89d5d2c586430906ac3c09dab6fb41a261ddc475febbcc6c79fd85872faeR25 would add tests but with multiple checksums in one row. This is part of https://github.com/owncloud/core/pull/27097 

but webdav only returned one checksum: https://github.com/owncloud/core/pull/27097/commits/05e11ce17a23937f38593508f7f6f8feeef89213

still digging for reasons where this went unnoticed ...

the current line in the tests was introduced in https://github.com/owncloud/core/commit/014530b29c19f4cf78f502ec07a7197eb0935170 which was part of https://github.com/owncloud/core/pull/27345 

This was the change that exposed all hashes via webdav: https://github.com/owncloud/core/pull/27345/files#diff-1d6ed4804160da213bc58248990a6936622ce53100a23535d207dba153f7e759

The PR also cemented the wrong rendering.

@dragotin @micbar @IljaN what do we do about this?