### PR TITLE
[tests-only] Fix tests with latest phpstan 0.12.71 release

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,7 +16,6 @@ parameters:
     - '#Instantiated class Test\\Util\\User\\Dummy not found.#'
     # errors below are to be addressed by own pull requests - non trivial changes required
     - '#Unsafe usage of new static\(\).#'
-    - '#Cannot instantiate interface OCP\\Files\\ObjectStore\\IObjectStore.#'
     - '#Instantiated class OCA\\Encryption\\Crypto\\Crypt not found.#'
     - '#Instantiated class OCA\\Encryption\\Util not found.#'
     - '#Instantiated class OCA\\Encryption\\KeyManager not found.#'

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^0.12"
+        "phpstan/phpstan": "^0.12.71"
     }
 }


### PR DESCRIPTION
## Description
A new release 0.12.71 of `phpstan` is out: https://github.com/phpstan/phpstan/releases/tag/0.12.71

https://github.com/phpstan/phpstan/issues/4471 made a fix/change so that an unwanted error is no longer reported. So now our CI fails with: https://drone.owncloud.com/owncloud/core/28484/4/7
```
-- --------------------------------------------------------------------- 
     Error                                                                
 -- --------------------------------------------------------------------- 
     Ignored error pattern #Cannot instantiate interface                  
     OCP\\Files\\ObjectStore\\IObjectStore.# was not matched in reported  
     errors.                                                              
 -- --------------------------------------------------------------------- 

 [ERROR] Found 1 error                                        
```

That error was ignored in `phpstan.neon` because it used to be incorrectly reported. With `phpstan` 0.12.70 it would report:
```
$ make test-php-phpstan
composer install
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead.
Package guzzlehttp/ringphp is abandoned, you should avoid using it. No replacement was suggested.
Package guzzlehttp/streams is abandoned, you should avoid using it. No replacement was suggested.
Package patchwork/jsqueeze is abandoned, you should avoid using it. No replacement was suggested.
Package jakub-onderka/php-console-color is abandoned, you should avoid using it. Use php-parallel-lint/php-console-color instead.
Package jakub-onderka/php-console-highlighter is abandoned, you should avoid using it. Use php-parallel-lint/php-console-highlighter instead.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Generating optimized autoload files
49 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Composer cleaner: Removed 5 files or directories.
phpstan composer.lock is not up to date.
composer bin phpstan install --no-progress
No lock file found. Updating dependencies instead of installing from lock file. Use composer update over composer install if you do not have a lock file.
Loading composer repositories with package information
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking phpstan/phpstan (0.12.70)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Downloading phpstan/phpstan (0.12.70)
  - Installing phpstan/phpstan (0.12.70): Extracting archive
Generating autoload files
1 package you are using is looking for funding.
Use the `composer fund` command to find out more!
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=2G --configuration=./phpstan.neon --level=0 apps core settings lib/private lib/public ocs ocs-provider
 1444/1444 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------------------ 
  Line   lib/private/Files/External/ConfigAdapter.php                      
 ------ ------------------------------------------------------------------ 
  94     Cannot instantiate interface OCP\Files\ObjectStore\IObjectStore.  
 ------ ------------------------------------------------------------------ 

                                                                                                                        
 [ERROR] Found 1 error
```

- require at least `phpstan` 0.12.71
- remove the error pattern from the ignored list

## How Has This Been Tested?
CI and local run of `make test-php-phpstan`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
