### PR TITLE
[Tests-Only] Add API test for searching resources across various folders by tag using REPORT

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -10,7 +10,6 @@ Feature: Search
     And user "Alice" has created folder "/फनी näme"
     And user "Alice" has created folder "/upload folder"
     And user "Alice" has created folder "/upload😀 😁"
-    And user "Alice" has created folder "/just-a-folder/inner-folder"
     And user "Alice" has uploaded file with content "does-not-matter" to "/upload.txt"
     And user "Alice" has uploaded file with content "does-not-matter" to "/a-image.png"
     And user "Alice" has uploaded file with content "does-not-matter" to "/just-a-folder/upload.txt"
@@ -21,7 +20,6 @@ Feature: Search
     And user "Alice" has uploaded file with content "does-not-matter" to "/फनी näme/a-image.png"
     And user "Alice" has uploaded file with content "does-not-matter" to "/upload😀 😁/upload😀 😁.txt"
     And user "Alice" has uploaded file with content "file with comma in filename" to "/upload😀 😁/upload,1.txt"
-    And user "Alice" has uploaded file with content "inner file" to "/just-a-folder/inner-folder/upload.txt"
 
   @smokeTest
   Scenario Outline: search for entry by pattern
@@ -254,7 +252,9 @@ Feature: Search
     And as user "Brian" the response should not contain file "फनी näme"
 
   Scenario: search for entries across various folders by tags using REPORT method
-    Given user "Alice" has created a "normal" tag with name "JustARegularTag1"
+    Given user "Alice" has created folder "/just-a-folder/inner-folder"
+    And user "Alice" has uploaded file with content "inner file" to "/just-a-folder/inner-folder/upload.txt"
+    And user "Alice" has created a "normal" tag with name "JustARegularTag1"
     And user "Alice" has created a "normal" tag with name "JustARegularTag2"
     And user "Alice" has added tag "JustARegularTag1" to folder "/just-a-folder/upload.txt"
     And user "Alice" has added tag "JustARegularTag1" to file "/फनी näme/upload.txt"

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -10,6 +10,7 @@ Feature: Search
     And user "Alice" has created folder "/फनी näme"
     And user "Alice" has created folder "/upload folder"
     And user "Alice" has created folder "/upload😀 😁"
+    And user "Alice" has created folder "/just-a-folder/inner-folder"
     And user "Alice" has uploaded file with content "does-not-matter" to "/upload.txt"
     And user "Alice" has uploaded file with content "does-not-matter" to "/a-image.png"
     And user "Alice" has uploaded file with content "does-not-matter" to "/just-a-folder/upload.txt"
@@ -20,6 +21,7 @@ Feature: Search
     And user "Alice" has uploaded file with content "does-not-matter" to "/फनी näme/a-image.png"
     And user "Alice" has uploaded file with content "does-not-matter" to "/upload😀 😁/upload😀 😁.txt"
     And user "Alice" has uploaded file with content "file with comma in filename" to "/upload😀 😁/upload,1.txt"
+    And user "Alice" has uploaded file with content "inner file" to "/just-a-folder/inner-folder/upload.txt"
 
   @smokeTest
   Scenario Outline: search for entry by pattern
@@ -250,3 +252,23 @@ Feature: Search
     Then the HTTP status code should be "207"
     And as user "Brian" the response should contain file "upload.txt"
     And as user "Brian" the response should not contain file "फनी näme"
+
+  Scenario: search for entries across various folders by tags using REPORT method
+    Given user "Alice" has created a "normal" tag with name "JustARegularTag1"
+    And user "Alice" has created a "normal" tag with name "JustARegularTag2"
+    And user "Alice" has added tag "JustARegularTag1" to folder "/just-a-folder/upload.txt"
+    And user "Alice" has added tag "JustARegularTag1" to file "/फनी näme/upload.txt"
+    And user "Alice" has added tag "JustARegularTag1" to file "/just-a-folder/inner-folder/upload.txt"
+    And user "Alice" has added tag "JustARegularTag2" to file "/upload😀 😁/upload,1.txt"
+    And user "Alice" has added tag "JustARegularTag2" to file "/upload.txt"
+    When user "Alice" searches for resources tagged with tag "JustARegularTag1" using the webDAV API
+    Then the HTTP status code should be "207"
+    And the search result by tags for user "Alice" should contain these entries:
+      | upload.txt |
+      | upload.txt |
+      | upload.txt |
+    When user "Alice" searches for resources tagged with tag "JustARegularTag2" using the webDAV API
+    Then the HTTP status code should be "207"
+    And the search result by tags for user "Alice" should contain these entries:
+      | upload,1.txt |
+      | upload.txt   |


### PR DESCRIPTION
## Description
This PR adds test for searching resources across various folders by tag using REPORT method

## Related Issue
- Part of https://github.com/owncloud/QA/issues/634#issuecomment-603657239
## Motivation and Context
More api-test coverage with `REPORT` method

## How Has This Been Tested?
- test environment: drone 🤖

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
