### PR TITLE
Expose non-generic messages for 403 HTTP status to the end user

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1202,8 +1202,14 @@ OC.Uploader.prototype = _.extend({
 						// file already exists
 						self.showConflict(upload);
 					} else if (status === 403) {
-						// not enough space
-						const message = t('files', 'You don’t have permission to upload or create files here');
+						// permission denied
+						var response = upload.getResponse();
+						message = response.message;
+						// If the message comes from a storage wrapper exception it should be already
+						// translated. Otherwise we have a default exception message and translate it here
+						if (message === '' || message === 'You don’t have permission to upload or create files here') {
+							message = t('files', 'You don’t have permission to upload or create files here');
+						}
 						OC.Notification.show(message, {type: 'error'});
 					} else if (status === 404) {
 						// target folder does not exist any more
@@ -1215,7 +1221,7 @@ OC.Uploader.prototype = _.extend({
 						}
 						self.cancelUploads();
 					} else if (status === 423) {
-						// not enough space
+						// file is locked
 						OC.Notification.show(t('files', 'The file {file} is currently locked, please try again later', {file: upload.getFileName()}), {type: 'error'});
 					} else if (status === 507) {
 						// not enough space

--- a/changelog/unreleased/38416
+++ b/changelog/unreleased/38416
@@ -1,0 +1,8 @@
+Bugfix: Show non-generic messages for 403 HTTP status to end user
+
+The real reason why 3rd party app canceled upload was ignored by Web UI and a generic
+'You are not allowed to upload here' message was shown instead. Now 'You are not allowed
+to upload here' is shown only if a real reason is empty.
+
+https://github.com/owncloud/files_antivirus/issues/395
+https://github.com/owncloud/core/pull/38416


### PR DESCRIPTION
## Description
https://github.com/owncloud/core/commit/8b2ebe23cf32e14e2de06a1f88343e63403d3628#diff-5f714a00dd14764258a4e4a95b600644974f29a1046a61a7cecd40f96337163d 

Introduces a regression: all messages that are coming from 3rd-party apps (files_antivirus, firewall, etc) are masked with a generic message for HTTP status 403
![image](https://user-images.githubusercontent.com/1108546/106977093-ee23b580-6759-11eb-99ee-81ee221db680.png)

## Related Issue
https://github.com/owncloud/enterprise/issues/4418
https://github.com/owncloud/files_antivirus/issues/395

## Motivation and Context
The real reason why the file hasn't been uploaded is misreported

## How Has This Been Tested?
1. Enable and set files_antivirus
2. Upload EICAR

#### Expected
Web UI reports that file is infected with EICAR

#### Actual
Web UI reports  that user has no upload permission

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
