### PR TITLE
polyfill samesite cookie attribute

### DIFF
--- a/changelog/unreleased/38400
+++ b/changelog/unreleased/38400
@@ -1,0 +1,10 @@
+Enhancement: Polyfill samesite cookie attribute
+
+Polyfill same-site cookie attribute for browsers which don't support it.
+https://auth0.com/blog/browser-behavior-changes-what-developers-need-to-know/
+
+1.) DETECT: tries to detect if given user_agent supports samesite attribute
+2.) FALLBACK: creates a second cookie "cookie-name-legacy" wich has no
+    samesite attribute (recommended by google)
+
+https://github.com/owncloud/core/pull/38400

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -40,6 +40,7 @@ use OCP\IConfig;
 use OCP\IRequest;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
+use OC\Http\CookieHelper;
 
 /**
  * Class for accessing variables in the request.
@@ -371,7 +372,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string|null the value in the $_COOKIE element
 	 */
 	public function getCookie($key) {
-		return isset($this->cookies[$key]) ? $this->cookies[$key] : null;
+		return CookieHelper::getRequestCookie($this, $key);
 	}
 
 	/**

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -372,7 +372,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string|null the value in the $_COOKIE element
 	 */
 	public function getCookie($key) {
-		return CookieHelper::getRequestCookie($this, $key);
+		$cookieHelper = new CookieHelper();
+		return $cookieHelper->getRequestCookie($this, $key);
 	}
 
 	/**

--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -23,12 +23,11 @@ namespace OC\Http;
 
 use OCP\IRequest;
 
-
 /**
  * Class CookieHelper
  *
  * This Class polyfills cookie to work around samesite restrictions on unsupported browsers.
- * It supports POLYFILL_DETECT mode which tries to detect if the samesite attribute ist supported.
+ * It supports POLYFILL_DETECT mode which tries to detect if the samesite attribute is supported.
  * It supports POLYFILL_FALLBACK mode which creates a second cookie without samesite attribute.
  *
  * @package OC\Http
@@ -48,9 +47,9 @@ class CookieHelper {
 
 	public static function setCookie(string $name, string $value = '', array $options = [], string $polyfill = self::POLYFILL_FALLBACK): void {
 		// check if given cookie options are allowed
-		foreach (array_keys($options) as $option) {
-			if (!in_array($option, array(self::PATH, self::DOMAIN, self::EXPIRES, self::SECURE, self::HTTPONLY, self::SAMESITE))) {
-				trigger_error(
+		foreach (\array_keys($options) as $option) {
+			if (!\in_array($option, [self::PATH, self::DOMAIN, self::EXPIRES, self::SECURE, self::HTTPONLY, self::SAMESITE])) {
+				\trigger_error(
 					'unknown cookie option : ' . $option,
 					E_WARNING
 				);
@@ -58,21 +57,21 @@ class CookieHelper {
 		}
 
 		// check if given polyfill mode is supported
-		if (!in_array($polyfill, array(self::POLYFILL_DETECT, self::POLYFILL_FALLBACK))) {
-			trigger_error(
+		if (!\in_array($polyfill, [self::POLYFILL_DETECT, self::POLYFILL_FALLBACK])) {
+			\trigger_error(
 				'unknown cookie polyfill : ' . $polyfill,
 				E_WARNING
 			);
 		}
 
 		// defaults
-		$path = array_key_exists(self::PATH, $options) ? $options[self::PATH] : '';
-		$domain = array_key_exists(self::DOMAIN, $options) ? $options[self::DOMAIN] : '';
-		$expires = array_key_exists(self::EXPIRES, $options) ? $options[self::EXPIRES] : 0;
-		$secure = array_key_exists(self::SECURE, $options) ? $options[self::SECURE] : false;
-		$httponly = array_key_exists(self::HTTPONLY, $options) ? $options[self::HTTPONLY] : false;
-		$sameSite = array_key_exists(self::SAMESITE, $options) ? $options[self::SAMESITE] : '';
-		$header = array(sprintf('Set-Cookie: %s=%s', $name, rawurlencode($value)));
+		$path = \array_key_exists(self::PATH, $options) ? $options[self::PATH] : '';
+		$domain = \array_key_exists(self::DOMAIN, $options) ? $options[self::DOMAIN] : '';
+		$expires = \array_key_exists(self::EXPIRES, $options) ? $options[self::EXPIRES] : 0;
+		$secure = \array_key_exists(self::SECURE, $options) ? $options[self::SECURE] : false;
+		$httponly = \array_key_exists(self::HTTPONLY, $options) ? $options[self::HTTPONLY] : false;
+		$sameSite = \array_key_exists(self::SAMESITE, $options) ? $options[self::SAMESITE] : '';
+		$header = [\sprintf('Set-Cookie: %s=%s', $name, \rawurlencode($value))];
 
 		// disable samesite
 		// if samesite is set to none secure is required
@@ -93,48 +92,46 @@ class CookieHelper {
 		}
 
 		if ($path !== '') {
-			array_push($header, sprintf('Path=%s', $path));
+			\array_push($header, \sprintf('Path=%s', $path));
 		}
 
 		if ($domain !== '') {
-			array_push($header, sprintf('Domain=%s', $domain));
+			\array_push($header, \sprintf('Domain=%s', $domain));
 		}
 
 		if ($expires > 0) {
-			array_push($header, sprintf('Max-Age=%d', $expires));
+			\array_push($header, \sprintf('Max-Age=%d', $expires));
 		}
 
 		if ($secure === true) {
-			array_push($header, 'Secure');
-		} else {
-			$sameSite = '';
+			\array_push($header, 'Secure');
 		}
 
 		if ($httponly) {
-			array_push($header, 'HttpOnly');
+			\array_push($header, 'HttpOnly');
 		}
 
-		foreach (array(self::SAMESITE_NONE, self::SAMESITE_LAX, self::SAMESITE_STRICT) as $v) {
-			if (strtolower($sameSite) === strtolower($v)) {
-				array_push($header, sprintf('SameSite=%s', $v));
+		foreach ([self::SAMESITE_NONE, self::SAMESITE_LAX, self::SAMESITE_STRICT] as $v) {
+			if (\strtolower($sameSite) === \strtolower($v)) {
+				\array_push($header, \sprintf('SameSite=%s', $v));
 				break;
 			}
 		}
 
-		header(implode('; ', $header), false);
+		\header(\implode('; ', $header), false);
 	}
 
-	// if polyfill is set to true it returns the cookie legacy name
+	// return the cookie legacy name
 	private static function legacyName(string $name): string {
-		return sprintf('%s-legacy', $name);
+		return \sprintf('%s-legacy', $name);
 	}
 
 	public static function getRequestCookie(IRequest $request, string $name) {
-		if (array_key_exists($name, $request->cookies)) {
+		if (\array_key_exists($name, $request->cookies)) {
 			return $request->cookies[$name];
 		}
 
-		if (array_key_exists(self::legacyName($name), $request->cookies)) {
+		if (\array_key_exists(self::legacyName($name), $request->cookies)) {
 			return $request->cookies[self::legacyName($name)];
 		}
 
@@ -150,7 +147,7 @@ class CookieHelper {
 		// https://developer.mozilla.org/de/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 		// https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
 		foreach (
-			array(
+			[
 				// chrome
 				'#(CriOS|Chrome)/([0-9]*)#' => function ($matches, $user_agent): bool {
 					$version = $matches[2];
@@ -170,8 +167,8 @@ class CookieHelper {
 						$version_major == 10 &&
 						$version_minor == 14 &&
 						(
-							preg_match('#Version\/.* Safari\/#', $user_agent) == true ||
-							preg_match('#AppleWebKit\/[\.\d]+ \(KHTML, like Gecko\)#', $user_agent) == true
+							\preg_match('#Version\/.* Safari\/#', $user_agent) == true ||
+							\preg_match('#AppleWebKit\/[\.\d]+ \(KHTML, like Gecko\)#', $user_agent) == true
 						)
 					);
 				},
@@ -182,8 +179,8 @@ class CookieHelper {
 					$version_build = $matches[3];
 					return !($version_major == 12 && $version_minor == 13 && $version_build == 2);
 				},
-			) as $regex => $check) {
-			if (preg_match($regex, $user_agent, $matches) == true) {
+			] as $regex => $check) {
+			if (\preg_match($regex, $user_agent, $matches) == true) {
 				if ($check($matches, $user_agent)) {
 					return false;
 				};

--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -1,0 +1,195 @@
+<?php declare(strict_types=1);
+/**
+ * @author Florian Schade <f.schade@icloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Http;
+
+use OCP\IRequest;
+
+
+/**
+ * Class CookieHelper
+ *
+ * This Class polyfills cookie to work around samesite restrictions on unsupported browsers.
+ * It supports POLYFILL_DETECT mode which tries to detect if the samesite attribute ist supported.
+ * It supports POLYFILL_FALLBACK mode which creates a second cookie without samesite attribute.
+ *
+ * @package OC\Http
+ */
+class CookieHelper {
+	public const SAMESITE_NONE = 'None';
+	public const SAMESITE_LAX = 'Lax';
+	public const SAMESITE_STRICT = 'Strict';
+	public const PATH = 'path';
+	public const DOMAIN = 'domain';
+	public const EXPIRES = 'expires';
+	public const SECURE = 'secure';
+	public const HTTPONLY = 'httponly';
+	public const SAMESITE = 'samesite';
+	public const POLYFILL_DETECT = 'detect';
+	public const POLYFILL_FALLBACK = 'fallback';
+
+	public static function setCookie(string $name, string $value = '', array $options = [], string $polyfill = self::POLYFILL_FALLBACK): void {
+		// check if given cookie options are allowed
+		foreach (array_keys($options) as $option) {
+			if (!in_array($option, array(self::PATH, self::DOMAIN, self::EXPIRES, self::SECURE, self::HTTPONLY, self::SAMESITE))) {
+				trigger_error(
+					'unknown cookie option : ' . $option,
+					E_WARNING
+				);
+			}
+		}
+
+		// check if given polyfill mode is supported
+		if (!in_array($polyfill, array(self::POLYFILL_DETECT, self::POLYFILL_FALLBACK))) {
+			trigger_error(
+				'unknown cookie polyfill : ' . $polyfill,
+				E_WARNING
+			);
+		}
+
+		// defaults
+		$path = array_key_exists(self::PATH, $options) ? $options[self::PATH] : '';
+		$domain = array_key_exists(self::DOMAIN, $options) ? $options[self::DOMAIN] : '';
+		$expires = array_key_exists(self::EXPIRES, $options) ? $options[self::EXPIRES] : 0;
+		$secure = array_key_exists(self::SECURE, $options) ? $options[self::SECURE] : false;
+		$httponly = array_key_exists(self::HTTPONLY, $options) ? $options[self::HTTPONLY] : false;
+		$sameSite = array_key_exists(self::SAMESITE, $options) ? $options[self::SAMESITE] : '';
+		$header = array(sprintf('Set-Cookie: %s=%s', $name, rawurlencode($value)));
+
+		// disable samesite
+		// if samesite is set to none secure is required
+		// if polyfill is set to POLYFILL_DETECT and $user_agent does not support samesite
+		if (
+			$sameSite === self::SAMESITE_NONE && $secure !== true ||
+			$polyfill === self::POLYFILL_DETECT && !self::canSameSite()
+		) {
+			$sameSite = '';
+		}
+
+		// create a second cookie to polyfill unsupported browsers
+		// if set to POLYFILL_FALLBACK use CookieHelper::getRequestCookie(...)
+		// https://web.dev/samesite-cookie-recipes/#handling-incompatible-clients
+		if ($polyfill === self::POLYFILL_FALLBACK && $sameSite !== '') {
+			unset($options[self::SAMESITE]);
+			self::setCookie(self::legacyName($name), $value, $options, self::POLYFILL_DETECT);
+		}
+
+		if ($path !== '') {
+			array_push($header, sprintf('Path=%s', $path));
+		}
+
+		if ($domain !== '') {
+			array_push($header, sprintf('Domain=%s', $domain));
+		}
+
+		if ($expires > 0) {
+			array_push($header, sprintf('Max-Age=%d', $expires));
+		}
+
+		if ($secure === true) {
+			array_push($header, 'Secure');
+		} else {
+			$sameSite = '';
+		}
+
+		if ($httponly) {
+			array_push($header, 'HttpOnly');
+		}
+
+		foreach (array(self::SAMESITE_NONE, self::SAMESITE_LAX, self::SAMESITE_STRICT) as $v) {
+			if (strtolower($sameSite) === strtolower($v)) {
+				array_push($header, sprintf('SameSite=%s', $v));
+				break;
+			}
+		}
+
+		header(implode('; ', $header), false);
+	}
+
+	// if polyfill is set to true it returns the cookie legacy name
+	private static function legacyName(string $name): string {
+		return sprintf('%s-legacy', $name);
+	}
+
+	public static function getRequestCookie(IRequest $request, string $name) {
+		if (array_key_exists($name, $request->cookies)) {
+			return $request->cookies[$name];
+		}
+
+		if (array_key_exists(self::legacyName($name), $request->cookies)) {
+			return $request->cookies[self::legacyName($name)];
+		}
+
+		return null;
+	}
+
+	public static function canSameSite($user_agent = ''): bool {
+		if ($user_agent === '') {
+			$user_agent = $_SERVER['HTTP_USER_AGENT'];
+		}
+
+		// check if given user_agent supports samesite
+		// https://developer.mozilla.org/de/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+		// https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+		foreach (
+			array(
+				// chrome
+				'#(CriOS|Chrome)/([0-9]*)#' => function ($matches, $user_agent): bool {
+					$version = $matches[2];
+					return $version < 67;
+				},
+				// ios
+				'#iP.+; CPU .*OS (\d+)_\d#' => function ($matches, $user_agent): bool {
+					$version = $matches[1];
+					return $version < 13;
+				},
+				// macos 10.14
+				'#Macintosh;.*Mac OS X (\d+)_(\d+)_.*AppleWebKit#' => function ($matches, $user_agent): bool {
+					$version_major = $matches[1];
+					$version_minor = $matches[2];
+
+					return (
+						$version_major == 10 &&
+						$version_minor == 14 &&
+						(
+							preg_match('#Version\/.* Safari\/#', $user_agent) == true ||
+							preg_match('#AppleWebKit\/[\.\d]+ \(KHTML, like Gecko\)#', $user_agent) == true
+						)
+					);
+				},
+				// uc
+				'#UCBrowser/(\d+)\.(\d+)\.(\d+)#' => function ($matches, $user_agent): bool {
+					$version_major = $matches[1];
+					$version_minor = $matches[2];
+					$version_build = $matches[3];
+					return !($version_major == 12 && $version_minor == 13 && $version_build == 2);
+				},
+			) as $regex => $check) {
+			if (preg_match($regex, $user_agent, $matches) == true) {
+				if ($check($matches, $user_agent)) {
+					return false;
+				};
+			}
+		}
+
+		return true;
+	}
+}

