### PR TITLE
Trigger events once

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -328,14 +328,18 @@
 			this.$fileList.on('click','td.filename>a.name, td.filesize, td.date', _.bind(this._onClickFile, this));
 
 			this.$fileList.on('change', 'td.filename>.selectCheckBox', _.bind(this._onClickFileCheckbox, this));
-			this.$el.on('urlChanged', _.bind(this._onUrlChanged, this));
+			// use namespaced event because "bind" will get in the way to remove the event later
+			this.$el.on('urlChanged.filelistbound', _.bind(this._onUrlChanged, this));
 			this.$el.find('.select-all').click(_.bind(this._onClickSelectAll, this));
 			this.$el.find('.download').click(_.bind(this._onClickDownloadSelected, this));
 			this.$el.find('.delete-selected').click(_.bind(this._onClickDeleteSelected, this));
 
 			this.$el.find('.selectedActions a').tooltip({placement:'top'});
 
-			this.$container.on('scroll', _.bind(this._onScroll, this));
+			if (!this.$container.data('scrollEventSet')) {
+				this.$container.on('scroll', _.bind(this._onScroll, this));
+			}
+			this.$container.data('scrollEventSet', true);
 
 			if (options.scrollTo) {
 				this.$fileList.one('updated', function() {
@@ -386,6 +390,9 @@
 			// remove summary
 			this.$el.find('tfoot tr.summary').remove();
 			this.$fileList.empty();
+			// remove events attached to the $el
+			this.$el.off('show', this._onResize);
+			this.$el.off('urlChanged.filelistbound');
 
 		},
 
@@ -1909,7 +1916,7 @@
 					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('files', 'via') + " " + folder.name });
 					var $name = $('<strong>', { class : 'shareTree-item-name', text : shareWith });
 					var $icon = $('<div>',    { class : 'shareTree-item-avatar' });
-                                       
+
 					if (oc_config.enable_avatars) {
 					       $icon.avatar(share.share_with, 32);
 					}

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -329,6 +329,8 @@
 
 			this.$fileList.on('change', 'td.filename>.selectCheckBox', _.bind(this._onClickFileCheckbox, this));
 			// use namespaced event because "bind" will get in the way to remove the event later
+			// note that the jquery element won't be removed, so it's possible to register
+			// the same listener twice or more. We'll remove the listener in the destroy method.
 			this.$el.on('urlChanged.filelistbound', _.bind(this._onUrlChanged, this));
 			this.$el.find('.select-all').click(_.bind(this._onClickSelectAll, this));
 			this.$el.find('.download').click(_.bind(this._onClickDownloadSelected, this));
@@ -336,10 +338,9 @@
 
 			this.$el.find('.selectedActions a').tooltip({placement:'top'});
 
-			if (!this.$container.data('scrollEventSet')) {
-				this.$container.on('scroll', _.bind(this._onScroll, this));
-			}
-			this.$container.data('scrollEventSet', true);
+			// namespaced event based on this jquery element, to be removed when is destroyed
+			// note that the listener is attached to the container, not to the element
+			this.$container.on('scroll.' + this.$el.attr('id'), _.bind(this._onScroll, this));
 
 			if (options.scrollTo) {
 				this.$fileList.one('updated', function() {
@@ -393,6 +394,8 @@
 			// remove events attached to the $el
 			this.$el.off('show', this._onResize);
 			this.$el.off('urlChanged.filelistbound');
+			// remove events attached to the $container
+			this.$container.off('scroll.' + this.$el.attr('id'));
 
 		},
 

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -123,38 +123,41 @@
 				return data;
 			});
 
-			// use delegate to catch the case with multiple file lists
-			fileList.$el.on('fileActionsReady', function(ev){
-				var $files = ev.$files;
+			if (!fileList.$el.data('shareEventsSet')) { // to prevent setting the same events twice
+				// use delegate to catch the case with multiple file lists
+				fileList.$el.on('fileActionsReady', function(ev){
+					var $files = ev.$files;
 
-				_.each($files, function(file) {
-					var $tr = $(file);
-					var shareTypes = $tr.attr('data-share-types') || '';
-					var shareOwner = $tr.attr('data-share-owner');
-					if (shareTypes || shareOwner) {
-						var hasLink = false;
-						var hasShares = false;
-						_.each(shareTypes.split(',') || [], function(shareType) {
-							shareType = parseInt(shareType, 10);
-							if (shareType === OC.Share.SHARE_TYPE_LINK) {
-								hasLink = true;
-							} else if (shareType === OC.Share.SHARE_TYPE_USER) {
-								hasShares = true;
-							} else if (shareType === OC.Share.SHARE_TYPE_GROUP) {
-								hasShares = true;
-							} else if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
-								hasShares = true;
-							}
-						});
-						OCA.Sharing.Util._updateFileActionIcon($tr, hasShares, hasLink);
-					}
+					_.each($files, function(file) {
+						var $tr = $(file);
+						var shareTypes = $tr.attr('data-share-types') || '';
+						var shareOwner = $tr.attr('data-share-owner');
+						if (shareTypes || shareOwner) {
+							var hasLink = false;
+							var hasShares = false;
+							_.each(shareTypes.split(',') || [], function(shareType) {
+								shareType = parseInt(shareType, 10);
+								if (shareType === OC.Share.SHARE_TYPE_LINK) {
+									hasLink = true;
+								} else if (shareType === OC.Share.SHARE_TYPE_USER) {
+									hasShares = true;
+								} else if (shareType === OC.Share.SHARE_TYPE_GROUP) {
+									hasShares = true;
+								} else if (shareType === OC.Share.SHARE_TYPE_REMOTE) {
+									hasShares = true;
+								}
+							});
+							OCA.Sharing.Util._updateFileActionIcon($tr, hasShares, hasLink);
+						}
+					});
 				});
-			});
 
 
-			fileList.$el.on('changeDirectory', function() {
-				OCA.Sharing.sharesLoaded = false;
-			});
+				fileList.$el.on('changeDirectory', function() {
+					OCA.Sharing.sharesLoaded = false;
+				});
+			}
+			fileList.$el.data('shareEventsSet', true);
 
 			fileActions.registerAction({
 				name: 'Share',

--- a/changelog/unreleased/38385
+++ b/changelog/unreleased/38385
@@ -1,0 +1,10 @@
+Bugfix: Prevent multiple calls by not registering the same listener twice
+
+Going back and forth among the file sections ("all files", "shared with you",
+etc) was making some event listeners to be registered twice or more times.
+This was causing the same ajax request to be called several times causing
+unnecessary load in the server.
+
+Now, these additional requests won't happen
+
+https://github.com/owncloud/core/pull/38385


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Prevent the registration of the same event listener several times, which causes the same action (from the duplicated listeners) to be performed multiple times.

Primary problem is with the "urlChanged" event, which causes an ajax request to be thrown. This means that, without this fix, the ajax requests performed were increasing along with the increasing event listeners being registered for that event.
The other events don't seem to be too critical since the attached action is pretty light.

## Related Issue
Helps with https://github.com/owncloud/enterprise/issues/4374

## Motivation and Context
No need to register the same event listener twice

## How Has This Been Tested?
Mostly tested going back and forth between the "all files" and "shared with you" sections in the files view, as well as checking there is no apparent problem with the scrolling in those sections.
Event registration has been checked with the firefox dev tools, ensuring there is no increasing event associated with the target web element. There could be multiple listeners for the same event, but it's expected to be for different purposes (not duplicated)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
