### PR TITLE
Prevent setlocale()-calls from overwriting themselves

### DIFF
--- a/changelog/unreleased/38286
+++ b/changelog/unreleased/38286
@@ -1,3 +1,4 @@
 Change: Remove package patchwork/utf8
 
 https://github.com/owncloud/core/pull/38286
+https://github.com/owncloud/core/pull/38315

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1279,10 +1279,10 @@ class OC_Util {
 		if (\basename('§') === '§') {
 			return true;
 		}
-			
-		\setlocale(LC_CTYPE, 'en_US.UTF-8', 'fr_FR.UTF-8', 'es_ES.UTF-8', 'de_DE.UTF-8', 'ru_RU.UTF-8', 'pt_BR.UTF-8', 'it_IT.UTF-8', 'ja_JP.UTF-8', 'zh_CN.UTF-8', '0');
+
 		\setlocale(LC_ALL, 'C.UTF-8', 'C');
-		
+		\setlocale(LC_CTYPE, 'en_US.UTF-8', 'fr_FR.UTF-8', 'es_ES.UTF-8', 'de_DE.UTF-8', 'ru_RU.UTF-8', 'pt_BR.UTF-8', 'it_IT.UTF-8', 'ja_JP.UTF-8', 'zh_CN.UTF-8', '0');
+
 		return \basename('§') === '§';
 	}
 


### PR DESCRIPTION
## Description
https://github.com/owncloud/core/pull/38286 removed the `patchwork/utf8` lib while preserving its functionality. During this, the order of the `setlocale()`-calls got mixed up, so the values for `LC_CTYPE` were annihilated by the second call with `LC_ALL`.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/38303

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
