### PR TITLE
[tests-only] skip test scenario on old oC10 due to encryption issue 229

### DIFF
--- a/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
@@ -678,7 +678,7 @@ Feature: accept/decline shares coming from internal users
       | /textfile0.txt       |
       | /textfile0%20(2).txt |
 
-  @skipOnLDAP
+  @skipOnLDAP @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: user shares folder with matching folder name a user before that user has logged in
     Given these users have been created with skeleton files but not initialized:
       | username |


### PR DESCRIPTION
## Description
See discussion in linked encryption issue. The scenario only works when running with current core master, because of changes to events.

## Related Issue
- Fixes https://github.com/owncloud/encryption/issues/229

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
