### PR TITLE
[tests-only] Adjust regex for SUITE_SCENARIO in acceptance tests

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -473,7 +473,7 @@ function run_behat_tests() {
 				# Match lines that have [someSuite/someName.feature:n] - the part inside the
 				# brackets is the suite, feature and line number of the expected failure.
 				# Else ignore the line.
-				if [[ "${SUITE_SCENARIO}" =~ \[(\S+\/\S+\.feature:\d+)] ]]; then
+				if [[ "${SUITE_SCENARIO}" =~ \[([a-zA-Z0-9]+/[a-zA-Z0-9]+\.feature:[0-9]+)] ]]; then
 				  SUITE_SCENARIO="${BASH_REMATCH[1]}"
 				else
 				  continue


### PR DESCRIPTION
## Description
The expected-failures processing in `tests/acceptance/run.sh` was not finding unexpected passing scenarios. I had used regex with `\S` and `\d` to try to match non-whitespace and digits. But they were not working in the Bash regex. (Maybe the `\` were getting stripped out somewhere in the Bash command processor before going to the regex or... Maybe I could add more `\` to escape the `\`! I don't really care to know, because that would get too complex for future readers anyway)

Specify the actual character ranges to be matched. `[a-zA-Z0-9]` (alpha-numeric) and `[0-9]` (digit). That is more readable and it works - double bonus!

I tested locally by making some changes to the expected-failures files and seeing that I could get "unexpected passes" reported.

Note: the same fix is also applied in web PR https://github.com/owncloud/web/pull/4626

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
