### PR TITLE
[Tests-Only] Expand API tests for addUser, createSubAdmin, deleteUser, disableUser, enableUser and editUser

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -121,3 +121,22 @@ Feature: add user
       | 123      |
       | -123     |
       | 0.0      |
+
+  Scenario: subadmin should not be able to create a user
+    Given user "brand-new-user" has been deleted
+    And user "subadmin" has been created with default attributes and without skeleton files
+    And group "group101" has been created
+    And user "subadmin" has been added to group "group101"
+    And user "subadmin" has been made a subadmin of group "group101"
+    When the user "subadmin" sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "106"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist
+
+  Scenario: normal user should not be able to create another user
+    Given user "brand-new-user" has been deleted
+    And user "Alice" has been created with default attributes and without skeleton files
+    When the user "Alice" sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "brand-new-user" should not exist

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -44,3 +44,14 @@ Feature: create a subadmin
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "brand-new-user" should not be a subadmin of group "brand-new-group"
+
+  Scenario: normal user should not be able to make another user a subadmin
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | Alice          |
+      | Brian          |
+    And group "group101" has been created
+    When user "Alice" makes user "Brian" a subadmin of group "group101" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "Brian" should not be a subadmin of group "group101"

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -59,3 +59,66 @@ Feature: delete users
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "Brian" should exist
+
+  Scenario: administrator deletes another admin user
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | another-admin  |
+    And user "another-admin" has been added to group "admin"
+    When the administrator deletes user "another-admin" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "another-admin" should not exist
+
+  Scenario: subadmin deletes a user with subadmin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "new-group" has been created
+    And user "another-subadmin" has been added to group "new-group"
+    And user "another-subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" deletes user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "another-subadmin" should not exist
+  
+  Scenario: subadmin should not be to delete another subadmin of same group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "new-group" has been created
+    And user "another-subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" deletes user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-subadmin" should exist
+
+  Scenario: subadmin should not be able to delete a user with admin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | subadmin       |
+      | another-admin  |
+    And user "another-admin" has been added to group "admin"
+    And group "new-group" has been created
+    And user "another-admin" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" deletes user "another-admin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-admin" should exist
+
+  Scenario: subadmin should not be able to delete a user not in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | subadmin       |
+      | brand-new-user |
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" deletes user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "brand-new-user" should exist

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -218,3 +218,39 @@ Feature: disable user
       | dav_version |
       | old         |
       | new         |
+
+  Scenario: Subadmin should be able to disable user with subadmin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "another-subadmin" has been added to group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" disables user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "another-subadmin" should be disabled
+
+  Scenario: Subadmin should not be able to disable another subadmin of same group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" disables user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-subadmin" should be enabled
+
+  Scenario: normal user cannot disable himself
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+    When user "Alice" disables user "Alice" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "Alice" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -127,3 +127,66 @@ Feature: edit users
     And the attributes of user "brand-new-user" returned by the API should include
       | quota definition | default |
     And the quota definition of user "brand-new-user" should be "default"
