### PR TITLE
[tests-only] improve user-creation error

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -962,7 +962,10 @@ trait Provisioning {
 					$httpStatusCode = $e->getResponse()->getStatusCode();
 					$reasonPhrase = $e->getResponse()->getReasonPhrase();
 					$exceptionToThrow = new Exception(
-						__METHOD__ . "Unexpected failure when creating a user: HTTP status $httpStatusCode HTTP reason $reasonPhrase OCS status $ocsStatusCode OCS message $messageText"
+						__METHOD__ . " Unexpected failure when creating the user '" .
+						$userAttributes['userid'] . "': HTTP status $httpStatusCode " .
+						"HTTP reason $reasonPhrase OCS status $ocsStatusCode " .
+						"OCS message $messageText"
 					);
 				}
 			}


### PR DESCRIPTION
## Description
improve the error message when a user could not be created in the test run
1. a space was missing
2. when multiple users are created in a table its not clear which one failed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
