### PR TITLE
[Tests-Only]Add tests for sharee test

### DIFF
--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -536,3 +536,26 @@ Feature: sharees
       | ocs-api-version | ocs-status | http-status |
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
+
+  Scenario Outline: Search without exact match such that the search string matches the user getting the sharees
+    Given user "sharee2" has been created with default attributes and skeleton files
+    And using OCS API version "<ocs-api-version>"
+    When user "sharee1" gets the sharees using the sharing API with parameters
+      | search   | sharee |
+      | itemType | file   |
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "<http-status>"
+    And the "exact users" sharees returned should be empty
+    And the "users" sharees returned should be
+      | Sharee One | 0 | sharee1 |
+      | Sharee Two | 0 | sharee2 |
+    And the "exact groups" sharees returned should be empty
+    And the "groups" sharees returned should be
+      | ShareeGroup  | 1 | ShareeGroup  |
+      | ShareeGroup2 | 1 | ShareeGroup2 |
+    And the "exact remotes" sharees returned should be empty
+    And the "remotes" sharees returned should be empty
+    Examples:
+      | ocs-api-version | ocs-status | http-status |
+      | 1               | 100        | 200         |
+      | 2               | 200        | 200         |

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1908,6 +1908,8 @@ class FeatureContext extends BehatVariablesContext {
 			return 'User Grp';
 		} elseif ($username === 'sharee1') {
 			return 'Sharee One';
+		} elseif ($username === 'sharee2') {
+			return 'Sharee Two';
 		} elseif (\in_array($username, ["grp1", "***redacted***"])) {
 			return $username;
 		}


### PR DESCRIPTION
## Description
In this PR, an acceptance test scenario is added to get share recipient such that the requesting user has the matching name as the search string

# Related Issue
-  https://github.com/owncloud/core/issues/38397

## How Has This Been Tested?
- CI
- https://github.com/owncloud/ocis/pull/1637

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