+
+  Scenario: the administrator can edit user information with admin permissions
+    Given these users have been created with default attributes and skeleton files:
+      | username            |
+      | another-admin       |
+    And user "another-admin" has been added to group "admin"
+    When user "another-admin" changes the quota of user "another-admin" to "12MB" using the provisioning API
+    And user "another-admin" changes the email of user "another-admin" to "another-admin@example.com" using the provisioning API
+    And user "another-admin" changes the display of user "another-admin" to "Anne Brown" using the provisioning API
+    Then the display name of user "another-admin" should be "Anne Brown"
+    And the email address of user "another-admin" should be "another-admin@example.com"
+    And the quota definition of user "another-admin" should be "12 MB"
+
+  Scenario: a subadmin should be able to edit user information with subadmin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "new-group" has been created
+    And user "another-subadmin" has been added to group "new-group"
+    And user "another-subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" changes the quota of user "another-subadmin" to "12MB" using the provisioning API
+    And user "subadmin" changes the email of user "another-subadmin" to "brand-new-user@example.com" using the provisioning API
+    And user "subadmin" changes the display of user "another-subadmin" to "Anne Brown" using the provisioning API
+    Then the display name of user "another-subadmin" should be "Anne Brown"
+    And the email address of user "another-subadmin" should be "brand-new-user@example.com"
+    And the quota definition of user "another-subadmin" should be "12 MB"
+
+    Scenario: a subadmin should not be able to edit user information of another subadmin of same group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "new-group" has been created
+    And user "another-subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" changes the quota of user "another-subadmin" to "12MB" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    When user "subadmin" changes the email of user "another-subadmin" to "brand-new-user@example.com" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    When user "subadmin" changes the display of user "another-subadmin" to "Anne Brown" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the display name of user "another-subadmin" should be "Regular User"
+    And the email address of user "another-subadmin" should be "another-subadmin@owncloud.org"
+    And the quota definition of user "another-subadmin" should be "default"
+
+  Scenario: a normal user should not be able to edit another user's information
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    When user "Alice" changes the display name of user "Brian" to "New Brian" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    When user "Alice" changes the email of user "Brian" to "brian-new-email@example.com" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the display name of user "Brian" should be "Brian Murphy"
+    And the email address of user "Brian" should be "brian@example.org"

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -88,3 +88,69 @@ Feature: enable user
     Given user "Alice" has been created with default attributes and skeleton files
     When user "Alice" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "200"
+
+  Scenario: normal user should not be to enable himself
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+    And user "Alice" has been disabled
+    When user "Alice" tries to enable user "Alice" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "Alice" should be disabled
+
+  Scenario: subadmin should be to enable user in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username    |
+      | Alice       |
+      | subadmin    |
+    And group "brand-new-group" has been created
+    And user "Alice" has been added to group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been disabled
+    When user "subadmin" tries to enable user "Alice" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "Alice" should be enabled
+
+  Scenario: subadmin should not be to enable user not in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username    |
+      | Alice       |
+      | subadmin    |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been disabled
+    When user "subadmin" tries to enable user "Alice" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "Alice" should be disabled
+
+  Scenario: subadmin should be to enable user with subadmin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username    |
+      | Alice       |
+      | subadmin    |
+    And group "brand-new-group" has been created
+    And user "Alice" has been added to group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been disabled
+    When user "subadmin" tries to enable user "Alice" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "Alice" should be enabled
+
+  Scenario: subadmin should not be to enable another subadmin of same group
+    Given these users have been created with default attributes and skeleton files:
+      | username            |
+      | subadmin            |
+      | another-subadmin    |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "another-subadmin" has been disabled
+    When user "subadmin" tries to enable user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-subadmin" should be disabled

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -105,3 +105,38 @@ Feature: add user
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And the API should not return any data
+
+  Scenario Outline: admin creates a user with unusual username
+    Given user "<username>" has been deleted
+    When the administrator sends a user creation request for user "<username>" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "<username>" should exist
+    And user "<username>" should be able to access a skeleton file
+    Examples:
+      | username |
+      | user-1   |
+      | null     |
+      | nil      |
+      | 123      |
+      | -123     |
+      | 0.0      |
+
+  Scenario: subadmin should not be to create a user
+    Given user "brand-new-user" has been deleted
+    And user "subadmin" has been created with default attributes and without skeleton files
+    And group "group101" has been created
+    And user "subadmin" has been added to group "group101"
+    And user "subadmin" has been made a subadmin of group "group101"
+    When the user "subadmin" sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And user "brand-new-user" should not exist
+
+  Scenario: normal user should not be to create another user
+    Given user "brand-new-user" has been deleted
+    And user "Alice" has been created with default attributes and without skeleton files
+    When the user "Alice" sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "brand-new-user" should not exist

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -44,3 +44,14 @@ Feature: create a subadmin
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "brand-new-user" should not be a subadmin of group "brand-new-group"
+
+  Scenario: normal user should not be to make another user a subadmin
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | Alice          |
+      | Brian          |
+    And group "group101" has been created
+    When user "Alice" makes user "Brian" a subadmin of group "group101" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "Brian" should not be a subadmin of group "group101"

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -60,3 +60,66 @@ Feature: delete users
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should exist
+
+  Scenario: administrator deletes another admin user
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | another-admin  |
+    And user "another-admin" has been added to group "admin"
+    When the administrator deletes user "another-admin" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "another-admin" should not exist
+
+  Scenario: subadmin deletes a user with subadmin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "new-group" has been created
+    And user "another-subadmin" has been added to group "new-group"
+    And user "another-subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" deletes user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "another-subadmin" should not exist
+
+  Scenario: subadmin should not be able to delete another subadmin of same group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "new-group" has been created
+    And user "another-subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" deletes user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-subadmin" should exist
+
+  Scenario: subadmin should not be able to delete a user with admin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | subadmin       |
+      | another-admin  |
+    And user "another-admin" has been added to group "admin"
+    And group "new-group" has been created
+    And user "another-admin" has been added to group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" deletes user "another-admin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-admin" should exist
+
+  Scenario: subadmin should not be able to delete a user not in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username       |
+      | subadmin       |
+      | brand-new-user |
+    And group "new-group" has been created
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" deletes user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "brand-new-user" should exist

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -219,3 +219,39 @@ Feature: disable user
       | dav_version |
       | old         |
       | new         |
