### PR TITLE
[Tests-Only]used environment variable for language setup

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1338,7 +1338,7 @@ def acceptance(ctx):
 		'replaceUsernames': False,
 		'extraSetup': [],
 		'extraServices': [],
-		'extraEnvironment': {},
+		'extraEnvironment': {'OC_LANGUAGE':'en-EN'},
 		'extraCommandsBeforeTestRun': [],
 		'extraApps': {},
 		'useBundledApp': False,

--- a/tests/TestHelpers/TranslationHelper.php
+++ b/tests/TestHelpers/TranslationHelper.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Talank Baral <talank@jankaritech.com>
+ * @copyright Copyright (c) 2021 Talank Baral talank@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace TestHelpers;
+
+/**
+ * Class TranslationHelper
+ *
+ * Helper functions that are needed to run tests on different languages
+ *
+ * @package TestHelpers
+ */
+class TranslationHelper {
+	/**
+	 * @param $language
+	 *
+	 * @return string
+	 */
+	public static function getLanguage($language) {
+		if (!isset($language)) {
+			if (\getenv('OC_LANGUAGE') !== false) {
+				$language = \getenv('OC_LANGUAGE');
+			}
+		}
+		return $language;
+	}
+}

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -713,6 +713,11 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function theOCSStatusMessageShouldBe($statusMessage, $language=null) {
+		if (!isset($language)) {
+			if (\getenv('OC_LANGUAGE') !== false) {
+				$language = \getenv('OC_LANGUAGE');
+			}
+		}
 		$statusMessage = $this->getActualStatusMessage($statusMessage, $language);
 
 		Assert::assertEquals(

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -27,6 +27,7 @@ use Behat\Gherkin\Node\TableNode;
 use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;
 use TestHelpers\OcsApiHelper;
+use TestHelpers\TranslationHelper;
 
 require_once 'bootstrap.php';
 
@@ -713,11 +714,7 @@ class OCSContext implements Context {
 	 * @return void
 	 */
 	public function theOCSStatusMessageShouldBe($statusMessage, $language=null) {
-		if (!isset($language)) {
-			if (\getenv('OC_LANGUAGE') !== false) {
-				$language = \getenv('OC_LANGUAGE');
-			}
-		}
+		$language = TranslationHelper::getLanguage($language);
 		$statusMessage = $this->getActualStatusMessage($statusMessage, $language);
 
 		Assert::assertEquals(

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -29,6 +29,7 @@ use TestHelpers\OcsApiHelper;
 use TestHelpers\OcisHelper;
 use TestHelpers\SharingHelper;
 use TestHelpers\HttpRequestHelper;
+use TestHelpers\TranslationHelper;
 
 /**
  * Sharing trait
@@ -1631,11 +1632,7 @@ trait Sharing {
 	 */
 	public function userGetsInfoOfLastShareUsingTheSharingApi($user, $language=null) {
 		$share_id = $this->getLastShareIdOf($user);
-		if (!isset($language)) {
-			if (\getenv('OC_LANGUAGE') !== false) {
-				$language = \getenv('OC_LANGUAGE');
-			}
-		}
+		$language = TranslationHelper::getLanguage($language);
 		$this->getShareData($user, $share_id, $language);
 	}
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1631,6 +1631,11 @@ trait Sharing {
 	 */
 	public function userGetsInfoOfLastShareUsingTheSharingApi($user, $language=null) {
 		$share_id = $this->getLastShareIdOf($user);
+		if (!isset($language)) {
+			if (\getenv('OC_LANGUAGE') !== false) {
+				$language = \getenv('OC_LANGUAGE');
+			}
+		}
 		$this->getShareData($user, $share_id, $language);
 	}
 


### PR DESCRIPTION
## Description
used environment variable `OC_LANGUAGE` for language setup. Now, requests are made with the accepted language of that environment variable. And, while comparing the status message in response, we convert English to `OC_LANGUAGE` using the fixture file `multiLanguageErrors.json` and assert accordingly.

We shall need to add more data on the fixture `multiLanguageErrors.json` if we want to increase the scope of multiple language API tests.

## Related Issue
- https://github.com/owncloud/QA/issues/608

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
