### PR TITLE
[tests-only] Expand API test coverage for hidden file

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -337,3 +337,23 @@ Feature: Restore deleted files/folders
       | dav-path |
       | old      |
       | new      |
+
+  @smokeTest
+  Scenario Outline: A deleted hidden file can be restored
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has uploaded file with content "to delete" to "<path>"
+    And user "Alice" has deleted file "<path>"
+    When user "Alice" restores the folder with original path "<path>" using the trashbin API
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Alice"
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And as "Alice" the file with original path "<path>" should not exist in the trashbin
+    And as "Alice" file "<path>" should exist
+    And the content of file "<path>" for user "Alice" should be "to delete"
+    Examples:
+      | dav-path | path                 |
+      | old      | .hidden_file         |
+      | old      | /FOLDER/.hidden_file |
+      | new      | .hidden_file         |
+      | new      | /FOLDER/.hidden_file |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -338,22 +338,36 @@ Feature: Restore deleted files/folders
       | old      |
       | new      |
 
-  @smokeTest
+
   Scenario Outline: A deleted hidden file can be restored
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/FOLDER"
-    And user "Alice" has uploaded file with content "to delete" to "<path>"
-    And user "Alice" has deleted file "<path>"
-    When user "Alice" restores the folder with original path "<path>" using the trashbin API
-    Then the HTTP status code should be "201"
-    And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And as "Alice" the file with original path "<path>" should not exist in the trashbin
-    And as "Alice" file "<path>" should exist
-    And the content of file "<path>" for user "Alice" should be "to delete"
+    And user "Alice" has uploaded the following files with content "hidden file"
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    And user "Alice" has deleted the following files
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    When user "Alice" restores the following files with original path
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    Then the HTTP status code of responses on all endpoints should be "201"
+    And as "Alice" the files with following original paths should not exist in the trashbin
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    And as "Alice" the following files should exist
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    And the content of the following files for user "Alice" should be "hidden file"
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
     Examples:
-      | dav-path | path                 |
-      | old      | .hidden_file         |
-      | old      | /FOLDER/.hidden_file |
-      | new      | .hidden_file         |
-      | new      | /FOLDER/.hidden_file |
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -334,3 +334,35 @@ Feature: move (rename) file
       | dav_version |
       | old         |
       | new         |
+
+  @smokeTest
+  Scenario Outline: Moving a hidden file
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "I am a hidden file" to "<file_name_from>"
+    When user "Alice" moves file "<file_name_from>" to "<file_name_to>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Alice"
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "<file_name_to>" for user "Alice" should be "I am a hidden file"
+    Examples:
+      | dav_version | file_name_from         | file_name_to          |
+      | old         | .hidden_file           | /FOLDER/.hidden_file  |
+      | old         | /FOLDER/.hidden_file   | .hidden_file          |
+      | new         | .hidden_file           | /FOLDER/.hidden_file  |
+      | new         | /FOLDER/.hidden_file   | .hidden_file          |
+
+  @smokeTest
+  Scenario Outline: Renaming to/from a hidden file
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "I am a hidden file" to "<file_name_from>"
+    When user "Alice" moves file "<file_name_from>" to "<file_name_to>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Alice"
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "<file_name_to>" for user "Alice" should be "I am a hidden file"
+    Examples:
+      | dav_version | file_name_from  | file_name_to    |
+      | old         | .hidden_file    | hidden_file.txt |
+      | old         | hidden_file.txt | .hidden_file    |
+      | new         | .hidden_file    | hidden_file.txt |
+      | new         | hidden_file.txt | .hidden_file    |

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -335,34 +335,42 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @smokeTest
   Scenario Outline: Moving a hidden file
     Given using <dav_version> DAV path
-    And user "Alice" has uploaded file with content "I am a hidden file" to "<file_name_from>"
-    When user "Alice" moves file "<file_name_from>" to "<file_name_to>" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And the content of file "<file_name_to>" for user "Alice" should be "I am a hidden file"
+    And user "Alice" has uploaded the following files with content "hidden file"
+      | path                    |
+      | .hidden_file101         |
+      | /FOLDER/.hidden_file102 |
+    When user "Alice" moves the following files using the WebDAV API
+      | from                    | to                      |
+      | .hidden_file101         | /FOLDER/.hidden_file101 |
+      | /FOLDER/.hidden_file102 | .hidden_file102         |
+    Then the HTTP status code of responses on all endpoints should be "201"
+    And as "Alice" the following files should exist
+      | path                    |
+      | .hidden_file102         |
+      | /FOLDER/.hidden_file101 |
     Examples:
