### PR TITLE
[tests-only] check that unlocking does not unlock other items with the same name

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -6,9 +6,9 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: a second lock cannot be set on a folder when its exclusively locked
     Given using <dav-path> DAV path
-    And user "Alice" has locked file "textfile0.txt" setting following properties
+    And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | exclusive |
-    When user "Alice" locks file "textfile0.txt" using the WebDAV API setting following properties
+    When user "Alice" locks file "textfile0.txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "423"
     And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
@@ -21,9 +21,9 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: if a parent resource is exclusively locked a child resource cannot be locked again
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | exclusive |
-    When user "Alice" locks folder "PARENT/CHILD" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT/CHILD" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "423"
     And 1 locks should be reported for file "PARENT/CHILD/child.txt" of user "Alice" by the WebDAV API
@@ -36,10 +36,10 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: if a parent resource is exclusively locked with depth 0 a child resource can be locked again
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | exclusive |
       | depth     | 0         |
-    When user "Alice" locks folder "PARENT/CHILD" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT/CHILD" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "200"
     And 1 locks should be reported for file "PARENT/CHILD/child.txt" of user "Alice" by the WebDAV API
@@ -53,9 +53,9 @@ Feature: there can be only one exclusive lock on a resource
   @skipOnOcV10 @issue-34358
   Scenario Outline: if a child resource is exclusively locked a parent resource cannot be locked again
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | exclusive |
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "423"
     And 1 locks should be reported for file "PARENT/CHILD/child.txt" of user "Alice" by the WebDAV API
@@ -68,9 +68,9 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: if a child resource is exclusively locked a parent resource can be locked with depth 0
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | exclusive |
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
       | depth     | 0            |
     Then the HTTP status code should be "200"
@@ -87,9 +87,9 @@ Feature: there can be only one exclusive lock on a resource
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Brian" has locked file "textfile0 (2).txt" setting following properties
+    And user "Brian" has locked file "textfile0 (2).txt" setting the following properties
       | lockscope | exclusive |
-    When user "Brian" locks file "textfile0 (2).txt" using the WebDAV API setting following properties
+    When user "Brian" locks file "textfile0 (2).txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "423"
     And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
@@ -106,9 +106,9 @@ Feature: there can be only one exclusive lock on a resource
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Alice" has locked file "textfile0.txt" setting following properties
+    And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | exclusive |
-    When user "Brian" locks file "textfile0 (2).txt" using the WebDAV API setting following properties
+    When user "Brian" locks file "textfile0 (2).txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "423"
     And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
@@ -125,9 +125,9 @@ Feature: there can be only one exclusive lock on a resource
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Brian" has locked file "textfile0 (2).txt" setting following properties
+    And user "Brian" has locked file "textfile0 (2).txt" setting the following properties
       | lockscope | exclusive |
-    When user "Alice" locks file "textfile0.txt" using the WebDAV API setting following properties
+    When user "Alice" locks file "textfile0.txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "423"
     And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
@@ -5,9 +5,9 @@ Feature: there can be only one exclusive lock on a resource
   Scenario Outline: if a child resource is exclusively locked a parent resource cannot be locked again
     Given user "Alice" has been created with default attributes and skeleton files
     And using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | exclusive |
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "200"
     And 2 locks should be reported for file "PARENT/CHILD/child.txt" of user "Alice" by the WebDAV API

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -7,7 +7,7 @@ Feature: lock folders
   @smokeTest
   Scenario Outline: upload to a locked folder
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "FOLDER" setting following properties
+    And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -21,7 +21,7 @@ Feature: lock folders
 
   Scenario Outline: upload to a subfolder of a locked folder
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/CHILD/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -36,7 +36,7 @@ Feature: lock folders
   @smokeTest
   Scenario Outline: create folder in a locked folder
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "FOLDER" setting following properties
+    And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" creates folder "/FOLDER/new-folder" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -50,7 +50,7 @@ Feature: lock folders
 
   Scenario Outline: create folder in a subfolder of a locked folder
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" creates folder "/PARENT/CHILD/new-folder" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -64,7 +64,7 @@ Feature: lock folders
 
   Scenario Outline: Move file out of a locked folder
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" moves file "/PARENT/parent.txt" to "/parent.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -79,7 +79,7 @@ Feature: lock folders
 
   Scenario Outline: Move file out of a locked sub folder one level higher into locked parent folder
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" moves file "/PARENT/CHILD/child.txt" to "/PARENT/child.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -95,7 +95,7 @@ Feature: lock folders
   Scenario Outline: lockdiscovery of a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
       | propertyName    |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -9,7 +9,7 @@ Feature: persistent-locking in case of a public link
   Scenario Outline: Uploading a file into a locked public folder
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share of folder "FOLDER" with change permission
-    When user "Alice" locks folder "FOLDER" using the WebDAV API setting following properties
+    When user "Alice" locks folder "FOLDER" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then uploading a file should not work using the old public WebDAV API
     And uploading a file should not work using the new public WebDAV API
@@ -24,7 +24,7 @@ Feature: persistent-locking in case of a public link
   @skipOnOcV10 @issue-36064
   Scenario Outline: Uploading a file into a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     And the public uploads file "CHILD/test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
@@ -39,7 +39,7 @@ Feature: persistent-locking in case of a public link
   @skipOnOcV10 @smokeTest @issue-36064
   Scenario Outline: Overwrite a file inside a locked public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
@@ -52,7 +52,7 @@ Feature: persistent-locking in case of a public link
   @skipOnOcV10 @issue-36064
   Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "changed text" using the <public-webdav-api-version> public WebDAV API
     And the public uploads file "CHILD/child.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
@@ -67,7 +67,7 @@ Feature: persistent-locking in case of a public link
   @smokeTest @skipOnOcV10.3
   Scenario Outline: Public locking is not supported
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    When the public locks "/CHILD" in the last public shared folder using the <public-webdav-api-version> public WebDAV API setting following properties
+    When the public locks "/CHILD" in the last public shared folder using the <public-webdav-api-version> public WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "405"
     And the value of the item "//s:message" in the response should be "Locking not allowed from public endpoint"

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -6,7 +6,7 @@ Feature: LOCKDISCOVERY for public links
 
   Scenario Outline: lockdiscovery root of public link when root is locked
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/" in the last created public link using the WebDAV API
       | propertyName    |
