### PR TITLE
[Tests-Only] Add API test for deleting a share with wrong authentication

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
@@ -174,3 +174,20 @@ Feature: sharing
       | /PARENT/parent.txt | 2               | 404              | parent.txt     |
       | /PARENT            | 1               | 200              | PARENT         |
       | /PARENT            | 2               | 404              | PARENT         |
+
+  @issue-ocis-1229
+  Scenario Outline: delete a share with wrong authentication
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    When user "Brian" tries to delete the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 404             | 200              |
+      | 2               | 404             | 404              |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -197,3 +197,16 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  @issue-ocis-1229
+  Scenario Outline: delete a share with wrong authentication
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" tries to delete the last share using the sharing API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 404             | 200              |
+      | 2               | 404             | 404              |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1587,6 +1587,7 @@ trait Sharing {
 
 	/**
 	 * @When /^user "([^"]*)" deletes the last share using the sharing API$/
+	 * @When /^user "([^"]*)" tries to delete the last share using the sharing API$/
 	 *
 	 * @param string $user
 	 *


### PR DESCRIPTION
## Description
adds API test for trying to delete a share with wrong auhentication

>Note: needs to be added in expected_to_fail file in ocis

## Related Issue
- https://github.com/owncloud/ocis/issues/1229

## How Has This Been Tested?
- test environment: local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
