### PR TITLE
[tests-only] Bump behat/gherkin to 4.7.1

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "behat/behat": "^3.8",
-        "behat/gherkin": "4.6.2",
+        "behat/gherkin": "4.7.1",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
         "behat/mink-selenium2-driver": "^1.4",


### PR DESCRIPTION
## Description
```
$ composer update
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading behat/gherkin (v4.6.2 => v4.7.1)
```

I have pinned to 4.7.1 for now. What to do about test tool dependencies? Currently we let them automatically just fetch the "latest compatible release version", and sometimes that means that we wake up and discover that CI has broken overnight. But if we pin the version(s) then there needs to be regular checks and PRs to implement newer versions.


## Related Issue
- Fixes #38338 


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
