### PR TITLE
[Tests-Only] Added api test for getting the version number after moving a file

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -403,3 +403,15 @@ Feature: dav-versions
     When user "Alice" restores version index "1" of file "/renamedfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/renamedfile.txt" for user "Alice" should be "old content"
+    
+  @issue-ocis-1238
+  Scenario: The version number is wrong after moving a file
+    Given user "Alice" has created folder "testFolder"
+    And user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 1" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 2" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 3" to "textfile0.txt"
+    When user "Alice" moves file "textfile0.txt" to "/testFolder/textfile0.txt" using the WebDAV API
+    And user "Alice" tries to get versions of file "/testFolder/textfile0.txt" from "Alice"
+    Then the HTTP status code should be "207"
+    And the number of versions should be "3"

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -405,13 +405,18 @@ Feature: dav-versions
     And the content of file "/renamedfile.txt" for user "Alice" should be "old content"
     
   @issue-ocis-1238
-  Scenario: The version number is wrong after moving a file
+  Scenario: User can access version number after moving a file
     Given user "Alice" has created folder "testFolder"
     And user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"
     And user "Alice" has uploaded file with content "version 1" to "textfile0.txt"
     And user "Alice" has uploaded file with content "version 2" to "textfile0.txt"
     And user "Alice" has uploaded file with content "version 3" to "textfile0.txt"
     When user "Alice" moves file "textfile0.txt" to "/testFolder/textfile0.txt" using the WebDAV API
-    And user "Alice" tries to get versions of file "/testFolder/textfile0.txt" from "Alice"
+    And user "Alice" gets the number of versions of file "/testFolder/textfile0.txt"
     Then the HTTP status code should be "207"
     And the number of versions should be "3"
+
+  Scenario: Original file has version number 0
+    Given user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"
+    When user "Alice" gets the number of versions of file "textfile0.txt"
+    Then the number of versions should be "0"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -399,6 +399,31 @@ trait WebDav {
 	}
 
 	/**
+	 * @When user :user gets the number of versions of file :file
+	 *
+	 * @param string $user
+	 * @param string $file
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userGetsFileVersions($user, $file) {
+		$user = $this->getActualUsername($user);
+		$fileId = $this->getFileIdForPath($user, $file);
+		$path = "/meta/" . $fileId . "/v";
+		$response = $this->makeDavRequest(
+			$user,
+			"PROPFIND",
+			$path,
+			null,
+			null,
+			null,
+			2
+		);
+		$this->setResponse($response);
+	}
+
+	/**
 	 * @Then the number of versions should be :arg1
 	 *
 	 * @param int $number


### PR DESCRIPTION
## Description
Added api test for getting the version number after moving a file

## Related Issue
- Demonstrates https://github.com/owncloud/ocis/issues/1238

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/1613

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [z] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
