### PR TITLE
Encryption: new config.sample parameter to define the file format

### DIFF
--- a/changelog/unreleased/38337
+++ b/changelog/unreleased/38337
@@ -1,0 +1,9 @@
+Enhancement: New config parameter to define the encrypted file format
+
+A new config parameter has been introduced to define if encrypted files
+are written in the old or new format. The new format has a significant
+reduced filesize and is set to default. Files in the old format are still
+readable, only new encrypted files are written in the new format. 
+
+https://github.com/owncloud/core/pull/38337
+https://github.com/owncloud/encryption/pull/224

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1352,6 +1352,16 @@ $CONFIG = [
 'cipher' => 'AES-256-CFB',
 
 /**
+ * Define the file format for encrypting files
+ * Define if encrypted files will be written in the old format (`true`) or the new
+ * binary format (`false`) which has a significant reduced filesize. Defaults to `false`.
+ * With binary, only new files are written in the binary format, existing encrypted files
+ * in the old format stay readable. This guarantees a smooth transition.
+ */
+
+'encryption.use_legacy_encoding' => false,
+
+/**
  * Define the minimum supported ownCloud desktop client version
  * Define the minimum ownCloud desktop client version that is allowed to sync with
  * this server instance. All connections made from earlier clients will be denied


### PR DESCRIPTION
## Description
Add a new config.sample.php parmeter `encryption.use_legacy_encoding` 

## Related Issue
https://github.com/owncloud/encryption/pull/224 (allow binary encoding for written files to reduce file size)

## Motivation and Context
Allow writing in the new and old format

## How Has This Been Tested?
See the refrenced PR

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)


Set to draft until the final definition is made.
**Merge only if the referenced PR has been merged.** 
Post merging, a `config-to-docs` run must be made in docs to transport the changes into the documentation.