-      | dav_version | file_name_from         | file_name_to          |
-      | old         | .hidden_file           | /FOLDER/.hidden_file  |
-      | old         | /FOLDER/.hidden_file   | .hidden_file          |
-      | new         | .hidden_file           | /FOLDER/.hidden_file  |
-      | new         | /FOLDER/.hidden_file   | .hidden_file          |
+      | dav_version |
+      | old         |
+      | new         |
 
-  @smokeTest
   Scenario Outline: Renaming to/from a hidden file
     Given using <dav_version> DAV path
-    And user "Alice" has uploaded file with content "I am a hidden file" to "<file_name_from>"
-    When user "Alice" moves file "<file_name_from>" to "<file_name_to>" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And the content of file "<file_name_to>" for user "Alice" should be "I am a hidden file"
+    And user "Alice" has uploaded the following files with content "hidden file"
+      | path                    |
+      | .hidden_file101         |
+      | hidden_file101.txt      |
+    When user "Alice" moves the following files using the WebDAV API
+      | from               | to                 |
+      | .hidden_file101    | hidden_file102.txt |
+      | hidden_file101.txt | .hidden_file102    |
+    Then the HTTP status code of responses on all endpoints should be "201"
+    And as "Alice" the following files should exist
+      | path               |
+      | .hidden_file102    |
+      | hidden_file102.txt |
     Examples:
-      | dav_version | file_name_from  | file_name_to    |
-      | old         | .hidden_file    | hidden_file.txt |
-      | old         | hidden_file.txt | .hidden_file    |
-      | new         | .hidden_file    | hidden_file.txt |
-      | new         | hidden_file.txt | .hidden_file    |
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
@@ -69,3 +69,18 @@ Feature: delete file
       | new         | "sample,1.txt" |
       | new         | ",,,.txt"      |
       | new         | ",,,.,"        |
+
+  @smokeTest
+  Scenario Outline: delete a hidden file
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has uploaded file with content "to delete" to "<path>"
+    When user "Alice" deletes file "<path>" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "<path>" should not exist
+    Examples:
+      | dav_version | path                 |
+      | old         | .hidden_file         |
+      | old         | /FOLDER/.hidden_file |
+      | new         | .hidden_file         |
+      | new         | /FOLDER/.hidden_file |

--- a/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFile.feature
@@ -70,17 +70,23 @@ Feature: delete file
       | new         | ",,,.txt"      |
       | new         | ",,,.,"        |
 
-  @smokeTest
   Scenario Outline: delete a hidden file
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/FOLDER"
-    And user "Alice" has uploaded file with content "to delete" to "<path>"
-    When user "Alice" deletes file "<path>" using the WebDAV API
-    Then the HTTP status code should be "204"
-    And as "Alice" file "<path>" should not exist
+    And user "Alice" has uploaded the following files with content "hidden file"
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    When user "Alice" deletes the following files
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the following files should not exist
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
     Examples:
-      | dav_version | path                 |
-      | old         | .hidden_file         |
-      | old         | /FOLDER/.hidden_file |
-      | new         | .hidden_file         |
-      | new         | /FOLDER/.hidden_file |
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -197,3 +197,17 @@ Feature: download file
       | dav_version |
       | old         |
       | new         |
+
+  @smokeTest
+  Scenario Outline: download a hidden file
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has uploaded file with content "I am a hidden file" to "<path>"
+    When user "Alice" downloads file "<path>" using the WebDAV API
+    Then the downloaded content should be "I am a hidden file"
+    Examples:
+      | dav_version | path                 |
+      | old         | .hidden_file         |
+      | old         | /FOLDER/.hidden_file |
+      | new         | .hidden_file         |
+      | new         | /FOLDER/.hidden_file |

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -198,16 +198,20 @@ Feature: download file
       | old         |
       | new         |
 