+
+  Scenario: Subadmin should be able to disable user with subadmin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "another-subadmin" has been added to group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" disables user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "another-subadmin" should be disabled
+
+  Scenario: Subadmin should not be able to disable another subadmin of same group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" disables user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-subadmin" should be enabled
+
+  Scenario: normal user cannot disable himself
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+    When user "Alice" disables user "Alice" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "Alice" should be enabled

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -114,7 +114,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "Alice" should be enabled
 
-  Scenario: subadmin should not be to enable user not in their group
+  Scenario: subadmin should not be able to enable user not in their group
     Given these users have been created with default attributes and skeleton files:
       | username    |
       | Alice       |

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -89,3 +89,69 @@ Feature: enable user
     Given user "Alice" has been created with default attributes and skeleton files
     When user "Alice" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "200"
+
+  Scenario: normal user should not be able to enable himself
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+    And user "Alice" has been disabled
+    When user "Alice" tries to enable user "Alice" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "Alice" should be disabled
+
+  Scenario: subadmin should be able to enable user in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username    |
+      | Alice       |
+      | subadmin    |
+    And group "brand-new-group" has been created
+    And user "Alice" has been added to group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been disabled
+    When user "subadmin" tries to enable user "Alice" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "Alice" should be enabled
+
+  Scenario: subadmin should not be to enable user not in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username    |
+      | Alice       |
+      | subadmin    |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been disabled
+    When user "subadmin" tries to enable user "Alice" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "Alice" should be disabled
+
+  Scenario: subadmin should be able to enable user with subadmin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username    |
+      | Alice       |
+      | subadmin    |
+    And group "brand-new-group" has been created
+    And user "Alice" has been added to group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been disabled
+    When user "subadmin" tries to enable user "Alice" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "Alice" should be enabled
+
+  Scenario: subadmin should not be able to enable another subadmin of same group
+    Given these users have been created with default attributes and skeleton files:
+      | username            |
+      | subadmin            |
+      | another-subadmin    |
+    And group "brand-new-group" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "another-subadmin" has been disabled
+    When user "subadmin" tries to enable user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-subadmin" should be disabled


### PR DESCRIPTION
## Description
expands apiProvisioning tests for ocs v1 and v2 in:
- addUser
- deleteUser
- editUser
- disableUser
- enableUser
- createSubAdmin

## Related Issue

- part of https://github.com/owncloud/core/issues/31533

## How Has This Been Tested?
- test environment: local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
