### PR TITLE
Added connection_parameters to redis and redis.cluster config section in order to allow redis with TLS/SSL

### DIFF
--- a/changelog/unreleased/38386
+++ b/changelog/unreleased/38386
@@ -1,0 +1,7 @@
+Enhancement: Added additional connection parameters to redis config
+
+In order to provide redis SLL/TLS support a new section connection_parameters added to redis and redis.cluster configuration in config.php.
+Requirements for connection_parameters: php-redis extension >= 5.3.0
+Requirements for redis ssl/tls: redis server >= 6.0
+
+https://github.com/owncloud/core/pull/38386

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1055,6 +1055,20 @@ $CONFIG = [
 	'timeout' => 0.0,
 	'password' => '', // Optional, if not defined no password will be used.
 	'dbindex' => 0,   // Optional, if undefined SELECT will not run and will use Redis Server's default DB Index. Out of the box, every Redis instance supports 16 databases so `<dbIndex>` has to be set between 0 and 15.
+	 // Optional config option
+	 // In order to use connection_parameters php-redis extension >= 5.3.0 is required
+	 // In order to use SSL/TLS redis server >= 6.0 is required
+	 // In a single-server configuration, prefix the host with tls:// like tls://localhost
+	 // In a single-server configuration the SSL/TLS data **must** be in the stream section
+	'connection_parameters' => [
+		'stream' => [
+			'local_cert' => '/file/path/to/redis.crt',
+			'local_pk' => '/file/path/to/redis.key',
+			'cafile' => '/file/path/to/ca.crt',
+			'verify_peer_name' => true
+		],
+	],
+
   ],
 
 /**
@@ -1077,7 +1091,18 @@ $CONFIG = [
 	],
 	'timeout' => 0.0,
 	'read_timeout' => 0.0,
-	'failover_mode' => \RedisCluster::FAILOVER_DISTRIBUTE
+	'failover_mode' => \RedisCluster::FAILOVER_DISTRIBUTE,
+	 // Optional config option
+	 // In order to use connection_parameters php-redis extension >= 5.3.0 is required
+	 // In order to use SSL/TLS redis server >= 6.0 is required
+	 // In a cluster configuration, prefix the seeds with tls:// like tls://localhost:7000
+	 // In a cluster configuration the SSL/TLS data **must not** be in the stream section
+	'connection_parameters' => [
+		'local_cert' => '/file/path/to/redis.crt',
+		'local_pk' => '/file/path/to/redis.key',
+		'cafile' => '/file/path/to/ca.crt',
+		'verify_peer_name' => true
+	],
   ],
 
 /**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Since php-redis 5.3.0 it is possible to pass extra connection parameters as the last argument of Redis::Connect or RedisCluster::constructor.
This arguments can now be defined in the config.php redis.cluser:connection_parameters or redis:connection_parameters.
Due we don't rely on php-redis >= 5.3.0 we check if the extra connection parameters are supported and throw an exception if defined but not supported by the current version.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4368


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
