### PR TITLE
[tests-only] Add API tests to expand addUser tests

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -140,3 +140,26 @@ Feature: add user
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "brand-new-user" should not exist
+
+  Scenario: subadmin should be able to create a new user into their group
+    Given user "brand-new-user" has been deleted
+    And user "subadmin" has been created with default attributes and without skeleton files
+    And group "group101" has been created
+    And user "subadmin" has been added to group "group101"
+    And user "subadmin" has been made a subadmin of group "group101"
+    When the groupadmin "subadmin" sends a user creation request for user "brand-new-user" password "%alt1%" group "group101" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
+
+  Scenario: subadmin should not be able to create a new user into other group
+    Given user "brand-new-user" has been deleted
+    And user "subadmin" has been created with default attributes and without skeleton files
+    And group "group101" has been created
+    And group "group102" has been created
+    And user "subadmin" has been added to group "group101"
+    And user "subadmin" has been made a subadmin of group "group101"
+    When the groupadmin "subadmin" tries to create new user "brand-new-user" password "%alt1%" in other group "group102" using the provisioning API
+    Then the OCS status code should be "105"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should not exist

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -140,3 +140,26 @@ Feature: add user
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And user "brand-new-user" should not exist
+
+  Scenario: subadmin should be able to create a new user into their group
+    Given user "brand-new-user" has been deleted
+    And user "subadmin" has been created with default attributes and without skeleton files
+    And group "group101" has been created
+    And user "subadmin" has been added to group "group101"
+    And user "subadmin" has been made a subadmin of group "group101"
+    When the groupadmin "subadmin" sends a user creation request for user "brand-new-user" password "%alt1%" group "group101" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should exist
+
+  Scenario: subadmin should not be able to create a new user into other group
+    Given user "brand-new-user" has been deleted
+    And user "subadmin" has been created with default attributes and without skeleton files
+    And group "group101" has been created
+    And group "group102" has been created
+    And user "subadmin" has been added to group "group101"
+    And user "subadmin" has been made a subadmin of group "group101"
+    When the groupadmin "subadmin" tries to create new user "brand-new-user" password "%alt1%" in other group "group102" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And user "brand-new-user" should not exist

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1366,6 +1366,13 @@ trait Provisioning {
 			"/cloud/users",
 			$bodyTable
 		);
+		$this->addUserToCreatedUsersList(
+			$userToCreate,
+			$password,
+			null,
+			$email,
+			$this->theHTTPStatusCodeWasSuccess()
+		);
 	}
 
 	/**
@@ -1416,6 +1423,105 @@ trait Provisioning {
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$this->manuallyAddSkeletonFilesForUser($user, $password);
 		}
+	}
+
+	/**
+	 * @When /^the groupadmin "([^"]*)" sends a user creation request for user "([^"]*)" password "([^"]*)" group "([^"]*)" using the provisioning API$/
+	 *
+	 * @param string $groupadmin
+	 * @param string $userToCreate
+	 * @param string $password
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theGroupAdminCreatesUserPasswordGroupUsingTheProvisioningApi(
+		$groupadmin, $userToCreate, $password, $group
+	) {
+		$userToCreate = $this->getActualUsername($userToCreate);
+		$password = $this->getActualPassword($password);
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			$email = $userToCreate . '@owncloud.org';
+			$bodyTable = new TableNode(
+				[
+					['userid', $userToCreate],
+					['password', $userToCreate],
+					['username', $userToCreate],
+					['email', $email],
+					['groups[]', $group],
+				]
+			);
+		} else {
+			$email = null;
+			$bodyTable = new TableNode(
+				[['userid', $userToCreate], ['password', $password], ['groups[]', $group]]
+			);
+		}
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$groupadmin,
+			"POST",
+			"/cloud/users",
+			$bodyTable
+		);
+		$this->addUserToCreatedUsersList(
+			$userToCreate,
+			$password,
+			null,
+			$email,
+			$this->theHTTPStatusCodeWasSuccess()
+		);
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			$this->manuallyAddSkeletonFilesForUser($userToCreate, $password);
+		}
+	}
+
+	/**
+	 * @When /^the groupadmin "([^"]*)" tries to create new user "([^"]*)" password "([^"]*)" in other group "([^"]*)" using the provisioning API$/
+	 *
+	 * @param string $groupadmin
+	 * @param string $userToCreate
+	 * @param string $password
+	 * @param string $group
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theGroupAdminCreatesUserPasswordInOtherGroupUsingTheProvisioningApi(
+		$groupadmin, $userToCreate, $password, $group
+	) {
+		$userToCreate = $this->getActualUsername($userToCreate);
+		$password = $this->getActualPassword($password);
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			$email = $userToCreate . '@owncloud.org';
+			$bodyTable = new TableNode(
+				[
+					['userid', $userToCreate],
+					['password', $userToCreate],
+					['username', $userToCreate],
+					['email', $email],
+					['groups[]', $group],
+				]
+			);
+		} else {
+			$email = null;
+			$bodyTable = new TableNode(
+				[['userid', $userToCreate], ['password', $password], ['groups[]', $group]]
+			);
+		}
+		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+			$groupadmin,
+			"POST",
+			"/cloud/users",
+			$bodyTable
+		);
+		$this->addUserToCreatedUsersList(
+			$userToCreate,
+			$password,
+			null,
+			$email,
+			$this->theHTTPStatusCodeWasSuccess()
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
expands apiProvisioning tests for ocs v1 and v2 in:
- addUser

## Related Issue
- Part of https://github.com/owncloud/core/issues/31533

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
