### PR TITLE
[docs-only] Remove old mount_file from config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1456,12 +1456,6 @@ $CONFIG = [
 'part_file_in_storage' => true,
 
 /**
- * Define the location of `mount.json`
- * Defaults to `data/mount.json` in the ownCloud directory.
- */
-'mount_file' => '/var/www/owncloud/data/mount.json',
-
-/**
  * Prevent cache changes due to changes in the filesystem
  * When `true`, prevent ownCloud from changing the cache due to changes in the
  * filesystem for all storage.


### PR DESCRIPTION
## Description

`mount_file` is an old config option from a long time ago. There is a migration from it https://github.com/owncloud/core/blob/master/apps/files_external/appinfo/Migrations/Version20170814051424.php 

Remove it from `config.sample.php` so that it people do not accidentally try to use it.

This supersedes docs PR https://github.com/owncloud/docs/pull/3182

Note: there is still code in https://github.com/owncloud/core/blob/master/lib/private/Files/External/Service/LegacyStoragesService.php that can read `mount.json`. That needs to remain in the code-base so that the migration can run when someone upgrades from ownCloud9.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
