### PR TITLE
[tests-only] Do not run occ group:list in OCIS CI

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -720,7 +720,9 @@ trait Provisioning {
 		$this->ldap->add($newDN, $entry);
 		\array_push($this->ldapCreatedGroups, $group);
 		// For syncing the ldap groups
-		$this->runOcc(['group:list']);
+		if (OcisHelper::isTestingOnOc10()) {
+			$this->runOcc(['group:list']);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
When running CI with `cs3org/reva` we use LDAP. But the existing code tries to run `occ group:list` to sync the groups after creating an LDAP group. That is only useful on oC10 - the `occ` command does not exist on OCIS-reva.

This was noticed while investigating https://github.com/owncloud/core/issues/38382

We might also need to do some "magic" in OCIS-reva to make sure that the new group "really is known" to OCIS-reva. But that will come later if we need it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