@@ -21,7 +21,7 @@ Feature: LOCKDISCOVERY for public links
 
   Scenario Outline: lockdiscovery subfolder of a locked public link when root is locked
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | propertyName    |
@@ -36,7 +36,7 @@ Feature: LOCKDISCOVERY for public links
 
   Scenario Outline: lockdiscovery subfolder of a public link when subfolder is locked
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | propertyName    |
@@ -51,7 +51,7 @@ Feature: LOCKDISCOVERY for public links
 
   Scenario Outline: lockdiscovery file in a subfolder of a public link when subfolder is locked
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | propertyName    |
@@ -66,7 +66,7 @@ Feature: LOCKDISCOVERY for public links
 
   Scenario Outline: lockdiscovery file in a subfolder of a public link when root is locked
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | propertyName    |
@@ -81,7 +81,7 @@ Feature: LOCKDISCOVERY for public links
 
   Scenario Outline: lockdiscovery file in a subfolder of a public link when the file is locked
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT/CHILD/child.txt" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD/child.txt" setting the following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | propertyName    |
@@ -96,7 +96,7 @@ Feature: LOCKDISCOVERY for public links
 
   Scenario Outline: lockdiscovery file in a subfolder of a public link when the folder above the public link is locked
     Given user "Alice" has created a public link share of folder "PARENT/CHILD" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public gets the following properties of entry "/child.txt" in the last created public link using the WebDAV API
       | propertyName    |

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
@@ -10,7 +10,7 @@ Feature: persistent-locking in case of a public link
   Scenario Outline: Uploading a file into a locked public folder
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share of folder "FOLDER" with change permission
-    When user "Alice" locks folder "FOLDER" using the WebDAV API setting following properties
+    When user "Alice" locks folder "FOLDER" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then uploading a file should not work using the old public WebDAV API
     And the HTTP status code should be "423"
@@ -25,7 +25,7 @@ Feature: persistent-locking in case of a public link
   @issue-36064
   Scenario Outline: Uploading a file into a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     And the public uploads file "CHILD/test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
@@ -41,7 +41,7 @@ Feature: persistent-locking in case of a public link
   #after fixing the issue delete this Scenario and use the one above
   Scenario Outline: Uploading a file into a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     And the public uploads file "CHILD/test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
@@ -56,7 +56,7 @@ Feature: persistent-locking in case of a public link
   @smokeTest @issue-36064
   Scenario Outline: Overwrite a file inside a locked public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
@@ -70,7 +70,7 @@ Feature: persistent-locking in case of a public link
   #after fixing the issue delete this Scenario and use the one above
   Scenario Outline: Overwrite a file inside a locked public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "204"
@@ -83,7 +83,7 @@ Feature: persistent-locking in case of a public link
   @issue-36064
   Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "changed text" using the <public-webdav-api-version> public WebDAV API
     And the public uploads file "CHILD/child.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
@@ -98,7 +98,7 @@ Feature: persistent-locking in case of a public link
   @issue-36064
   Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "changed text" using the <public-webdav-api-version> public WebDAV API
     And the public uploads file "CHILD/child.txt" with content "test" using the <public-webdav-api-version> public WebDAV API

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -7,7 +7,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @smokeTest
   Scenario Outline: rename a file in a locked folder
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" moves file "/PARENT/parent.txt" to "/PARENT/renamed-file.txt" sending the locktoken of folder "PARENT" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -23,7 +23,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @smokeTest
   Scenario Outline: move a file into a locked folder
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "FOLDER" setting following properties
+    And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" moves file "/PARENT/parent.txt" to "/FOLDER/moved-file.txt" sending the locktoken of folder "FOLDER" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -39,9 +39,9 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @smokeTest
   Scenario Outline: move a file into a locked folder is impossible when using the wrong token
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "FOLDER" setting following properties
+    And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" moves file "/PARENT/parent.txt" to "/FOLDER/moved-file.txt" sending the locktoken of folder "PARENT/CHILD" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -59,7 +59,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Brian" moves file "PARENT (2)/parent.txt" to "PARENT (2)/renamed-file.txt" sending the locktoken of file "PARENT" of user "Alice" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -76,7 +76,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
   Scenario Outline: public cannot overwrite a file in a folder locked by the owner even when sending the locktoken
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "Alice" using the old public WebDAV API
     Then the HTTP status code should be "423"
@@ -93,9 +93,9 @@ Feature: actions on a locked item are possible if the token is sent with the req
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Alice" has locked file "textfile0.txt" setting following properties
+    And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |
-    And user "Brian" has locked file "textfile0 (2).txt" setting following properties
+    And user "Brian" has locked file "textfile0 (2).txt" setting the following properties
       | lockscope | shared |
     When user "Alice" uploads file with content "from user 0" to "textfile0.txt" sending the locktoken of file "textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "200"

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
@@ -7,7 +7,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
     And using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Brian" moves file "PARENT (2)/parent.txt" to "PARENT (2)/renamed-file.txt" sending the locktoken of file "PARENT" of user "Alice" using the WebDAV API
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
@@ -7,9 +7,9 @@ Feature: actions on a locked item are possible if the token is sent with the req
     And using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Alice" has locked file "textfile0.txt" setting following properties
+    And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |
-    And user "Brian" has locked file "textfile0 (2).txt" setting following properties
+    And user "Brian" has locked file "textfile0 (2).txt" setting the following properties
       | lockscope | shared |
     When user "Alice" uploads file with content "from user 0" to "textfile0.txt" sending the locktoken of file "textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "423"

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesOc10Issue36064.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesOc10Issue36064.feature
@@ -12,7 +12,7 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
     And user "Carol" has created a public link share of folder "PARENT (2)" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "test.txt" with content "test" using the old public WebDAV API
     Then the HTTP status code should be "423"

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
@@ -12,7 +12,7 @@ Feature: lock should propagate correctly if a share is reshared
     Given using <dav-path> DAV path
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -32,7 +32,7 @@ Feature: lock should propagate correctly if a share is reshared
     Given using <dav-path> DAV path
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/parent.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -54,7 +54,7 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
     And user "Carol" has created a public link share of folder "PARENT (2)" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "test.txt" with content "test" using the new public WebDAV API
     Then the HTTP status code should be "423"
@@ -72,7 +72,7 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
     When user "Brian" moves folder "/PARENT (2)" to "/PARENT-renamed" using the WebDAV API
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -92,7 +92,7 @@ Feature: lock should propagate correctly if a share is reshared
     Given using <dav-path> DAV path
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
-    And user "Brian" has locked folder "PARENT (2)" setting following properties
+    And user "Brian" has locked folder "PARENT (2)" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "423"

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -17,7 +17,7 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has shared folder "Shares/PARENT" with user "Carol"
     And user "Carol" has accepted share "/PARENT" offered by user "Brian"
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -39,7 +39,7 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has shared folder "Shares/PARENT" with user "Carol"
     And user "Carol" has accepted share "/PARENT" offered by user "Brian"
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/parent.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -63,7 +63,7 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Brian" has shared folder "Shares/PARENT" with user "Carol"
     And user "Carol" has accepted share "/PARENT" offered by user "Brian"
     And user "Carol" has created a public link share of folder "Shares/PARENT" with change permission
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When the public uploads file "test.txt" with content "test" using the new public WebDAV API
     Then the HTTP status code should be "423"
@@ -83,7 +83,7 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Brian" has shared folder "Shares/PARENT" with user "Carol"
     And user "Carol" has accepted share "/PARENT" offered by user "Brian"
     When user "Brian" moves folder "/Shares/PARENT" to "/PARENT-renamed" using the WebDAV API
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "423"
@@ -105,7 +105,7 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has shared folder "Shares/PARENT" with user "Carol"
     And user "Carol" has accepted share "/PARENT" offered by user "Brian"
-    And user "Brian" has locked folder "Shares/PARENT" setting following properties
+    And user "Brian" has locked folder "Shares/PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "423"

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -9,7 +9,7 @@ Feature: set timeouts of LOCKS
     Given using <dav-path> DAV path
     And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"
     And parameter "lock_timeout_max" of app "core" has been set to "<max-timeout>"
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | exclusive |
     And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
       | propertyName    |
