### PR TITLE
Fix problem with user-encryption when the a shared file is moved

### DIFF
--- a/apps/files_trashbin/ajax/preview.php
+++ b/apps/files_trashbin/ajax/preview.php
@@ -82,5 +82,5 @@ try {
 	$image->show();
 } catch (\Exception $e) {
 	\OC_Response::setStatus(500);
-	\OCP\Util::writeLog('core', $e->getmessage(), \OCP\Util::DEBUG);
+	\OCP\Util::writeLog('core', $e->getmessage(), \OCP\Util::ERROR);
 }

--- a/changelog/unreleased/38375
+++ b/changelog/unreleased/38375
@@ -1,0 +1,12 @@
+Bugfix: Fix broken signature when a backup copy is generated
+
+Previously, when a user uploaded a file and then moved it to a shared folder
+in order for a second user to get the file, a copy of the file was generated
+inside the share owner's trashbin. This allowed the share owner to restore
+the file into the share again if needed.
+Using encryption, that backup copy was wrongly generated and couldn't be
+decrypted due to a wrong signature.
+
+This issue is now fixed, and the backup copy can be restored normally.
+
+https://github.com/owncloud/core/pull/38375


### PR DESCRIPTION
Checked scenario below but moving a file instead of a folder:
    admin creates "folderA"
    admins shares "folderA" with user1 and user2
    user1 creates "folderB" (in his home) and uploads content inside "folderB"
    user1 moves "folderB" inside the shared folder "folderA" (leads to "folderA/folderB" being shared)
    user2 moves "folderA/folderB" (step3) in his own home directory
    admin has a "folderB" in his trashbin
    admin restores the "folderB" from the trashbin -> "folderA/folderB" reappears
    contents from "folderA/folderB" (the ones restored that are now shared again) aren't accessible (Bad Encryption exception)

The file / folder in the admin's trashbin had a wrong signature caused
by a wrong update of the encryptedVersion in the DB. This change bypass
that update in that particular scenario. The rest of the scenarios
weren't affected and will work the same way as before

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Fix broken signature of a backup copy created from the shared folder when the file is moved to the home directory of another user.

Minor additional changes included:
* Raise log level for a possible 500 code in the trashbin previews (The "Bad signature" exception caused by this issue wasn't being logged there)
* Fix possible "array access offset on bool type" if `$sourceStorage->getCache()->get(...)` returned false.

## Related Issue
https://github.com/owncloud/enterprise/issues/4372
steps to reproduce are above and in https://github.com/owncloud/enterprise/issues/4372#issuecomment-769843523

## Motivation and Context
The code creates a broken copy of a file inside the trashbin. Restoring the file from the trashbin will still keep the broken signature. This change fixes this behaviour, so the file can be restored if needed.

## How Has This Been Tested?
Tested following the reproduction steps.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
