### PR TITLE
[tests-only] Specify a relative path to multiLanguageErrors.json in tests

### DIFF
--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -826,7 +826,7 @@ class OCSContext implements Context {
 	public function getActualStatusMessage($statusMessage, $language) {
 		if ($language !== null) {
 			$multiLingualMessage = \json_decode(
-				\file_get_contents("./tests/acceptance/fixtures/multiLanguageErrors.json"),
+				\file_get_contents(__DIR__ . "/../../fixtures/multiLanguageErrors.json"),
 				true
 			);
 


### PR DESCRIPTION
## Description
When acceptance test CI is run from apps there is a problem with the path to `multiLanguageErrors.json`

https://drone.owncloud.com/owncloud/admin_audit/1836/61/14

`Warning: file_get_contents(./tests/acceptance/fixtures/multiLanguageErrors.json): failed to open stream: No such file or directory in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/OCSContext.php line 829`

Specify it relative to the location of the bootstrap directory that contains `OCSContext.php`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