@@ -33,7 +33,7 @@ Feature: set timeouts of LOCKS
 
   Scenario Outline: set timeout on folder
     Given using <dav-path> DAV path
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
     And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
@@ -66,7 +66,7 @@ Feature: set timeouts of LOCKS
     Given using <dav-path> DAV path
     And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"
     And parameter "lock_timeout_max" of app "core" has been set to "<max-timeout>"
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
     And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
@@ -100,7 +100,7 @@ Feature: set timeouts of LOCKS
   Scenario Outline: as owner set timeout on folder as public check it
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share of folder "PARENT"
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
     And the public gets the following properties of entry "/" in the last created public link using the WebDAV API

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
@@ -9,7 +9,7 @@ Feature: set timeouts of LOCKS on shares
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
     And user "Brian" gets the following properties of folder "PARENT (2)" using the WebDAV API
@@ -42,7 +42,7 @@ Feature: set timeouts of LOCKS on shares
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
-    When user "Brian" locks folder "PARENT (2)" using the WebDAV API setting following properties
+    When user "Brian" locks folder "PARENT (2)" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
     And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -13,7 +13,7 @@ Feature: set timeouts of LOCKS on shares
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
     And user "Brian" gets the following properties of folder "Shares/PARENT" using the WebDAV API
@@ -47,7 +47,7 @@ Feature: set timeouts of LOCKS on shares
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
-    When user "Brian" locks folder "Shares/PARENT" using the WebDAV API setting following properties
+    When user "Brian" locks folder "Shares/PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
     And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
@@ -14,7 +14,7 @@ Feature: independent locks
     And user "Alice" has created folder "notlocked/PARENT"
     And user "Alice" has created folder "alsonotlocked"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/alsonotlocked/PARENT"
-    When user "Alice" locks folder "locked/PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "locked/PARENT" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/PARENT/file.txt"
     And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/alsonotlocked/PARENT"
@@ -33,7 +33,7 @@ Feature: independent locks
     And user "Alice" has created folder "notlocked/PARENT"
     And user "Alice" has created folder "alsonotlocked"
     And user "Alice" has created folder "alsonotlocked/PARENT"
-    When user "Alice" locks folder "PARENT" using the WebDAV API setting following properties
+    When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/PARENT/file.txt"
     And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/alsonotlocked/PARENT/file.txt"
@@ -52,7 +52,7 @@ Feature: independent locks
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/textfile0.txt"
     And user "Alice" has created folder "notlocked"
     And user "Alice" has created folder "notlocked/textfile0.txt"
-    When user "Alice" locks file "locked/textfile0.txt" using the WebDAV API setting following properties
+    When user "Alice" locks file "locked/textfile0.txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/textfile0.txt/real-file.txt"
     And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/textfile0.txt"
@@ -73,7 +73,7 @@ Feature: independent locks
     And user "Alice" has created folder "notlocked/"
     And user "Alice" has created folder "notlocked/<foldername>"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "notlocked/<foldername>/<filename>"
-    When user "Alice" locks file "locked/<to-lock>" using the WebDAV API setting following properties
+    When user "Alice" locks file "locked/<to-lock>" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/<foldername>/file.txt"
     And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/<foldername>/<filename>"

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToRoot.feature
@@ -14,7 +14,7 @@ Feature: independent locks
     And user "Brian" has created folder "toShare"
     And user "Alice" has shared folder "toShare" with user "Carol"
     And user "Brian" has shared folder "toShare" with user "Carol"
-    When user "Carol" locks folder "/toShare" using the WebDAV API setting following properties
+    When user "Carol" locks folder "/toShare" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/toShare (2)/file.txt"
     But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/toShare/file.txt"
@@ -34,7 +34,7 @@ Feature: independent locks
     And user "Alice" has created folder "notlocked/toShare"
     And user "Alice" has shared folder "locked/toShare" with user "Brian"
     And user "Alice" has shared folder "notlocked/toShare" with user "Brian"
-    When user "Brian" locks folder "/toShare" using the WebDAV API setting following properties
+    When user "Brian" locks folder "/toShare" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/toShare (2)/file.txt"
     But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/toShare/file.txt"
@@ -55,7 +55,7 @@ Feature: independent locks
     And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/FromBrian/textfile0.txt"
     And user "Alice" has shared folder "FromAlice" with user "Carol"
     And user "Brian" has shared folder "FromBrian" with user "Carol"
-    When user "Carol" locks file "/FromBrian/textfile0.txt" using the WebDAV API setting following properties
+    When user "Carol" locks file "/FromBrian/textfile0.txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/FromAlice/textfile0.txt"
     But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/FromBrian/textfile0.txt"
@@ -75,7 +75,7 @@ Feature: independent locks
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "notlocked/textfile0.txt"
     And user "Alice" has shared folder "locked" with user "Brian"
     And user "Alice" has shared folder "notlocked" with user "Brian"
-    When user "Brian" locks file "/locked/textfile0.txt" using the WebDAV API setting following properties
+    When user "Brian" locks file "/locked/textfile0.txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/textfile0.txt"
     But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/textfile0.txt"

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
@@ -18,7 +18,7 @@ Feature: independent locks
     And user "Brian" has shared folder "toShare" with user "Carol"
     And user "Carol" has accepted share "/toShare" offered by user "Alice"
     And user "Carol" has accepted share "/toShare" offered by user "Brian"
-    When user "Carol" locks folder "/Shares/toShare" using the WebDAV API setting following properties
+    When user "Carol" locks folder "/Shares/toShare" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare (2)/file.txt"
     But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare/file.txt"
@@ -40,7 +40,7 @@ Feature: independent locks
     And user "Alice" has shared folder "notlocked/toShare" with user "Brian"
     And user "Brian" has accepted share "/locked/toShare" offered by user "Alice"
     And user "Brian" has accepted share "/notlocked/toShare" offered by user "Alice"
-    When user "Brian" locks folder "/Shares/toShare" using the WebDAV API setting following properties
+    When user "Brian" locks folder "/Shares/toShare" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare (2)/file.txt"
     But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/toShare/file.txt"
@@ -63,7 +63,7 @@ Feature: independent locks
     And user "Brian" has shared folder "FromBrian" with user "Carol"
     And user "Carol" has accepted share "/FromAlice" offered by user "Alice"
     And user "Carol" has accepted share "/FromBrian" offered by user "Brian"
-    When user "Carol" locks file "/Shares/FromBrian/textfile0.txt" using the WebDAV API setting following properties
+    When user "Carol" locks file "/Shares/FromBrian/textfile0.txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Carol" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/FromAlice/textfile0.txt"
     But user "Carol" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/FromBrian/textfile0.txt"
@@ -85,7 +85,7 @@ Feature: independent locks
     And user "Alice" has shared folder "notlocked" with user "Brian"
     And user "Brian" has accepted share "/locked" offered by user "Alice"
     And user "Brian" has accepted share "/notlocked" offered by user "Alice"
