### PR TITLE
Prevent getting a version expiry list when no versions available

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -538,7 +538,7 @@ class Storage {
 	protected static function getExpireList($time, $versions, $quotaExceeded = false) {
 		$expiration = self::getExpiration();
 
-		if ($expiration->shouldAutoExpire()) {
+		if ($expiration->shouldAutoExpire() && \count($versions) > 0) {
 			list($toDelete, $size) = self::getAutoExpireList($time, $versions);
 		} else {
 			$size = 0;

--- a/changelog/unreleased/38373
+++ b/changelog/unreleased/38373
@@ -1,0 +1,8 @@
+Bugfix: Prevent getting a version expiry list when no versions available
+
+Previous to this fix, when getting a version expiry list with an empty
+version array, ownCloud ran into an error. Not a critical one, but still
+not nice and spams the owncloud.log file.
+
+https://github.com/owncloud/core/pull/38390
+https://github.com/owncloud/core/issues/38373


### PR DESCRIPTION
## Description
Previous to this little fix, when getting a version expiry list with an empty `$version` array, OC ran into an error. Not a critical one, but still not nice and spams the `owncloud.log` file.

**How does this happen?**

Versions of a file expire at a certain point of time. When a version is added to a file, an expiry command is scheduled via cronjob. Eventually the cronjob runs and will expire (=delete) the version of this file. But it is also possible to clean up all versions in between those two actions, for instance with the command `occ version:cleanup`. When the cronjob runs afterwards, no versions will be available to expire -> error.

**Steps to reproduce:**

* Create a new file, then edit that file -> a version will be created.
* Clean up all versions: `occ version:cleanup`.
* Run cronjob to expire versions: `occ system:cron`.
* Check your `owncloud.log` file, it should've logged the error: `Trying to access array offset on value of type bool at /path/to/your/owncloud`.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/38373

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
