### PR TITLE
[tests-only] Add replaceUsernames option to .drone.star

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1335,6 +1335,7 @@ def acceptance(ctx):
 		'scalityS3': False,
 		'testingRemoteSystem': True,
 		'useHttps': True,
+		'replaceUsernames': False,
 		'extraSetup': [],
 		'extraServices': [],
 		'extraEnvironment': {},
@@ -1432,6 +1433,7 @@ def acceptance(ctx):
 								environment['TEST_SERVER_URL'] = '%s://%s' % (protocol, serverUnderTest)
 
 								environment['BEHAT_FILTER_TAGS'] = params['filterTags']
+								environment['REPLACE_USERNAMES'] = params['replaceUsernames']
 
 								if (params['runAllSuites'] == False):
 									environment['BEHAT_SUITE'] = suite

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -182,11 +182,11 @@ Feature: edit users
       | username |
       | Alice    |
       | Brian    |
-    When user "Alice" changes the display name of user "Brian" to "New Brian" using the provisioning API
+    When user "Alice" tries to change the display name of user "Brian" to "New Brian" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    When user "Alice" changes the email of user "Brian" to "brian-new-email@example.com" using the provisioning API
+    When user "Alice" tries to change the email of user "Brian" to "brian-new-email@example.com" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the display name of user "Brian" should be "Brian Murphy"
-    And the email address of user "Brian" should be "brian@example.org"
+    And the display name of user "Brian" should not have changed
+    And the email address of user "Brian" should not have changed

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -182,11 +182,11 @@ Feature: edit users
       | username |
       | Alice    |
       | Brian    |
-    When user "Alice" changes the display name of user "Brian" to "New Brian" using the provisioning API
+    When user "Alice" tries to change the display name of user "Brian" to "New Brian" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    When user "Alice" changes the email of user "Brian" to "brian-new-email@example.com" using the provisioning API
+    When user "Alice" tries to change the email of user "Brian" to "brian-new-email@example.com" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
-    And the display name of user "Brian" should be "Brian Murphy"
-    And the email address of user "Brian" should be "brian@example.org"
+    And the display name of user "Brian" should not have changed
+    And the email address of user "Brian" should not have changed


### PR DESCRIPTION
## Description
To make it easier for developers and QA to run the acceptance tests in CI with different user names and attributes.

Documented in PR https://github.com/owncloud/docs/pull/3091

2nd commit - Refactor provisioning tests to allow REPLACE_USERNAMES - a lot of the provisioning test code did not abstract-out the usernames used in the test steps. That was noticed in the demo PR #38365 which should pass after this commit is added.

## Related Issue
- Fixes #33596


## How Has This Been Tested?
CI - see demo PR #38365 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
