### PR TITLE
[tests-only] Refactor examples table tags related to PRs 38345 and 37272

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -4,7 +4,7 @@ Feature: CORS headers
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @files_sharing-app-required @skipOnOcV10.5 @skipOnOcV10.6.0
+  @files_sharing-app-required
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
@@ -37,6 +37,9 @@ Feature: CORS headers
       | 2               | /cloud/groups                                    | 997      | 401       |
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
+    @skipOnOcV10.5 @skipOnOcV10.6.0
+    Examples:
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /config                                          | 100      | 200       |
       | 2               | /config                                          | 200      | 200       |
 


### PR DESCRIPTION
## Description
PR #37272 fixed a problem, and 2 Scenario Outlines were correctly merged into a single Scenario Outline with a single examples table.

PR #38345 added some skip* tags to that Scenario Outline. We needed to skip a couple of the examples on old oC10 releases, because they will nt pass on those old releases. We had to skip the whole Scenario Outline (all the examples), because `Behat/Gherkin` did not support multiple example tables with different tags.

Now https://github.com/Behat/Gherkin/issues/117 feature has been released. We can make multiple example tables with different tags on the same Scenario Outline.

This PR implements our first "multiple examples tables".

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