-  @smokeTest
   Scenario Outline: download a hidden file
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/FOLDER"
-    And user "Alice" has uploaded file with content "I am a hidden file" to "<path>"
-    When user "Alice" downloads file "<path>" using the WebDAV API
-    Then the downloaded content should be "I am a hidden file"
+    And user "Alice" has uploaded the following files with content "hidden file"
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    When user "Alice" downloads file ".hidden_file" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "hidden file"
+    When user "Alice" downloads file "./FOLDER/.hidden_file" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded content should be "hidden file"
     Examples:
-      | dav_version | path                 |
-      | old         | .hidden_file         |
-      | old         | /FOLDER/.hidden_file |
-      | new         | .hidden_file         |
-      | new         | /FOLDER/.hidden_file |
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -199,3 +199,18 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
+  @smokeTest
+  Scenario Outline: upload a hidden file and check download content
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/FOLDER"
+    When user "Alice" uploads file with content "uploaded content" to "<path>" using the WebDAV API
+    Then the following headers should match these regular expressions for user "Alice"
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "<path>" for user "Alice" should be "uploaded content"
+    Examples:
+      | dav_version | path                 |
+      | old         | .hidden_file         |
+      | old         | /FOLDER/.hidden_file |
+      | new         | .hidden_file         |
+      | new         | /FOLDER/.hidden_file |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -200,17 +200,23 @@ Feature: upload file
       | old         |
       | new         |
 
-  @smokeTest
   Scenario Outline: upload a hidden file and check download content
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" uploads file with content "uploaded content" to "<path>" using the WebDAV API
-    Then the following headers should match these regular expressions for user "Alice"
-      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And the content of file "<path>" for user "Alice" should be "uploaded content"
+    When user "Alice" uploads the following files with content "hidden file"
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    Then the HTTP status code of responses on all endpoints should be "201"
+    And as "Alice" the following files should exist
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
+    And the content of the following files for user "Alice" should be "hidden file"
+      | path                 |
+      | .hidden_file         |
+      | /FOLDER/.hidden_file |
     Examples:
-      | dav_version | path                 |
-      | old         | .hidden_file         |
-      | old         | /FOLDER/.hidden_file |
-      | new         | .hidden_file         |
-      | new         | /FOLDER/.hidden_file |
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -616,6 +616,28 @@ class TrashbinContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" restores the following (?:files|folders|entries) with original path$/
+	 *
+	 * @param string $user
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userRestoresFollowingFiles($user, TableNode $table) {
+		$this->featureContext->verifyTableNodeColumns($table, ["path"]);
+		$paths = $table->getHash();
+
+		foreach ($paths as $originalPath) {
+			$this->elementInTrashIsRestored($user, $originalPath["path"]);
+			
+			$this->featureContext->pushToLastHttpStatusCodesArray(
+				$this->featureContext->getResponse()->getStatusCode()
+			);
+		}
+	}
+
+	/**
 	 * @Given /^user "([^"]*)" has restored the (?:file|folder|entry) with original path "([^"]*)"$/
 	 *
 	 * @param string $user
@@ -681,6 +703,25 @@ class TrashbinContext implements Context {
 			$this->isInTrash($user, $originalPath),
 			"File previously located at $originalPath was found in the trashbin"
 		);
+	}
+
+	/**
+	 * @Then /^as "([^"]*)" the (?:files|folders|entries) with following original paths should not exist in the trashbin$/
+	 *
+	 * @param string $user
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function followingElementsAreNotInTrashCheckingOriginalPath(
+		$user, TableNode $table
+	) {
+		$this->featureContext->verifyTableNodeColumns($table, ["path"]);
+		$paths = $table->getHash($table);
+
+		foreach ($paths as $originalPath) {
+			$this->elementIsNotInTrashCheckingOriginalPath($user, $originalPath["path"]);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
API test coverage for `hidden` files
- move to/from
- rename to/from
- upload
- download
- delete
- restore from trashbin

## Related Issue
- closes https://github.com/owncloud/core/issues/36362

## How Has This Been Tested?
- test environment: local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
