### PR TITLE
[tests-only] Skip new resetUserPassword tests on user-keys encryption

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -97,6 +97,7 @@ Feature: reset user password
     Then the OCS status code should be "998"
     And the HTTP status code should be "200"
 
+  @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: admin resets password of user with admin permissions
     Given these users have been created with skeleton files:
       | username | password  | displayname | email           |
@@ -108,6 +109,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "Alice" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "Alice" using password "%regular%" should not be able to download file "textfile0.txt"
 
+  @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user with subadmin permissions in their group
     Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |
@@ -122,6 +124,7 @@ Feature: reset user password
     And the HTTP status code should be "200"
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
+
 
   Scenario: subadmin should not be able to reset the password of another subadmin of same group
     Given these users have been created with skeleton files:

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -97,6 +97,7 @@ Feature: reset user password
     Then the OCS status code should be "998"
     And the HTTP status code should be "404"
 
+  @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: admin resets password of user with admin permissions
     Given these users have been created with skeleton files:
       | username | password  | displayname | email           |
@@ -108,6 +109,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "Alice" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "Alice" using password "%regular%" should not be able to download file "textfile0.txt"
 
+  @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user with subadmin permissions in their group
     Given these users have been created with skeleton files:
       | username       | password   | displayname | email                    |
@@ -122,6 +124,7 @@ Feature: reset user password
     And the HTTP status code should be "200"
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
+
 
   Scenario: subadmin should not be able to reset the password of another subadmin of same group
     Given these users have been created with skeleton files:


### PR DESCRIPTION
## Description
See issue.

## Related Issue
- Fixes https://github.com/owncloud/encryption/issues/233

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
