### PR TITLE
Change X-XSS-Protection "1; block" -> "0"

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,7 +18,7 @@
     Header      unset X-Content-Type-Options
     Header always set X-Content-Type-Options "nosniff"
     Header      unset X-XSS-Protection
-    Header always set X-XSS-Protection "1; mode=block"
+    Header always set X-XSS-Protection "0"
     Header      unset X-Robots-Tag
     Header always set X-Robots-Tag "none"
     Header      unset X-Frame-Options

--- a/changelog/unreleased/38305
+++ b/changelog/unreleased/38305
@@ -1,4 +1,11 @@
 Change: Change X-XSS-Protection "1; block" -> "0"
 
+OWASP/CheatSheetSeries#376 (comment)
+  https://github.com/OWASP/CheatSheetSeries/issues/376#issuecomment-602663932
+Suggest remove vs. "0"
+  https://github.com/helmetjs/helmet/issues/230#issuecomment-614106165
+X-XSS-Protection header has been deprecated
+  https://owasp.org/www-project-secure-headers/#x-xss-protection
+
 https://github.com/owncloud/core/issues/38236
 https://github.com/owncloud/core/pull/38305

--- a/changelog/unreleased/38305
+++ b/changelog/unreleased/38305
@@ -1,0 +1,4 @@
+Change: Change X-XSS-Protection "1; block" -> "0"
+
+https://github.com/owncloud/core/issues/38236
+https://github.com/owncloud/core/pull/38305

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -236,7 +236,7 @@
 
 			if (xhr.status === 200) {
 				var securityHeaders = {
-					'X-XSS-Protection': '1; mode=block',
+					'X-XSS-Protection': '0',
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -416,7 +416,7 @@ describe('OC.SetupChecks tests', function() {
 			async.done(function( data, s, x ){
 				expect(data).toEqual([
 				{
-					msg: 'The "X-XSS-Protection" HTTP header is not configured to equal to "1; mode=block". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					msg: 'The "X-XSS-Protection" HTTP header is not configured to equal to "0". This is a potential security or privacy risk and we recommend adjusting this setting.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 				}, {
 					msg: 'The "X-Content-Type-Options" HTTP header is not configured to equal to "nosniff". This is a potential security or privacy risk and we recommend adjusting this setting.',
@@ -457,7 +457,7 @@ describe('OC.SetupChecks tests', function() {
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
-					msg: 'The "X-XSS-Protection" HTTP header is not configured to equal to "1; mode=block". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					msg: 'The "X-XSS-Protection" HTTP header is not configured to equal to "0". This is a potential security or privacy risk and we recommend adjusting this setting.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING,
 				}, {
 					msg: 'The "X-Content-Type-Options" HTTP header is not configured to equal to "nosniff". This is a potential security or privacy risk and we recommend adjusting this setting.',
@@ -474,7 +474,7 @@ describe('OC.SetupChecks tests', function() {
 			suite.server.requests[0].respond(
 				200,
 				{
-					'X-XSS-Protection': '1; mode=block',
+					'X-XSS-Protection': '0',
 					'X-Content-Type-Options': 'nosniff',
 					'X-Robots-Tag': 'none',
 					'X-Frame-Options': 'SAMEORIGIN',
@@ -497,7 +497,7 @@ describe('OC.SetupChecks tests', function() {
 
 		suite.server.requests[0].respond(200,
 			{
-				'X-XSS-Protection': '1; mode=block',
+				'X-XSS-Protection': '0',
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
 				'X-Frame-Options': 'SAMEORIGIN',
@@ -543,7 +543,7 @@ describe('OC.SetupChecks tests', function() {
 
 		suite.server.requests[0].respond(200,
 			{
-				'X-XSS-Protection': '1; mode=block',
+				'X-XSS-Protection': '0',
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
 				'X-Frame-Options': 'SAMEORIGIN',
@@ -568,7 +568,7 @@ describe('OC.SetupChecks tests', function() {
 		suite.server.requests[0].respond(200,
 			{
 				'Strict-Transport-Security': 'max-age=15551999',
-				'X-XSS-Protection': '1; mode=block',
+				'X-XSS-Protection': '0',
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
 				'X-Frame-Options': 'SAMEORIGIN',
@@ -593,7 +593,7 @@ describe('OC.SetupChecks tests', function() {
 		suite.server.requests[0].respond(200,
 			{
 				'Strict-Transport-Security': 'iAmABogusHeader342',
-				'X-XSS-Protection': '1; mode=block',
+				'X-XSS-Protection': '0',
 				'X-Content-Type-Options': 'nosniff',
 				'X-Robots-Tag': 'none',
 				'X-Frame-Options': 'SAMEORIGIN',
@@ -617,7 +617,7 @@ describe('OC.SetupChecks tests', function() {
 
 		suite.server.requests[0].respond(200, {
 			'Strict-Transport-Security': 'max-age=15768000',
-			'X-XSS-Protection': '1; mode=block',
+			'X-XSS-Protection': '0',
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
 			'X-Frame-Options': 'SAMEORIGIN',
@@ -637,7 +637,7 @@ describe('OC.SetupChecks tests', function() {
 
 		suite.server.requests[0].respond(200, {
 			'Strict-Transport-Security': 'max-age=99999999',
-			'X-XSS-Protection': '1; mode=block',
+			'X-XSS-Protection': '0',
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
 			'X-Frame-Options': 'SAMEORIGIN',
@@ -657,7 +657,7 @@ describe('OC.SetupChecks tests', function() {
 
 		suite.server.requests[0].respond(200, {
 			'Strict-Transport-Security': 'max-age=99999999; includeSubDomains',
-			'X-XSS-Protection': '1; mode=block',
+			'X-XSS-Protection': '0',
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
 			'X-Frame-Options': 'SAMEORIGIN',
@@ -677,7 +677,7 @@ describe('OC.SetupChecks tests', function() {
 
 		suite.server.requests[0].respond(200, {
 			'Strict-Transport-Security': 'max-age=99999999; preload; includeSubDomains',
-			'X-XSS-Protection': '1; mode=block',
+			'X-XSS-Protection': '0',
 			'X-Content-Type-Options': 'nosniff',
 			'X-Robots-Tag': 'none',
 			'X-Frame-Options': 'SAMEORIGIN',

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -258,7 +258,7 @@ class OC_Response {
 		// Send fallback headers for installations that don't have the possibility to send
 		// custom headers on the webserver side
 		if (\getenv('modHeadersAvailable') !== 'true') {
-			\header('X-XSS-Protection: 1; mode=block'); // Enforce browser based XSS filters
+			\header('X-XSS-Protection: 0'); // Disable browser based XSS filters: https://github.com/owncloud/core/issues/38236
 			\header('X-Content-Type-Options: nosniff'); // Disable sniffing the content type for IE
 			\header('X-Frame-Options: SAMEORIGIN'); // Disallow iFraming from other domains
 			\header('X-Robots-Tag: none'); // https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -53,7 +53,7 @@ Feature: download file
       | X-Frame-Options                   | SAMEORIGIN                                                       |
       | X-Permitted-Cross-Domain-Policies | none                                                             |
       | X-Robots-Tag                      | none                                                             |
-      | X-XSS-Protection                  | 1; mode=block                                                    |
+      | X-XSS-Protection                  | 0                                                                |
     And the downloaded content should start with "Welcome"
     Examples:
       | dav_version |

--- a/tests/data/setUploadLimit/htaccess
+++ b/tests/data/setUploadLimit/htaccess
@@ -10,7 +10,7 @@
   <IfModule mod_env.c>
     # Add security and privacy related headers
     Header set X-Content-Type-Options "nosniff"
-    Header set X-XSS-Protection "1; mode=block"
+    Header set X-XSS-Protection "0"
     Header set X-Robots-Tag "none"
     Header set X-Frame-Options "SAMEORIGIN"
     SetEnv modHeadersAvailable true


### PR DESCRIPTION
## Description

https://github.com/OWASP/CheatSheetSeries/issues/376#issuecomment-602663932:

> I've been studying this issue for a while and it's *dangerous* to set this header. It makes sites that are not vulnerable to XSS, vulnerable.
> ...
> Developers need to either remove the header or set it to zero, I think the debate is over. There is NO good reason to set this header to blocking mode.

Seen suggest remove vs. "0" by https://github.com/helmetjs/helmet/issues/230#issuecomment-614106165:

> The recommendation as a security community is to have a default value of 0 so that browsers don't set their own defaults.

and by https://owasp.org/www-project-secure-headers/#x-xss-protection:

> Warning: The X-XSS-Protection header has been deprecated by modern browsers and its use can introduce additional security issues on the client side. As such, it is recommended to set the header as X-XSS-Protection: 0 in order to disable the XSS Auditor, and not allow it to take the default behavior of the browser handling the response. Please use Content-Security-Policy instead.

## Related Issue
- Fixes #38236

## Motivation and Context
#38236

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/3037
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