-    When user "Brian" locks file "/Shares/locked/textfile0.txt" using the WebDAV API setting following properties
+    When user "Brian" locks file "/Shares/locked/textfile0.txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then user "Brian" should be able to upload file "filesForUpload/lorem.txt" to "/Shares/notlocked/textfile0.txt"
     But user "Brian" should not be able to upload file "filesForUpload/lorem.txt" to "/Shares/locked/textfile0.txt"

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
@@ -59,3 +59,55 @@ Feature: UNLOCK locked items
       | lock-scope |
       | shared     |
       | exclusive  |
+
+
+  Scenario Outline: locking a folder does not lock other items with the same name in other parts of the file system
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "locked"
+    And user "Alice" has created folder "locked/PARENT"
+    And user "Alice" has created folder "notlocked"
+    And user "Alice" has created folder "notlocked/PARENT"
+    And user "Alice" has created folder "alsonotlocked"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/alsonotlocked/PARENT"
+    Given user "Alice" has locked folder "locked/PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    Given user "Alice" has locked folder "notlocked/PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    Given user "Alice" has locked file "alsonotlocked/PARENT" setting following properties
+      | lockscope | <lock-scope> |
+    When user "Alice" unlocks the last created lock of folder "notlocked/PARENT" using the WebDAV API
+    And user "Alice" unlocks the last created lock of file "alsonotlocked/PARENT" using the WebDAV API
+    Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/PARENT/file.txt"
+    And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/alsonotlocked/PARENT"
+    But user "Alice" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/PARENT/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |
+
+
+  Scenario Outline: unlocking a file does not unlock other items with the same name in other parts of the file system
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "locked"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/textfile0.txt"
+    And user "Alice" has created folder "notlocked"
+    And user "Alice" has created folder "notlocked/textfile0.txt"
+    Given user "Alice" has locked file "locked/textfile0.txt" setting following properties
+      | lockscope | <lock-scope> |
+    And user "Alice" has locked file "notlocked/textfile0.txt" setting following properties
+      | lockscope | <lock-scope> |
+    And user "Alice" has locked file "textfile0.txt" setting following properties
+      | lockscope | <lock-scope> |
+    When user "Alice" unlocks the last created lock of file "unlocked/textfile0.txt" using the WebDAV API
+    And user "Alice" unlocks the last created lock of file "textfile0.txt" using the WebDAV API
+    Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/textfile0.txt/real-file.txt"
+    And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/textfile0.txt"
+    But user "Alice" should not be able to upload file "filesForUpload/lorem.txt" to "/locked/textfile0.txt"
+    Examples:
+      | dav-path | lock-scope |
+      | old      | shared     |
+      | old      | exclusive  |
+      | new      | shared     |
+      | new      | exclusive  |

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
@@ -61,7 +61,7 @@ Feature: UNLOCK locked items
       | exclusive  |
 
 
-  Scenario Outline: locking a folder does not lock other items with the same name in other parts of the file system
+  Scenario Outline: unlocking a file or folder does not unlock another folder with the same name in another part of the file system
     Given using <dav-path> DAV path
     And user "Alice" has created folder "locked"
     And user "Alice" has created folder "locked/PARENT"
@@ -88,7 +88,7 @@ Feature: UNLOCK locked items
       | new      | exclusive  |
 
 
-  Scenario Outline: unlocking a file does not unlock other items with the same name in other parts of the file system
+  Scenario Outline: unlocking a file or folder does not unlock another file with the same name in another part of the file system
     Given using <dav-path> DAV path
     And user "Alice" has created folder "locked"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/textfile0.txt"
@@ -100,7 +100,7 @@ Feature: UNLOCK locked items
       | lockscope | <lock-scope> |
     And user "Alice" has locked file "textfile0.txt" setting following properties
       | lockscope | <lock-scope> |
-    When user "Alice" unlocks the last created lock of file "unlocked/textfile0.txt" using the WebDAV API
+    When user "Alice" unlocks the last created lock of file "notlocked/textfile0.txt" using the WebDAV API
     And user "Alice" unlocks the last created lock of file "textfile0.txt" using the WebDAV API
     Then user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/notlocked/textfile0.txt/real-file.txt"
     And user "Alice" should be able to upload file "filesForUpload/lorem.txt" to "/textfile0.txt"

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
@@ -7,7 +7,7 @@ Feature: UNLOCK locked items
   @smokeTest
   Scenario Outline: unlock a single lock set by the user itself
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks the last created lock of folder "PARENT" using the WebDAV API
     Then 0 locks should be reported for folder "PARENT" of user "Alice" by the WebDAV API
@@ -22,9 +22,9 @@ Feature: UNLOCK locked items
 
   Scenario Outline: unlock one of multiple locks set by the user itself
     Given using <dav-path> DAV path
-    And user "Alice" has locked file "textfile0.txt" setting following properties
+    And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |
-    And user "Alice" has locked file "textfile0.txt" setting following properties
+    And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |
     When user "Alice" unlocks the last created lock of file "textfile0.txt" using the WebDAV API
     Then 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
@@ -35,7 +35,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: unlocking a file that was locked by the user locking the folder above is not possible
     Given using <dav-path> DAV path
-    And user "Alice" has locked folder "PARENT/CHILD" setting following properties
+    And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks file "PARENT/CHILD/child.txt" with the last created lock of folder "PARENT/CHILD" using the WebDAV API
     Then 1 locks should be reported for file "PARENT/CHILD/child.txt" of user "Alice" by the WebDAV API
@@ -50,7 +50,7 @@ Feature: UNLOCK locked items
   @skipOnOcV10 @issue-34302 @files_sharing-app-required @skipOnOcV10.3
   Scenario Outline: as public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked file "PARENT/parent.txt" setting following properties
+    And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     When the public unlocks file "/parent.txt" with the last created lock of file "PARENT/parent.txt" of user "Alice" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -69,11 +69,11 @@ Feature: UNLOCK locked items
     And user "Alice" has created folder "notlocked/PARENT"
     And user "Alice" has created folder "alsonotlocked"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/alsonotlocked/PARENT"
-    Given user "Alice" has locked folder "locked/PARENT" setting following properties
+    Given user "Alice" has locked folder "locked/PARENT" setting the following properties
       | lockscope | <lock-scope> |
-    Given user "Alice" has locked folder "notlocked/PARENT" setting following properties
+    Given user "Alice" has locked folder "notlocked/PARENT" setting the following properties
       | lockscope | <lock-scope> |
-    Given user "Alice" has locked file "alsonotlocked/PARENT" setting following properties
+    Given user "Alice" has locked file "alsonotlocked/PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks the last created lock of folder "notlocked/PARENT" using the WebDAV API
     And user "Alice" unlocks the last created lock of file "alsonotlocked/PARENT" using the WebDAV API
@@ -94,11 +94,11 @@ Feature: UNLOCK locked items
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/locked/textfile0.txt"
     And user "Alice" has created folder "notlocked"
     And user "Alice" has created folder "notlocked/textfile0.txt"
-    Given user "Alice" has locked file "locked/textfile0.txt" setting following properties
+    Given user "Alice" has locked file "locked/textfile0.txt" setting the following properties
       | lockscope | <lock-scope> |
