### PR TITLE
Allow command maintenance:mimetype:update-db --repair-filecache to run properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /config/config.php
 /config/*.config.php
 /config/mount.php
+/config/mimetypealiases.json
+/config/mimetypemapping.json
 /apps/inc.php
 /assets
 /build/composer.phar

--- a/changelog/unreleased/38426
+++ b/changelog/unreleased/38426
@@ -1,0 +1,7 @@
+Bugfix: Fix command maintenance:mimetype:update-db --repair-filecache
+
+While running the command maintenance:mimetype:update-db --repair-filecache,
+existing records in the filecache table were not updated due to a faulty sql statement.
+
+https://github.com/owncloud/core/issues/38425
+https://github.com/owncloud/core/pull/38426

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -169,7 +169,7 @@ class Loader implements IMimeTypeLoader {
 				'mimetype', $update->createPositionalParameter($is_folderId)
 			))
 			->andWhere($update->expr()->like(
-				$update->createFunction('LOWER(`name`)'), $update->createPositionalParameter($ext)
+				$update->createFunction('LOWER(`name`)'), $update->createPositionalParameter("%.$ext")
 			));
 		return $update->execute();
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This command was designed, to sync ne mimetypes  to the `mimetypes` table and update existing records in the `filecache` table, due a faulty sql statement, the update never worked. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/38425


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
