### PR TITLE
Hide federated user suggestions when sharing if system users are found

### DIFF
--- a/changelog/unreleased/38389
+++ b/changelog/unreleased/38389
@@ -1,0 +1,8 @@
+Enhancement: Hide federated user suggestions if system users are found
+
+Hide federated user suggestions when sharing if system users are
+found. This improves the usability of sharing resources with existing users
+via email address.
+
+https://github.com/owncloud/core/pull/38389
+https://github.com/owncloud/enterprise/issues/4392

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -264,8 +264,10 @@
 							}
 						}
 
-						var suggestions = users.concat(groups).concat(remotes);
-
+						var suggestions = users.concat(groups);
+						if (suggestions.length < 1) {
+							suggestions = suggestions.concat(remotes);
+						}
 
 						if (suggestions.length > 0) {
 							suggestions.sort(function (a, b) {


### PR DESCRIPTION
## Description
Hide federated user suggestions when sharing if system users are found. This improves the usability of sharing resources with existing users via email address.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4392

## Screenshots:

![image](https://user-images.githubusercontent.com/50302941/107495213-15321b00-6b90-11eb-8e00-2735e8ec98da.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