-    And user "Alice" has locked file "notlocked/textfile0.txt" setting following properties
+    And user "Alice" has locked file "notlocked/textfile0.txt" setting the following properties
       | lockscope | <lock-scope> |
-    And user "Alice" has locked file "textfile0.txt" setting following properties
+    And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks the last created lock of file "notlocked/textfile0.txt" using the WebDAV API
     And user "Alice" unlocks the last created lock of file "textfile0.txt" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
@@ -5,7 +5,7 @@ Feature: UNLOCK locked items
   Scenario Outline: as public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
     Given user "Alice" has been created with default attributes and skeleton files
     And user "Alice" has created a public link share of folder "PARENT" with change permission
-    And user "Alice" has locked file "PARENT/parent.txt" setting following properties
+    And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     When the public unlocks file "/parent.txt" with the last created lock of file "PARENT/parent.txt" of user "Alice" using the WebDAV API
     Then the HTTP status code should be "405"

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
@@ -8,7 +8,7 @@ Feature: UNLOCK locked items (sharing)
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
-    And user "Alice" has locked file "PARENT/parent.txt" setting following properties
+    And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     When user "Brian" unlocks file "parent.txt" with the last created lock of file "PARENT/parent.txt" of user "Alice" using the WebDAV API
@@ -26,7 +26,7 @@ Feature: UNLOCK locked items (sharing)
   Scenario Outline: as share receiver unlocking a file in a share locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
-    And user "Alice" has locked file "PARENT/parent.txt" setting following properties
+    And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
     When user "Brian" unlocks file "PARENT (2)/parent.txt" with the last created lock of file "PARENT/parent.txt" of user "Alice" using the WebDAV API
@@ -44,7 +44,7 @@ Feature: UNLOCK locked items (sharing)
   Scenario Outline: as share receiver unlocking a shared folder locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
     When user "Brian" unlocks folder "PARENT (2)" with the last created lock of folder "PARENT" of user "Alice" using the WebDAV API
@@ -66,7 +66,7 @@ Feature: UNLOCK locked items (sharing)
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
-    And user "Alice" has locked file "PARENT/parent.txt" setting following properties
+    And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     When user "Brian" unlocks file "parent.txt" with the last created lock of file "PARENT/parent.txt" of user "Alice" using the WebDAV API
@@ -85,7 +85,7 @@ Feature: UNLOCK locked items (sharing)
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
-    And user "Brian" has locked file "parent.txt" setting following properties
+    And user "Brian" has locked file "parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     When user "Brian" unlocks the last created lock of file "parent.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -103,7 +103,7 @@ Feature: UNLOCK locked items (sharing)
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
-    And user "Brian" has locked file "parent.txt" setting following properties
+    And user "Brian" has locked file "parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks file "PARENT/parent.txt" with the last created lock of file "parent.txt" of user "Brian" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -121,7 +121,7 @@ Feature: UNLOCK locked items (sharing)
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
-    And user "Brian" has locked file "PARENT (2)/parent.txt" setting following properties
+    And user "Brian" has locked file "PARENT (2)/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks file "PARENT/parent.txt" with the last created lock of file "PARENT (2)/parent.txt" of user "Brian" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -139,7 +139,7 @@ Feature: UNLOCK locked items (sharing)
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
-    And user "Brian" has locked folder "PARENT (2)" setting following properties
+    And user "Brian" has locked folder "PARENT (2)" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks folder "PARENT" with the last created lock of folder "PARENT (2)" of user "Brian" using the WebDAV API
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -11,7 +11,7 @@ Feature: UNLOCK locked items (sharing)
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
-    And user "Alice" has locked file "PARENT/parent.txt" setting following properties
+    And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Alice"
@@ -30,7 +30,7 @@ Feature: UNLOCK locked items (sharing)
   Scenario Outline: as share receiver unlocking a file in a share locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
-    And user "Alice" has locked file "PARENT/parent.txt" setting following properties
+    And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
@@ -49,7 +49,7 @@ Feature: UNLOCK locked items (sharing)
   Scenario Outline: as share receiver unlocking a shared folder locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
-    And user "Alice" has locked folder "PARENT" setting following properties
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
@@ -72,7 +72,7 @@ Feature: UNLOCK locked items (sharing)
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and skeleton files
-    And user "Alice" has locked file "PARENT/parent.txt" setting following properties
+    And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Alice"
@@ -93,7 +93,7 @@ Feature: UNLOCK locked items (sharing)
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Alice"
-    And user "Brian" has locked file "Shares/parent.txt" setting following properties
+    And user "Brian" has locked file "Shares/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     When user "Brian" unlocks the last created lock of file "Shares/parent.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -112,7 +112,7 @@ Feature: UNLOCK locked items (sharing)
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Alice"
-    And user "Brian" has locked file "Shares/parent.txt" setting following properties
+    And user "Brian" has locked file "Shares/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks file "PARENT/parent.txt" with the last created lock of file "Shares/parent.txt" of user "Brian" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -131,7 +131,7 @@ Feature: UNLOCK locked items (sharing)
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
-    And user "Brian" has locked file "Shares/PARENT/parent.txt" setting following properties
+    And user "Brian" has locked file "Shares/PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks file "PARENT/parent.txt" with the last created lock of file "Shares/PARENT/parent.txt" of user "Brian" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -150,7 +150,7 @@ Feature: UNLOCK locked items (sharing)
     And user "Brian" has been created with default attributes and skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
-    And user "Brian" has locked folder "Shares/PARENT" setting following properties
+    And user "Brian" has locked folder "Shares/PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks folder "PARENT" with the last created lock of folder "Shares/PARENT" of user "Brian" using the WebDAV API
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -110,7 +110,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When user :user locks file/folder :file using the WebDAV API setting following properties
+	 * @When user :user locks file/folder :file using the WebDAV API setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -123,7 +123,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has locked file/folder :file setting following properties
+	 * @Given user :user has locked file/folder :file setting the following properties
 	 *
 	 * @param string $user
 	 * @param string $file
@@ -136,7 +136,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given the public has locked the last public shared file/folder setting following properties
+	 * @Given the public has locked the last public shared file/folder setting the following properties
 	 *
 	 * @param TableNode $properties
 	 *
@@ -150,7 +150,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the public locks the last public shared file/folder using the WebDAV API setting following properties
+	 * @When the public locks the last public shared file/folder using the WebDAV API setting the following properties
 	 *
 	 * @param TableNode $properties
 	 *
@@ -164,7 +164,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given the public has locked :file in the last public shared folder setting following properties
+	 * @Given the public has locked :file in the last public shared folder setting the following properties
 	 *
 	 * @param string $file
 	 * @param TableNode $properties
@@ -181,7 +181,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When /^the public locks "([^"]*)" in the last public shared folder using the (old|new) public WebDAV API setting following properties$/
+	 * @When /^the public locks "([^"]*)" in the last public shared folder using the (old|new) public WebDAV API setting the following properties$/
 	 *
 	 * @param string $file
 	 * @param string $publicWebDAVAPIVersion

