### PR TITLE
[tests-only] check if webdav locks don't influece each other

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -118,6 +118,7 @@ config = {
 				'apiWebdavEtagPropagation2',
 				'apiWebdavLocks',
 				'apiWebdavLocks2',
+				'apiWebdavLocks3',
 				'apiWebdavLocksUnlock',
 				'apiWebdavMove1',
 				'apiWebdavMove2',

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -484,6 +484,17 @@ default:
         - WebDavLockingContext:
         - WebDavPropertiesContext:
 
+    apiWebdavLocks3:
+      paths:
+        - '%paths.base%/../features/apiWebdavLocks3'
+      context: *common_ldap_suite_context
+      contexts:
+        - FeatureContext: *common_feature_context_params
+        - OccContext:
+        - PublicWebDavContext:
+        - WebDavLockingContext:
+        - WebDavPropertiesContext:
+
     apiWebdavLocksUnlock:
       paths:
         - '%paths.base%/../features/apiWebdavLocksUnlock'

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
@@ -1,0 +1,160 @@
+@api @issue-ocis-reva-172
+Feature: independent locks
+  Make sure all locks are independent and don't interact with other items that have the same name
+
+  Background:
+    Given user "Alice" has been created with default attributes and skeleton files
+
+
+  Scenario Outline: locking a folder does not lock other items with the same name in other parts of the file system
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "locked"
+    And user "Alice" has created folder "locked/PARENT"
+    And user "Alice" has created folder "notlocked"
+    And user "Alice" has created folder "notlocked/PARENT"
+    And user "Alice" has created folder "alsonotlocked"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/alsonotlocked/PARENT"
+    When user "Alice" locks folder "locked/PARENT" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/PARENT/file.txt"
+    And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/alsonotlocked/PARENT"
+    But user "Alice" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/PARENT/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a folder on the root level does not lock other folders with the same name in other parts of the file system
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "notlocked"
+    And user "Alice" has created folder "notlocked/PARENT"
+    And user "Alice" has created folder "alsonotlocked"
+    And user "Alice" has created folder "alsonotlocked/PARENT"
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/PARENT/file.txt"
+    And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/alsonotlocked/PARENT/file.txt"
+    But user "Alice" should not be able to upload file "filesForUpload/lorem.txt" to "/PARENT/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a file does not lock other items with the same name in other parts of the file system
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "locked"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/textfile0.txt"
+    And user "Alice" has created folder "notlocked"
+    And user "Alice" has created folder "notlocked/textfile0.txt"
+    When user "Alice" locks file "locked/textfile0.txt" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/textfile0.txt/real-file.txt"
+    And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/textfile0.txt"
+    But user "Alice" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a file/folder with git specific names does not lock other items with the same name in other parts of the file system
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "locked/"
+    And user "Alice" has created folder "locked/<foldername>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/<foldername>/<filename>"
+    And user "Alice" has created folder "notlocked/"
+    And user "Alice" has created folder "notlocked/<foldername>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "notlocked/<foldername>/<filename>"
+    When user "Alice" locks file "locked/<to-lock>" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/<foldername>/file.txt"
+    And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/<foldername>/<filename>"
+    But user "Alice" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/<foldername>/<filename>"
+    Examples:
+      | dav-path | lock-scope | foldername | filename | to-lock     |
+      | old      | shared     | .git       | config   | .git        |
+      | old      | shared     | .git       | config   | .git/config |
+      | old      | exclusive  | .git       | config   | .git        |
+      | old      | exclusive  | .git       | config   | .git/config |
+      | new      | shared     | .git       | config   | .git        |
+      | new      | shared     | .git       | config   | .git/config |
+      | new      | exclusive  | .git       | config   | .git        |
+      | new      | exclusive  | .git       | config   | .git/config |
+
+
+  Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from different users)
+    Given using <dav-path> DAV path
+    And the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and skeleton files
+    And user "Alice" has shared folder "PARENT" with user "Carol"
+    And user "Brian" has shared folder "PARENT" with user "Carol"
+    And user "Carol" has accepted share "/PARENT" offered by user "Alice"
+    And user "Carol" has accepted share "/PARENT" offered by user "Brian"
+    When user "Carol" locks folder "/Shares/PARENT" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/PARENT (2)/file.txt"
+    But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/PARENT/file.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from the same user)
+    Given using <dav-path> DAV path
+    And the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Alice" has created folder "locked/"
+    And user "Alice" has created folder "locked/toShare"
+    And user "Alice" has created folder "notlocked/"
+    And user "Alice" has created folder "notlocked/toShare"
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Alice" has shared folder "locked/toShare" with user "Brian"
+    And user "Alice" has shared folder "notlocked/toShare" with user "Brian"
+    And user "Brian" has accepted share "/locked/toShare" offered by user "Alice"
+    And user "Brian" has accepted share "/notlocked/toShare" offered by user "Alice"
+    When user "Brian" locks folder "/Shares/toShare" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare (2)/file.txt"
+    But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare/file.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a file in a received share does not lock other items with the same name in other received shares
+    Given using <dav-path> DAV path
+    And the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Brian" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and skeleton files
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/FOLDER/textfile0.txt"
+    And user "Alice" has shared folder "PARENT" with user "Carol"
+    And user "Brian" has shared folder "FOLDER" with user "Carol"
+    And user "Carol" has accepted share "/PARENT" offered by user "Alice"
+    And user "Carol" has accepted share "/FOLDER" offered by user "Brian"
+    When user "Carol" locks folder "/Shares/PARENT/textfile0.txt" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/FOLDER/textfile0.txt"
+    But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/PARENT/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToRoot.feature
@@ -1,0 +1,87 @@
+@api @issue-ocis-reva-172 @notToImplementOnOCIS
+Feature: independent locks
+  Make sure all locks are independent and don't interact with other items that have the same name
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+
+
+  Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from different users)
+    Given using <dav-path> DAV path
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "toShare"
+    And user "Brian" has created folder "toShare"
+    And user "Alice" has shared folder "toShare" with user "Carol"
+    And user "Brian" has shared folder "toShare" with user "Carol"
+    When user "Carol" locks folder "/toShare" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/toShare (2)/file.txt"
+    But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/toShare/file.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from the same user)
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "locked/"
+    And user "Alice" has created folder "locked/toShare"
+    And user "Alice" has created folder "notlocked/"
+    And user "Alice" has created folder "notlocked/toShare"
+    And user "Alice" has shared folder "locked/toShare" with user "Brian"
+    And user "Alice" has shared folder "notlocked/toShare" with user "Brian"
+    When user "Brian" locks folder "/toShare" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/toShare (2)/file.txt"
+    But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/toShare/file.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a file in a received share does not lock other items with the same name in other received shares (shares from different users)
+    Given using <dav-path> DAV path
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FromAlice"
+    And user "Brian" has created folder "FromBrian"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/FromAlice/textfile0.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/FromBrian/textfile0.txt"
+    And user "Alice" has shared folder "FromAlice" with user "Carol"
+    And user "Brian" has shared folder "FromBrian" with user "Carol"
+    When user "Carol" locks file "/FromBrian/textfile0.txt" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/FromAlice/textfile0.txt"
+    But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/FromBrian/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a file in a received share does not lock other items with the same name in other received shares (shares from same user)
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "locked/"
+    And user "Alice" has created folder "notlocked/"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "locked/textfile0.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "notlocked/textfile0.txt"
+    And user "Alice" has shared folder "locked" with user "Brian"
+    And user "Alice" has shared folder "notlocked" with user "Brian"
+    When user "Brian" locks file "/locked/textfile0.txt" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/textfile0.txt"
+    But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
@@ -1,0 +1,97 @@
+@api @issue-ocis-reva-172
+Feature: independent locks
+  Make sure all locks are independent and don't interact with other items that have the same name
+
+  Background:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+
+
+  Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from different users)
+    Given using <dav-path> DAV path
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "toShare"
+    And user "Brian" has created folder "toShare"
+    And user "Alice" has shared folder "toShare" with user "Carol"
+    And user "Brian" has shared folder "toShare" with user "Carol"
+    And user "Carol" has accepted share "/toShare" offered by user "Alice"
+    And user "Carol" has accepted share "/toShare" offered by user "Brian"
+    When user "Carol" locks folder "/Shares/toShare" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare (2)/file.txt"
+    But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare/file.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from the same user)
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "locked/"
+    And user "Alice" has created folder "locked/toShare"
+    And user "Alice" has created folder "notlocked/"
+    And user "Alice" has created folder "notlocked/toShare"
+    And user "Alice" has shared folder "locked/toShare" with user "Brian"
+    And user "Alice" has shared folder "notlocked/toShare" with user "Brian"
+    And user "Brian" has accepted share "/locked/toShare" offered by user "Alice"
+    And user "Brian" has accepted share "/notlocked/toShare" offered by user "Alice"
+    When user "Brian" locks folder "/Shares/toShare" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare (2)/file.txt"
+    But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare/file.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a file in a received share does not lock other items with the same name in other received shares (shares from different users)
+    Given using <dav-path> DAV path
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FromAlice"
+    And user "Brian" has created folder "FromBrian"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/FromAlice/textfile0.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/FromBrian/textfile0.txt"
+    And user "Alice" has shared folder "FromAlice" with user "Carol"
+    And user "Brian" has shared folder "FromBrian" with user "Carol"
+    And user "Carol" has accepted share "/FromAlice" offered by user "Alice"
+    And user "Carol" has accepted share "/FromBrian" offered by user "Brian"
+    When user "Carol" locks file "/Shares/FromBrian/textfile0.txt" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/FromAlice/textfile0.txt"
+    But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/FromBrian/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: locking a file in a received share does not lock other items with the same name in other received shares (shares from same user)
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "locked/"
+    And user "Alice" has created folder "notlocked/"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/textfile0.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/notlocked/textfile0.txt"
+    And user "Alice" has shared folder "locked" with user "Brian"
+    And user "Alice" has shared folder "notlocked" with user "Brian"
+    And user "Brian" has accepted share "/locked" offered by user "Alice"
+    And user "Brian" has accepted share "/notlocked" offered by user "Alice"
+    When user "Brian" locks file "/Shares/locked/textfile0.txt" using the WebDAV API setting following properties
+      | lockscope | <lock-scope> |
+    Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/notlocked/textfile0.txt"
+    But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/locked/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2007,7 +2007,7 @@ trait WebDav {
 			$initialContent = (string) $this->response->getBody();
 		}
 		$this->userUploadsAFileTo($user, $source, $destination);
-		$this->theHTTPStatusCodeShouldBe("403");
+		$this->theHTTPStatusCodeShouldBe(["403", "423"]);
 		if ($fileAlreadyExists) {
 			$this->downloadFileAsUserUsingPassword($user, $destination);
 			$currentContent = (string) $this->response->getBody();

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -20,7 +20,7 @@ Feature: Locks
       | path        | /simple-folder            |
       | permissions | read,update,create,delete |
     When the public accesses the last created public link using the webUI
-    And the user deletes folder "lorem.txt" using the webUI
+    And the user deletes file "lorem.txt" using the webUI
     Then notifications should be displayed on the webUI with the text
       | The file "lorem.txt" is locked and cannot be deleted. |
     And as "brand-new-user" file "simple-folder/lorem.txt" should exist


### PR DESCRIPTION
## Description
add tests to make sure webdav locks don't interact negetivly with each other

## Related Issue
part of https://github.com/owncloud/core/issues/38302


## Motivation and Context
make sure https://github.com/owncloud/enterprise/issues/4355 is not caused by webdav locks

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
