### PR TITLE
Allow passing DB platform

### DIFF
--- a/changelog/unreleased/38379
+++ b/changelog/unreleased/38379
@@ -1,0 +1,6 @@
+Enhancement: Allow force set DB patforms
+
+A new 'db.platform' option added to config.php. It allows using a specific
+database platform and do not rely on autodetection.
+
+https://github.com/owncloud/core/pull/38379

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1223,6 +1223,18 @@ $CONFIG = [
 'mysql.utf8mb4' => false,
 
 /**
+ * Force a specific database platform class.
+ * False means that autodetection will take place.
+ *
+ * E.g. to fix MariaDB 1.2.7+ taken for MySQL
+ * 'db.platform' => '\Doctrine\DBAL\Platforms\MariaDb1027Platform',
+ *
+ * See:
+ * https://docs.microsoft.com/en-us/azure/mariadb/concepts-limits#current-known-issues
+ */
+'db.platform' => false,
+
+/**
  * Define supported database types
  * Database types that are supported for installation.
  *

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -78,6 +78,10 @@ class ConnectionFactory {
 		if ($this->config->getValue('mysql.utf8mb4', false)) {
 			$this->defaultConnectionParams['mysql']['charset'] = 'utf8mb4';
 		}
+		$dbPlatform = $this->config->getValue('db.platform', false);
+		if ($dbPlatform !== false) {
+			$this->defaultConnectionParams['mysql']['platform'] = new $dbPlatform();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
with this patch it is possible to pass the correct DB platform via `config.php` manually:
```
'db.platform' => '\Doctrine\DBAL\Platforms\MariaDb1027Platform',
```

or via a separate `db.config.php` file:
```
<?php
$CONFIG = [
	'db.platform' => '\Doctrine\DBAL\Platforms\MariaDb1027Platform',
];
```

## Related Issue
OC fails to install using MariaDB on Azure due to a known issue with MySQL version reporting https://docs.microsoft.com/en-us/azure/mariadb/concepts-limits#current-known-issues
>MariaDB server instance displays the incorrect server version after connection is established. To get the correct server instance engine version, use the select version(); command.

## Motivation and Context
Fixes installation and upgrade for  MariaDB at Azure environment


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
