### PR TITLE
[Tests-Only] Expand API tests for getUser, removeSubAdmin and resetUserPassword

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -140,3 +140,42 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+
+  Scenario: admin gets information of a user with admin permissions
+    Given these users have been created with default attributes and skeleton files:
+      | username       | displayname    |
+      | Alice          | Admin Alice    |
+    And user "Alice" has been added to group "admin"
+    When the administrator retrieves the information of user "Alice" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "Admin Alice"
+    And the quota definition returned by the API should be "default"
+
+  Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "another-subadmin" has been added to group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" retrieves the information of user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "Regular User"
+    And the quota definition returned by the API should be "default"
+
+  Scenario: a subadmin should not be able to get information of another subadmin of same group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" retrieves the information of user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -42,3 +42,17 @@ Feature: remove subadmin
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "subadmin" should be a subadmin of group "brand-new-group"
+
+  Scenario: subadmin should not be able to remove subadmin of another group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "new-group-1" has been created
+    And group "new-group-2" has been created
+    And user "subadmin" has been made a subadmin of group "new-group-1"
+    And user "another-subadmin" has been made a subadmin of group "new-group-2"
+    When user "subadmin" removes user "another-subadmin" from being a subadmin of group "new-group-2" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-subadmin" should be a subadmin of group "new-group-2"

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -96,3 +96,43 @@ Feature: reset user password
     When the administrator resets the password of user "nonexistentuser" to "%alt1%" using the provisioning API
     Then the OCS status code should be "998"
     And the HTTP status code should be "200"
+
+  Scenario: admin resets password of user with admin permissions
+    Given these users have been created with skeleton files:
+      | username | password  | displayname | email           |
+      | Alice    | %regular% | New user    | alice@oc.com.np |
+    And user "Alice" has been added to group "admin"
+    When the administrator resets the password of user "Alice" to "%alt1%" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "Alice" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "Alice" using password "%regular%" should not be able to download file "textfile0.txt"
+
+  Scenario: subadmin should be able to reset the password of a user with subadmin permissions in their group
+    Given these users have been created with skeleton files:
+      | username       | password   | displayname | email                    |
+      | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
+      | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
+    And group "new-group" has been created
+    And user "brand-new-user" has been added to group "new-group"
+    And user "brand-new-user" has been made a subadmin of group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" tries to reset the password of user "brand-new-user" to "%alt1%" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
+    But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
+
+  Scenario: subadmin should not be able to reset the password of another subadmin of same group
+    Given these users have been created with skeleton files:
+      | username         | password   | displayname | email                      |
+      | another-subadmin | %regular%  | New user    | another.subadmin@oc.com.np |
+      | subadmin         | %subadmin% | Sub Admin   | sub.admin@oc.com.np        |
+    And group "new-group" has been created
+    And user "another-subadmin" has been made a subadmin of group "new-group"
+    And user "subadmin" has been made a subadmin of group "new-group"
+    When user "subadmin" tries to reset the password of user "another-subadmin" to "%alt1%" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the content of file "textfile0.txt" for user "another-subadmin" using password "%regular%" should be "ownCloud test text file 0" plus end-of-line
+    But user "another-subadmin" using password "%alt1%" should not be able to download file "textfile0.txt"

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -141,3 +141,42 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+
+  Scenario: admin gets information of a user with admin permissions
+    Given these users have been created with default attributes and skeleton files:
+      | username       | displayname    |
+      | Alice          | Admin Alice    |
+    And user "Alice" has been added to group "admin"
+    When the administrator retrieves the information of user "Alice" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "Admin Alice"
+    And the quota definition returned by the API should be "default"
+
+  Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "another-subadmin" has been added to group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" retrieves the information of user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "Regular User"
+    And the quota definition returned by the API should be "default"
+
+  Scenario: a subadmin should not be able to get information of another subadmin of same group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" retrieves the information of user "another-subadmin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -44,3 +44,17 @@ Feature: remove subadmin
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "subadmin" should be a subadmin of group "brand-new-group"
+
+  Scenario: subadmin should not be able to remove subadmin of another group
+    Given these users have been created with default attributes and skeleton files:
+      | username         |
+      | subadmin         |
+      | another-subadmin |
+    And group "new-group-1" has been created
+    And group "new-group-2" has been created
+    And user "subadmin" has been made a subadmin of group "new-group-1"
+    And user "another-subadmin" has been made a subadmin of group "new-group-2"
+    When user "subadmin" removes user "another-subadmin" from being a subadmin of group "new-group-2" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And user "another-subadmin" should be a subadmin of group "new-group-2"


### PR DESCRIPTION
## Description
expands apiProvisioning tests for ocs v1 and v2 in:
- getUser
- removeSubAdmin
- resetUserPassword

## Related Issue
- part of https://github.com/owncloud/core/issues/31533

## How Has This Been Tested?
- test environment: drone :robot: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