--- a/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/delete.feature
@@ -14,7 +14,7 @@ Feature: Locks
   Scenario Outline: deleting a file in a public share of a locked folder
     Given user "brand-new-user" has created folder "/simple-folder"
     And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "brand-new-user" has locked folder "simple-folder" setting following properties
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has created a public link share with settings
       | path        | /simple-folder            |

--- a/tests/acceptance/features/webUIWebdavLockProtection/move.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/move.feature
@@ -13,7 +13,7 @@ Feature: Locks
   Scenario Outline: moving a locked file
     Given user "brand-new-user" has created folder "/simple-empty-folder"
     And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "brand-new-user" has locked file "lorem.txt" setting following properties
+    And user "brand-new-user" has locked file "lorem.txt" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     When the user moves file "lorem.txt" into folder "simple-empty-folder" using the webUI
@@ -33,7 +33,7 @@ Feature: Locks
     Given user "brand-new-user" has created folder "/simple-folder"
     And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
     And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "brand-new-user" has locked file "/simple-folder/lorem.txt" setting following properties
+    And user "brand-new-user" has locked file "/simple-folder/lorem.txt" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     When the user moves file "lorem.txt" into folder "simple-folder" using the webUI
@@ -50,7 +50,7 @@ Feature: Locks
   Scenario Outline: moving a file into a locked folder
     Given user "brand-new-user" has created folder "/simple-empty-folder"
     And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "brand-new-user" has locked file "/simple-empty-folder" setting following properties
+    And user "brand-new-user" has locked file "/simple-empty-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     When the user moves file "lorem.txt" into folder "simple-empty-folder" using the webUI
@@ -68,7 +68,7 @@ Feature: Locks
 
   Scenario Outline: renaming of a locked file
     Given user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    And user "brand-new-user" has locked file "lorem.txt" setting following properties
+    And user "brand-new-user" has locked file "lorem.txt" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     When the user renames file "lorem.txt" to "a-renamed-file.txt" using the webUI
@@ -88,7 +88,7 @@ Feature: Locks
   Scenario Outline: renaming a file in a public share of a locked folder
     Given user "brand-new-user" has created folder "/simple-folder"
     And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "brand-new-user" has locked folder "simple-folder" setting following properties
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with
@@ -110,7 +110,7 @@ Feature: Locks
     Given user "brand-new-user" has created folder "/simple-folder"
     And user "brand-new-user" has created folder "/simple-folder/simple-empty-folder"
     And user "brand-new-user" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
-    And user "brand-new-user" has locked file "simple-folder/lorem.txt" setting following properties
+    And user "brand-new-user" has locked file "simple-folder/lorem.txt" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with

--- a/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
+++ b/tests/acceptance/features/webUIWebdavLockProtection/upload.feature
@@ -12,7 +12,7 @@ Feature: Locks
 
   Scenario Outline: uploading a file, trying to overwrite a locked file
     Given user "brand-new-user" has uploaded file with content "original content" to "/lorem.txt"
-    And user "brand-new-user" has locked file "lorem.txt" setting following properties
+    And user "brand-new-user" has locked file "lorem.txt" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     When the user uploads overwriting file "lorem.txt" using the webUI
@@ -30,7 +30,7 @@ Feature: Locks
   Scenario Outline: uploading a file, trying to overwrite a file in a locked folder
     Given user "brand-new-user" has created folder "/simple-folder"
     And user "brand-new-user" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
-    And user "brand-new-user" has locked folder "simple-folder" setting following properties
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     And the user has opened folder "simple-folder" using the webUI
@@ -48,7 +48,7 @@ Feature: Locks
 
   Scenario Outline: uploading a new file into a locked folder
     Given user "brand-new-user" has created folder "/simple-folder"
-    And user "brand-new-user" has locked folder "simple-folder" setting following properties
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     And the user has opened folder "simple-folder" using the webUI
@@ -66,7 +66,7 @@ Feature: Locks
   Scenario Outline: uploading a file, trying to overwrite a file in a locked folder in a public share
     Given user "brand-new-user" has created folder "/simple-folder"
     And user "brand-new-user" has uploaded file with content "original content" to "/simple-folder/lorem.txt"
-    And user "brand-new-user" has locked folder "simple-folder" setting following properties
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "brand-new-user" has logged in using the webUI
     And the user has created a new public link for folder "simple-folder" using the webUI with

--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -12,9 +12,9 @@ Feature: Locks
     And user "brand-new-user" has logged in using the webUI
 
   Scenario: setting a lock shows the lock symbols at the correct files/folders
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked file "data.zip" setting following properties
+    And user "brand-new-user" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     When the user browses to the files page
     Then folder "simple-folder" should be marked as locked on the webUI
@@ -28,9 +28,9 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
-    Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
+    Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "user-with-display-name" has locked file "data.zip" setting following properties
+    And user "user-with-display-name" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     When the user re-logs in with username "user-with-display-name" and password "%regular%" using the webUI
     And folder "simple-folder" should be marked as locked by user "My fancy name" in the locks tab of the details panel on the webUI
@@ -41,9 +41,9 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
-    Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
+    Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "user-with-display-name" has locked file "data.zip" setting following properties
+    And user "user-with-display-name" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     And the administrator has changed the display name of user "user-with-display-name" to "An ordinary name"
     When the user re-logs in with username "user-with-display-name" and password "%regular%" using the webUI
@@ -54,9 +54,9 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username               | displayname   | email       |
       | user-with-display-name | My fancy name | mail@oc.org |
-    Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
+    Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "user-with-display-name" has locked file "data.zip" setting following properties
+    And user "user-with-display-name" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     When the user re-logs in with username "user-with-display-name" and password "%regular%" using the webUI
     And folder "simple-folder" should be marked as locked by user "My fancy name (mail@oc.org)" in the locks tab of the details panel on the webUI
@@ -66,18 +66,18 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username        | email       |
       | user-with-email | mail@oc.org |
-    Given user "user-with-email" has locked folder "simple-folder" setting following properties
+    Given user "user-with-email" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "user-with-email" has locked file "data.zip" setting following properties
+    And user "user-with-email" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     When the user re-logs in with username "user-with-email" and password "%regular%" using the webUI
     And folder "simple-folder" should be marked as locked by user "user-with-email (mail@oc.org)" in the locks tab of the details panel on the webUI
     And file "data.zip" should be marked as locked by user "user-with-email (mail@oc.org)" in the locks tab of the details panel on the webUI
 
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the favorites page
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked file "data.zip" setting following properties
+    And user "brand-new-user" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     When the user marks folder "simple-folder" as favorite using the webUI
     And the user marks folder "simple-empty-folder" as favorite using the webUI
@@ -96,9 +96,9 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username |
       | receiver |
-    And user "brand-new-user" has locked folder "simple-folder" setting following properties
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked file "data.zip" setting following properties
+    And user "brand-new-user" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     And user "brand-new-user" has shared file "data.zip" with user "receiver"
     And user "brand-new-user" has shared file "data.tar.gz" with user "receiver"
@@ -114,9 +114,9 @@ Feature: Locks
 
   @skipOnOcV10 @issue-33867 @files_sharing-app-required
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-by-link page
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked file "data.zip" setting following properties
+    And user "brand-new-user" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     And user "brand-new-user" has created a public link share with settings
       | path | data.zip |
