### PR TITLE
[Tests-Only] api tests for moving file

### DIFF
--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -220,3 +220,17 @@ Feature: sharing
       | sharer_folder | group_folder    | receiver_file  |
       | ?abc=oc #     | ?abc=oc g%rp#   | # oc?test=oc&a |
       | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d   |
+
+  Scenario: receiver moves file within a received folder to new folder
+    Given user "Alice" has created folder "folderToShare"
+    And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileToShare1.txt"
+    And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileToShare2.txt"
+    And user "Alice" has shared folder "folderToShare" with user "Brian" with permissions "share,read,change"
+    And user "Brian" has accepted share "/folderToShare" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/folderToShare/fileToShare1.txt" to "FOLDER" using the WebDAV API
+    And user "Brian" moves folder "/Shares/folderToShare/fileToShare2.txt" to "FOLDER" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Brian" file "FOLDER/fileToShare1.txt" should exist
+    And as "Brian" file "FOLDER/fileToShare2.txt" should exist
+    But as "Alice" folder "/folderToShare/fileToShare1.txt" should not exist
+    And as "Alice" folder "/folderToShare/fileToShare2.txt" should not exist

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -224,13 +224,13 @@ Feature: sharing
   Scenario: receiver moves file within a received folder to new folder
     Given user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileToShare1.txt"
-    And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileToShare2.txt"
+    And user "Alice" has uploaded file with content "thisIsAnotherFileInsideTheSharedFolder" to "/folderToShare/fileToShare2.txt"
     And user "Alice" has shared folder "folderToShare" with user "Brian" with permissions "share,read,change"
     And user "Brian" has accepted share "/folderToShare" offered by user "Alice"
-    When user "Brian" moves folder "/Shares/folderToShare/fileToShare1.txt" to "FOLDER" using the WebDAV API
-    And user "Brian" moves folder "/Shares/folderToShare/fileToShare2.txt" to "FOLDER" using the WebDAV API
-    Then the HTTP status code should be "204"
-    And as "Brian" file "FOLDER/fileToShare1.txt" should exist
-    And as "Brian" file "FOLDER/fileToShare2.txt" should exist
-    But as "Alice" folder "/folderToShare/fileToShare1.txt" should not exist
-    And as "Alice" folder "/folderToShare/fileToShare2.txt" should not exist
+    When user "Brian" moves file "/Shares/folderToShare/fileToShare1.txt" to "/FOLDER/fileToShare1.txt" using the WebDAV API
+    And user "Brian" moves file "/Shares/folderToShare/fileToShare2.txt" to "/FOLDER/fileToShare2.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/FOLDER/fileToShare1.txt" should exist
+    And as "Brian" file "/FOLDER/fileToShare2.txt" should exist
+    But as "Alice" file "/folderToShare/fileToShare1.txt" should not exist
+    And as "Alice" file "/folderToShare/fileToShare2.txt" should not exist

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1046,6 +1046,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When /^the user (declines|accepts) share "([^"]*)" offered by user "([^"]*)" using the webUI$/
+	 * @Given /^the user has (declined|accepted) share "([^"]*)" offered by user "([^"]*)" using the webUI$/
 	 *
 	 * @param string $action
 	 * @param string $share

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -92,3 +92,20 @@ Feature: move files
     Then file "data.zip" should not be listed on the webUI
     And as "Alice" file "simple-folder/simple-empty-folder/data.zip" should exist
     But as "Alice" file "simple-folder/data.zip" should not exist
+
+  @files_sharing-app-required
+  Scenario: receiver moves file within a received folder to new folder using webUI
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "Alice" has uploaded file with content "file to share 1" to "/simple-empty-folder/fileToShare1.txt"
+    And user "Alice" has uploaded file with content "file to share 2" to "/simple-empty-folder/fileToShare2.txt"
+    And user "Alice" has shared folder "simple-empty-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    And the user accepts share "simple-empty-folder" offered by user "Alice" using the webUI
+    When the user moves file "/Shares/simple-empty/fileToShare1.txt" into folder "/simple-folder" using the webUI
+    And user "Brian" moves folder "/Shares/FOLDER/fileToShare2.txt" to "/simple-folder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/simple-folder/fileToShare1.txt" should exist
+    And as "Brian" file "/simple-folder/fileToShare2.txt" should exist
+    But as "Alice" file "/simple-empty-folder/fileToShare1.txt" should not exist
+    But as "Alice" file "/simple-empty-folder/fileToShare2.txt" should not exist

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -92,20 +92,3 @@ Feature: move files
     Then file "data.zip" should not be listed on the webUI
     And as "Alice" file "simple-folder/simple-empty-folder/data.zip" should exist
     But as "Alice" file "simple-folder/data.zip" should not exist
-
-  @files_sharing-app-required
-  Scenario: receiver moves file within a received folder to new folder using webUI
-    Given user "Brian" has been created with default attributes and without skeleton files
-    And the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "Alice" has uploaded file with content "file to share 1" to "/simple-empty-folder/fileToShare1.txt"
-    And user "Alice" has uploaded file with content "file to share 2" to "/simple-empty-folder/fileToShare2.txt"
-    And user "Alice" has shared folder "simple-empty-folder" with user "Brian"
-    And user "Brian" has logged in using the webUI
-    And the user accepts share "simple-empty-folder" offered by user "Alice" using the webUI
-    When the user moves file "/Shares/simple-empty/fileToShare1.txt" into folder "/simple-folder" using the webUI
-    And user "Brian" moves folder "/Shares/FOLDER/fileToShare2.txt" to "/simple-folder" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And as "Brian" file "/simple-folder/fileToShare1.txt" should exist
-    And as "Brian" file "/simple-folder/fileToShare2.txt" should exist
-    But as "Alice" file "/simple-empty-folder/fileToShare1.txt" should not exist
-    But as "Alice" file "/simple-empty-folder/fileToShare2.txt" should not exist


### PR DESCRIPTION
## Description
This PR adds api test for moving file within a received shared folder to new destination.

## Related Issue
- https://github.com/owncloud/ocis/issues/873

## How Has This Been Tested?
- CI
- https://github.com/owncloud/ocis/pull/1537

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