--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -40,7 +40,7 @@ class CookieHelper {
 	public const DOMAIN = 'domain';
 	public const EXPIRES = 'expires';
 	public const SECURE = 'secure';
-	public const HTTPONLY = 'httponly ';
+	public const HTTPONLY = 'httponly';
 	public const SAMESITE = 'samesite';
 	public const POLYFILL_DETECT = 'detect';
 	public const POLYFILL_FALLBACK = 'fallback';

--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -49,19 +49,14 @@ class CookieHelper {
 		// check if given cookie options are allowed
 		foreach (\array_keys($options) as $option) {
 			if (!\in_array($option, [self::PATH, self::DOMAIN, self::EXPIRES, self::SECURE, self::HTTPONLY, self::SAMESITE])) {
-				\trigger_error(
-					'unknown cookie option : ' . $option,
-					E_WARNING
-				);
+				throw new \Exception('Unknown cookie option:' . $option);
 			}
 		}
 
 		// check if given polyfill mode is supported
 		if (!\in_array($polyfill, [self::POLYFILL_DETECT, self::POLYFILL_FALLBACK])) {
-			\trigger_error(
-				'unknown cookie polyfill : ' . $polyfill,
-				E_WARNING
-			);
+			throw new \Exception('Unknown cookie polyfill:' . $polyfill);
+
 		}
 
 		// defaults

--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -2,7 +2,7 @@
 /**
  * @author Florian Schade <f.schade@icloud.com>
  *
- * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @copyright Copyright (c) 2021, ownCloud GmbH
  * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify

--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -40,7 +40,7 @@ class CookieHelper {
 	public const DOMAIN = 'domain';
 	public const EXPIRES = 'expires';
 	public const SECURE = 'secure';
-	public const HTTPONLY = 'httponly';
+	public const HTTPONLY = 'httponly ';
 	public const SAMESITE = 'samesite';
 	public const POLYFILL_DETECT = 'detect';
 	public const POLYFILL_FALLBACK = 'fallback';
@@ -56,7 +56,6 @@ class CookieHelper {
 		// check if given polyfill mode is supported
 		if (!\in_array($polyfill, [self::POLYFILL_DETECT, self::POLYFILL_FALLBACK])) {
 			throw new \Exception('Unknown cookie polyfill:' . $polyfill);
-
 		}
 
 		// defaults

--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -138,7 +138,7 @@ class CookieHelper {
 		return null;
 	}
 
-	public function canSameSite($user_agent = ''): bool {
+	public function canSameSite(string $user_agent = ''): bool {
 		if ($user_agent === '') {
 			$user_agent = $_SERVER['HTTP_USER_AGENT'];
 		}

--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -45,6 +45,13 @@ class CookieHelper {
 	public const POLYFILL_DETECT = 'detect';
 	public const POLYFILL_FALLBACK = 'fallback';
 
+	/**
+	 * @param string $name
+	 * @param string $value
+	 * @param array $options
+	 * @param string $polyfill
+	 * @throws \Exception
+	 */
 	public function setCookie(string $name, string $value = '', array $options = [], string $polyfill = self::POLYFILL_FALLBACK): void {
 		// check if given cookie options are allowed
 		foreach (\array_keys($options) as $option) {
@@ -112,7 +119,7 @@ class CookieHelper {
 			}
 		}
 
-		\header(\implode('; ', $header), false);
+		$this->setHeader($header);
 	}
 
 	// return the cookie legacy name
@@ -120,6 +127,18 @@ class CookieHelper {
 		return \sprintf('%s-legacy', $name);
 	}
 
+	/**
+	 * @param array $header
+	 */
+	public function setHeader(array $header) {
+		\header(\implode('; ', $header), false);
+	}
+
+	/**
+	 * @param IRequest $request
+	 * @param string $name
+	 * @return mixed|null
+	 */
 	public function getRequestCookie(IRequest $request, string $name) {
 		if (\array_key_exists($name, $request->cookies)) {
 			return $request->cookies[$name];
@@ -132,6 +151,10 @@ class CookieHelper {
 		return null;
 	}
 
+	/**
+	 * @param string $user_agent
+	 * @return bool
+	 */
 	public function canSameSite(string $user_agent = ''): bool {
 		if ($user_agent === '') {
 			$user_agent = $_SERVER['HTTP_USER_AGENT'];

--- a/lib/private/Http/CookieHelper.php
+++ b/lib/private/Http/CookieHelper.php
@@ -45,7 +45,7 @@ class CookieHelper {
 	public const POLYFILL_DETECT = 'detect';
 	public const POLYFILL_FALLBACK = 'fallback';
 
-	public static function setCookie(string $name, string $value = '', array $options = [], string $polyfill = self::POLYFILL_FALLBACK): void {
+	public function setCookie(string $name, string $value = '', array $options = [], string $polyfill = self::POLYFILL_FALLBACK): void {
 		// check if given cookie options are allowed
 		foreach (\array_keys($options) as $option) {
 			if (!\in_array($option, [self::PATH, self::DOMAIN, self::EXPIRES, self::SECURE, self::HTTPONLY, self::SAMESITE])) {
@@ -78,7 +78,7 @@ class CookieHelper {
 		// if polyfill is set to POLYFILL_DETECT and $user_agent does not support samesite
 		if (
 			$sameSite === self::SAMESITE_NONE && $secure !== true ||
-			$polyfill === self::POLYFILL_DETECT && !self::canSameSite()
+			$polyfill === self::POLYFILL_DETECT && !$this->canSameSite()
 		) {
 			$sameSite = '';
 		}
@@ -88,7 +88,7 @@ class CookieHelper {
 		// https://web.dev/samesite-cookie-recipes/#handling-incompatible-clients
 		if ($polyfill === self::POLYFILL_FALLBACK && $sameSite !== '') {
 			unset($options[self::SAMESITE]);
-			self::setCookie(self::legacyName($name), $value, $options, self::POLYFILL_DETECT);
+			$this->setCookie(self::legacyName($name), $value, $options, self::POLYFILL_DETECT);
 		}
 
 		if ($path !== '') {
@@ -122,23 +122,23 @@ class CookieHelper {
 	}
 
 	// return the cookie legacy name
-	private static function legacyName(string $name): string {
+	private function legacyName(string $name): string {
 		return \sprintf('%s-legacy', $name);
 	}
 
-	public static function getRequestCookie(IRequest $request, string $name) {
+	public function getRequestCookie(IRequest $request, string $name) {
 		if (\array_key_exists($name, $request->cookies)) {
 			return $request->cookies[$name];
 		}
 
-		if (\array_key_exists(self::legacyName($name), $request->cookies)) {
-			return $request->cookies[self::legacyName($name)];
+		if (\array_key_exists($this->legacyName($name), $request->cookies)) {
+			return $request->cookies[$this->legacyName($name)];
 		}
 
 		return null;
 	}
 
-	public static function canSameSite($user_agent = ''): bool {
+	public function canSameSite($user_agent = ''): bool {
 		if ($user_agent === '') {
 			$user_agent = $_SERVER['HTTP_USER_AGENT'];
 		}

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -86,7 +86,8 @@ class CryptoWrapper {
 
 			// FIXME: Required for CI
 			if (!\defined('PHPUNIT_RUN')) {
-				CookieHelper::setCookie(
+				$cookieHelper = new CookieHelper();
+				$cookieHelper->setCookie(
 					self::COOKIE_NAME,
 					$this->passphrase, [
 					CookieHelper::PATH => \OC::$WEBROOT === '' ? '/' : \OC::$WEBROOT,

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -166,7 +166,8 @@ class Internal extends Session {
 
 		\session_start();
 
-		CookieHelper::setCookie(
+		$cookieHelper = new CookieHelper();
+		$cookieHelper->setCookie(
 			\session_name(),
 			\session_id(), [
 			CookieHelper::PATH => \OC::$WEBROOT ?: '/',

--- a/tests/lib/Http/CookieHelperTest.php
+++ b/tests/lib/Http/CookieHelperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Test\Http;
+
+use OC\Http\CookieHelper;
+use Test\TestCase;
+
+class CookieHelperTest extends TestCase {
+
+	/** @var CookieHelper $sut */
+	private $sut;
+
+	public function userAgentProvider() {
+		return [
+			["Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.4324.152 Safari/537.36", false],
+			["Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.152 Safari/537.36", true],
+			["Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148", false],
+			["Mozilla/5.0 (iPhone; CPU iPhone OS 14_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148", true],
+			["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1.2 Safari/605.1.15", true],
+			["Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; F5121 Build/34.0.A.1.247) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 UCBrowser/12.13.2.944 Mobile Safari/537.36", false],
+		];
+	}
+
+	/**
+	 * @dataProvider userAgentProvider
+	 */
+	public function testCanSameSite($ua, $canSameSite) {
+		$this->sut = new CookieHelper();
+		$this->assertTrue($this->sut->canSameSite($ua) == $canSameSite);
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
some browsers do not support samesite cookie attribute, this pr introduces a cookie helper to polyfill those requirements. The samesite attribute is needed to define where the cookie can be used. This is a major requirement when using openid connect where the idp is deployed to a different domain or similar scenarios.  The cookie helper supports 2 types of polyfills.

1.) DETECT: tries to detect if given user_agent supports samesite attribute
2.) FALLBACK: creates a second cookie "cookie-name-legacy" wich has no samesite attribute (recommended by google)

the detect polyfill is required because the session_cookie is not able to have 2 cookies.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4191

## Motivation and Context
- https://auth0.com/blog/browser-behavior-changes-what-developers-need-to-know/
- https://blog.chromium.org/2019/10/developers-get-ready-for-new.html
- https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
- https://developer.mozilla.org/de/docs/Web/HTTP/Headers/Set-Cookie/SameSite

## How Has This Been Tested?
- local installation 
- openidconnect on azure ad 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] test with all supported browsers
- [x] test with supported idps
- [x] test with supported platforms
- [ ] changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
- [ ] unit tests