### PR TITLE
Add the owner to public link shares

### DIFF
--- a/changelog/unreleased/38396
+++ b/changelog/unreleased/38396
@@ -1,0 +1,7 @@
+Bugfix: Add the owner to public link shares
+
+Add the owner to public link shares because we cannot retrieve this
+information otherwise.
+
+https://github.com/owncloud/core/pull/38396
+https://github.com/owncloud/files_spaces/issues/51

--- a/core/js/sharemodel.js
+++ b/core/js/sharemodel.js
@@ -70,8 +70,6 @@
 			delete data.url;
 
 			// these can be read from the parent object or fileinfo
-			delete data.displayname_file_owner;
-			delete data.displayname_owner;
 			delete data.file_parent;
 			delete data.path;
 			delete data.storage;

--- a/core/js/sharemodel.js
+++ b/core/js/sharemodel.js
@@ -74,8 +74,6 @@
 			delete data.path;
 			delete data.storage;
 			delete data.storage_id;
-			delete data.uid_file_owner;
-			delete data.uid_owner;
 			delete data.mimetype;
 			delete data.parent;
 


### PR DESCRIPTION
## Description
Add the owner to public link shares because we cannot retrieve this information otherwise (in contrast to what the comment in https://github.com/owncloud/core/blob/master/core/js/sharemodel.js#L72 says).

## Related Issue
- needed for https://github.com/owncloud/files_spaces/issues/51

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
