### PR TITLE
fix(files_versions): when resolving the storage of a file the full pa…

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -78,7 +78,7 @@ class Storage {
 		//until the end one version per week
 		6 => ['intervalEndsAfter' => -1,      'step' => 604800],
 	];
-	
+
 	/** @var \OCA\Files_Versions\AppInfo\Application */
 	private static $application;
 
@@ -161,8 +161,9 @@ class Storage {
 			}
 
 			list($uid, $filename) = self::getUidAndFilename($filename);
+			$fullFileName = "/$uid/files$filename";
 			/** @var \OCP\Files\Storage\IStorage $storage */
-			list($storage, $internalPath) = Filesystem::resolvePath($filename);
+			list($storage, $internalPath) = Filesystem::resolvePath($fullFileName);
 			if ($storage->instanceOfStorage(IVersionedStorage::class)) {
 				/** @var IVersionedStorage $storage */
 				if ($storage->saveVersion($internalPath)) {
@@ -762,7 +763,7 @@ class Storage {
 
 		return false;
 	}
-	
+
 	/**
 	 * Static workaround
 	 * @return FileHelper

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -161,6 +161,8 @@ class Storage {
 			}
 
 			list($uid, $filename) = self::getUidAndFilename($filename);
+			// $filename is expected to start with "/" and be a
+			// full path such as "/folder1/folder2/filename"
 			$fullFileName = "/$uid/files$filename";
 			/** @var \OCP\Files\Storage\IStorage $storage */
 			list($storage, $internalPath) = Filesystem::resolvePath($fullFileName);

--- a/changelog/unreleased/38430
+++ b/changelog/unreleased/38430
@@ -1,0 +1,7 @@
+Bugfix: Fix storage lookup in versions when storing a new version
+
+Versioning has been integrated with the new storage based versioning IVersionedStorage.
+Until today this was only tested with objectstore versioning which is hooked up as primary storage.
+When trying to access a versioned storage which is mounted as non-root this logic did not work out.
+
+https://github.com/owncloud/core/pull/38430


### PR DESCRIPTION
…th has to be taken into account


## Description
files_versions has been integrated with the new storage based versioning IVersionedStorage
Until today this was only tested with objectstore versioning which is hooked up as primary storage.

When trying to access a versioned storage which is mounted as non-root this logic did not work out.


## Motivation and Context
Allow to use versioned storage in mounted storages.

## How Has This Been Tested?
- under development in files_spaces

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