@@ -139,9 +139,9 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username |
       | sharer   |
-    And user "sharer" has locked folder "simple-folder" setting following properties
+    And user "sharer" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "sharer" has locked file "data.zip" setting following properties
+    And user "sharer" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     And user "sharer" has shared file "data.zip" with user "brand-new-user"
     And user "sharer" has shared file "data.tar.gz" with user "brand-new-user"
@@ -172,13 +172,13 @@ Feature: Locks
     And user "sharer" has shared file "data.zip" with user "receiver"
     And user "sharer" has shared file "data.tar.gz" with group "receiver-group"
     And user "receiver" has shared file "data (2).zip" with user "brand-new-user"
-    And user "sharer" has locked file "data.zip" setting following properties
+    And user "sharer" has locked file "data.zip" setting the following properties
       | lockscope | shared |
-    And user "receiver" has locked file "data (2).zip" setting following properties
+    And user "receiver" has locked file "data (2).zip" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked file "data (2).zip" setting following properties
+    And user "brand-new-user" has locked file "data (2).zip" setting the following properties
       | lockscope | shared |
-    And user "receiver2" has locked file "data.tar (2).gz" setting following properties
+    And user "receiver2" has locked file "data.tar (2).gz" setting the following properties
       | lockscope | shared |
     When the user browses to the files page
     Then file "data (2).zip" should be marked as locked on the webUI
@@ -198,7 +198,7 @@ Feature: Locks
     And file "data.tar (2).gz" should be marked as locked by user "receiver2" in the locks tab of the details panel on the webUI
 
   Scenario: setting a lock on a folder shows the symbols at the sub-elements
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
     When the user opens folder "simple-folder" using the webUI
     Then folder "simple-empty-folder" should be marked as locked on the webUI
@@ -207,7 +207,7 @@ Feature: Locks
     And file "data.zip" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
 
   Scenario: setting a depth:0 lock on a folder does not shows the symbols at the sub-elements
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | depth | 0 |
     When the user browses to the files page
     Then folder "simple-folder" should be marked as locked on the webUI
@@ -221,7 +221,7 @@ Feature: Locks
       | username |
       | sharer   |
     And user "sharer" has created folder "/to-share-folder"
-    And user "sharer" has locked folder "to-share-folder" setting following properties
+    And user "sharer" has locked folder "to-share-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "sharer" has shared folder "to-share-folder" with user "brand-new-user"
     When the user declines share "to-share-folder" offered by user "sharer" using the webUI
@@ -240,7 +240,7 @@ Feature: Locks
       | username |
       | sharer   |
     And user "sharer" has created folder "/to-share-folder"
-    And user "sharer" has locked folder "to-share-folder" setting following properties
+    And user "sharer" has locked folder "to-share-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "sharer" has shared folder "to-share-folder" with user "brand-new-user"
     When the user declines share "to-share-folder" offered by user "sharer" using the webUI
@@ -261,7 +261,7 @@ Feature: Locks
       | username |
       | sharer   |
     And user "sharer" has created folder "/to-share-folder"
-    And user "sharer" has locked folder "to-share-folder" setting following properties
+    And user "sharer" has locked folder "to-share-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "sharer" has shared folder "to-share-folder" with user "brand-new-user"
     When the user declines share "to-share-folder" offered by user "sharer" using the webUI
@@ -285,7 +285,7 @@ Feature: Locks
       | sharer   |
     And user "sharer" has created folder "/parent"
     And user "sharer" has created folder "/parent/subfolder"
-    And user "sharer" has locked folder "parent" setting following properties
+    And user "sharer" has locked folder "parent" setting the following properties
       | lockscope | <lockscope> |
     And user "sharer" has shared folder "parent" with user "brand-new-user"
     When the user declines share "parent" offered by user "sharer" using the webUI
@@ -307,9 +307,9 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username |
       | sharer   |
-    And user "sharer" has locked file "lorem.txt" setting following properties
+    And user "sharer" has locked file "lorem.txt" setting the following properties
       | lockscope | <lockscope> |
-    And user "sharer" has locked folder "simple-folder" setting following properties
+    And user "sharer" has locked folder "simple-folder" setting the following properties
       | lockscope | <lockscope> |
     And user "sharer" has shared file "lorem.txt" with user "brand-new-user"
     And user "sharer" has shared folder "simple-folder" with user "brand-new-user"

--- a/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue33867.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue33867.feature
@@ -16,9 +16,9 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username |
       | sharer   |
-    And user "sharer" has locked folder "simple-folder" setting following properties
+    And user "sharer" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "sharer" has locked file "data.zip" setting following properties
+    And user "sharer" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     And user "sharer" has shared file "data.zip" with user "brand-new-user"
     And user "sharer" has shared file "data.tar.gz" with user "brand-new-user"
@@ -38,9 +38,9 @@ Feature: Locks
 
   @issue-33867 @files_sharing-app-required
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-by-link page
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked file "data.zip" setting following properties
+    And user "brand-new-user" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     And user "brand-new-user" has created a public link share with settings
       | path | data.zip |
@@ -67,9 +67,9 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username |
       | sharer   |
-    And user "sharer" has locked folder "simple-folder" setting following properties
+    And user "sharer" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "sharer" has locked file "data.zip" setting following properties
+    And user "sharer" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     And user "sharer" has shared file "data.zip" with user "brand-new-user"
     And user "sharer" has shared file "data.tar.gz" with user "brand-new-user"

--- a/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue34315.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue34315.feature
@@ -16,9 +16,9 @@ Feature: Locks
     Given these users have been created with skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
-    Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
+    Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "user-with-display-name" has locked file "data.zip" setting following properties
+    And user "user-with-display-name" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     And the administrator has changed the display name of user "user-with-display-name" to "An ordinary name"
     When the user re-logs in with username "user-with-display-name" and password "%regular%" using the webUI

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -12,7 +12,7 @@ Feature: Unlock locked files and folders
     And user "brand-new-user" has logged in using the webUI
 
   Scenario: unlocking by webDAV deletes the lock symbols at the correct files/folders
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
     When user "brand-new-user" unlocks the last created lock of folder "simple-folder" using the WebDAV API
     And the user browses to the files page
@@ -22,9 +22,9 @@ Feature: Unlock locked files and folders
     Given these users have been created with skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
-    Given user "user-with-display-name" has locked folder "simple-folder" setting following properties
+    Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
-    And user "user-with-display-name" has locked file "data.zip" setting following properties
+    And user "user-with-display-name" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
     And the administrator has changed the display name of user "user-with-display-name" to "An ordinary name"
     When user "user-with-display-name" unlocks the last created lock of folder "simple-folder" using the WebDAV API
@@ -33,9 +33,9 @@ Feature: Unlock locked files and folders
 
   @skipOnLDAP
   Scenario Outline: deleting the only remaining lock of a file/folder
-    Given user "brand-new-user" has locked file "lorem.txt" setting following properties
+    Given user "brand-new-user" has locked file "lorem.txt" setting the following properties
       | lockscope | <lockscope> |
