### PR TITLE
[tests-only] Expand test coverage in apiTrashbin for unusual files/folders

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -134,3 +134,67 @@ Feature: files and folders can be deleted from the trashbin
     But as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     But as "Alice" the file with original path "/FOLDER/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/FOLDER/CHILD/child.txt" should exist in the trashbin
+
+
+  Scenario Outline: delete files with special characters from the trashbin
+    Given user "Alice" has uploaded the following files with content "special character file"
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    And user "Alice" has deleted the following files
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    When user "Alice" deletes the following files with original path from the trashbin
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the files with following original paths should not exist in the trashbin
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: delete folders with special characters from the trashbin
+    Given user "Alice" has created the following folders
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    And user "Alice" has deleted the following folders
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    When user "Alice" deletes the following files with original path from the trashbin
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the folders with following original paths should not exist in the trashbin
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -283,3 +283,69 @@ Feature: files and folders exist in the trashbin after being deleted
       | dav-path |
       | old      |
       | new      |
+
+  @issue-ocis-1547
+  Scenario Outline: deleting files with special characters moves it to trashbin
+    Given using <dav-path> DAV path
+    And user "Alice" has uploaded the following files with content "special character file"
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    When user "Alice" deletes the following files
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the following files should not exist
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    But as "Alice" the files with following original paths should exist in the trashbin
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @issue-ocis-1547
+  Scenario Outline: deleting folders with special characters moves it to trashbin
+    Given using <dav-path> DAV path
+    And user "Alice" has created the following folders
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    When user "Alice" deletes the following files
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    But as "Alice" the following folders should not exist
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    And as "Alice" the folders with following original paths should exist in the trashbin
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -371,3 +371,81 @@ Feature: Restore deleted files/folders
       | dav-path |
       | old      |
       | new      |
+
+
+  Scenario Outline: restoring files with special characters
+    Given using <dav-path> DAV path
+    And user "Alice" has uploaded the following files with content "special character file"
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    And user "Alice" has deleted the following files
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    When user "Alice" restores the following files with original path
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    Then the HTTP status code of responses on all endpoints should be "201"
+    And as "Alice" the files with following original paths should not exist in the trashbin
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    But as "Alice" the following files should exist
+      | path             |
+      | qa&dev.txt       |
+      | !@tester$^.txt   |
+      | %file *?2.txt    |
+      | # %ab ab?=ed.txt |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: restoring folders with special characters
+    Given using <dav-path> DAV path
+    And user "Alice" has created the following folders
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    And user "Alice" has deleted the following folders
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    When user "Alice" restores the following folders with original path
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    Then the HTTP status code of responses on all endpoints should be "201"
+    And as "Alice" the folders with following original paths should not exist in the trashbin
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    But as "Alice" the following folders should exist
+      | path         |
+      | qa&dev       |
+      | !@tester$^   |
+      | %file *?2    |
+      | # %ab ab?=ed |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -423,6 +423,27 @@ class TrashbinContext implements Context {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" deletes the following (?:files|folders|entries) with original path from the trashbin$/
+	 *
+	 * @param string $user
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function deleteFollowingFilesFromTrashbin($user, $table) {
+		$this->featureContext->verifyTableNodeColumns($table, ["path"]);
+		$paths = $table->getHash();
+
+		foreach ($paths as $path) {
+			$this->deleteFileFromTrashbin($user, $path["path"]);
+			
+			$this->featureContext->pushToLastHttpStatusCodesArray(
+				$this->featureContext->getResponse()->getStatusCode()
+			);
+		}
+	}
+
+	/**
 	 * @Then /^as "([^"]*)" (?:file|folder|entry) "([^"]*)" should exist in the trashbin$/
 	 *
 	 * @param string $user
@@ -721,6 +742,25 @@ class TrashbinContext implements Context {
 
 		foreach ($paths as $originalPath) {
 			$this->elementIsNotInTrashCheckingOriginalPath($user, $originalPath["path"]);
+		}
+	}
+
+	/**
+	 * @Then /^as "([^"]*)" the (?:files|folders|entries) with following original paths should exist in the trashbin$/
+	 *
+	 * @param string $user
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function followingElementsAreInTrashCheckingOriginalPath(
+		$user, TableNode $table
+	) {
+		$this->featureContext->verifyTableNodeColumns($table, ["path"]);
+		$paths = $table->getHash($table);
+
+		foreach ($paths as $originalPath) {
+			$this->elementIsInTrashCheckingOriginalPath($user, $originalPath["path"]);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2831,6 +2831,23 @@ trait WebDav {
 	}
 
 	/**
+	 * @Given /^user "([^"]*)" has created the following folders$/
+	 *
+	 * @param string $user
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function userHasCreatedFollowingFolders($user, TableNode $table) {
+		$this->verifyTableNodeColumns($table, ["path"]);
+		$paths = $table->getHash();
+
+		foreach ($paths as $path) {
+			$this->userHasCreatedFolder($user, $path["path"]);
+		}
+	}
+
+	/**
 	 * @When the user creates folder :destination using the WebDAV API
 	 *
 	 * @param string $destination


### PR DESCRIPTION
## Description
adds test coverage in apiTrashbin for files/folder with special characters
- list in trashbin
- delete from trashbin
- restore from trashbin

## Related Issue
- https://github.com/owncloud/ocis/issues/1547

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
