### PR TITLE
pre-signed download urls for password protected public links

### DIFF
--- a/apps/dav/lib/Files/PublicFiles/PublicShareSigner.php
+++ b/apps/dav/lib/Files/PublicFiles/PublicShareSigner.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @author David Christofas <dchristofas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Files\PublicFiles;
+
+class PublicShareSigner {
+	private $token;
+	private $fileName;
+	private $validUntil;
+	private $signingKey;
+
+	public function __construct(String $token, String $fileName, \DateTime $validUntil, String $signingKey) {
+		$this->token = $token;
+		$this->fileName = $fileName;
+		$this->validUntil = $validUntil->format(\DateTime::ATOM);
+		$this->signingKey = $signingKey;
+	}
+
+	public function getSignature() {
+		return \hash_hmac('sha512/256', \implode('|', [$this->token, $this->fileName, $this->validUntil]), $this->signingKey, false);
+	}
+}

--- a/apps/dav/tests/unit/Files/PublicFiles/PublicShareSignerTest.php
+++ b/apps/dav/tests/unit/Files/PublicFiles/PublicShareSignerTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author David Christofas <dchristofas@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\DAV\Tests\Unit\Files\PublicFiles;
+
+use OCA\DAV\Files\PublicFiles\PublicShareSigner;
+use Test\TestCase;
+
+class PublicShareSignerTest extends TestCase {
+	public function testGet() {
+		$s = new PublicShareSigner('someToken', 'someFileName', new \DateTime(), 'somekey');
+		$hash = $s->getSignature();
+		self::assertIsString($hash);
+		self::assertEquals(64, \strlen($hash));
+	}
+
+	public function testVerify() {
+		$expectedHash = 'd67966402971bd3eb18aea62faf122a30e2dd5c9101aa9e106a56574cc535c6c';
+		$date = \DateTime::createFromFormat(\DateTime::ATOM, '2009-01-03T18:15:05Z');
+		$s = new PublicShareSigner('someToken', 'someFileName', $date, 'somekey');
+		self::assertEquals($expectedHash, $s->getSignature());
+	}
+}

--- a/changelog/unreleased/38376
+++ b/changelog/unreleased/38376
@@ -1,0 +1,5 @@
+Enhancement: Implement pre-signed download urls for public links
+
+Added pre-signed download urls for password protected public links to support clients which don't use cookies.
+
+https://github.com/owncloud/core/pull/38376


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
When a propfind request is done for a password protected public link share and the property `'{http://owncloud.org/ns}downloadURL'` is requested, then a signed url is created and sent to the client as the value of that property.
The downloadURL property was added some time ago but haven't been used since because the demand disappeared. So I think using this property should be fine. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To support clients which don't use cookies I implemented pre-signed urls
for password protected public links. The share password is used as the
signing key and the signed url is then added to the propfind response in
the field `downloadURL` which was added before but never used. This
change allows owncloud Web to implement a more efficient download
mechanism for password protected link shares.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
