### PR TITLE
[tests-only] skip createPublicLinkShareToShares on core 10.5 and 10.6

### DIFF
--- a/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFiltered.feature
@@ -34,6 +34,7 @@ Feature: get shares filtered by type (user, group etc)
       | path        | /fileToShareWithPublic.txt |
       | permissions | read                       |
 
+
   Scenario Outline: getting shares shared to users
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" gets the user shares shared by him using the sharing API
@@ -46,6 +47,7 @@ Feature: get shares filtered by type (user, group etc)
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
 
   Scenario Outline: getting shares shared to groups
     Given using OCS API version "<ocs_api_version>"
@@ -60,6 +62,7 @@ Feature: get shares filtered by type (user, group etc)
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario Outline: getting shares shared to public links
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" gets the public link shares shared by him using the sharing API
@@ -72,6 +75,7 @@ Feature: get shares filtered by type (user, group etc)
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
 
   Scenario Outline: getting shares shared to users and groups
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
@@ -6,7 +6,7 @@ Feature: create a public link share when share_folder is set to Shares
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and skeleton files
 
-
+  @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario Outline: Creating a new public link share of a file gives the correct response
     Given using OCS API version "<ocs_api_version>"
     And the administrator has enabled DAV tech_preview


### PR DESCRIPTION
## Description
PR #38295 fixed a bug. The API test that was added will only pass on `master` (versions of oC10 later then 10.6.0)

Skip it on old versions of oC10. We only need to think back to 10.5 and 10.6.0 nowadays.

This will fix nightly fails like https://drone.owncloud.com/owncloud/files_primary_s3/2066/119/17 which was running this scenario against `latest` `0.6.0.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
