### PR TITLE
[tests-only] Refactor starlark

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -147,7 +147,7 @@ config = {
 				'apiFederationToShares2',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['git', 'latest', '10.4.1']
+			'federatedServerVersions': ['git', 'latest', '10.5.0']
 		},
 		'cli': {
 			'suites': [
@@ -170,7 +170,7 @@ config = {
 				'cliExternalStorage',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['git', 'latest', '10.4.1']
+			'federatedServerVersions': ['git', 'latest', '10.5.0']
 		},
 		'webUI': {
 			'suites': {
@@ -233,7 +233,7 @@ config = {
 				'webUISharingExternal2': 'webUISharingExt2',
 			},
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['git', 'latest', '10.3.2']
+			'federatedServerVersions': ['git', 'latest', '10.5.0']
 		},
 		'webUIFirefox': {
 			'suites': {

--- a/.drone.star
+++ b/.drone.star
@@ -1150,7 +1150,7 @@ def phpTests(ctx, testType):
 					keyString = '-' + category if params['includeKeyInMatrixName'] else ''
 					filesExternalType = externalType if externalType != 'none' else ''
 					externalNameString = '-' + externalType if externalType != 'none' else ''
-					name = '%s%s-php%s-%s%s' % (testType, keyString, phpVersion, db.replace(":", ""), externalNameString)
+					name = '%s%s-php%s-%s%s' % (testType, keyString, phpVersion, getShortDbNameAndVersion(db), externalNameString)
 					maxLength = 50
 					nameLength = len(name)
 					if nameLength > maxLength:
@@ -1408,8 +1408,7 @@ def acceptance(ctx):
 									keyString = '-' + category if params['includeKeyInMatrixName'] else ''
 									partString = '' if params['numberOfParts'] == 1 else '-%d-%d' % (params['numberOfParts'], runPart)
 									federatedServerVersionString = '-' + federatedServerVersion.replace('daily-', '').replace('-qa', '') if (federatedServerVersion != '') else ''
-									dbString = db.replace(':', '')
-									name = '%s%s%s%s%s-%s-php%s' % (alternateSuiteName, keyString, partString, federatedServerVersionString, browserString, dbString, phpVersion)
+									name = '%s%s%s%s%s-%s-php%s' % (alternateSuiteName, keyString, partString, federatedServerVersionString, browserString, getShortDbNameAndVersion(db), phpVersion)
 									maxLength = 50
 									nameLength = len(name)
 									if nameLength > maxLength:
@@ -1901,8 +1900,14 @@ def owncloudService(phpVersion, name = 'server', path = '/drone/src', ssl = True
 		]
 	}]
 
+def getShortDbNameAndVersion(db):
+	return '%s%s' % (getDbType(db), getDbVersion(db))
+
 def getDbName(db):
-	return db.split(':')[0]
+	return db.partition(':')[0]
+
+def getDbVersion(db):
+	return db.partition(':')[2]
 
 def getDbUsername(db):
 	name = getDbName(db)


### PR DESCRIPTION
## Description
1) Refactor database string used in pipeline names. Currently the pipelines have names that include strings like "postgresql9.4". When I was testing with postgresql 10.3 I wasted some time because the string got a bit longer, and was already longer for "postgresql9.4" (compared to the usual "mariadb:10.2"). The pipeline name happened to reach the limit of 50 characters.

Use the "short" db names insteads, "postgresql" becomes "pgsql". That will keep all the db names about the same length, and save this pain a little bit in future.

2) Use 10.5.0 as 2nd-latest federated version for tests - we run the federated tests against 3 different federated server version - the current git master, the latest release, and the 2nd-latest release. This helps ensure that federated shares work between multiple core versions. The latest release has a fixed way to find the tarball. The 2nd-latest has to be specified by release number. Update these to 10.5.0 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