-    And user "brand-new-user" has locked folder "simple-folder" setting following properties
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | <lockscope> |
     And the user has browsed to the files page
     When the user unlocks the lock no 1 of file "lorem.txt" on the webUI
@@ -52,9 +52,9 @@ Feature: Unlock locked files and folders
 
   @skipOnLDAP
   Scenario Outline: deleting the only remaining lock of a file/folder and reloading the page
-    Given user "brand-new-user" has locked file "lorem.txt" setting following properties
+    Given user "brand-new-user" has locked file "lorem.txt" setting the following properties
       | lockscope | exclusive |
-    And user "brand-new-user" has locked folder "simple-folder" setting following properties
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | exclusive |
     And the user has browsed to the files page
     When the user unlocks the lock no 1 of file "lorem.txt" on the webUI
@@ -72,7 +72,7 @@ Feature: Unlock locked files and folders
 
   @skipOnLDAP
   Scenario Outline: deleting the only remaining lock of a folder by deleting it from a file in folder
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | <lockscope> |
     And the user has browsed to the files page
     And the user has opened folder "simple-folder" using the webUI
@@ -92,7 +92,7 @@ Feature: Unlock locked files and folders
 
   @skipOnLDAP
   Scenario Outline: deleting the only remaining lock of a folder by deleting it from a file in folder and reloading the page
-    Given user "brand-new-user" has locked folder "simple-folder" setting following properties
+    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | <lockscope> |
     And the user has browsed to the files page
     And the user has opened folder "simple-folder" using the webUI
@@ -123,17 +123,17 @@ Feature: Unlock locked files and folders
     And user "brand-new-user" has shared folder "/FOLDER_TO_SHARE" with user "receiver1"
     And user "brand-new-user" has shared file "/lorem.txt" with user "receiver2"
     And user "brand-new-user" has shared folder "/FOLDER_TO_SHARE" with user "receiver2"
-    And user "brand-new-user" has locked file "lorem.txt" setting following properties
+    And user "brand-new-user" has locked file "lorem.txt" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked folder "FOLDER_TO_SHARE" setting following properties
+    And user "brand-new-user" has locked folder "FOLDER_TO_SHARE" setting the following properties
       | lockscope | shared |
-    And user "receiver1" has locked file "lorem (2).txt" setting following properties
+    And user "receiver1" has locked file "lorem (2).txt" setting the following properties
       | lockscope | shared |
-    And user "receiver1" has locked folder "FOLDER_TO_SHARE" setting following properties
+    And user "receiver1" has locked folder "FOLDER_TO_SHARE" setting the following properties
       | lockscope | shared |
-    And user "receiver2" has locked file "lorem (2).txt" setting following properties
+    And user "receiver2" has locked file "lorem (2).txt" setting the following properties
       | lockscope | shared |
-    And user "receiver2" has locked folder "FOLDER_TO_SHARE" setting following properties
+    And user "receiver2" has locked folder "FOLDER_TO_SHARE" setting the following properties
       | lockscope | shared |
     And the user has browsed to the files page
     When the user unlocks the lock no 1 of file "lorem.txt" on the webUI
@@ -164,17 +164,17 @@ Feature: Unlock locked files and folders
     And user "brand-new-user" has shared folder "/FOLDER_TO_SHARE" with user "receiver1"
     And user "brand-new-user" has shared file "/lorem.txt" with user "receiver2"
     And user "brand-new-user" has shared folder "/FOLDER_TO_SHARE" with user "receiver2"
-    And user "receiver1" has locked file "lorem (2).txt" setting following properties
+    And user "receiver1" has locked file "lorem (2).txt" setting the following properties
       | lockscope | shared |
-    And user "receiver1" has locked folder "FOLDER_TO_SHARE" setting following properties
+    And user "receiver1" has locked folder "FOLDER_TO_SHARE" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked file "lorem.txt" setting following properties
+    And user "brand-new-user" has locked file "lorem.txt" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked folder "FOLDER_TO_SHARE" setting following properties
+    And user "brand-new-user" has locked folder "FOLDER_TO_SHARE" setting the following properties
       | lockscope | shared |
-    And user "receiver2" has locked file "lorem (2).txt" setting following properties
+    And user "receiver2" has locked file "lorem (2).txt" setting the following properties
       | lockscope | shared |
-    And user "receiver2" has locked folder "FOLDER_TO_SHARE" setting following properties
+    And user "receiver2" has locked folder "FOLDER_TO_SHARE" setting the following properties
       | lockscope | shared |
     And the user has browsed to the files page
     When the user unlocks the lock no 2 of file "lorem.txt" on the webUI
@@ -205,17 +205,17 @@ Feature: Unlock locked files and folders
     And user "brand-new-user" has shared folder "/FOLDER_TO_SHARE" with user "receiver1"
     And user "brand-new-user" has shared file "/lorem.txt" with user "receiver2"
     And user "brand-new-user" has shared folder "/FOLDER_TO_SHARE" with user "receiver2"
-    And user "receiver1" has locked file "lorem (2).txt" setting following properties
+    And user "receiver1" has locked file "lorem (2).txt" setting the following properties
       | lockscope | shared |
-    And user "receiver1" has locked folder "FOLDER_TO_SHARE" setting following properties
+    And user "receiver1" has locked folder "FOLDER_TO_SHARE" setting the following properties
       | lockscope | shared |
-    And user "receiver2" has locked file "lorem (2).txt" setting following properties
+    And user "receiver2" has locked file "lorem (2).txt" setting the following properties
       | lockscope | shared |
-    And user "receiver2" has locked folder "FOLDER_TO_SHARE" setting following properties
+    And user "receiver2" has locked folder "FOLDER_TO_SHARE" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked file "lorem.txt" setting following properties
+    And user "brand-new-user" has locked file "lorem.txt" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked folder "FOLDER_TO_SHARE" setting following properties
+    And user "brand-new-user" has locked folder "FOLDER_TO_SHARE" setting the following properties
       | lockscope | shared |
     And the user has browsed to the files page
     When the user unlocks the lock no 3 of file "lorem.txt" on the webUI
@@ -239,7 +239,7 @@ Feature: Unlock locked files and folders
       | username  |
       | receiver1 |
     And user "brand-new-user" has shared file "/lorem.txt" with user "receiver1"
-    And user "receiver1" has locked file "lorem (2).txt" setting following properties
+    And user "receiver1" has locked file "lorem (2).txt" setting the following properties
       | lockscope | <lockscope> |
     And the user has browsed to the files page
     When the user unlocks the lock no 1 of file "lorem.txt" on the webUI
@@ -255,7 +255,7 @@ Feature: Unlock locked files and folders
       | shared    |
 
   Scenario Outline: deleting a locked file
-    Given user "brand-new-user" has locked file "lorem.txt" setting following properties
+    Given user "brand-new-user" has locked file "lorem.txt" setting the following properties
       | lockscope | <lockscope> |
     And the user has browsed to the files page
     When the user deletes file "lorem.txt" using the webUI


### PR DESCRIPTION
## Description
test that when a file/folder is unlocked other items in the filesystem with the same name don't get unlocked

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #38302 

## Motivation and Context
make sure owncloud/enterprise#4355 is not caused by webdav locks

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
