### PR TITLE
Fix rendering of leading/trailing spaces in the file name

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -437,6 +437,7 @@ table td.filename .nametext .innernametext {
 	position: relative;
 	display: inline-block;
 	vertical-align: top;
+	white-space: pre;
 }
 
 @media only screen and (min-width: 1500px) {

--- a/changelog/unreleased/38319
+++ b/changelog/unreleased/38319
@@ -1,0 +1,6 @@
+Bugfix: Fix rendering of leading/trailing spaces in the file name
+
+Leading and trailing spaces in the file name were stripped in the Web UI
+
+https://github.com/owncloud/core/issues/38316
+https://github.com/owncloud/core/pull/38319


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue
- Fixes https://github.com/owncloud/core/issues/38316


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Upload two files, `test .txt` with a whitespace embedded before the dot, and `test.txt` without any whitespace.
### Expected 
space after the filename and before the dot for `test .txt`

### Expected 
Both filenames are looking the same

## Screenshots (if appropriate):
**before**
<img src="https://user-images.githubusercontent.com/1108546/105050076-addfea00-5a6d-11eb-96b5-c9b553c0da82.png" >

**after**
![Screenshot_20210120_151940](https://user-images.githubusercontent.com/991300/105174107-1f35a080-5b33-11eb-9fac-71ec35f236d6.png)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
