### PR TITLE
[Tests-Only] Expand API tests for getGroups, getSubAdminGroups and getUserGroups

### DIFF
--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
@@ -70,3 +70,30 @@ Feature: get groups
       | users             |
       | sysusers          |
       | sailing-lovers    |
+
+
+  Scenario: subadmin gets all the groups
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And group "0" has been created
+    And group "España" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" gets all the groups using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
+      | España          |
+      | admin           |
+      | brand-new-group |
+      | 0               |
+
+
+  Scenario: normal user cannot get a list of all the groups
+    Given user "Alice" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And group "0" has been created
+    And group "España" has been created
+    When user "Alice" gets all the groups using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -21,10 +21,58 @@ Feature: get subadmin groups
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
 
-  Scenario: admin tries to get subadmin groups of a user which do not exist
+
+  Scenario: admin tries to get subadmin groups of a user which does not exist
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
     When the administrator gets all the groups where user "nonexistentuser" is subadmin using the provisioning API
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
+    And the API should not return any data
+
+  @issue-owncloud-sdk-658
+  Scenario: subadmin gets groups where he/she is subadmin
+    Given user "Alice" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And group "😅 😆" has been created
+    And user "Alice" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been made a subadmin of group "😅 😆"
+    When user "Alice" gets all the groups where user "Alice" is subadmin using the provisioning API
+    # Then the OCS status code should be "100"
+    # And the HTTP status code should be "200"
+    # Then the subadmin groups returned by the API should be
+    #   | brand-new-group |
+    #   | 😅 😆           |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data
+
+
+  Scenario: subadmin of a group should not be able to get subadmin groups of another subadmin user
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And group "brand-new-group" has been created
+    And group "😅 😆" has been created
+    And user "Alice" has been made a subadmin of group "brand-new-group"
+    And user "Brian" has been made a subadmin of group "😅 😆"
+    When user "Alice" tries to get all the groups where user "Brian" is subadmin using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data
+
+
+  Scenario: normal user should not be able to get subadmin groups of a subadmin user
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And group "brand-new-group" has been created
+    And group "😅 😆" has been created
+    And user "Alice" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been made a subadmin of group "😅 😆"
+    When user "Brian" tries to get all the groups where user "Alice" is subadmin using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
     And the API should not return any data

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -127,3 +127,19 @@ Feature: get user groups
     And the HTTP status code should be "200"
     Then the groups returned by the API should be
       | users |
+
+
+  Scenario: normal user gets his/her groups
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+    And group "group1" has been created
+    And group "group2" has been created
+    And user "Alice" has been added to group "group1"
+    And user "Alice" has been added to group "group2"
+    When user "Alice" gets all the groups of user "Alice" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
+      | group1 |
+      | group2 |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
@@ -70,3 +70,30 @@ Feature: get groups
       | users             |
       | sysusers          |
       | sailing-lovers    |
+
+
+  Scenario: subadmin gets all the groups
+    Given user "subadmin" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And group "0" has been created
+    And group "España" has been created
+    And user "subadmin" has been made a subadmin of group "brand-new-group"
+    When user "subadmin" gets all the groups using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
+      | España          |
+      | admin           |
+      | brand-new-group |
+      | 0               |
+
+
+  Scenario: normal user cannot get a list of all the groups
+    Given user "Alice" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And group "0" has been created
+    And group "España" has been created
+    When user "Alice" gets all the groups using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -21,10 +21,58 @@ Feature: get subadmin groups
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 
-  Scenario: admin tries to get subadmin groups of a user which do not exist
+
+  Scenario: admin tries to get subadmin groups of a user which does not exist
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
     When the administrator gets all the groups where user "nonexistentuser" is subadmin using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
+    And the API should not return any data
+
+  @issue-owncloud-sdk-658
+  Scenario: subadmin gets groups where he/she is subadmin
+    Given user "Alice" has been created with default attributes and skeleton files
+    And group "brand-new-group" has been created
+    And group "😅 😆" has been created
+    And user "Alice" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been made a subadmin of group "😅 😆"
+    When user "Alice" gets all the groups where user "Alice" is subadmin using the provisioning API
+    # Then the OCS status code should be "200"
+    # And the HTTP status code should be "200"
+    # Then the subadmin groups returned by the API should be
+    #   | brand-new-group |
+    #   | 😅 😆           |
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data
+
+
+  Scenario: subadmin of a group should not be able to get subadmin groups of another subadmin user
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And group "brand-new-group" has been created
+    And group "😅 😆" has been created
+    And user "Alice" has been made a subadmin of group "brand-new-group"
+    And user "Brian" has been made a subadmin of group "😅 😆"
+    When user "Alice" tries to get all the groups where user "Brian" is subadmin using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
+    And the API should not return any data
+
+
+  Scenario: normal user should not be able to get subadmin groups of a subadmin user
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And group "brand-new-group" has been created
+    And group "😅 😆" has been created
+    And user "Alice" has been made a subadmin of group "brand-new-group"
+    And user "Alice" has been made a subadmin of group "😅 😆"
+    When user "Brian" tries to get all the groups where user "Alice" is subadmin using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
     And the API should not return any data

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -128,3 +128,19 @@ Feature: get user groups
     And the HTTP status code should be "200"
     Then the groups returned by the API should be
       | users |
+
+
+  Scenario: normal user gets his/her groups
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | Alice    |
+    And group "group1" has been created
+    And group "group2" has been created
+    And user "Alice" has been added to group "group1"
+    And user "Alice" has been added to group "group2"
+    When user "Alice" gets all the groups of user "Alice" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
+      | group1 |
+      | group2 |

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2426,6 +2426,21 @@ trait Provisioning {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" tries to get all the groups using the provisioning API$/
+	 * @When /^user "([^"]*)" gets all the groups using the provisioning API$/
+	 *
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function userTriesToGetAllTheGroupsUsingTheProvisioningApi($user) {
+		$fullUrl = $this->getBaseUrl() . "/ocs/v{$this->ocsApiVersion}.php/cloud/groups";
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $this->getActualUsername($user), $this->getUserPassword($user)
+		);
+	}
+
+	/**
 	 * @When the administrator gets all the groups of user :user using the provisioning API
 	 *
 	 * @param string $user
@@ -3755,6 +3770,23 @@ trait Provisioning {
 			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$user/subadmins";
 		$this->response = HttpRequestHelper::get(
 			$fullUrl, $this->getAdminUsername(), $this->getAdminPassword()
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" gets all the groups where user "([^"]*)" is subadmin using the provisioning API$/
+	 * @When /^user "([^"]*)" tries to get all the groups where user "([^"]*)" is subadmin using the provisioning API$/
+	 *
+	 * @param string $user
+	 * @param string $anotherUser
+	 *
+	 * @return void
+	 */
+	public function userTriesToGetAllTheGroupsWhereUserIsSubadminUsingTheProvisioningApi($user, $anotherUser) {
+		$fullUrl = $this->getBaseUrl()
+			. "/ocs/v{$this->ocsApiVersion}.php/cloud/users/$anotherUser/subadmins";
+		$this->response = HttpRequestHelper::get(
+			$fullUrl, $this->getActualUsername($user), $this->getUserPassword($user)
 		);
 	}
 


### PR DESCRIPTION
## Description
expands apiProvisioningGroup tests for ocs v1 and v2 in:
- getGroups
- getSubAdminGroups
- getUserGroups

## Related Issue
- part of https://github.com/owncloud/core/issues/31533

## How Has This Been Tested?
- test environment: local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
