### PR TITLE
[tests-only] name the used skeleton dir explicitly in the feature files

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -2,7 +2,7 @@
 Feature: CORS headers
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @files_sharing-app-required
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header

--- a/tests/acceptance/features/apiAuth/corsOc10Issue34679.feature
+++ b/tests/acceptance/features/apiAuth/corsOc10Issue34679.feature
@@ -2,7 +2,7 @@
 Feature: CORS headers current oC10 behavior for issue-34679
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @issue-34679 @files_sharing-app-required
   Scenario Outline: CORS headers should be returned when invalid password is used

--- a/tests/acceptance/features/apiAuth/filesAppAuth.feature
+++ b/tests/acceptance/features/apiAuth/filesAppAuth.feature
@@ -2,7 +2,7 @@
 Feature: auth
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario: access files app anonymously

--- a/tests/acceptance/features/apiAuth/tokenAuth.feature
+++ b/tests/acceptance/features/apiAuth/tokenAuth.feature
@@ -3,7 +3,7 @@ Feature: tokenAuth
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And token auth has been enforced
 
   Scenario: creating a user with basic auth should be blocked when token auth is enforced

--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -2,7 +2,7 @@
 Feature: auth
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario: using WebDAV anonymously

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -2,7 +2,7 @@
 Feature: auth
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @issue-32068 @skipOnOcV10
   @issue-ocis-reva-30

--- a/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
@@ -2,7 +2,7 @@
 Feature: auth
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @issue-ocis-reva-30
   @smokeTest

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -728,7 +728,7 @@ Feature: capabilities
 
   Scenario: When in a group that is excluded from sharing, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
@@ -757,7 +757,7 @@ Feature: capabilities
 
   Scenario: When not in any group that is excluded from sharing, can_share is on
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
@@ -786,7 +786,7 @@ Feature: capabilities
 
   Scenario: When in a group that is excluded from sharing and in another group, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -3,7 +3,7 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario: Getting info of comments using files endpoint

--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -3,7 +3,7 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiComments/deleteComments.feature
+++ b/tests/acceptance/features/apiComments/deleteComments.feature
@@ -3,7 +3,7 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -98,6 +98,6 @@ Feature: Comments
     Given user "Alice" has created folder "/FOLDER_TO_COMMENT"
     And user "Alice" has commented with content "Comment from owner" on folder "/FOLDER_TO_COMMENT"
     And user "Alice" has been deleted
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     When user "Alice" creates folder "/FOLDER_TO_COMMENT" using the WebDAV API
     Then user "Alice" should have 0 comments on folder "/FOLDER_TO_COMMENT"

--- a/tests/acceptance/features/apiComments/editComments.feature
+++ b/tests/acceptance/features/apiComments/editComments.feature
@@ -3,7 +3,7 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
@@ -4,9 +4,9 @@ Feature: propagation of etags between federated and local server
   Background:
     Given using OCS API version "1"
     And using server "REMOTE"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
 
   Scenario: Overwrite a federated shared folder as sharer propagates etag for recipient
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"

--- a/tests/acceptance/features/apiFederationToRoot1/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federated.feature
@@ -3,9 +3,9 @@ Feature: federated
 
   Background:
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: Federate share a file with another server
@@ -161,7 +161,7 @@ Feature: federated
     Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "Brian" creates a share using the sharing API with settings
       | path        | /textfile0 (2).txt |
@@ -472,7 +472,7 @@ Feature: federated
     And user "Alice" has created folder "zzzfolder/remote"
     And user "Alice" has uploaded file with content "remote content" to "/randomfile.txt"
     And using server "LOCAL"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/zzzfolder"
     And user "Brian" has created folder "zzzfolder/local"
     And user "Brian" has uploaded file with content "local content" to "/randomfile.txt"
@@ -494,7 +494,7 @@ Feature: federated
     And user "Alice" has created folder "zzzfolder/remote"
     And user "Alice" has uploaded file with content "remote content" to "/randomfile.txt"
     And using server "LOCAL"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/zzzfolder"
     And user "Brian" has created folder "zzzfolder/local"
     And user "Brian" has uploaded file with content "local content" to "/randomfile.txt"

--- a/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
@@ -3,9 +3,9 @@ Feature: current oC10 behavior for issue-31276
 
   Background:
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
 
   @issue-31276
   Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password

--- a/tests/acceptance/features/apiFederationToRoot2/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot2/federated.feature
@@ -3,9 +3,9 @@ Feature: federated
 
   Background:
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
 
   @issue-35839 @skipOnOcV10
   Scenario: "Auto accept from trusted servers" enabled with remote server

--- a/tests/acceptance/features/apiFederationToRoot2/federatedOc10Issue35839.feature
+++ b/tests/acceptance/features/apiFederationToRoot2/federatedOc10Issue35839.feature
@@ -3,9 +3,9 @@ Feature: current oC10 behavior for issue-35839
 
   Background:
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
 
   @issue-35839
   Scenario: "Auto accept from trusted servers" enabled with remote server

--- a/tests/acceptance/features/apiFederationToShares1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederationToShares1/etagPropagation.feature
@@ -6,11 +6,11 @@ Feature: propagation of etags between federated and local server
     And using server "REMOTE"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using server "LOCAL"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
 
   Scenario: Overwrite a federated shared folder as sharer propagates etag for recipient
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"

--- a/tests/acceptance/features/apiFederationToShares1/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares1/federated.feature
@@ -5,11 +5,11 @@ Feature: federated
     Given using server "REMOTE"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using server "LOCAL"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: Federate share a file with another server
@@ -165,7 +165,7 @@ Feature: federated
     Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "Brian" creates a share using the sharing API with settings
       | path        | /Shares/textfile0.txt |
@@ -476,7 +476,7 @@ Feature: federated
     And user "Alice" has created folder "zzzfolder/remote"
     And user "Alice" has uploaded file with content "remote content" to "/randomfile.txt"
     And using server "LOCAL"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/zzzfolder"
     And user "Brian" has created folder "zzzfolder/local"
     And user "Brian" has uploaded file with content "local content" to "/randomfile.txt"
@@ -500,7 +500,7 @@ Feature: federated
     And user "Alice" has created folder "zzzfolder/remote"
     And user "Alice" has uploaded file with content "remote content" to "/randomfile.txt"
     And using server "LOCAL"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/zzzfolder"
     And user "Brian" has created folder "zzzfolder/local"
     And user "Brian" has uploaded file with content "local content" to "/randomfile.txt"

--- a/tests/acceptance/features/apiFederationToShares2/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares2/federated.feature
@@ -5,11 +5,11 @@ Feature: federated
     Given using server "REMOTE"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using server "LOCAL"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
 
   @issue-35839 @skipOnOcV10
   Scenario: "Auto accept from trusted servers" enabled with remote server

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -2,7 +2,7 @@
 Feature: caldav
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @caldav
   Scenario: Accessing a not existing calendar of another user

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -2,7 +2,7 @@
 Feature: carddav
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @carddav
   Scenario: Accessing a not existing addressbook of another user

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -299,7 +299,7 @@ Feature: checksums
   @issue-ocis-reva-196
   Scenario Outline: Uploading a file with invalid SHA1 checksum overwriting an existing file
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:f005ba11f005ba11f005ba11f005ba11f005ba11" using the WebDAV API
     Then as user "Brian" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:0c1d334e686d1039c9ead0dbc047f02dbf696be8 MD5:d991cd854c53729d066c6ed5e34bcda3 ADLER32:8685092b"
     And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
@@ -311,7 +311,7 @@ Feature: checksums
   @issue-ocis-reva-56
   Scenario: Upload overwriting a file with new chunking and correct checksum
     Given using new DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     When user "Brian" creates a new chunking upload with id "chunking-42" using the WebDAV API
     And user "Brian" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "Brian" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
@@ -323,7 +323,7 @@ Feature: checksums
   @issue-ocis-reva-56
   Scenario: Upload overwriting a file with new chunking and invalid checksum
     Given using new DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     When user "Brian" creates a new chunking upload with id "chunking-42" using the WebDAV API
     And user "Brian" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "Brian" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -7,7 +7,7 @@ Feature: external-storage
 
   @public_link_share-feature-required @files_sharing-app-required
   Scenario: Share by public link a file inside a local external storage
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -25,7 +25,7 @@ Feature: external-storage
       | mimetype | httpd/unix-directory |
 
   Scenario: Move a file into storage
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -35,7 +35,7 @@ Feature: external-storage
     And as "Alice" file "/local_storage/foo1/textfile0.txt" should exist
 
   Scenario: Move a file out of storage
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -47,7 +47,7 @@ Feature: external-storage
     And as "Brian" file "/local.txt" should exist
 
   Scenario: Download a file that exists in filecache but not storage fails with 404
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/local_storage/foo3"
     And user "Alice" has moved file "/textfile0.txt" to "/local_storage/foo3/textfile0.txt"
     And file "foo3/textfile0.txt" has been deleted from local storage on the server
@@ -58,7 +58,7 @@ Feature: external-storage
     And as "Alice" file "local_storage/foo3/textfile0.txt" should exist
 
   Scenario: Upload a file to external storage while quota is set on home storage
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And the quota of user "Alice" has been set to "1 B"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/local_storage/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
@@ -66,7 +66,7 @@ Feature: external-storage
 
   Scenario Outline: query OCS endpoint for information about the mount
     Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>"
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -7,28 +7,28 @@ Feature: quota
 	# Owner
 
   Scenario: Uploading a file as owner having enough quota
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And the quota of user "Alice" has been set to "10 MB"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
 
   @smokeTest
   Scenario: Uploading a file as owner having insufficient quota
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And the quota of user "Alice" has been set to "20 B"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
     Then as "Alice" the files uploaded to "/testquota.txt" with all mechanisms should not exist
 
   Scenario: Overwriting a file as owner having enough quota
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "10 MB"
     When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
   Scenario: Overwriting a file as owner having insufficient quota
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "20 B"
     When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms using the WebDAV API
@@ -39,7 +39,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Uploading a file in received folder having enough quota
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -52,7 +52,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Uploading a file in received folder having insufficient quota
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -66,7 +66,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Overwriting a file in received folder having enough quota
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -80,7 +80,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Overwriting a file in received folder having insufficient quota
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -97,7 +97,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Overwriting a received file having enough quota
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -110,7 +110,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Overwriting a received file having insufficient quota
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -38,14 +38,14 @@ Feature: add user
       | a space  |
 
   Scenario: admin tries to create an existing user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "102"
     And the HTTP status code should be "200"
     And the API should not return any data
 
   Scenario: admin tries to create an existing disabled user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And user "brand-new-user" has been disabled
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "102"
@@ -114,7 +114,7 @@ Feature: add user
       | BrAnD-nEw-UsEr |
 
   Scenario: admin tries to create an existing user but with username containing capital letters
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator sends a user creation request for user "BRAND-NEW-USER" password "%alt1%" using the provisioning API
     Then the OCS status code should be "102"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -9,7 +9,7 @@ Feature: access user provisioning API using app password
 
   @smokeTest @notToImplementOnOCIS
   Scenario: admin deletes the user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And a new client token for the administrator has been generated
     And a new browser session for the administrator has been started
@@ -20,7 +20,7 @@ Feature: access user provisioning API using app password
 
   @notToImplementOnOCIS
   Scenario: subadmin gets users in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -37,7 +37,7 @@ Feature: access user provisioning API using app password
 
   @smokeTest
   Scenario: normal user gets their own information using the app password
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | brand-new-user | New User    |
     And a new client token for "brand-new-user" has been generated
@@ -49,7 +49,7 @@ Feature: access user provisioning API using app password
 
   @notToImplementOnOCIS
   Scenario: subadmin tries to get users of other group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -65,7 +65,7 @@ Feature: access user provisioning API using app password
     And the HTTP status code should be "200"
 
   Scenario: normal user tries to get other user information using the app password
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -9,7 +9,7 @@ Feature: create a subadmin
 
   @smokeTest
   Scenario: admin creates a subadmin
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     When the administrator makes user "brand-new-user" a subadmin of group "brand-new-group" using the provisioning API
     Then the OCS status code should be "100"
@@ -25,7 +25,7 @@ Feature: create a subadmin
     And user "nonexistentuser" should not be a subadmin of group "brand-new-group"
 
   Scenario: admin tries to create a subadmin using a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "not-group" has been deleted
     When the administrator makes user "brand-new-user" a subadmin of group "not-group" using the provisioning API
     Then the OCS status code should be "102"
@@ -33,7 +33,7 @@ Feature: create a subadmin
     And the API should not return any data
 
   Scenario: subadmin of a group tries to make another user subadmin of their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -46,7 +46,7 @@ Feature: create a subadmin
     And user "brand-new-user" should not be a subadmin of group "brand-new-group"
 
   Scenario: normal user should not be able to make another user a subadmin
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | Alice          |
       | Brian          |

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -9,7 +9,7 @@ Feature: delete users
 
   @smokeTest
   Scenario: Delete a user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator deletes user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -17,7 +17,7 @@ Feature: delete users
 
   @skipOnOcV10.3
   Scenario: Delete a user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username | email               |
       | a@-+_.b  | a.b@example.com     |
       | a space  | a.space@example.com |
@@ -33,7 +33,7 @@ Feature: delete users
       | a space  |
 
   Scenario: Delete a user, and specify the user name in different case
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator deletes user "Brand-New-User" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -41,7 +41,7 @@ Feature: delete users
 
   @smokeTest @notToImplementOnOCIS
   Scenario: subadmin deletes a user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -54,7 +54,7 @@ Feature: delete users
     And user "brand-new-user" should not exist
 
   Scenario: normal user tries to delete a user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -64,7 +64,7 @@ Feature: delete users
     And user "Brian" should exist
 
   Scenario: administrator deletes another admin user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | another-admin  |
     And user "another-admin" has been added to group "admin"
@@ -74,7 +74,7 @@ Feature: delete users
     And user "another-admin" should not exist
 
   Scenario: subadmin deletes a user with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -86,9 +86,9 @@ Feature: delete users
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "another-subadmin" should not exist
-  
+
   Scenario: subadmin should not be able to delete another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -101,7 +101,7 @@ Feature: delete users
     And user "another-subadmin" should exist
 
   Scenario: subadmin should not be able to delete a user with admin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | another-admin  |
@@ -115,7 +115,7 @@ Feature: delete users
     And user "another-admin" should exist
 
   Scenario: subadmin should not be able to delete a user not in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -16,7 +16,7 @@ Feature: disable an app
     And app "comments" should be disabled
 
   Scenario: subadmin tries to disable an app
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And app "comments" has been enabled
@@ -26,7 +26,7 @@ Feature: disable an app
     And app "comments" should be enabled
 
   Scenario: normal user tries to disable an app
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And app "comments" has been enabled
     When user "brand-new-user" disables app "comments"
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -9,7 +9,7 @@ Feature: disable user
 
   @smokeTest
   Scenario: admin disables an user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator disables user "Alice" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -17,7 +17,7 @@ Feature: disable user
 
   @skipOnOcV10.3
   Scenario Outline: admin disables an user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username   | email   |
       | <username> | <email> |
     When the administrator disables user "<username>" using the provisioning API
@@ -31,7 +31,7 @@ Feature: disable user
 
   @smokeTest @notToImplementOnOCIS
   Scenario: Subadmin should be able to disable an user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | subadmin |
@@ -46,7 +46,7 @@ Feature: disable user
 
   @notToImplementOnOCIS
   Scenario: Subadmin should not be able to disable an user not in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | subadmin |
@@ -62,7 +62,7 @@ Feature: disable user
 
   @notToImplementOnOCIS
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username      |
       | subadmin      |
       | another-admin |
@@ -77,7 +77,7 @@ Feature: disable user
     And user "another-admin" should be enabled
 
   Scenario: Admin can disable another admin user
-    Given user "another-admin" has been created with default attributes and skeleton files
+    Given user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     When the administrator disables user "another-admin" using the provisioning API
     Then the OCS status code should be "100"
@@ -86,7 +86,7 @@ Feature: disable user
 
   @notToImplementOnOCIS
   Scenario: Admin can disable subadmins in the same group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And the administrator has been added to group "brand-new-group"
@@ -97,7 +97,7 @@ Feature: disable user
     And user "subadmin" should be disabled
 
   Scenario: Admin user cannot disable himself
-    Given user "another-admin" has been created with default attributes and skeleton files
+    Given user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     When user "another-admin" disables user "another-admin" using the provisioning API
     Then the OCS status code should be "101"
@@ -105,7 +105,7 @@ Feature: disable user
     And user "another-admin" should be enabled
 
   Scenario: disable an user with a regular user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -116,7 +116,7 @@ Feature: disable user
 
   @notToImplementOnOCIS
   Scenario: Subadmin should not be able to disable himself
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And user "subadmin" has been made a subadmin of group "brand-new-group"
@@ -127,50 +127,50 @@ Feature: disable user
 
   @smokeTest
   Scenario: Making a web request with a disabled user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "403"
 
   Scenario: Disabled user tries to download file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" downloads file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to upload file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" uploads file with content "uploaded content" to "newTextFile.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to rename file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" moves file "/textfile0.txt" to "/renamedTextfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to move file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" moves file "/textfile0.txt" to "/PARENT/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to delete file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to share a file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to share a folder
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
@@ -179,7 +179,7 @@ Feature: disable user
   Scenario: getting shares shared by disabled user
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared file "/textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
@@ -190,7 +190,7 @@ Feature: disable user
   Scenario: getting shares shared by disabled user in a group
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And group "group0" has been created
     And user "Brian" has been added to group "group0"
@@ -201,14 +201,14 @@ Feature: disable user
     And the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line
 
   Scenario: Disabled user tries to create public link share
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" creates a public link share using the sharing API with settings
       | path | textfile0.txt |
     Then the HTTP status code should be "401"
 
   Scenario Outline: getting public link share shared by disabled user using the new public WebDAV API
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created a public link share with settings
       | path        | /textfile0.txt |
       | permissions | read           |
@@ -220,7 +220,7 @@ Feature: disable user
       | new         |
 
   Scenario: Subadmin should be able to disable user with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -234,7 +234,7 @@ Feature: disable user
     And user "another-subadmin" should be disabled
 
   Scenario: Subadmin should not be able to disable another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -247,7 +247,7 @@ Feature: disable user
     And user "another-subadmin" should be enabled
 
   Scenario: normal user cannot disable himself
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
     When user "Alice" disables user "Alice" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -9,7 +9,7 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user email
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
@@ -17,7 +17,7 @@ Feature: edit users
 
   @skipOnOcV10.3
   Scenario Outline: the administrator can edit a user email of an user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username   | email   |
       | <username> | <email> |
     When the administrator changes the email of user "<username>" to "a-different-email@example.com" using the provisioning API
@@ -31,21 +31,21 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user display (the API allows editing the "display name" by using the key word "display")
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the display of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And the display name of user "brand-new-user" should be "A New User"
 
   Scenario: the administrator can edit a user display name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And the display name of user "brand-new-user" should be "A New User"
 
   Scenario: the administrator can clear a user display name and then it defaults to the username
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "A New User"
     When the administrator changes the display name of user "brand-new-user" to "" using the provisioning API
     Then the HTTP status code should be "200"
@@ -54,14 +54,14 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user quota
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: the administrator can override an existing user email
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -72,7 +72,7 @@ Feature: edit users
 
   @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: the administrator can clear an existing user email
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -83,7 +83,7 @@ Feature: edit users
 
   @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin should be able to edit the user information in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -98,7 +98,7 @@ Feature: edit users
     And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: a normal user should be able to change their email address
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -107,7 +107,7 @@ Feature: edit users
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   Scenario Outline: a normal user should be able to change their display name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" changes the display name of user "brand-new-user" to "<display-name>" using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -120,7 +120,7 @@ Feature: edit users
       | Phil Cyclist 🚴 |
 
   Scenario: a normal user should not be able to change their quota
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
@@ -129,7 +129,7 @@ Feature: edit users
     And the quota definition of user "brand-new-user" should be "default"
 
   Scenario: the administrator can edit user information with admin permissions
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username            |
       | another-admin       |
     And user "another-admin" has been added to group "admin"
@@ -141,7 +141,7 @@ Feature: edit users
     And the quota definition of user "another-admin" should be "12 MB"
 
   Scenario: a subadmin should be able to edit user information with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -157,7 +157,7 @@ Feature: edit users
     And the quota definition of user "another-subadmin" should be "12 MB"
 
     Scenario: a subadmin should not be able to edit user information of another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -17,7 +17,7 @@ Feature: enable an app
     And the information for app "comments" should have a valid version
 
   Scenario: subadmin tries to enable an app
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And app "comments" has been disabled
@@ -27,7 +27,7 @@ Feature: enable an app
     And app "comments" should be disabled
 
   Scenario: normal user tries to enable an app
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And app "comments" has been disabled
     When user "brand-new-user" enables app "comments"
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -9,7 +9,7 @@ Feature: enable user
 
   @smokeTest
   Scenario: admin enables an user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When the administrator enables user "Alice" using the provisioning API
     Then the OCS status code should be "100"
@@ -18,7 +18,7 @@ Feature: enable user
 
   @skipOnOcV10.3
   Scenario Outline: admin enables an user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username   | email   |
       | <username> | <email> |
     And user "<username>" has been disabled
@@ -32,7 +32,7 @@ Feature: enable user
       | a space  | a.space@example.com |
 
   Scenario: admin enables another admin user
-    Given user "another-admin" has been created with default attributes and skeleton files
+    Given user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When the administrator enables user "another-admin" using the provisioning API
@@ -42,7 +42,7 @@ Feature: enable user
 
   @notToImplementOnOCIS
   Scenario: admin enables subadmins in the same group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And the administrator has been added to group "brand-new-group"
@@ -54,14 +54,14 @@ Feature: enable user
     And user "subadmin" should be enabled
 
   Scenario: admin tries to enable himself
-    And user "another-admin" has been created with default attributes and skeleton files
+    And user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When user "another-admin" tries to enable user "another-admin" using the provisioning API
     Then user "another-admin" should be disabled
 
   Scenario: normal user tries to enable other user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -73,7 +73,7 @@ Feature: enable user
 
   @notToImplementOnOCIS
   Scenario: subadmin tries to enable himself
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And user "subadmin" has been made a subadmin of group "brand-new-group"
@@ -85,12 +85,12 @@ Feature: enable user
 
   @notToImplementOnOCIS
   Scenario: Making a web request with an enabled user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When user "Alice" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "200"
 
   Scenario: normal user should not be able to enable himself
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
     And user "Alice" has been disabled
@@ -100,7 +100,7 @@ Feature: enable user
     And user "Alice" should be disabled
 
   Scenario: subadmin should be able to enable user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username    |
       | Alice       |
       | subadmin    |
@@ -114,7 +114,7 @@ Feature: enable user
     And user "Alice" should be enabled
 
   Scenario: subadmin should not be able to enable user not in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username    |
       | Alice       |
       | subadmin    |
@@ -127,7 +127,7 @@ Feature: enable user
     And user "Alice" should be disabled
 
   Scenario: subadmin should be able to enable user with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username    |
       | Alice       |
       | subadmin    |
@@ -142,7 +142,7 @@ Feature: enable user
     And user "Alice" should be enabled
 
   Scenario: subadmin should not be able to enable another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username            |
       | subadmin            |
       | another-subadmin    |

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -9,7 +9,7 @@ Feature: get subadmins
 
   @smokeTest
   Scenario: admin gets subadmin users of a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
     When the administrator gets all the subadmins of group "brand-new-group" using the provisioning API
@@ -19,7 +19,7 @@ Feature: get subadmins
     And the HTTP status code should be "200"
 
   Scenario: admin tries to get subadmin users of a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "nonexistentgroup" has been deleted
     When the administrator gets all the subadmins of group "nonexistentgroup" using the provisioning API
     Then the OCS status code should be "101"
@@ -27,7 +27,7 @@ Feature: get subadmins
     And the API should not return any data
 
   Scenario: subadmin tries to get other subadmins of the same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -40,7 +40,7 @@ Feature: get subadmins
     And the API should not return any data
 
   Scenario: normal user tries to get the subadmins of the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -9,7 +9,7 @@ Feature: get user
 
   @smokeTest
   Scenario: admin gets an existing user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname    |
       | brand-new-user | Brand New User |
     When the administrator retrieves the information of user "brand-new-user" using the provisioning API
@@ -20,7 +20,7 @@ Feature: get user
 
   @skipOnOcV10.3
   Scenario Outline: admin gets an existing user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username   | displayname   | email   |
       | <username> | <displayname> | <email> |
     When the administrator retrieves the information of user "<username>" using the provisioning API
@@ -35,7 +35,7 @@ Feature: get user
       | a space  | A Space Name | a.space@example.com |
 
   Scenario: admin gets an existing user, providing uppercase username in the URL
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname    |
       | brand-new-user | Brand New User |
     When the administrator retrieves the information of user "BRAND-NEW-USER" using the provisioning API
@@ -52,7 +52,7 @@ Feature: get user
 
   @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin gets information of a user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | subadmin       | Sub Admin   |
       | brand-new-user | New User    |
@@ -67,7 +67,7 @@ Feature: get user
 
   @notToImplementOnOCIS
   Scenario: a subadmin tries to get information of a user not in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -79,7 +79,7 @@ Feature: get user
     And the API should not return any data
 
   Scenario: a normal user tries to get information of another user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -90,7 +90,7 @@ Feature: get user
 
   @smokeTest
   Scenario: a normal user gets their own information
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | brand-new-user | New User    |
     When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
@@ -100,7 +100,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a normal user gets their own information, providing uppercase username as authentication
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | brand-new-user | New User    |
     When user "BRAND-NEW-USER" retrieves the information of user "brand-new-user" using the provisioning API
@@ -111,7 +111,7 @@ Feature: get user
 
   @skipOnOcV10.3
   Scenario: a normal user gets their own information, providing uppercase username in the URL
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | brand-new-user | New User    |
     When user "brand-new-user" retrieves the information of user "BRAND-NEW-USER" using the provisioning API
@@ -122,7 +122,7 @@ Feature: get user
 
   @skipOnOcV10.3
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | Brand-New-User | New User    |
     When user "Brand-New-User" retrieves the information of user "brand-new-user" using the provisioning API
@@ -132,7 +132,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | Brand-New-User | New User    |
     When user "brand-new-user" retrieves the information of user "Brand-New-User" using the provisioning API
@@ -142,7 +142,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: admin gets information of a user with admin permissions
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname    |
       | Alice          | Admin Alice    |
     And user "Alice" has been added to group "admin"
@@ -153,7 +153,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -168,7 +168,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a subadmin should not be able to get information of another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -9,7 +9,7 @@ Feature: get users
 
   @smokeTest @notToImplementOnOCIS
   Scenario: admin gets all users
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator gets the list of all users using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -18,7 +18,7 @@ Feature: get users
       | admin          |
 
   Scenario: admin gets all users
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator gets the list of all users using the provisioning API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -27,7 +27,7 @@ Feature: get users
 
   @smokeTest @notToImplementOnOCIS
   Scenario: subadmin gets the users in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -41,7 +41,7 @@ Feature: get users
     And the HTTP status code should be "200"
 
   Scenario: normal user tries to get other users
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -9,7 +9,7 @@ Feature: remove subadmin
 
   @smokeTest
   Scenario: admin removes subadmin from a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
     When the administrator removes user "brand-new-user" from being a subadmin of group "brand-new-group" using the provisioning API
@@ -18,7 +18,7 @@ Feature: remove subadmin
     And user "brand-new-user" should not be a subadmin of group "brand-new-group"
 
   Scenario: subadmin tries to remove other subadmin in the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -31,7 +31,7 @@ Feature: remove subadmin
     And user "another-subadmin" should be a subadmin of group "brand-new-group"
 
   Scenario: normal user tries to remove subadmin in the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -44,7 +44,7 @@ Feature: remove subadmin
     And user "subadmin" should be a subadmin of group "brand-new-group"
 
   Scenario: subadmin should not be able to remove subadmin of another group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -9,7 +9,7 @@ Feature: reset user password
 
   @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: reset user password
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
@@ -26,7 +26,7 @@ Feature: reset user password
 
   @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57 @toImplementOnOCIS
   Scenario: subadmin should be able to reset the password of a user in their group
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -41,7 +41,7 @@ Feature: reset user password
 
   @toImplementOnOCIS
   Scenario: subadmin should not be able to reset the password of a user not in their group
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -54,7 +54,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should not be able to reset the password of another user
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username         | password   | displayname    | email                    |
       | brand-new-user   | %regular%  | New user       | brand.new.user@oc.com.np |
       | another-new-user | %altadmin% | Wanna Be Admin | wanna.be.admin@oc.com.np |
@@ -65,7 +65,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should be able to reset their own password
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When user "brand-new-user" resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
@@ -76,7 +76,7 @@ Feature: reset user password
 
   @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario Outline: reset user password including emoji
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "<password>" using the provisioning API
@@ -99,7 +99,7 @@ Feature: reset user password
 
   @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: admin resets password of user with admin permissions
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username | password  | displayname | email           |
       | Alice    | %regular% | New user    | alice@oc.com.np |
     And user "Alice" has been added to group "admin"
@@ -111,7 +111,7 @@ Feature: reset user password
 
   @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user with subadmin permissions in their group
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -127,7 +127,7 @@ Feature: reset user password
 
 
   Scenario: subadmin should not be able to reset the password of another subadmin of same group
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username         | password   | displayname | email                      |
       | another-subadmin | %regular%  | New user    | another.subadmin@oc.com.np |
       | subadmin         | %subadmin% | Sub Admin   | sub.admin@oc.com.np        |

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -30,14 +30,14 @@ Feature: add user
       | a space  |
 
   Scenario: admin tries to create an existing user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And the API should not return any data
 
   Scenario: admin tries to create an existing disabled user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And user "brand-new-user" has been disabled
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "400"
@@ -100,7 +100,7 @@ Feature: add user
       | BrAnD-nEw-UsEr |
 
   Scenario: admin tries to create an existing user but with username containing capital letters
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator sends a user creation request for user "BRAND-NEW-USER" password "%alt1%" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -9,7 +9,7 @@ Feature: access user provisioning API using app password
 
   @smokeTest @notToImplementOnOCIS
   Scenario: admin deletes the user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And a new client token for the administrator has been generated
     And a new browser session for the administrator has been started
@@ -20,7 +20,7 @@ Feature: access user provisioning API using app password
 
   @notToImplementOnOCIS
   Scenario: subadmin gets users in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -37,7 +37,7 @@ Feature: access user provisioning API using app password
 
   @smokeTest
   Scenario: normal user gets their own information using the app password
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | brand-new-user | New User    |
     And a new client token for "brand-new-user" has been generated
@@ -49,7 +49,7 @@ Feature: access user provisioning API using app password
 
   @notToImplementOnOCIS
   Scenario: subadmin tries to get users of other group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -65,7 +65,7 @@ Feature: access user provisioning API using app password
     And the HTTP status code should be "200"
 
   Scenario: normal user tries to get other user information using the app password
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -9,7 +9,7 @@ Feature: create a subadmin
 
   @smokeTest
   Scenario: admin creates a subadmin
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     When the administrator makes user "brand-new-user" a subadmin of group "brand-new-group" using the provisioning API
     Then the OCS status code should be "200"
@@ -25,7 +25,7 @@ Feature: create a subadmin
     And user "nonexistentuser" should not be a subadmin of group "brand-new-group"
 
   Scenario: admin tries to create a subadmin using a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "not-group" has been deleted
     When the administrator makes user "brand-new-user" a subadmin of group "not-group" using the provisioning API
     Then the OCS status code should be "400"
@@ -33,7 +33,7 @@ Feature: create a subadmin
 
   @issue-31276 @skipOnOcV10
   Scenario: subadmin of a group tries to make another user subadmin of their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -46,7 +46,7 @@ Feature: create a subadmin
     And user "brand-new-user" should not be a subadmin of group "brand-new-group"
 
   Scenario: normal user should not be able to make another user a subadmin
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | Alice          |
       | Brian          |

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdminOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdminOc10Issue31276.feature
@@ -7,7 +7,7 @@ Feature: current oC10 behavior for issue-31276
   @issue-31276
   Scenario: subadmin of a group tries to make another user subadmin of their group
     Given using OCS API version "2"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -9,7 +9,7 @@ Feature: delete users
 
   @smokeTest
   Scenario: Delete a user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator deletes user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -17,7 +17,7 @@ Feature: delete users
 
   @skipOnOcV10.3
   Scenario: Delete a user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username | email               |
       | a@-+_.b  | a.b@example.com     |
       | a space  | a.space@example.com |
@@ -33,7 +33,7 @@ Feature: delete users
       | a space  |
 
   Scenario: Delete a user, and specify the user name in different case
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator deletes user "Brand-New-User" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -41,7 +41,7 @@ Feature: delete users
 
   @smokeTest @notToImplementOnOCIS
   Scenario: subadmin deletes a user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -55,7 +55,7 @@ Feature: delete users
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to delete a user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -65,7 +65,7 @@ Feature: delete users
     And user "Brian" should exist
 
   Scenario: administrator deletes another admin user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | another-admin  |
     And user "another-admin" has been added to group "admin"
@@ -75,7 +75,7 @@ Feature: delete users
     And user "another-admin" should not exist
 
   Scenario: subadmin deletes a user with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -89,7 +89,7 @@ Feature: delete users
     And user "another-subadmin" should not exist
 
   Scenario: subadmin should not be able to delete another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -102,7 +102,7 @@ Feature: delete users
     And user "another-subadmin" should exist
 
   Scenario: subadmin should not be able to delete a user with admin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | another-admin  |
@@ -116,7 +116,7 @@ Feature: delete users
     And user "another-admin" should exist
 
   Scenario: subadmin should not be able to delete a user not in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUserOc10Issue31276.feature
@@ -7,7 +7,7 @@ Feature: current oC10 behavior for issue-31276
   @issue-31276
   Scenario: normal user tries to delete a user
     Given using OCS API version "2"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -17,7 +17,7 @@ Feature: disable an app
 
   @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to disable an app
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And app "comments" has been enabled
@@ -28,7 +28,7 @@ Feature: disable an app
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to disable an app
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And app "comments" has been enabled
     When user "brand-new-user" disables app "comments"
     Then the OCS status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/disableAppOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableAppOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: subadmin tries to disable an app
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And app "comments" has been enabled
@@ -21,7 +21,7 @@ Feature: current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: normal user tries to disable an app
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And app "comments" has been enabled
     When user "brand-new-user" disables app "comments"
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -9,7 +9,7 @@ Feature: disable user
 
   @smokeTest
   Scenario: admin disables an user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator disables user "Alice" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -17,7 +17,7 @@ Feature: disable user
 
   @skipOnOcV10.3
   Scenario Outline: admin disables an user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username   | email   |
       | <username> | <email> |
     When the administrator disables user "<username>" using the provisioning API
@@ -31,7 +31,7 @@ Feature: disable user
 
   @smokeTest @notToImplementOnOCIS
   Scenario: Subadmin should be able to disable an user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | subadmin |
@@ -46,7 +46,7 @@ Feature: disable user
 
   @issue-31276 @skipOnOcV10
   Scenario: Subadmin should not be able to disable an user not in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | subadmin |
@@ -62,7 +62,7 @@ Feature: disable user
 
   @issue-31276 @skipOnOcV10
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username      |
       | subadmin      |
       | another-admin |
@@ -77,7 +77,7 @@ Feature: disable user
     And user "another-admin" should be enabled
 
   Scenario: Admin can disable another admin user
-    Given user "another-admin" has been created with default attributes and skeleton files
+    Given user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     When the administrator disables user "another-admin" using the provisioning API
     Then the OCS status code should be "200"
@@ -86,7 +86,7 @@ Feature: disable user
 
   @notToImplementOnOCIS
   Scenario: Admin can disable subadmins in the same group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And the administrator has been added to group "brand-new-group"
@@ -97,7 +97,7 @@ Feature: disable user
     And user "subadmin" should be disabled
 
   Scenario: Admin user cannot disable himself
-    Given user "another-admin" has been created with default attributes and skeleton files
+    Given user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     When user "another-admin" disables user "another-admin" using the provisioning API
     Then the OCS status code should be "400"
@@ -106,7 +106,7 @@ Feature: disable user
 
   @issue-31276 @skipOnOcV10
   Scenario: disable an user with a regular user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -117,7 +117,7 @@ Feature: disable user
 
   @notToImplementOnOCIS
   Scenario: Subadmin should not be able to disable himself
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And user "subadmin" has been made a subadmin of group "brand-new-group"
@@ -128,50 +128,50 @@ Feature: disable user
 
   @smokeTest
   Scenario: Making a web request with a disabled user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" sends HTTP method "GET" to URL "/index.php/apps/files"
     And the HTTP status code should be "403"
 
   Scenario: Disabled user tries to download file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" downloads file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to upload file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" uploads file with content "uploaded content" to "newTextFile.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to rename file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" moves file "/textfile0.txt" to "/renamedTextfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to move file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" moves file "/textfile0.txt" to "/PARENT/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to delete file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to share a file
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     Then the HTTP status code should be "401"
 
   Scenario: Disabled user tries to share a folder
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
@@ -180,7 +180,7 @@ Feature: disable user
   Scenario: getting shares shared by disabled user
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared file "/textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
@@ -191,7 +191,7 @@ Feature: disable user
   Scenario: getting shares shared by disabled user in a group
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And group "group0" has been created
     And user "Brian" has been added to group "group0"
@@ -202,14 +202,14 @@ Feature: disable user
     And the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line
 
   Scenario: Disabled user tries to create public link share
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" creates a public link share using the sharing API with settings
       | path | textfile0.txt |
     Then the HTTP status code should be "401"
 
   Scenario Outline: getting public link share shared by disabled user using the new public WebDAV API
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created a public link share with settings
       | path        | /textfile0.txt |
       | permissions | read           |
@@ -221,7 +221,7 @@ Feature: disable user
       | new         |
 
   Scenario: Subadmin should be able to disable user with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -235,7 +235,7 @@ Feature: disable user
     And user "another-subadmin" should be disabled
 
   Scenario: Subadmin should not be able to disable another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -248,7 +248,7 @@ Feature: disable user
     And user "another-subadmin" should be enabled
 
   Scenario: normal user cannot disable himself
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
     When user "Alice" disables user "Alice" using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/disableUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUserOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: Subadmin should not be able to disable an user not in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | subadmin |
@@ -26,7 +26,7 @@ Feature: current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username      |
       | subadmin      |
       | another-admin |
@@ -43,7 +43,7 @@ Feature: current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: disable an user with a regular user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -9,7 +9,7 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user email
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
@@ -17,7 +17,7 @@ Feature: edit users
 
   @skipOnOcV10.3
   Scenario Outline: the administrator can edit a user email of an user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username   | email   |
       | <username> | <email> |
     When the administrator changes the email of user "<username>" to "a-different-email@example.com" using the provisioning API
@@ -31,21 +31,21 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user display (the API allows editing the "display name" by using the key word "display")
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the display of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the display name of user "brand-new-user" should be "A New User"
 
   Scenario: the administrator can edit a user display name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the display name of user "brand-new-user" should be "A New User"
 
   Scenario: the administrator can clear a user display name and then it defaults to the username
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "A New User"
     When the administrator changes the display name of user "brand-new-user" to "" using the provisioning API
     Then the HTTP status code should be "200"
@@ -54,14 +54,14 @@ Feature: edit users
 
   @smokeTest
   Scenario: the administrator can edit a user quota
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: the administrator can override existing user email
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -72,7 +72,7 @@ Feature: edit users
 
   @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: the administrator can clear an existing user email
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -83,7 +83,7 @@ Feature: edit users
 
   @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin should be able to edit the user information in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -98,7 +98,7 @@ Feature: edit users
     And the quota definition of user "brand-new-user" should be "12 MB"
 
   Scenario: a normal user should be able to change their email address
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -107,7 +107,7 @@ Feature: edit users
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
   Scenario Outline: a normal user should be able to change their display name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" changes the display name of user "brand-new-user" to "<display-name>" using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -120,7 +120,7 @@ Feature: edit users
       | Phil Cyclist 🚴 |
 
   Scenario: a normal user should not be able to change their quota
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
@@ -129,7 +129,7 @@ Feature: edit users
     And the quota definition of user "brand-new-user" should be "default"
 
   Scenario: the administrator can edit user information with admin permissions
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username            |
       | another-admin       |
     And user "another-admin" has been added to group "admin"
@@ -141,7 +141,7 @@ Feature: edit users
     And the quota definition of user "another-admin" should be "12 MB"
 
   Scenario: a subadmin should be able to edit user information with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -157,7 +157,7 @@ Feature: edit users
     And the quota definition of user "another-subadmin" should be "12 MB"
 
   Scenario: a subadmin should not be able to edit user information of another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -17,7 +17,7 @@ Feature: enable an app
 
   @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to enable an app
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And app "comments" has been disabled
@@ -28,7 +28,7 @@ Feature: enable an app
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to enable an app
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And app "comments" has been disabled
     When user "brand-new-user" enables app "comments"
     Then the OCS status code should be "401"

--- a/tests/acceptance/features/apiProvisioning-v2/enableAppOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableAppOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: enable an app - current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: subadmin tries to enable an app
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     And app "comments" has been disabled
@@ -21,7 +21,7 @@ Feature: enable an app - current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: normal user tries to enable an app
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And app "comments" has been disabled
     When user "brand-new-user" enables app "comments"
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -9,7 +9,7 @@ Feature: enable user
 
   @smokeTest
   Scenario: admin enables an user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When the administrator enables user "Alice" using the provisioning API
     Then the OCS status code should be "200"
@@ -18,7 +18,7 @@ Feature: enable user
 
   @skipOnOcV10.3
   Scenario Outline: admin enables an user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username   | email   |
       | <username> | <email> |
     And user "<username>" has been disabled
@@ -32,7 +32,7 @@ Feature: enable user
       | a space  | a.space@example.com |
 
   Scenario: admin enables another admin user
-    Given user "another-admin" has been created with default attributes and skeleton files
+    Given user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When the administrator enables user "another-admin" using the provisioning API
@@ -42,7 +42,7 @@ Feature: enable user
 
   @notToImplementOnOCIS
   Scenario: admin enables subadmins in the same group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And the administrator has been added to group "brand-new-group"
@@ -54,7 +54,7 @@ Feature: enable user
     And user "subadmin" should be enabled
 
   Scenario: admin tries to enable himself
-    Given user "another-admin" has been created with default attributes and skeleton files
+    Given user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When user "another-admin" tries to enable user "another-admin" using the provisioning API
@@ -62,7 +62,7 @@ Feature: enable user
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to enable other user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -74,7 +74,7 @@ Feature: enable user
 
   @notToImplementOnOCIS
   Scenario: subadmin tries to enable himself
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And user "subadmin" has been made a subadmin of group "brand-new-group"
@@ -86,13 +86,13 @@ Feature: enable user
 
   @notToImplementOnOCIS
   Scenario: Making a web request with an enabled user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When user "Alice" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "200"
 
   @notToImplementOnOCIS
   Scenario: normal user should not be able to enable himself
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
     And user "Alice" has been disabled
@@ -102,7 +102,7 @@ Feature: enable user
     And user "Alice" should be disabled
 
   Scenario: subadmin should be able to enable user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username    |
       | Alice       |
       | subadmin    |
@@ -116,7 +116,7 @@ Feature: enable user
     And user "Alice" should be enabled
 
   Scenario: subadmin should not be able to enable user not in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username    |
       | Alice       |
       | subadmin    |
@@ -129,7 +129,7 @@ Feature: enable user
     And user "Alice" should be disabled
 
   Scenario: subadmin should be able to enable user with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username    |
       | Alice       |
       | subadmin    |
@@ -144,7 +144,7 @@ Feature: enable user
     And user "Alice" should be enabled
 
   Scenario: subadmin should not be able to enable another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username            |
       | subadmin            |
       | another-subadmin    |

--- a/tests/acceptance/features/apiProvisioning-v2/enableUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUserOc10Issue31276.feature
@@ -7,7 +7,7 @@ Feature: enable user - current oC10 behavior for issue-31276
   @issue-31276
   Scenario: normal user tries to enable other user
     Given using OCS API version "2"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -9,7 +9,7 @@ Feature: get subadmins
 
   @smokeTest
   Scenario: admin gets subadmin users of a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
     When the administrator gets all the subadmins of group "brand-new-group" using the provisioning API
@@ -19,7 +19,7 @@ Feature: get subadmins
     And the HTTP status code should be "200"
 
   Scenario: admin tries to get subadmin users of a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "nonexistentgroup" has been deleted
     When the administrator gets all the subadmins of group "nonexistentgroup" using the provisioning API
     Then the OCS status code should be "400"
@@ -28,7 +28,7 @@ Feature: get subadmins
 
   @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to get other subadmins of the same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -42,7 +42,7 @@ Feature: get subadmins
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get the subadmins of the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdminsOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdminsOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: get subadmins - current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: subadmin tries to get other subadmins of the same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -24,7 +24,7 @@ Feature: get subadmins - current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: normal user tries to get the subadmins of the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -9,7 +9,7 @@ Feature: get user
 
   @smokeTest
   Scenario: admin gets an existing user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname    |
       | brand-new-user | Brand New User |
     When the administrator retrieves the information of user "brand-new-user" using the provisioning API
@@ -20,7 +20,7 @@ Feature: get user
 
   @skipOnOcV10.3
   Scenario Outline: admin gets an existing user with special characters in the username
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username   | displayname   | email   |
       | <username> | <displayname> | <email> |
     When the administrator retrieves the information of user "<username>" using the provisioning API
@@ -35,7 +35,7 @@ Feature: get user
       | a space  | A Space Name | a.space@example.com |
 
   Scenario: admin gets an existing user, providing uppercase username in the URL
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname    |
       | brand-new-user | Brand New User |
     When the administrator retrieves the information of user "BRAND-NEW-USER" using the provisioning API
@@ -52,7 +52,7 @@ Feature: get user
 
   @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin gets information of a user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | subadmin       | Sub Admin   |
       | brand-new-user | New User    |
@@ -67,7 +67,7 @@ Feature: get user
 
   @notToImplementOnOCIS
   Scenario: a subadmin tries to get information of a user not in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -80,7 +80,7 @@ Feature: get user
 
   @issue-31276 @skipOnOcV10
   Scenario: a normal user tries to get information of another user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -91,7 +91,7 @@ Feature: get user
 
   @smokeTest
   Scenario: a normal user gets their own information
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | brand-new-user | New User    |
     When user "brand-new-user" retrieves the information of user "brand-new-user" using the provisioning API
@@ -101,7 +101,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a normal user gets their own information, providing uppercase username as authentication
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | brand-new-user | New User    |
     When user "BRAND-NEW-USER" retrieves the information of user "brand-new-user" using the provisioning API
@@ -112,7 +112,7 @@ Feature: get user
 
   @skipOnOcV10.3
   Scenario: a normal user gets their own information, providing uppercase username in the URL
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | brand-new-user | New User    |
     When user "brand-new-user" retrieves the information of user "BRAND-NEW-USER" using the provisioning API
@@ -123,7 +123,7 @@ Feature: get user
 
   @skipOnOcV10.3
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | Brand-New-User | New User    |
     When user "Brand-New-User" retrieves the information of user "brand-new-user" using the provisioning API
@@ -133,7 +133,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname |
       | Brand-New-User | New User    |
     When user "brand-new-user" retrieves the information of user "Brand-New-User" using the provisioning API
@@ -143,7 +143,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: admin gets information of a user with admin permissions
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname    |
       | Alice          | Admin Alice    |
     And user "Alice" has been added to group "admin"
@@ -154,7 +154,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -169,7 +169,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
 
   Scenario: a subadmin should not be able to get information of another subadmin of same group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |

--- a/tests/acceptance/features/apiProvisioning-v2/getUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: get user - current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: a normal user tries to get information of another user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -9,7 +9,7 @@ Feature: get users
 
   @smokeTest @notToImplementOnOCIS
   Scenario: admin gets all users
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator gets the list of all users using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -18,7 +18,7 @@ Feature: get users
       | admin          |
 
   Scenario: admin gets all users
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator gets the list of all users using the provisioning API
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
@@ -27,7 +27,7 @@ Feature: get users
 
   @smokeTest @notToImplementOnOCIS
   Scenario: subadmin gets the users in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -42,7 +42,7 @@ Feature: get users
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get other users
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |

--- a/tests/acceptance/features/apiProvisioning-v2/getUsersOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsersOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: get users - current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: normal user tries to get other users
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -9,7 +9,7 @@ Feature: remove subadmin
 
   @smokeTest
   Scenario: admin removes subadmin from a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
     When the administrator removes user "brand-new-user" from being a subadmin of group "brand-new-group" using the provisioning API
@@ -19,7 +19,7 @@ Feature: remove subadmin
 
   @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to remove other subadmin in the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -33,7 +33,7 @@ Feature: remove subadmin
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to remove subadmin in the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |
@@ -46,7 +46,7 @@ Feature: remove subadmin
     And user "subadmin" should be a subadmin of group "brand-new-group"
 
   Scenario: subadmin should not be able to remove subadmin of another group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdminOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdminOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: remove subadmin - current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: subadmin tries to remove other subadmin in the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | subadmin         |
       | another-subadmin |
@@ -24,7 +24,7 @@ Feature: remove subadmin - current oC10 behavior for issue-31276
 
   @issue-31276
   Scenario: normal user tries to remove subadmin in the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | subadmin       |
       | brand-new-user |

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -9,7 +9,7 @@ Feature: reset user password
 
   @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: reset user password
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
@@ -26,7 +26,7 @@ Feature: reset user password
 
   @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57 @notToImplementOnOCIS
   Scenario: subadmin should be able to reset the password of a user in their group
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -41,7 +41,7 @@ Feature: reset user password
 
   @toImplementOnOCIS
   Scenario: subadmin should not be able to reset the password of a user not in their group
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -54,7 +54,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should not be able to reset the password of another user
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username         | password   | displayname    | email                    |
       | brand-new-user   | %regular%  | New user       | brand.new.user@oc.com.np |
       | another-new-user | %altadmin% | Wanna Be Admin | wanna.be.admin@oc.com.np |
@@ -65,7 +65,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
 
   Scenario: a user should be able to reset their own password
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When user "brand-new-user" resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
@@ -76,7 +76,7 @@ Feature: reset user password
 
   @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario Outline: reset user password including emoji
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "<password>" using the provisioning API
@@ -99,7 +99,7 @@ Feature: reset user password
 
   @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: admin resets password of user with admin permissions
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username | password  | displayname | email           |
       | Alice    | %regular% | New user    | alice@oc.com.np |
     And user "Alice" has been added to group "admin"
@@ -111,7 +111,7 @@ Feature: reset user password
 
   @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user with subadmin permissions in their group
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
       | brand-new-user | %regular%  | New user    | brand.new.user@oc.com.np |
       | subadmin       | %subadmin% | Sub Admin   | sub.admin@oc.com.np      |
@@ -127,7 +127,7 @@ Feature: reset user password
 
 
   Scenario: subadmin should not be able to reset the password of another subadmin of same group
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username         | password   | displayname | email                      |
       | another-subadmin | %regular%  | New user    | another.subadmin@oc.com.np |
       | subadmin         | %subadmin% | Sub Admin   | sub.admin@oc.com.np        |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -99,14 +99,14 @@ Feature: add groups
     And group "brand-new-group" should exist
 
   Scenario: normal user tries to create a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" tries to send a group creation request for group "brand-new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "brand-new-group" should not exist
 
   Scenario: subadmin tries to create a group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" tries to send a group creation request for group "another-new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -9,7 +9,7 @@ Feature: add users to group
 
   @smokeTest @skipOnLDAP
   Scenario: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And these groups have been created:
       | groupname   |
       | simplegroup |
@@ -25,7 +25,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And these groups have been created:
       | groupname           | comment                                 |
       | brand-new-group     | dash                                    |
@@ -56,7 +56,7 @@ Feature: add users to group
   # once the issue is fixed merge with scenario above
   @skipOnLDAP @toImplementOnOCIS @issue-product-284
   Scenario: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And these groups have been created:
       | groupname           | comment                                 |
       | maintenance#123     | Hash sign                               |
@@ -80,7 +80,7 @@ Feature: add users to group
 
   @issue-31015 @skipOnLDAP
   Scenario: adding a user to a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     # After fixing issue-31015, change the following step to "has been created"
     And the administrator sends a group creation request for the following group using the provisioning API
       | groupname        | comment                            |
@@ -105,7 +105,7 @@ Feature: add users to group
 
   @skipOnLDAP  @toImplementOnOCIS
   Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
-    Given user "mixed-case-user" has been created with default attributes and skeleton files
+    Given user "mixed-case-user" has been created with default attributes and small skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -123,7 +123,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: normal user tries to add himself to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" tries to add himself to group "brand-new-group" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
@@ -131,7 +131,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: admin tries to add user to a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "nonexistentgroup" has been deleted
     When the administrator tries to add user "brand-new-user" to group "nonexistentgroup" using the provisioning API
     Then the OCS status code should be "102"
@@ -140,7 +140,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: admin tries to add user to a group without sending the group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator tries to add user "brand-new-user" to group "" using the provisioning API
     Then the OCS status code should be "101"
     And the HTTP status code should be "200"
@@ -157,7 +157,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: a subadmin cannot add users to groups the subadmin is responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | brand-new-user |
       | subadmin       |
@@ -170,7 +170,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: a subadmin cannot add users to groups the subadmin is not responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-subadmin |
@@ -185,7 +185,7 @@ Feature: add users to group
   # merge this with scenario on line 62 once the issue is fixed
   @issue-31015 @skipOnLDAP @toImplementOnOCIS @issue-product-284
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator sends a group creation request for group "<group_id>" using the provisioning API
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "100"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -88,7 +88,7 @@ Feature: delete groups
 
 
   Scenario: normal user tries to delete the group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "brand-new-user" has been added to group "brand-new-group"
     When user "brand-new-user" tries to delete group "brand-new-group" using the provisioning API
@@ -97,7 +97,7 @@ Feature: delete groups
     And group "brand-new-group" should exist
 
   Scenario: subadmin of the group tries to delete the group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" tries to delete group "brand-new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
@@ -9,7 +9,7 @@ Feature: get group
 
   @smokeTest
   Scenario: admin gets users in the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | brand-new-user |
       | 123            |
@@ -53,7 +53,7 @@ Feature: get group
 
   @smokeTest
   Scenario: subadmin gets users in a group they are responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -70,7 +70,7 @@ Feature: get group
       | Brian |
 
   Scenario: subadmin tries to get users in a group they are not responsible for
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
@@ -79,7 +79,7 @@ Feature: get group
     And the HTTP status code should be "401"
 
   Scenario: normal user tries to get users in their group
-    Given user "newuser" has been created with default attributes and skeleton files
+    Given user "newuser" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     When user "newuser" gets all the members of group "brand-new-group" using the provisioning API
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
@@ -73,7 +73,7 @@ Feature: get groups
 
 
   Scenario: subadmin gets all the groups
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "0" has been created
     And group "España" has been created
@@ -89,7 +89,7 @@ Feature: get groups
 
 
   Scenario: normal user cannot get a list of all the groups
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "0" has been created
     And group "España" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -9,7 +9,7 @@ Feature: get subadmin groups
 
   @smokeTest
   Scenario: admin gets subadmin groups of a user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "😅 😆" has been created
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
@@ -32,7 +32,7 @@ Feature: get subadmin groups
 
   @issue-owncloud-sdk-658
   Scenario: subadmin gets groups where he/she is subadmin
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "😅 😆" has been created
     And user "Alice" has been made a subadmin of group "brand-new-group"
@@ -49,7 +49,7 @@ Feature: get subadmin groups
 
 
   Scenario: subadmin of a group should not be able to get subadmin groups of another subadmin user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -64,7 +64,7 @@ Feature: get subadmin groups
 
 
   Scenario: normal user should not be able to get subadmin groups of a subadmin user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -9,7 +9,7 @@ Feature: get user groups
 
   @smokeTest @notToImplementOnOCIS
   Scenario: admin gets groups of an user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     And group "brand-new-group" has been created
     And group "0" has been created
@@ -36,7 +36,7 @@ Feature: get user groups
 
   @issue-31015 @skipOnOcV10
   Scenario: admin gets groups of an user, including groups containing a slash
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     And group "Mgmt/Sydney" has been created
     And group "var/../etc" has been created
@@ -54,7 +54,7 @@ Feature: get user groups
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | brand-new-user |
       | subadmin       |
@@ -70,7 +70,7 @@ Feature: get user groups
     And the HTTP status code should be "200"
 
   Scenario: normal user tries to get the groups of another user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -83,7 +83,7 @@ Feature: get user groups
 
   @notToImplementOnOCIS
   Scenario: admin gets groups of an user who is not in any groups
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
@@ -92,7 +92,7 @@ Feature: get user groups
 
   @smokeTest @skipOnOcV10
   Scenario: admin gets groups of an user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     And group "brand-new-group" has been created
     And group "0" has been created
@@ -120,7 +120,7 @@ Feature: get user groups
 
   @skipOnOcV10
   Scenario: admin gets groups of an user who is not in any groups
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "100"
@@ -130,7 +130,7 @@ Feature: get user groups
 
 
   Scenario: normal user gets his/her groups
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
     And group "group1" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroupsOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroupsOc10Issue31015.feature
@@ -9,7 +9,7 @@ Feature: get user groups
 
   @issue-31015
   Scenario: admin gets groups of an user, including groups containing a slash
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     # After fixing issue-31015, change the following steps to "has been created"
     And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -9,7 +9,7 @@ Feature: remove a user from a group
 
   @smokeTest
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -23,7 +23,7 @@ Feature: remove a user from a group
       | नेपाली          | Unicode group name                    |
 
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -46,7 +46,7 @@ Feature: remove a user from a group
 
   @toImplementOnOCIS
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -64,7 +64,7 @@ Feature: remove a user from a group
 
   @issue-31015 @skipOnOcV10
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -79,7 +79,7 @@ Feature: remove a user from a group
 
   @toImplementOnOCIS
   Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -99,7 +99,7 @@ Feature: remove a user from a group
       | brand-new-user | MIXED-GROUP | Mixed-Group | mixed-group |
 
   Scenario: admin tries to remove a user from a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "nonexistentgroup" has been deleted
     When the administrator removes user "brand-new-user" from group "nonexistentgroup" using the provisioning API
     Then the OCS status code should be "102"
@@ -108,7 +108,7 @@ Feature: remove a user from a group
 
   @smokeTest
   Scenario: a subadmin can remove users from groups the subadmin is responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | brand-new-user |
       | subadmin       |
@@ -121,7 +121,7 @@ Feature: remove a user from a group
     And user "brand-new-user" should not belong to group "brand-new-group"
 
   Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-subadmin |
@@ -135,7 +135,7 @@ Feature: remove a user from a group
     And user "brand-new-user" should belong to group "brand-new-group"
 
   Scenario: normal user tries to remove a user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -150,7 +150,7 @@ Feature: remove a user from a group
   # merge this with scenario on line 62 once the issue is fixed
   @issue-31015 @skipOnOcV10 @toImplementOnOCIS
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroupOc10Issue31015.feature
@@ -9,7 +9,7 @@ Feature: remove a user from a group
 
   @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     # After fixing issue-31015, change the following step to "has been created"
     And the administrator sends a group creation request for group "<group_id>" using the provisioning API
     #And group "<group_id>" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -100,14 +100,14 @@ Feature: add groups
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to create a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" tries to send a group creation request for group "brand-new-group" using the provisioning API
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And group "brand-new-group" should not exist
 
   Scenario: subadmin tries to create a group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" tries to send a group creation request for group "another-new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: add groups
 
   @issue-31276
   Scenario: normal user tries to create a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" tries to send a group creation request for group "brand-new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -9,7 +9,7 @@ Feature: add users to group
 
   @smokeTest @skipOnLDAP
   Scenario Outline: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
@@ -22,7 +22,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario Outline: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
@@ -43,7 +43,7 @@ Feature: add users to group
   # once the issue is fixed merge with scenario above
   @skipOnLDAP @toImplementOnOCIS @issue-product-284
   Scenario Outline: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
@@ -60,7 +60,7 @@ Feature: add users to group
 
   @issue-31015 @skipOnOcV10
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"
@@ -74,7 +74,7 @@ Feature: add users to group
 
   @skipOnLDAP @toImplementOnOCIS @issue-product-283
   Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
-    Given user "mixed-case-user" has been created with default attributes and skeleton files
+    Given user "mixed-case-user" has been created with default attributes and small skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -92,7 +92,7 @@ Feature: add users to group
 
   @issue-31276 @skipOnLDAP @skipOnOcV10
   Scenario: normal user tries to add himself to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" tries to add himself to group "brand-new-group" using the provisioning API
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -100,7 +100,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: admin tries to add user to a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "nonexistentgroup" has been deleted
     When the administrator tries to add user "brand-new-user" to group "nonexistentgroup" using the provisioning API
     Then the OCS status code should be "400"
@@ -109,7 +109,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: admin tries to add user to a group without sending the group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator tries to add user "brand-new-user" to group "" using the provisioning API
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
@@ -126,7 +126,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: subadmin adds users to groups the subadmin is responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | brand-new-user |
       | subadmin       |
@@ -139,7 +139,7 @@ Feature: add users to group
 
   @skipOnLDAP
   Scenario: subadmin tries to add user to groups the subadmin is not responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-subadmin |
@@ -154,7 +154,7 @@ Feature: add users to group
   # merge this with scenario on line 62 once the issue is fixed
   @issue-31015 @skipOnLDAP @toImplementOnOCIS @issue-product-284
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator sends a group creation request for group "<group_id>" using the provisioning API
     When the administrator adds user "brand-new-user" to group "<group_id>" using the provisioning API
     Then the OCS status code should be "200"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31015.feature
@@ -9,7 +9,7 @@ Feature: add users to group
 
   @issue-31015 @skipOnLDAP
   Scenario Outline: adding a user to a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     # After fixing issue-31015, change the following step to "has been created"
     And the administrator sends a group creation request for group "<group_id>" using the provisioning API
     #And group "<group_id>" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: add users to group
 
   @issue-31276 @skipOnLDAP
   Scenario: normal user tries to add himself to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When user "brand-new-user" tries to add himself to group "brand-new-group" using the provisioning API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -89,7 +89,7 @@ Feature: delete groups
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to delete the group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "brand-new-user" has been added to group "brand-new-group"
     When user "brand-new-user" tries to delete group "brand-new-group" using the provisioning API
@@ -99,7 +99,7 @@ Feature: delete groups
 
   @issue-31276 @skipOnOcV10
   Scenario: subadmin of the group tries to delete the group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" tries to delete group "brand-new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: delete groups
 
   @issue-31276
   Scenario: normal user tries to delete the group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "brand-new-user" has been added to group "brand-new-group"
     When user "brand-new-user" tries to delete group "brand-new-group" using the provisioning API
@@ -20,7 +20,7 @@ Feature: delete groups
 
   @issue-31276
   Scenario: subadmin of the group tries to delete the group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" tries to delete group "brand-new-group" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
@@ -9,7 +9,7 @@ Feature: get group
 
   @smokeTest
   Scenario: admin gets users in the group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | brand-new-user |
       | 123            |
@@ -53,7 +53,7 @@ Feature: get group
 
   @smokeTest
   Scenario: subadmin gets users in a group they are responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -71,7 +71,7 @@ Feature: get group
 
   @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to get users in a group they are not responsible for
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
@@ -81,7 +81,7 @@ Feature: get group
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get users in their group
-    Given user "newuser" has been created with default attributes and skeleton files
+    Given user "newuser" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     When user "newuser" gets all the members of group "brand-new-group" using the provisioning API
     Then the OCS status code should be "401"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroupOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: get group
 
   @issue-31276
   Scenario: subadmin tries to get users in a group they are not responsible for
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "another-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
@@ -20,7 +20,7 @@ Feature: get group
 
   @issue-31276
   Scenario: normal user tries to get users in their group
-    Given user "newuser" has been created with default attributes and skeleton files
+    Given user "newuser" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     When user "newuser" gets all the members of group "brand-new-group" using the provisioning API
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
@@ -73,7 +73,7 @@ Feature: get groups
 
 
   Scenario: subadmin gets all the groups
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "0" has been created
     And group "España" has been created
@@ -89,7 +89,7 @@ Feature: get groups
 
 
   Scenario: normal user cannot get a list of all the groups
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "0" has been created
     And group "España" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -9,7 +9,7 @@ Feature: get subadmin groups
 
   @smokeTest
   Scenario: admin gets subadmin groups of a user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "😅 😆" has been created
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
@@ -32,7 +32,7 @@ Feature: get subadmin groups
 
   @issue-owncloud-sdk-658
   Scenario: subadmin gets groups where he/she is subadmin
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And group "😅 😆" has been created
     And user "Alice" has been made a subadmin of group "brand-new-group"
@@ -49,7 +49,7 @@ Feature: get subadmin groups
 
 
   Scenario: subadmin of a group should not be able to get subadmin groups of another subadmin user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -64,7 +64,7 @@ Feature: get subadmin groups
 
 
   Scenario: normal user should not be able to get subadmin groups of a subadmin user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -9,7 +9,7 @@ Feature: get user groups
 
   @smokeTest @notToImplementOnOCIS
   Scenario: admin gets groups of an user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     And group "brand-new-group" has been created
     And group "0" has been created
@@ -36,7 +36,7 @@ Feature: get user groups
 
   @issue-31015 @skipOnOcV10
   Scenario: admin gets groups of an user, including groups containing a slash
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     And group "Mgmt/Sydney" has been created
     And group "var/../etc" has been created
@@ -54,7 +54,7 @@ Feature: get user groups
 
   @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | brand-new-user |
       | subadmin       |
@@ -71,7 +71,7 @@ Feature: get user groups
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get the groups of another user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -84,7 +84,7 @@ Feature: get user groups
 
   @notToImplementOnOCIS
   Scenario: admin gets groups of an user who is not in any groups
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
@@ -93,7 +93,7 @@ Feature: get user groups
 
   @smokeTest @skipOnOcV10
   Scenario: admin gets groups of an user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     And group "brand-new-group" has been created
     And group "0" has been created
@@ -121,7 +121,7 @@ Feature: get user groups
 
   @skipOnOcV10
   Scenario: admin gets groups of an user who is not in any groups
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
     Then the OCS status code should be "200"
@@ -131,7 +131,7 @@ Feature: get user groups
 
 
   Scenario: normal user gets his/her groups
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
     And group "group1" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31015.feature
@@ -9,7 +9,7 @@ Feature: get user groups
 
   @issue-31015
   Scenario: admin gets groups of an user, including groups containing a slash
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     # After fixing issue-31015, change the following steps to "has been created"
     And the administrator sends a group creation request for group "Mgmt/Sydney" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: get user groups
 
   @issue-31276
   Scenario: normal user tries to get the groups of another user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -9,7 +9,7 @@ Feature: remove a user from a group
 
   @smokeTest
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -23,7 +23,7 @@ Feature: remove a user from a group
       | नेपाली          | Unicode group name                    |
 
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -46,7 +46,7 @@ Feature: remove a user from a group
 
   @toImplementOnOCIS @issue-product-284
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -64,7 +64,7 @@ Feature: remove a user from a group
 
   @issue-31015 @skipOnOcV10
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API
@@ -79,7 +79,7 @@ Feature: remove a user from a group
 
   @toImplementOnOCIS @issue-product-283
   Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -99,7 +99,7 @@ Feature: remove a user from a group
       | brand-new-user | MIXED-GROUP | Mixed-Group | mixed-group |
 
   Scenario: admin tries to remove a user from a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "nonexistentgroup" has been deleted
     When the administrator removes user "brand-new-user" from group "nonexistentgroup" using the provisioning API
     Then the OCS status code should be "400"
@@ -108,7 +108,7 @@ Feature: remove a user from a group
 
   @smokeTest
   Scenario: a subadmin can remove users from groups the subadmin is responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       |
       | brand-new-user |
       | subadmin       |
@@ -121,7 +121,7 @@ Feature: remove a user from a group
     And user "brand-new-user" should not belong to group "brand-new-group"
 
   Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-subadmin |
@@ -136,7 +136,7 @@ Feature: remove a user from a group
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to remove a user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |
@@ -151,7 +151,7 @@ Feature: remove a user from a group
   # merge this with scenario on line 62 once the issue is fixed
   @issue-31015 @skipOnOcV10 @toImplementOnOCIS @issue-product-284
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the provisioning API

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31015.feature
@@ -9,7 +9,7 @@ Feature: remove a user from a group
 
   @issue-31015
   Scenario Outline: admin removes a user from a group that has a forward-slash in the group name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
       # After fixing issue-31015, change the following step to "has been created"
     And the administrator sends a group creation request for group "<group_id>" using the provisioning API
     #And group "<group_id>" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31276.feature
@@ -9,7 +9,7 @@ Feature: remove a user from a group
 
   @issue-31276
   Scenario: normal user tries to remove a user in their group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username         |
       | brand-new-user   |
       | another-new-user |

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
@@ -2,7 +2,7 @@
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10.3
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares without specifying expireDate

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareReceivedInMultipleWays.feature
@@ -2,7 +2,7 @@
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: Creating a new share with user who already received a share through their group
     Given using OCS API version "<ocs_api_version>"
@@ -33,7 +33,7 @@ Feature: share resources where the sharee receives the share in multiple ways
   @issue-ocis-reva-243
   Scenario Outline: Share of folder and sub-folder to same user - core#20645
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp4" has been created
     And user "Brian" has been added to group "grp4"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareWhenExcludedFromSharing.feature
@@ -2,11 +2,11 @@
 Feature: cannot share resources when in a group that is excluded from sharing
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -23,7 +23,7 @@ Feature: cannot share resources when in a group that is excluded from sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a file with a group
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And group "grp2" has been created

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
@@ -2,7 +2,7 @@
 Feature: shares are received in the default folder for received shares
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario Outline: Do not allow sharing of the entire share_folder

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupAndUserWithSameName.feature
@@ -2,7 +2,7 @@
 Feature: sharing works when a username and group name are the same
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnLDAP @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: creating a new share with user and a group having same name

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupCaseSensitive.feature
@@ -2,7 +2,7 @@
 Feature: share with groups, group names are case-sensitive
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnLDAP @issue-ldap-250
   Scenario Outline: group names are case-sensitive, sharing with groups with different upper and lower case names

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -2,12 +2,12 @@
 Feature: cannot share resources outside the group when share with membership groups is enabled
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: sharer should not be able to share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And group "grp1" has been created
     And user "Alice" has been added to group "grp0"
@@ -24,7 +24,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a folder to a user who is not member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
@@ -39,7 +39,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a folder to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp0"
@@ -55,7 +55,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should not be able to share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And group "grp1" has been created
     And user "Alice" has been added to group "grp0"
@@ -72,7 +72,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a file to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp0"
@@ -88,7 +88,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a file to a user who is not a member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     When user "Alice" shares folder "/textfile0.txt" with user "Brian" using the sharing API

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
@@ -2,7 +2,7 @@
 Feature: share resources with a disabled user
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: Creating a new share with a disabled user
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
@@ -2,7 +2,7 @@
 Feature: share resources with a disabled user - current oC10 behavior for issue-32068
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @issue-32068
   Scenario: Creating a new share with a disabled user

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
@@ -4,7 +4,7 @@ Feature: a default expiration date can be specified for shares with users or gro
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10.3
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares without specifying expireDate

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
@@ -4,7 +4,7 @@ Feature: share resources where the sharee receives the share in multiple ways
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: Creating a new share with user who already received a share through their group
     Given using OCS API version "<ocs_api_version>"
@@ -39,7 +39,7 @@ Feature: share resources where the sharee receives the share in multiple ways
   @issue-ocis-reva-243
   Scenario Outline: Share of folder and sub-folder to same user - core#20645
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp4" has been created
     And user "Brian" has been added to group "grp4"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareWhenExcludedFromSharing.feature
@@ -4,11 +4,11 @@ Feature: cannot share resources when in a group that is excluded from sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -27,7 +27,7 @@ Feature: cannot share resources when in a group that is excluded from sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a file with a group
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And group "grp2" has been created

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
@@ -4,7 +4,7 @@ Feature: shares are received in the default folder for received shares
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario Outline: Do not allow sharing of the entire share_folder

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
@@ -4,7 +4,7 @@ Feature: sharing works when a username and group name are the same
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnLDAP @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: creating a new share with user and a group having same name

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
@@ -4,7 +4,7 @@ Feature: share with groups, group names are case-sensitive
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnLDAP @issue-ldap-250
   Scenario Outline: group names are case-sensitive, sharing with groups with different upper and lower case names

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -4,12 +4,12 @@ Feature: cannot share resources outside the group when share with membership gro
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: sharer should not be able to share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And group "grp1" has been created
     And user "Alice" has been added to group "grp0"
@@ -28,7 +28,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a folder to a user who is not member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
@@ -47,7 +47,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a folder to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp0"
@@ -67,7 +67,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should not be able to share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And group "grp1" has been created
     And user "Alice" has been added to group "grp0"
@@ -86,7 +86,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a file to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp0"
@@ -106,7 +106,7 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a file to a user who is not a member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     When user "Alice" shares folder "/textfile0.txt" with user "Brian" using the sharing API

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature
@@ -4,7 +4,7 @@ Feature: share resources with a disabled user
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: Creating a new share with a disabled user
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
@@ -2,7 +2,7 @@
 Feature: sharing
 
   Scenario Outline: Delete all group shares
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -22,7 +22,7 @@ Feature: sharing
 
   @smokeTest
   Scenario Outline: delete a share
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs_api_version>"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
@@ -51,7 +51,7 @@ Feature: sharing
   @smokeTest @files_trashbin-app-required
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -66,7 +66,7 @@ Feature: sharing
   @files_trashbin-app-required
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has created folder "/shared/sub"
@@ -88,7 +88,7 @@ Feature: sharing
       | username |
       | Alice    |
       | Brian    |
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
     And user "Carol" has shared file "/PARENT/parent.txt" with group "grp1"
@@ -101,7 +101,7 @@ Feature: sharing
 
   Scenario: sharee of a read-only share folder tries to delete the shared folder
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -112,7 +112,7 @@ Feature: sharing
 
   Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -137,7 +137,7 @@ Feature: sharing
   Scenario Outline: A Group share recipient tries to delete the share
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -160,7 +160,7 @@ Feature: sharing
 
   Scenario Outline: An individual share recipient tries to delete the share
     Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared entry "<entry_to_share>" with user "Brian"
     When user "Brian" deletes the last share using the sharing API

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/excludeGroupFromReceivingShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/excludeGroupFromReceivingShares.feature
@@ -5,7 +5,7 @@ Feature: Exclude groups from receiving shares
   So that users do not mistakenly share with groups they should not e.g. huge meta groups
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -88,7 +88,7 @@ Feature: sharing
   @smokeTest
   Scenario: unshare from self
     And group "grp1" has been created
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Carol    |
     And user "Brian" has been added to group "grp1"

--- a/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
@@ -7,7 +7,7 @@ Feature: Exclude groups from receiving shares
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
@@ -7,7 +7,7 @@ Feature: accept/decline shares coming from internal users
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -549,7 +549,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: user accepts shares received from multiple users with the same name when auto-accept share is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-    And user "David" has been created with default attributes and skeleton files
+    And user "David" has been created with default attributes and small skeleton files
     And user "Brian" has shared folder "/PARENT" with user "Alice"
     And user "Carol" has shared folder "/PARENT" with user "Alice"
     When user "Alice" accepts share "/PARENT" offered by user "Brian" using the sharing API
@@ -680,7 +680,7 @@ Feature: accept/decline shares coming from internal users
 
   @skipOnLDAP @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: user shares folder with matching folder name a user before that user has logged in
-    Given these users have been created with skeleton files but not initialized:
+    Given these users have been created with small skeleton files but not initialized:
       | username |
       | David    |
     And user "Alice" uploads file with content "uploaded content" to "/PARENT/abc.txt" using the WebDAV API

--- a/tests/acceptance/features/apiShareManagementToRoot/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/disableSharing.feature
@@ -5,7 +5,7 @@ Feature: sharing
   So that ownCloud users cannot share file or folder
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -99,7 +99,7 @@ Feature: sharing
   Scenario Outline: user shares a file with user who is in their group when sharing outside the group has been restricted
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -115,7 +115,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp2" has been created
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp2"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -144,7 +144,7 @@ Feature: sharing
   Scenario Outline: user who is a member of a group tries to share a file in the group when group sharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
     When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"

--- a/tests/acceptance/features/apiShareManagementToRoot/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/mergeShare.feature
@@ -3,7 +3,7 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
@@ -3,7 +3,7 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareOc10Issue30325.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareOc10Issue30325.feature
@@ -3,7 +3,7 @@ Feature: sharing - current oC10 behavior for issue-30325
 
   Background:
     Given using OCS API version "1"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
@@ -9,7 +9,7 @@ Feature: accept/decline shares coming from internal users
     And auto-accept shares has been disabled
     And using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -296,7 +296,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/Shares/testfile (2) (2).txt" for user "Carol" should be "First file"
 
   Scenario: user accepts shares received from multiple users with the same name when auto-accept share is disabled
-    Given user "David" has been created with default attributes and skeleton files
+    Given user "David" has been created with default attributes and small skeleton files
     And user "Brian" has shared folder "/PARENT" with user "Alice"
     And user "Carol" has shared folder "/PARENT" with user "Alice"
     And user "Alice" has created folder "Shares"
@@ -437,7 +437,7 @@ Feature: accept/decline shares coming from internal users
 
   @skipOnLDAP
   Scenario: user shares folder with matching folder name a user before that user has logged in
-    Given these users have been created with skeleton files but not initialized:
+    Given these users have been created with small skeleton files but not initialized:
       | username |
       | David    |
     And user "Alice" uploads file with content "uploaded content" to "/PARENT/abc.txt" using the WebDAV API

--- a/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
@@ -9,7 +9,7 @@ Feature: accept/decline shares coming from internal users to the Shares folder
     And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using OCS API version "1"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using OCS API version "1"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareOperationsToRoot/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/accessToShare.feature
@@ -2,7 +2,7 @@
 Feature: sharing
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareOperationsToRoot/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/changingFilesShare.feature
@@ -2,7 +2,7 @@
 Feature: sharing
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -82,7 +82,7 @@ Feature: sharing
 
   Scenario: Move files between shares by different users
     Given the administrator has enabled DAV tech_preview
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has shared folder "/PARENT" with user "Carol"
     And user "Brian" has shared folder "/PARENT" with user "Carol"

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingShares.feature
@@ -2,7 +2,7 @@
 Feature: sharing
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -36,7 +36,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: getting all shares of a file
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Carol    |
       | David    |
@@ -56,7 +56,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: getting all shares of a file with reshares
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Carol    |
       | David    |
@@ -77,7 +77,7 @@ Feature: sharing
   Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Carol" has been added to group "grp1"
     And user "Carol" has created folder "/shared"
     And user "Carol" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -108,7 +108,7 @@ Feature: sharing
   @skipOnLDAP
   Scenario: Share of folder to a group, remove user from that group
     Given using OCS API version "1"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And group "group0" has been created
     And user "Brian" has been added to group "group0"
     And user "Carol" has been added to group "group0"

--- a/tests/acceptance/features/apiShareOperationsToRoot/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/uploadToShare.feature
@@ -2,10 +2,10 @@
 Feature: sharing
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   Scenario: Uploading file to a user read-only share folder does not work
-    Given user "Brian" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -17,7 +17,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group read-only share folder does not work
     Given using <dav-path> DAV path
-    Given user "Brian" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -35,7 +35,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a user upload-only share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -58,7 +58,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group upload-only share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -84,7 +84,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Uploading file to a user read/write share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -105,7 +105,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group read/write share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -129,7 +129,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Check quota of owners parent directory of a shared file
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And the quota of user "Brian" has been set to "0"
     And user "Alice" has moved file "/welcome.txt" to "/myfile.txt"
     And user "Alice" has shared file "myfile.txt" with user "Brian"
@@ -150,7 +150,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -167,7 +167,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -186,7 +186,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a user shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -203,7 +203,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -222,7 +222,7 @@ Feature: sharing
 
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" creates folder "/READ_ONLY" using the WebDAV API
     And user "Alice" has created a share with settings
       | path        | /READ_ONLY |

--- a/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -94,7 +94,7 @@ Feature: sharing
 
   Scenario: Move files between shares by different users
     Given the administrator has enabled DAV tech_preview
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has shared folder "/PARENT" with user "Carol"
     And user "Brian" has shared folder "/PARENT" with user "Carol"

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -41,7 +41,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: getting all shares of a file
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Carol    |
       | David    |
@@ -63,7 +63,7 @@ Feature: sharing
   @smokeTest @issue-ocis-reva-243
   Scenario Outline: getting all shares of a file with reshares
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Carol    |
       | David    |
@@ -86,7 +86,7 @@ Feature: sharing
   Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Carol" has been added to group "grp1"
     And user "Carol" has created folder "/shared"
     And user "Carol" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
@@ -183,7 +183,7 @@ Feature: sharing
   @skipOnLDAP @issue-ocis-reva-194
   Scenario: Share of folder to a group, remove user from that group
     Given using OCS API version "1"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And group "group0" has been created
     And user "Brian" has been added to group "group0"
     And user "Carol" has been added to group "group0"

--- a/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature
@@ -4,11 +4,11 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
 
   Scenario: Uploading file to a user read-only share folder does not work
-    Given user "Brian" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -22,7 +22,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group read-only share folder does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -42,7 +42,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a user upload-only share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -67,7 +67,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group upload-only share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -94,7 +94,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Uploading file to a user read/write share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -117,7 +117,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group read/write share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -142,7 +142,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Check quota of owners parent directory of a shared file
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And the quota of user "Brian" has been set to "0"
     And user "Alice" has moved file "/welcome.txt" to "/myfile.txt"
     And user "Alice" has shared file "myfile.txt" with user "Brian"
@@ -165,7 +165,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -184,7 +184,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -205,7 +205,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a user shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -224,7 +224,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -245,7 +245,7 @@ Feature: sharing
 
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" creates folder "/READ_ONLY" using the WebDAV API
     And user "Alice" has created a share with settings
       | path        | /READ_ONLY |
@@ -263,7 +263,7 @@ Feature: sharing
 
   Scenario Outline: Sharer can download file uploaded with different permission by sharee to a shared folder
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER        |
       | shareType   | user          |

--- a/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
@@ -2,7 +2,7 @@
 Feature: accessing a public link share
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
 

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -3,7 +3,7 @@
 Feature: changing a public link share
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
 

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -3,7 +3,7 @@
 Feature: create a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1) using the old public WebDAV API

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue36442.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue36442.feature
@@ -3,7 +3,7 @@
 Feature: create a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @issue-36442
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
@@ -3,7 +3,7 @@
 Feature: create a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @issue-37605
   Scenario: Get the mtime of a file inside a folder shared by public link using new webDAV version

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
@@ -4,7 +4,7 @@ Feature: create a public link share when share_folder is set to Shares
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario Outline: Creating a new public link share of a file gives the correct response

--- a/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
@@ -2,7 +2,7 @@
 Feature: multilinksharing
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: Creating three public shares of a folder

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
@@ -6,7 +6,7 @@ Feature: reshare as public link
   So that I can give controlled access to others
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   Scenario Outline: creating a public link from a share with read permission only is not allowed

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -5,7 +5,7 @@ Feature: reshare as public link
   So that I can give controlled access to others
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
@@ -5,7 +5,7 @@ Feature: reshare as public link
   So that I can give controlled access to others
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -3,7 +3,7 @@ Feature: update a public link share
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @issue-37653 @skipOnOcV10
   Scenario Outline: API responds with a full set of parameters when owner changes the expireDate of a public share

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShareOc10Issue37653.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShareOc10Issue37653.feature
@@ -3,7 +3,7 @@ Feature: update a public link share
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @issue-37653
   Scenario Outline: API responds with a full set of parameters when owner changes the expireDate of a public share

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -3,7 +3,7 @@
 Feature: upload to a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario: Uploading same file to a public upload-only share multiple times via old API

--- a/tests/acceptance/features/apiShareReshareToRoot1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot1/reShare.feature
@@ -2,7 +2,7 @@
 Feature: sharing
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
 

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareChain.feature
@@ -2,7 +2,7 @@
 Feature: resharing can be done on a reshared resource
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   Scenario: Reshared files can be still accessed if a user in the middle removes it.

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareDisabled.feature
@@ -2,7 +2,7 @@
 Feature: resharing can be disabled
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   @smokeTest

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareSubfolder.feature
@@ -2,7 +2,7 @@
 Feature: a subfolder of a received share can be reshared
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   @smokeTest

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -2,13 +2,13 @@
 Feature: resharing a resource with an expiration date
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   Scenario Outline: User should not be able to re-share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Carol" has been added to group "grp1"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -24,7 +24,7 @@ Feature: resharing a resource with an expiration date
   Scenario Outline: User should not be able to re-share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Carol" has been added to group "grp1"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian"

--- a/tests/acceptance/features/apiShareReshareToRoot3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot3/reShareUpdate.feature
@@ -2,7 +2,7 @@
 Feature: sharing
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
 

--- a/tests/acceptance/features/apiShareReshareToRoot3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot3/reShareWithExpiryDate.feature
@@ -2,7 +2,7 @@
 Feature: resharing a resource with an expiration date
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.3

--- a/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
 

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
@@ -4,7 +4,7 @@ Feature: resharing can be done on a reshared resource
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   Scenario: Reshared files can be still accessed if a user in the middle removes it.

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
@@ -4,7 +4,7 @@ Feature: resharing can be disabled
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   @smokeTest

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
@@ -4,7 +4,7 @@ Feature: a subfolder of a received share can be reshared
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   @smokeTest

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -4,13 +4,13 @@ Feature: resharing a resource with an expiration date
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   Scenario Outline: User should not be able to re-share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Carol" has been added to group "grp1"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -27,7 +27,7 @@ Feature: resharing a resource with an expiration date
   Scenario Outline: User should not be able to re-share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Carol" has been added to group "grp1"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian"

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
 

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
@@ -4,7 +4,7 @@ Feature: resharing a resource with an expiration date
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.3

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
@@ -4,7 +4,7 @@ Feature: resharing a resource with an expiration date
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.3 @issue-37013

--- a/tests/acceptance/features/apiShareUpdateToRoot/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToRoot/updateShare.feature
@@ -3,7 +3,7 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: Allow modification of reshare
@@ -27,7 +27,7 @@ Feature: sharing
 
   Scenario Outline: keep group permissions in sync
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
@@ -170,7 +170,7 @@ Feature: sharing
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"

--- a/tests/acceptance/features/apiShareUpdateToRoot/updateShareOc10Issue37217.feature
+++ b/tests/acceptance/features/apiShareUpdateToRoot/updateShareOc10Issue37217.feature
@@ -4,7 +4,7 @@ Feature: sharing
   @issue-37217
   Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: Allow modification of reshare
@@ -32,7 +32,7 @@ Feature: sharing
   @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: keep group permissions in sync
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
@@ -234,7 +234,7 @@ Feature: sharing
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShareOc10Issue37217.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShareOc10Issue37217.feature
@@ -6,7 +6,7 @@ Feature: sharing
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -2,7 +2,7 @@
 Feature: sharees
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | sharee1  |
@@ -453,7 +453,7 @@ Feature: sharees
   @skipOnLDAP
   Scenario Outline: Enumerate only group members - only show partial results from member groups
     Given using OCS API version "<ocs-api-version>"
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username | displayname |
       | another  | Another     |
     And user "Another" has been added to group "ShareeGroup2"
@@ -538,7 +538,7 @@ Feature: sharees
       | 2               | 200        | 200         |
 
   Scenario Outline: Search without exact match such that the search string matches the user getting the sharees
-    Given user "sharee2" has been created with default attributes and skeleton files
+    Given user "sharee2" has been created with default attributes and small skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | search   | sharee |

--- a/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
@@ -8,7 +8,7 @@ Feature: Display notifications when receiving a share
     Given app "notifications" has been enabled
     And using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
@@ -9,7 +9,7 @@ Feature: Display notifications when receiving a share
     And app "notifications" has been enabled
     And using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -4,7 +4,7 @@ Feature: Assign tags to file/folder
   So that I can organize the files/folders easily
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiTags/assignTagsGroup.feature
+++ b/tests/acceptance/features/apiTags/assignTagsGroup.feature
@@ -3,7 +3,7 @@ Feature: Title of your feature
   I want to use this template for my feature file
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   Scenario: User can assign tags when in the tag's groups
     Given group "grp1" has been created

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -5,7 +5,7 @@ Feature: Creation of tags
   So that I could categorize my files
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -4,7 +4,7 @@ Feature: Deletion of tags
   I want to delete the tags that are already created
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario: Deleting a normal tag as regular user should work

--- a/tests/acceptance/features/apiTags/editTags.feature
+++ b/tests/acceptance/features/apiTags/editTags.feature
@@ -4,7 +4,7 @@ Feature: Editing the tags
   I want to be able to change the tags I have created
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: Renaming a normal tag as regular user should work

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -2,7 +2,7 @@
 Feature: tags
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -4,7 +4,7 @@ Feature: Unassigning tags from file/folder
   I want to be able to remove tags from file/folder
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiTranslation/translation.feature
+++ b/tests/acceptance/features/apiTranslation/translation.feature
@@ -6,7 +6,7 @@ Feature: translate messages in api response to preferred language
 
   Scenario Outline: user tries to get non existing share and uses some preferred language
     Given user "Alice" has been created with default attributes and without skeleton files
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Brian    |
       | Carol    |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -141,7 +141,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
-    And user "testtrashbin100" has been created with default attributes and skeleton files
+    And user "testtrashbin100" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin100" has deleted file "/textfile1.txt"
     When user "Brian" tries to list the trashbin content for user "testtrashbin100"
@@ -157,7 +157,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
-    And user "testtrashbin101" has been created with default attributes and skeleton files
+    And user "testtrashbin101" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin101" has deleted file "/textfile0.txt"
     And user "testtrashbin101" has deleted file "/textfile2.txt"
@@ -175,12 +175,12 @@ Feature: files and folders exist in the trashbin after being deleted
   @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
-    And user "testtrashbin102" has been created with default attributes and skeleton files
+    And user "testtrashbin102" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin102" has deleted file "/textfile0.txt"
     And user "testtrashbin102" has deleted file "/textfile2.txt"
     And the administrator deletes user "testtrashbin102" using the provisioning API
-    And these users have been created with default attributes and skeleton files but not initialized:
+    And these users have been created with default attributes and small skeleton files but not initialized:
       | username        |
       | testtrashbin102 |
     And user "testtrashbin102" has deleted file "/textfile3.txt"
@@ -273,7 +273,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | new      |
 
   @issue-ocis-541
-  Scenario Outline: deleted file has appropriate deletion time information 
+  Scenario Outline: deleted file has appropriate deletion time information
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2018 04:18:13 GMT" using the WebDAV API
     And user "Alice" has deleted file "file.txt"

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -39,7 +39,7 @@ Feature: using trashbin together with sharing
 
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with user "Brian"

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -43,7 +43,7 @@ Feature: using trashbin together with sharing
 
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with user "Brian"

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -2,7 +2,7 @@
 Feature: there can be only one exclusive lock on a resource
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: a second lock cannot be set on a folder when its exclusively locked
     Given using <dav-path> DAV path
@@ -85,7 +85,7 @@ Feature: there can be only one exclusive lock on a resource
   @files_sharing-app-required
   Scenario Outline: a share receiver cannot lock a resource exclusively locked by itself
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has locked file "textfile0 (2).txt" setting the following properties
       | lockscope | exclusive |
@@ -104,7 +104,7 @@ Feature: there can be only one exclusive lock on a resource
   @files_sharing-app-required
   Scenario Outline: a share receiver cannot lock a resource exclusively locked by the owner
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | exclusive |
@@ -123,7 +123,7 @@ Feature: there can be only one exclusive lock on a resource
   @files_sharing-app-required
   Scenario Outline: a share owner cannot lock a resource exclusively locked by a share receiver
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has locked file "textfile0 (2).txt" setting the following properties
       | lockscope | exclusive |

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
@@ -3,7 +3,7 @@ Feature: there can be only one exclusive lock on a resource
 
   @issue-34358
   Scenario Outline: if a child resource is exclusively locked a parent resource cannot be locked again
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And using <dav-path> DAV path
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | exclusive |

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -2,7 +2,7 @@
 Feature: lock folders
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: upload to a locked folder

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -3,7 +3,7 @@ Feature: persistent-locking in case of a public link
 
   Background:
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10 @smokeTest @issue-36064
   Scenario Outline: Uploading a file into a locked public folder

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -2,7 +2,7 @@
 Feature: LOCKDISCOVERY for public links
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: lockdiscovery root of public link when root is locked
     Given user "Alice" has created a public link share of folder "PARENT" with change permission

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
@@ -4,7 +4,7 @@ Feature: persistent-locking in case of a public link
 
   Background:
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest @issue-36064
   Scenario Outline: Uploading a file into a locked public folder

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -2,7 +2,7 @@
 Feature: actions on a locked item are possible if the token is sent with the request
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: rename a file in a locked folder
@@ -57,7 +57,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @skipOnOcV10 @issue-34338 @files_sharing-app-required
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
@@ -91,7 +91,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @skipOnOcV10 @issue-34360 @files_sharing-app-required
   Scenario Outline: two users having both a shared lock can use the resource
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
@@ -3,9 +3,9 @@ Feature: actions on a locked item are possible if the token is sent with the req
 
   @issue-34338 @files_sharing-app-required
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
@@ -3,9 +3,9 @@ Feature: actions on a locked item are possible if the token is sent with the req
 
   @issue-34360 @files_sharing-app-required
   Scenario Outline: two users having both a shared lock can use the resource
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesOc10Issue36064.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesOc10Issue36064.feature
@@ -3,7 +3,7 @@ Feature: lock should propagate correctly if a share is reshared
 
   @issue-36064
   Scenario Outline: public uploads to a reshared share that was locked by original owner
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
@@ -2,7 +2,7 @@
 Feature: lock should propagate correctly if a share is reshared
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -5,7 +5,7 @@ Feature: lock should propagate correctly if a share is reshared
     Given the administrator has enabled DAV tech_preview
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -2,7 +2,7 @@
 Feature: set timeouts of LOCKS
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10.3 @skipOnOcV10.4
   Scenario Outline: do not set timeout on folder and check the default timeout

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
@@ -2,12 +2,12 @@
 Feature: set timeouts of LOCKS on shares
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
 
   Scenario Outline: as owner set timeout on folder as receiver check it
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
@@ -40,7 +40,7 @@ Feature: set timeouts of LOCKS on shares
 
   Scenario Outline: as share receiver set timeout on folder as owner check it
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     When user "Brian" locks folder "PARENT (2)" using the WebDAV API setting the following properties
       | lockscope | shared    |

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -5,12 +5,12 @@ Feature: set timeouts of LOCKS on shares
     Given the administrator has enabled DAV tech_preview
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
 
   Scenario Outline: as owner set timeout on folder as receiver check it
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
@@ -44,7 +44,7 @@ Feature: set timeouts of LOCKS on shares
 
   Scenario Outline: as share receiver set timeout on folder as owner check it
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     When user "Brian" locks folder "Shares/PARENT" using the WebDAV API setting the following properties

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
@@ -3,7 +3,7 @@ Feature: independent locks
   Make sure all locks are independent and don't interact with other items that have the same name
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
 
   Scenario Outline: locking a folder does not lock other items with the same name in other parts of the file system

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
@@ -2,7 +2,7 @@
 Feature: UNLOCK locked items
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: unlock a single lock set by the user itself

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
@@ -3,7 +3,7 @@ Feature: UNLOCK locked items
 
   @issue-34302 @files_sharing-app-required @skipOnOcV10.3
   Scenario Outline: as public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
@@ -2,12 +2,12 @@
 Feature: UNLOCK locked items (sharing)
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
 
 
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
@@ -25,7 +25,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a file in a share locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
@@ -43,7 +43,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a shared folder locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
@@ -65,7 +65,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
@@ -83,7 +83,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlock a shared file
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has locked file "parent.txt" setting the following properties
       | lockscope | <lock-scope> |
@@ -101,7 +101,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a shared file locked by the receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has locked file "parent.txt" setting the following properties
       | lockscope | <lock-scope> |
@@ -119,7 +119,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a file in a share that was locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has locked file "PARENT (2)/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
@@ -137,7 +137,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a shared folder locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has locked folder "PARENT (2)" setting the following properties
       | lockscope | <lock-scope> |

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -5,12 +5,12 @@ Feature: UNLOCK locked items (sharing)
     Given the administrator has enabled DAV tech_preview
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
 
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
@@ -29,7 +29,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a file in a share locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
@@ -48,7 +48,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a shared folder locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
@@ -71,7 +71,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
@@ -90,7 +90,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlock a shared file
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Alice"
     And user "Brian" has locked file "Shares/parent.txt" setting the following properties
@@ -109,7 +109,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a shared file locked by the receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Alice"
     And user "Brian" has locked file "Shares/parent.txt" setting the following properties
@@ -128,7 +128,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a file in a share that was locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has locked file "Shares/PARENT/parent.txt" setting the following properties
@@ -147,7 +147,7 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a shared folder locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has locked folder "Shares/PARENT" setting the following properties

--- a/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
@@ -6,7 +6,7 @@ Feature: move (rename) file
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And the administrator has enabled async operations
 
   Scenario Outline: Moving a file
@@ -86,7 +86,7 @@ Feature: move (rename) file
 
   @files_sharing-app-required
   Scenario: Moving a file to a folder with no permissions
-    Given user "Brian" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
       | path        | testshare |
@@ -105,7 +105,7 @@ Feature: move (rename) file
 
   @files_sharing-app-required
   Scenario: Moving a file to overwrite a file in a folder with no permissions
-    Given user "Brian" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
       | path        | testshare |
@@ -188,7 +188,7 @@ Feature: move (rename) file
   Scenario Outline: enabling async operations does no difference to normal MOVE - Moving a file to a folder with no permissions
     Given the administrator has enabled async operations
     And using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
       | path        | testshare |

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
@@ -6,7 +6,7 @@ Feature: users cannot move (rename) a file to a blacklisted name
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And the administrator has enabled async operations
 
   Scenario: rename a file to a filename that is banned by default

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
@@ -6,7 +6,7 @@ Feature: users cannot move (rename) a file to or into an excluded directory
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And the administrator has enabled async operations
 
   Scenario: rename a file to an excluded directory name

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
@@ -38,7 +38,7 @@ Feature: users cannot move (rename) a folder to a blacklisted name
   @skipOnOcV10.3
   Scenario Outline: rename a folder to a folder name that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/testshare"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
@@ -6,7 +6,7 @@ Feature: users cannot move (rename) a folder to or into an excluded directory
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: Rename a folder to an excluded directory name
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -6,7 +6,7 @@ Feature: move (rename) file
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @smokeTest
   Scenario Outline: Moving a file
@@ -165,7 +165,7 @@ Feature: move (rename) file
   @files_sharing-app-required
   Scenario Outline: Moving a file to a shared folder with no permissions
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
       | path        | testshare |
@@ -184,7 +184,7 @@ Feature: move (rename) file
   @files_sharing-app-required
   Scenario Outline: Moving a file to overwrite a file in a shared folder with no permissions
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
       | path        | testshare |
@@ -234,7 +234,7 @@ Feature: move (rename) file
   @files_sharing-app-required
   Scenario Outline: Checking file id after a move between received shares
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/folderA"
     And user "Alice" has created folder "/folderB"
     And user "Alice" has shared folder "/folderA" with user "Brian"

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
@@ -6,7 +6,7 @@ Feature: users cannot move (rename) a file to a blacklisted name
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @issue-ocis-reva-211
   Scenario Outline: rename a file to a filename that is banned by default

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
@@ -6,7 +6,7 @@ Feature: users cannot move (rename) a file to or into an excluded directory
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: rename a file to an excluded directory name
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
+++ b/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
@@ -24,7 +24,7 @@ Feature: refuse access
 
   Scenario Outline: A disabled user cannot use webdav
     Given using <dav_version> DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When user "Alice" downloads file "/welcome.txt" using the WebDAV API
     Then the HTTP status code should be "401"

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -5,7 +5,7 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/just-a-folder"
     And user "Alice" has created folder "/फनी näme"
     And user "Alice" has created folder "/upload folder"

--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -49,7 +49,7 @@ Feature: copy file
   @issue-ocis-reva-11
   Scenario Outline: Copying a file to a folder with no permissions
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
       | path        | testshare |
@@ -69,7 +69,7 @@ Feature: copy file
   @issue-ocis-reva-11
   Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
       | path        | testshare |

--- a/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
@@ -6,7 +6,7 @@ Feature: get quota
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   Scenario Outline: Retrieving folder quota when no quota is set
     Given using <dav_version> DAV path
@@ -30,7 +30,7 @@ Feature: get quota
   @files_sharing-app-required
   Scenario Outline: Retrieving folder quota of shared folder with quota when no quota is set for recipient
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has been given unlimited quota
     And the quota of user "Brian" has been set to "10 MB"
     And user "Brian" has created folder "/testquota"
@@ -64,7 +64,7 @@ Feature: get quota
   @files_sharing-app-required
   Scenario Outline: Retrieving folder quota when quota is set and a file was received
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And the quota of user "Brian" has been set to "1 KB"
     And user "Alice" has uploaded file "/Alice.txt" of size 93 bytes
     And user "Alice" has shared file "Alice.txt" with user "Brian"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
@@ -6,7 +6,7 @@ Feature: upload file using new chunking
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
     And the administrator has enabled async operations

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
@@ -6,7 +6,7 @@ Feature: users cannot upload a file to a blacklisted name
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @issue-ocis-reva-15
   Scenario Outline: upload a file to a filename that is banned by default

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
@@ -6,7 +6,7 @@ Feature: users cannot upload a file to a blacklisted name using new chunking
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
     And the administrator has enabled async operations

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
@@ -6,7 +6,7 @@ Feature: users cannot upload a file to or into an excluded directory
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @issue-ocis-reva-54
   Scenario Outline: upload a file to an excluded directory name

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
@@ -6,7 +6,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
     And the administrator has enabled async operations

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to a blacklisted name using new chunking
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   Scenario: Upload a file to a filename that is banned by default using new chunking
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to a blacklisted name using old chunking
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10 @issue-36645
   Scenario: Upload a file to a filename that is banned by default using old chunking

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunkingOc10Issue36645.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunkingOc10Issue36645.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to a blacklisted name using old chunking
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @issue-36645
   Scenario: Upload a file to a filename that is banned by default using old chunking

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   Scenario: Upload a file to an excluded directory name using new chunking
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to or into an excluded directory using old c
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10 @issue-36645
   Scenario: Upload a file to an excluded directory name using old chunking

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunkingOc10Issue36645.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunkingOc10Issue36645.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to or into an excluded directory using old c
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @issue-36645
   Scenario: Upload a file to an excluded directory name using old chunking

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -7,7 +7,7 @@ Feature: upload file using new chunking
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
 
   Scenario: Upload chunked file asc with new chunking

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
@@ -7,7 +7,7 @@ Feature: upload file using old chunking
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
 
   @skipOnOcV10 @issue-36115
   Scenario: Upload chunked file asc

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunkingOc10Issue36115.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunkingOc10Issue36115.feature
@@ -8,7 +8,7 @@ Feature: upload file using old chunking
   Scenario: Upload chunked file asc
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     When user "Alice" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
       | number | content |
       | 1      | AAAAA   |

--- a/tests/acceptance/features/cliBackground/backgroundQueue.feature
+++ b/tests/acceptance/features/cliBackground/backgroundQueue.feature
@@ -23,7 +23,7 @@ Feature: get status, delete and execute jobs in background queue
       | OC\Authentication\Token\DefaultTokenCleanupJob     |
 
   Scenario: delete one of the job in background queue
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     When the administrator deletes last background job "OC\Command\CommandJob" using the occ command
     Then the command should have been successful

--- a/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
+++ b/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
@@ -7,7 +7,7 @@ Feature: poll incoming shares
   @files_sharing-app-required
   Scenario: poll incoming share with a federation share of deep nested folders when there is a file change in remote end
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/really/"
     And user "Alice" has created folder "/really/very/"
     And user "Alice" has created folder "/really/very/deeply/"
@@ -17,7 +17,7 @@ Feature: poll incoming shares
     And user "Alice" has created folder "/really/very/deeply/nested/folder/with/sub/"
     And user "Alice" has created folder "/really/very/deeply/nested/folder/with/sub/folders"
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has stored etag of element "/"
     And user "Alice" from server "REMOTE" has shared "/really" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
@@ -30,10 +30,10 @@ Feature: poll incoming shares
   @files_sharing-app-required
   Scenario: poll incoming share with a federation share and no file change
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/shareFolder/"
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has stored etag of element "/"
     And user "Alice" from server "REMOTE" has shared "/shareFolder" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
@@ -45,11 +45,11 @@ Feature: poll incoming shares
   @files_sharing-app-required
   Scenario: poll incoming share multiple times
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/shareFolder/"
     And using server "LOCAL"
     And user "Brian" has stored etag of element "/"
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" from server "REMOTE" has shared "/shareFolder" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
@@ -62,7 +62,7 @@ Feature: poll incoming shares
     Then the etag of element "/" of user "Brian" should not have changed
 
   Scenario: poll incoming share when there is no share
-    Given user "Brian" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and small skeleton files
     And user "Brian" has stored etag of element "/"
     When the administrator invokes occ command "incoming-shares:poll"
     Then the etag of element "/" of user "Brian" should not have changed

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
@@ -38,7 +38,7 @@ Feature: create local storage from the command line
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "Brian" should be "this is a file in local storage2"
 
   Scenario: user should not get access if the group of the user is removed from the applicable group and that group was not the only applicable group
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Carol    |
     And group "grp1" has been created
@@ -70,7 +70,7 @@ Feature: create local storage from the command line
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "Brian" should be "this is a file in local storage2"
 
   Scenario: users should get access if all the users and groups are removed from the applicable groups
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and small skeleton files:
       | username |
       | Carol    |
       | David    |

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
@@ -6,7 +6,7 @@ Feature: Scanning files on local storage
 
   @issue-33670 @skipOnOcV10
   Scenario: Adding a file to local storage and running scan should add files.
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And using new DAV path
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     When the administrator creates file "hello1.txt" with content "<? php :)" in local storage using the testing API
@@ -23,7 +23,7 @@ Feature: Scanning files on local storage
 
   @issue-33670 @skipOnOcV10
   Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And using new DAV path
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     And user "Alice" has created folder "/local_storage/folder1"
@@ -47,7 +47,7 @@ Feature: Scanning files on local storage
 
   @files_sharing-app-required @skipOnLDAP
   Scenario Outline: Adding a folder to local storage, sharing with groups and running scan for specific group should add files for users of that group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -80,7 +80,7 @@ Feature: Scanning files on local storage
       | commas,in,group,name |
 
   Scenario: Adding a folder to local storage, sharing with groups and running scan for a list of groups should add files for users in the groups
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -138,7 +138,7 @@ Feature: Scanning files on local storage
       | /local_storage3/folder3/hello3.txt |
 
   Scenario: Deleting a file from local storage and running scan for a specific path should remove the file.
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And using new DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/hello1.txt"
     When user "Alice" requests "/remote.php/dav/files/%username%/local_storage" with "PROPFIND" using basic auth
@@ -154,7 +154,7 @@ Feature: Scanning files on local storage
       | /local_storage/hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific user should add file for only that user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -183,7 +183,7 @@ Feature: Scanning files on local storage
       | /local_storage2/hello1.txt |
 
   Scenario: Adding a file on local storage and running file scan for a specific group should add file for only the users of that group
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorageOc10Issue33670.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorageOc10Issue33670.feature
@@ -5,7 +5,7 @@ Feature: Scanning files on local storage
   So that I can manage the balance between performance and "up-to-date-ness" of local storage
 
   Scenario: Adding a file to local storage and running scan should add files.
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And using new DAV path
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     # Need to re-scan. Config change doesn't come into effect until once scanned
@@ -23,7 +23,7 @@ Feature: Scanning files on local storage
       | /local_storage/hello2.txt |
 
   Scenario: Adding a file to local storage and running scan for a specific path should add files for only that path.
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And using new DAV path
     And the administrator has set the external storage "local_storage" to be never scanned automatically
     And user "Alice" has created folder "/local_storage/folder1"

--- a/tests/acceptance/features/cliMain/filesChecksum.feature
+++ b/tests/acceptance/features/cliMain/filesChecksum.feature
@@ -13,18 +13,18 @@ Feature: files checksum command
 
   @skipOnEncryptionType:user-keys @issue-encryption-182
   Scenario: Administrator verifies the checksum of all the files of a user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator invokes occ command "files:checksum:verify --user=%username%" for user "Alice"
     Then the command should have been successful
 
   @skipOnEncryptionType:user-keys @issue-encryption-182
   Scenario: Administrator fixes the mismatched checksums of all the files of a user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator invokes occ command "files:checksum:verify -r --user=%username%" for user "Alice"
     Then the command should have been successful
 
   Scenario: Administrator fixes the mismatched checksums of files in a certain path of a users
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator invokes occ command "files:checksum:verify -r --path=FOLDER --user=%username%" for user "Alice"
     Then the command should have been successful
 
@@ -39,7 +39,7 @@ Feature: files checksum command
     And the command should have failed with exit code 2
 
   Scenario: Administrator tries to verify the checksum of files in a certain path that does not exist
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator invokes occ command "files:checksum:verify --user=%username% --path=/dev/null" for user "Alice"
     Then the command output should contain the text 'Path "/%username%/files/dev/null" not found' about user "Alice"
     And the command should have failed with exit code 2

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -4,8 +4,8 @@ Feature: transfer-ownership
   @smokeTest
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of a file
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     When the administrator transfers ownership from "Alice" to "Brian" using the occ command
     Then the command should have been successful
@@ -13,8 +13,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of a file after updating the file
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has uploaded file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt"
     And user "Alice" has uploaded the following "3" chunks to "/PARENT/textfile0.txt" with old chunking
       | number | content |
@@ -27,8 +27,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of a folder
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     When the administrator transfers ownership from "Alice" to "Brian" using the occ command
@@ -37,9 +37,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
   Scenario: transferring ownership of file shares
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     And user "Alice" has shared file "/somefile.txt" with user "Carol" with permissions "share,update,read"
     When the administrator transfers ownership from "Alice" to "Brian" using the occ command
@@ -48,9 +48,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
   Scenario: transferring ownership of folder shared with third user
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "Alice" has shared folder "/test" with user "Carol" with permissions "all"
@@ -60,8 +60,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required
   Scenario: transferring ownership of folder shared with transfer recipient
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
@@ -73,9 +73,9 @@ Feature: transfer-ownership
   @skipOnEncryptionType:user-keys @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
   Scenario: transferring ownership of folder doubly shared with third user
     Given group "group1" has been created
-    And user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Carol" has been added to group "group1"
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
@@ -87,9 +87,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required
   Scenario: transferring ownership does not transfer received shares
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Carol" has created folder "/test"
     And user "Carol" has shared folder "/test" with user "Alice" with permissions "all"
     When the administrator transfers ownership from "Alice" to "Brian" using the occ command
@@ -98,10 +98,10 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required
   Scenario: transferring ownership does not transfer reshares
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
-    And user "David" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
+    And user "David" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/testByAlice"
     And user "Alice" has shared folder "/testByAlice" with user "Brian" with permissions "all"
     And user "Brian" has shared folder "/testByAlice" with user "Carol" with permissions "all"
@@ -118,17 +118,17 @@ Feature: transfer-ownership
 
   @local_storage @skipOnEncryptionType:user-keys
   Scenario: transferring ownership does not transfer external storage
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     When the administrator transfers ownership from "Alice" to "Brian" using the occ command
     Then the command should have been successful
     And as "Brian" folder "/local_storage" should not exist in the last received transfer folder
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required
   Scenario: transferring ownership does not fail with shared trashed files
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/sub"
     And user "Alice" has created folder "/sub/test"
     And user "Alice" has shared folder "/sub/test" with user "Carol" with permissions "all"
@@ -137,13 +137,13 @@ Feature: transfer-ownership
     Then the command should have been successful
 
   Scenario: transferring ownership fails with invalid source user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator transfers ownership from "invalid_user" to "Alice" using the occ command
     Then the command output should contain the text "Unknown source user"
     And the command should have failed with exit code 1
 
   Scenario: transferring ownership fails with invalid destination user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator transfers ownership from "Alice" to "invalid_user" using the occ command
     Then the command output should contain the text "Unknown destination user"
     And the command should have failed with exit code 1
@@ -151,8 +151,8 @@ Feature: transfer-ownership
   @smokeTest
   @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of only a single folder containing a file
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     When the administrator transfers ownership of path "test" from "Alice" to "Brian" using the occ command
@@ -160,8 +160,8 @@ Feature: transfer-ownership
     And the downloaded content when downloading file "/test/somefile.txt" for user "Brian" with range "bytes=0-6" from the last received transfer folder should be "This is"
 
   Scenario: transferring ownership of only a single folder containing an empty folder
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has created folder "/test/subfolder"
     When the administrator transfers ownership of path "test" from "Alice" to "Brian" using the occ command
@@ -170,8 +170,8 @@ Feature: transfer-ownership
     And as "Brian" folder "/test/subfolder" should exist in the last received transfer folder
 
   Scenario: transferring ownership of an account containing only an empty folder
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has deleted everything from folder "/"
     And user "Alice" has created folder "/test"
     When the administrator transfers ownership from "Alice" to "Brian" using the occ command
@@ -180,9 +180,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
   Scenario: transferring ownership of file shares
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "Alice" has shared file "/test/somefile.txt" with user "Carol" with permissions "share,update,read"
@@ -192,8 +192,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @public_link_share-feature-required @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
   Scenario: transferring ownership of folder shares which has public link
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file with content "Random data" to "/test/somefile.txt"
     And user "Alice" has created a public link share with settings
@@ -205,9 +205,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
   Scenario: transferring ownership of folder shared with third user
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "Alice" has shared folder "/test" with user "Carol" with permissions "all"
@@ -217,8 +217,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required
   Scenario: transferring ownership of folder shared with transfer recipient
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
@@ -230,9 +230,9 @@ Feature: transfer-ownership
   @skipOnEncryptionType:user-keys @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
   Scenario: transferring ownership of folder doubly shared with third user
     Given group "group1" has been created
-    And user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Carol" has been added to group "group1"
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
@@ -244,9 +244,9 @@ Feature: transfer-ownership
 
   @files_sharing-app-required
   Scenario: transferring ownership does not transfer received shares
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Carol" has created folder "/test"
     And user "Alice" has created folder "/sub"
     And user "Carol" has shared folder "/test" with user "Alice" with permissions "all"
@@ -257,8 +257,8 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @public_link_share-feature-required @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
   Scenario: transferring ownership of folder shared with transfer recipient and public link created of received share works
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has created folder "/test/foo"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
@@ -273,37 +273,37 @@ Feature: transfer-ownership
 
   @local_storage
   Scenario: transferring ownership does not transfer external storage
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "Alice" to "Brian" using the occ command
     Then the command should have been successful
     And as "Brian" folder "/local_storage" should not exist in the last received transfer folder
 
   Scenario: transferring ownership fails with invalid source user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "invalid_user" to "Alice" using the occ command
     Then the command output should contain the text "Unknown source user"
     And the command should have failed with exit code 1
 
   Scenario: transferring ownership fails with invalid destination user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "Alice" to "invalid_user" using the occ command
     Then the command output should contain the text "Unknown destination user"
     And the command should have failed with exit code 1
 
   Scenario: transferring ownership fails with invalid path
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     When the administrator transfers ownership of path "test" from "Alice" to "Brian" using the occ command
     Then the command output should contain the text "Unknown path provided"
     And the command should have failed with exit code 1
 
   Scenario: transferring ownership fails with empty files
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has deleted everything from folder "/"
     When the administrator transfers ownership from "Alice" to "Brian" using the occ command
     Then the command output should contain the text "No files/folders to transfer"
@@ -311,10 +311,10 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: troubleshoot transfer ownerships for all with share and reshare
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
-    And user "David" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
+    And user "David" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/testByAlice"
     And user "Alice" has shared folder "/testByAlice" with user "Brian" with permissions "all"
     And user "Brian" has shared folder "/testByAlice" with user "Carol" with permissions "all"
@@ -330,10 +330,10 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: troubleshoot transfer ownerships for invalid-initiator with reshare
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
-    And user "David" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
+    And user "David" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/testByAlice"
     And user "Alice" has shared folder "/testByAlice" with user "Brian" with permissions "all"
     And user "Brian" has shared folder "/testByAlice" with user "Carol" with permissions "all"
@@ -345,9 +345,9 @@ Feature: transfer-ownership
 
   @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: troubleshoot transfer ownerships for invalid-owner with share
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/test/somefile.txt"
     And user "Alice" has shared folder "/test" with user "Carol" with permissions "all"

--- a/tests/acceptance/features/cliProvisioning/addToGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addToGroup.feature
@@ -6,7 +6,7 @@ Feature: add users to group
 
   @smokeTest
   Scenario Outline: adding a user to a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     When the administrator adds user "brand-new-user" to group "<group_id>" using the occ command
     Then the command should have been successful
@@ -19,7 +19,7 @@ Feature: add users to group
       | नेपाली      | Unicode group name                    |
 
   Scenario Outline: adding a user to a group using mixes of upper and lower case in user and group names
-    Given user "mixed-case-user" has been created with default attributes and skeleton files
+    Given user "mixed-case-user" has been created with default attributes and small skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -36,7 +36,7 @@ Feature: add users to group
       | mixed-case-user | CASE-SENSITIVE-GROUP | Case-Sensitive-Group | case-sensitive-group |
 
   Scenario: admin tries to add user to a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "not-group" has been deleted
     When the administrator adds user "brand-new-user" to group "not-group" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -35,13 +35,13 @@ Feature: add a user using the using the occ command
       | email       | brand-new-user@example.com |
 
   Scenario: admin tries to create an existing user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator tries to create a user "brand-new-user" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'The user "%username%" already exists.' about user "brand-new-user"
 
   Scenario: admin tries to create an existing disabled user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And user "brand-new-user" has been disabled
     When the administrator tries to create a user "brand-new-user" using the occ command
     Then the command should have failed with exit code 1
@@ -86,7 +86,7 @@ Feature: add a user using the using the occ command
     And the display name of user "brand-new-user" should be "Brand-New-User"
 
   Scenario: admin tries to create an existing user but with username containing capital letters
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator creates this user using the occ command:
       | username       |
       | Brand-New-User |

--- a/tests/acceptance/features/cliProvisioning/deleteUser.feature
+++ b/tests/acceptance/features/cliProvisioning/deleteUser.feature
@@ -5,7 +5,7 @@ Feature: delete users
   So that I can remove users from ownCloud
 
   Scenario: admin deletes a user
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       |
       | brand-new-user |
     When the administrator deletes user "brand-new-user" using the occ command
@@ -14,7 +14,7 @@ Feature: delete users
     And user "brand-new-user" should not exist
 
   Scenario: Delete a user, and specify the user name in different case
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       |
       | brand-new-user |
     When the administrator deletes user "Brand-New-User" using the occ command

--- a/tests/acceptance/features/cliProvisioning/disableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/disableUser.feature
@@ -5,14 +5,14 @@ Feature: disable user
   So that I can remove access to files and resources for a user, without actually deleting the files and resources
 
   Scenario: admin disables an user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator disables user "Alice" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The specified user is disabled'
     And user "Alice" should be disabled
 
   Scenario: Admin can disable another admin user
-    Given user "another-admin" has been created with default attributes and skeleton files
+    Given user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     When the administrator disables user "another-admin" using the occ command
     Then the command should have been successful
@@ -20,7 +20,7 @@ Feature: disable user
     And user "another-admin" should be disabled
 
   Scenario: Admin can disable subadmins in the same group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And the administrator has been added to group "brand-new-group"

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -5,7 +5,7 @@ Feature: edit users
   So that I can keep the user information up-to-date
 
   Scenario: the administrator can edit a user email
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the email of user "brand-new-user" to "brand-new-user@example.com" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The email address of %username% updated to brand-new-user@example.com' about user "brand-new-user"
@@ -15,7 +15,7 @@ Feature: edit users
 
   @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: the administrator can clear a user email
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
     When the administrator changes the email of user "brand-new-user" to "''" using the occ command
     Then the command should have been successful
@@ -25,7 +25,7 @@ Feature: edit users
       | email |  |
 
   Scenario: the administrator can edit a user display name
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The displayname of %username% updated to A New User' about user "brand-new-user"
@@ -35,7 +35,7 @@ Feature: edit users
 
   @skipOnOcV10.3 @skipOnOcV10.4
   Scenario: the administrator can clear a user display name and then it defaults to the username
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "A New User"
     When the administrator changes the display name of user "brand-new-user" to "" using the occ command
     Then the command should have been successful
@@ -46,7 +46,7 @@ Feature: edit users
 
   @issue-23603 @skipOnOcV10
   Scenario: the administrator can edit a user quota
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The quota of brand-new-user updated to 12 MB'

--- a/tests/acceptance/features/cliProvisioning/editUserOc10Issue23603.feature
+++ b/tests/acceptance/features/cliProvisioning/editUserOc10Issue23603.feature
@@ -6,7 +6,7 @@ Feature: edit users
 
   @issue-23603
   Scenario: the administrator can edit a user quota
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the quota of user "brand-new-user" to "12MB" using the occ command
     Then the command should have failed with exit code 1
     #Then the command should have been successful

--- a/tests/acceptance/features/cliProvisioning/enableUser.feature
+++ b/tests/acceptance/features/cliProvisioning/enableUser.feature
@@ -5,7 +5,7 @@ Feature: enable user
   So that I can give a user access to their files and resources again if they are now authorized for that
 
   Scenario: admin enables an user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has been disabled
     When administrator enables user "Alice" using the occ command
     Then the command should have been successful
@@ -13,7 +13,7 @@ Feature: enable user
     And user "Alice" should be enabled
 
   Scenario: admin enables another admin user
-    Given user "another-admin" has been created with default attributes and skeleton files
+    Given user "another-admin" has been created with default attributes and small skeleton files
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When administrator enables user "another-admin" using the occ command
@@ -22,7 +22,7 @@ Feature: enable user
     And user "another-admin" should be enabled
 
   Scenario: admin enables subadmins in the same group
-    Given user "subadmin" has been created with default attributes and skeleton files
+    Given user "subadmin" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     And user "subadmin" has been added to group "brand-new-group"
     And the administrator has been added to group "brand-new-group"

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -6,7 +6,7 @@ Feature: get group
 
   @skipOnLDAP
   Scenario: admin gets users in the group
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       |
       | brand-new-user |
       | 123            |
@@ -22,7 +22,7 @@ Feature: get group
       | 123            | 123          |
 
   Scenario: admin gets user in the group who is disabled
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "Anne Brown"
     And user "brand-new-user" has been disabled
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/cliProvisioning/getUser.feature
+++ b/tests/acceptance/features/cliProvisioning/getUser.feature
@@ -5,7 +5,7 @@ Feature: get user
   So that I can see the information
 
   Scenario: admin gets an existing user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "Anne Brown"
     When the administrator retrieves the information of user "brand-new-user" in JSON format using the occ command
     Then the command should have been successful

--- a/tests/acceptance/features/cliProvisioning/getUserGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getUserGroups.feature
@@ -6,7 +6,7 @@ Feature: get user groups
 
   @issue-user_ldap-500
   Scenario: admin gets groups of an user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     And group "brand-new-group" has been created
     And group "0" has been created
@@ -29,7 +29,7 @@ Feature: get user groups
       | नेपाली               |
 
   Scenario: admin gets groups of an user who is not in any groups
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "unused-group" has been created
     When the administrator gets the groups of user "brand-new-user" in JSON format using the occ command
     Then the command should have been successful

--- a/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/removeFromGroup.feature
@@ -5,7 +5,7 @@ Feature: remove a user from a group
   So that I can manage user access to group resources
 
   Scenario Outline: admin removes a user from a group
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id>" has been created
     And user "brand-new-user" has been added to group "<group_id>"
     When the administrator removes user "brand-new-user" from group "<group_id>" using the occ command
@@ -19,7 +19,7 @@ Feature: remove a user from a group
       | नेपाली      | Unicode group name                    |
 
   Scenario Outline: remove a user from a group using mixes of upper and lower case in user and group names
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "<group_id1>" has been created
     And group "<group_id2>" has been created
     And group "<group_id3>" has been created
@@ -39,14 +39,14 @@ Feature: remove a user from a group
       | brand-new-user | CASE-SENSITIVE-GROUP | Case-Sensitive-Group | case-sensitive-group |
 
   Scenario: admin tries to remove a user from a group which does not exist
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "nonexistentgroup" has been deleted
     When the administrator removes user "brand-new-user" from group "nonexistentgroup" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Group "nonexistentgroup" does not exist'
 
   Scenario: admin tries to remove a user from a group which the user is not a member of
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created
     When the administrator removes user "brand-new-user" from group "brand-new-group" using the occ command
     Then the command should have been successful

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -6,7 +6,7 @@ Feature: reset user password
 
   @skipOnEncryptionType:user-keys
   Scenario: reset user password
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" using the occ command
@@ -16,7 +16,7 @@ Feature: reset user password
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: user should get email when admin does a "send email" password reset without specifying a password
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator invokes password reset for user "brand-new-user" using the occ command
@@ -29,14 +29,14 @@ Feature: reset user password
 
   @skipOnOcV10 @skipOnEncryption @issue-36985
   Scenario: user should get email when the administrator changes their password and specifies to also send email
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
     Then the command should have failed with exit code 1
 
   Scenario: administrator gets error message while trying to reset user password with send email when the email address of the user is not setup
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname |
       | brand-new-user | %regular% | New user    |
     When the administrator invokes password reset for user "brand-new-user" using the occ command
@@ -45,7 +45,7 @@ Feature: reset user password
 
   @skipOnOcV10.3
   Scenario: administrator gets error message while trying to reset specifying user password with send email when the email address of the user is not setup
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname |
       | brand-new-user | %regular% | New user    |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command
@@ -53,7 +53,7 @@ Feature: reset user password
     And the command output should contain the text "Email address is not set for the user %username%" about user "brand-new-user"
 
   Scenario: user should not get an email when the smtpmode value points to an invalid or missing mail program
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     And the administrator has set the mail smtpmode to "sendmail"
@@ -69,7 +69,7 @@ Feature: reset user password
     And the command output should contain the text 'User does not exist'
 
   Scenario: admin should be able to reset their own password
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and small skeleton files:
       | username       | displayname    |
       | brand-new-user | Brand New User |
     When the administrator resets their own password to "%alt1%" using the occ command

--- a/tests/acceptance/features/cliProvisioning/resetUserPasswordOc10Issue36985.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPasswordOc10Issue36985.feature
@@ -6,7 +6,7 @@ Feature: reset user password
 
   @skipOnEncryption @issue-36985
   Scenario: user should get email when the administrator changes their password and specifies to also send email
-    Given these users have been created with skeleton files:
+    Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     When the administrator resets the password of user "brand-new-user" to "%alt1%" sending email using the occ command

--- a/tests/acceptance/features/cliProvisioning/userLastSeen.feature
+++ b/tests/acceptance/features/cliProvisioning/userLastSeen.feature
@@ -5,13 +5,13 @@ Feature: get user last seen
   So that I can see when the user has last logged in to the owncloud server
 
   Scenario: admin gets last seen of a user
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator retrieves the time when user "brand-new-user" was last seen using the occ command
     Then the command should have been successful
     And the command output of user last seen should be recently
 
   Scenario: admin gets last seen of a user who has not been initialized
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and small skeleton files but not initialized:
       | username       |
       | brand-new-user |
     When the administrator retrieves the time when user "brand-new-user" was last seen using the occ command

--- a/tests/acceptance/features/cliProvisioning/userReport.feature
+++ b/tests/acceptance/features/cliProvisioning/userReport.feature
@@ -5,7 +5,7 @@ Feature: get user report
   So that I can see the total number of users in an ownCloud server
 
   Scenario: admin gets the user report
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and small skeleton files but not initialized:
       | username |
       | Alice    |
       | Brian    |
@@ -14,7 +14,7 @@ Feature: get user report
     And the total users returned by the command should be 3
 
   Scenario: admin gets the user report when the user is disabled
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and small skeleton files but not initialized:
       | username |
       | Alice    |
       | Brian    |
@@ -24,7 +24,7 @@ Feature: get user report
     And the total users returned by the command should be 3
 
   Scenario: admin gets the user report when a user has been created and deleted
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and small skeleton files but not initialized:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/cliProvisioning/userSettings.feature
+++ b/tests/acceptance/features/cliProvisioning/userSettings.feature
@@ -5,7 +5,7 @@ Feature: user settings
   So that I can set specific settings for a specific user
 
   Scenario: admin changes user language
-    Given user "brand-new-user" has been created with default attributes and skeleton files
+    Given user "brand-new-user" has been created with default attributes and small skeleton files
     When the administrator changes the language of user "brand-new-user" to "fr" using the occ command
     Then the command should have been successful
     And the language of user "brand-new-user" returned by the occ command should be "fr"

--- a/tests/acceptance/features/cliTrashbin/trashbin.feature
+++ b/tests/acceptance/features/cliTrashbin/trashbin.feature
@@ -5,7 +5,7 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control user trashbin space and which files are kept in that space
 
   Scenario: delete files and folder of a user from the trashbin
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
     And user "Alice" has deleted folder "/PARENT"
@@ -17,8 +17,8 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the folder with original path "/PARENT" should not exist in the trashbin
 
   Scenario: delete files and folder of all user from the trashbin
-    Given user "Alice" has been created with default attributes and skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Brian" has deleted file "/textfile1.txt"
     And user "Brian" has deleted folder "/PARENT"

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -116,7 +116,7 @@ Feature: admin storage settings
     And folder "local_storage1" should be listed on the webUI
 
   Scenario: administrator deletes local storage mount
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And the administrator has enabled the external storage
     And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
@@ -125,7 +125,7 @@ Feature: admin storage settings
     Then folder "local_storage1" should not be listed on the webUI
 
   Scenario: local storage mount is deleted when the last user applicable to it is deleted
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And the administrator has enabled the external storage
     And the administrator has browsed to the admin storage settings page
     And the administrator has created the local storage mount "local_storage1" from the admin storage settings page
@@ -135,7 +135,7 @@ Feature: admin storage settings
     Then the last created local storage mount should not be listed on the webUI
 
   Scenario: local storage mount is not deleted when the last group applicable to it is deleted but the member of the deleted group should not have access to it
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And group "brand-new-group" has been created
     And user "Alice" has been added to group "brand-new-group"
     And the administrator has enabled the external storage

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -5,7 +5,7 @@ Feature: deleting files and folders
   So that I can keep my filing system clean and tidy
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -37,7 +37,7 @@ Feature: Mark file as favorite
     And folder "simple-empty-folder" should not be listed in the favorites page on the webUI
 
   Scenario: mark files with same name and different path as favorites and list them in favourites page
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user marks file "lorem.txt" as favorite using the webUI

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -5,7 +5,7 @@ Feature: browse directly to details tab
   So that I can see the details immediately without needing to click in the UI
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -5,7 +5,7 @@ Feature: User can open the details panel for any file or folder
   So that the details of the file or folder are visible to me
 
   Background:
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
 
@@ -76,7 +76,7 @@ Feature: User can open the details panel for any file or folder
 
   @comments-app-required @files_sharing-app-required
   Scenario: the recipient user should be able to view different areas of details panel in Shared with you page
-    Given user "Brian" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and large skeleton files
     And user "Alice" has created folder "a-folder"
     And user "Alice" has shared folder "a-folder" with user "Brian"
     And user "Brian" has logged in using the webUI

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -5,7 +5,7 @@ Feature: scroll menu of actions that can be done on a file into view
   So that I can manage and work with my files
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -6,7 +6,7 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
@@ -78,7 +78,7 @@ Feature: Search
 
   @files_sharing-app-required
   Scenario: Search for a shared file
-    Given user "Carol" has been created with default attributes and skeleton files
+    Given user "Carol" has been created with default attributes and large skeleton files
     When user "Carol" shares file "/lorem.txt" with user "Alice" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "lorem" using the webUI
@@ -86,8 +86,8 @@ Feature: Search
 
   @files_sharing-app-required
   Scenario: Search for a re-shared file
-    Given user "Brian" has been created with default attributes and skeleton files
-    And user "Carol" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and large skeleton files
+    And user "Carol" has been created with default attributes and large skeleton files
     When user "Brian" shares file "/lorem.txt" with user "Carol" using the sharing API
     And user "Carol" shares file "/lorem (2).txt" with user "Alice" using the sharing API
     And the user reloads the current page of the webUI
@@ -96,7 +96,7 @@ Feature: Search
 
   @files_sharing-app-required
   Scenario: Search for a shared folder
-    Given user "Carol" has been created with default attributes and skeleton files
+    Given user "Carol" has been created with default attributes and large skeleton files
     When user "Carol" shares folder "simple-folder" with user "Alice" using the sharing API
     And the user reloads the current page of the webUI
     And the user searches for "simple" using the webUI

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -5,7 +5,7 @@ Feature: manage user quota
   So that users can only take up a certain amount of storage space
 
   Background:
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username |
       | Alice    |
     And the administrator has logged in using the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -5,7 +5,7 @@ Feature: delete users
   So that I can remove users
 
   Background:
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
@@ -5,7 +5,7 @@ Feature: disable users
   So that I can remove access to unnecessary users
 
   Background:
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username |
       | Alice    |
       | Brian    |
@@ -23,7 +23,7 @@ Feature: disable users
 
   Scenario: subadmin disables a user
     Given group "grp1" has been created
-    And user "subadmin" has been created with default attributes and skeleton files
+    And user "subadmin" has been created with default attributes and large skeleton files
     And user "Alice" has been added to group "grp1"
     And user "Brian" has been added to group "grp1"
     And user "subadmin" has been made a subadmin of group "grp1"

--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -8,7 +8,7 @@ Feature: edit users
     Given user admin has logged in using the webUI
 
   Scenario: Admin changes the display name of the user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And the administrator has browsed to the users page
     When the administrator changes the display name of user "Alice" to "New User" using the webUI
     And the administrator logs out of the webUI
@@ -20,7 +20,7 @@ Feature: edit users
 
   @skipOnEncryptionType:user-keys
   Scenario: Admin changes the password of the user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And the administrator has browsed to the users page
     When the administrator changes the password of user "Alice" to "new_password" using the webUI
     Then user "Alice" should exist
@@ -28,7 +28,7 @@ Feature: edit users
     But user "Brian" using password "%regular%" should not be able to download file "textfile0.txt"
 
   Scenario: Admin adds a user to a group
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And group "grp1" has been created
     And the administrator has browsed to the users page
     When the administrator adds user "Alice" to group "grp1" using the webUI
@@ -36,7 +36,7 @@ Feature: edit users
     And user "Alice" should belong to group "grp1"
 
   Scenario: Admin adds a user to a group when multiple groups are created
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
     And group "grp3" has been created
@@ -48,7 +48,7 @@ Feature: edit users
     And user "Alice" should not belong to group "grp3"
 
   Scenario: Admin adds a user to multiple groups
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
     And group "grp3" has been created
@@ -61,7 +61,7 @@ Feature: edit users
     And user "Alice" should not belong to group "grp1"
 
   Scenario: Admin removes a user from a group
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
     And the administrator has browsed to the users page
@@ -70,7 +70,7 @@ Feature: edit users
     And user "Alice" should not belong to group "grp1"
 
   Scenario: Admin removes user from multiple groups
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And group "grp1" has been created
     And group "grp2" has been created
     And group "grp3" has been created
@@ -86,7 +86,7 @@ Feature: edit users
     And user "Alice" should belong to group "grp3"
 
   Scenario: Admin changes the email of the user
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And the administrator has browsed to the users page
     When the administrator changes the email of user "Alice" to "new_email@oc.com" using the webUI
     Then user "Alice" should exist

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -5,7 +5,7 @@ Feature: move files
   So that I can organise my data structure
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFolders.feature
@@ -5,7 +5,7 @@ Feature: move folders
   So that I can organise my data structure
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -5,7 +5,7 @@ Feature: add users
   So that I can see various details about users
 
   Background:
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -6,7 +6,7 @@ Feature: accept/decline shares coming from internal users
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    Given user "Brian" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and large skeleton files
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -45,7 +45,7 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: receive shares with same name from different users
     Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and large skeleton files
     And user "Brian" has shared folder "/simple-folder" with user "Alice"
     And user "Carol" has shared folder "/simple-folder" with user "Alice"
     When user "Alice" logs in using the webUI

--- a/tests/acceptance/features/webUISharingAutocompletion1/shareAutocompletion.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion1/shareAutocompletion.feature
@@ -5,7 +5,7 @@ Feature: Autocompletion of share-with names
   So that I can efficiently share my files with other users or groups
 
   Background:
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username               | password  | displayname   | email        |
       | autocomplete-test-user | %regular% | Thomas Krause | ur@oc.net.np |
       | another-test-user      | %regular% | Another Name  | an@oc.com.np |
@@ -58,7 +58,7 @@ Feature: Autocompletion of share-with names
     Given the administrator has set the minimum characters for sharing autocomplete to "4"
     And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
-    And these users have been created with skeleton files but not initialized:
+    And these users have been created with large skeleton files but not initialized:
       | username | password | displayname | email        |
       | fiv      | %alt1%   | Someone     | fi@oc.com.np |
     And the user has opened the share dialog for folder "simple-folder"

--- a/tests/acceptance/features/webUISharingAutocompletion2/shareAutocompletionWithDifferentPatterns.feature
+++ b/tests/acceptance/features/webUISharingAutocompletion2/shareAutocompletionWithDifferentPatterns.feature
@@ -5,7 +5,7 @@ Feature: Autocompletion of share-with names
   So that I can efficiently share my files with other users or groups
 
   Background:
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username               | password  | displayname   | email        |
       | autocomplete-test-user | %regular% | Thomas Krause | ur@oc.net.np |
       | another-test-user      | %regular% | Another Name  | an@oc.com.np |
@@ -85,7 +85,7 @@ Feature: Autocompletion of share-with names
     And user "User Five" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the username of existing user contains the pattern somewhere in the middle
-    Given user "ivan" has been created with default attributes and skeleton files
+    Given user "ivan" has been created with default attributes and large skeleton files
     And user "autocomplete-test-user" has logged in using the webUI
     And the user has browsed to the files page
     And the user has opened the share dialog for folder "simple-folder"
@@ -182,7 +182,7 @@ Feature: Autocompletion of share-with names
     And group "ncell-customers" should not be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the user name contains the pattern somewhere in the middle but accounts medial search is disabled
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username | displayname |
       | ivan     | Ivan        |
     And user "autocomplete-test-user" has logged in using the webUI
@@ -193,7 +193,7 @@ Feature: Autocompletion of share-with names
     Then only user "Ivan" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the user name contains the pattern somewhere in the end but accounts medial search is disabled
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username              | displayname |
       | autocomplete-test-jb1 | Guest User  |
     And user "autocomplete-test-user" has logged in using the webUI
@@ -204,7 +204,7 @@ Feature: Autocompletion of share-with names
     Then only user "James Baker" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the name of existing user contains the pattern somewhere in the middle but accounts medial search is disabled
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username | displayname   |
       | someone  | finnance typo |
     And user "autocomplete-test-user" has logged in using the webUI
@@ -215,7 +215,7 @@ Feature: Autocompletion of share-with names
     Then only user "finnance typo" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the display name of existing user contains the pattern somewhere in the end but accounts medial search is disabled
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username | displayname |
       | someone  | Smith User  |
     And user "autocomplete-test-user" has logged in using the webUI
@@ -226,7 +226,7 @@ Feature: Autocompletion of share-with names
     Then only user "Smith User" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the beginning but accounts medial search is disabled
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username | displayname | email              |
       | someone  | Some One    | hello2js@oc.com.np |
     And user "autocomplete-test-user" has logged in using the webUI
@@ -237,7 +237,7 @@ Feature: Autocompletion of share-with names
     Then only user "John Finn Smith" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the middle but accounts medial search is disabled
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username | displayname | email         |
       | someone  | Some One    | net@oc.com.np |
     And user "autocomplete-test-user" has logged in using the webUI
@@ -248,7 +248,7 @@ Feature: Autocompletion of share-with names
     Then only user "Some One" should be listed in the autocomplete list on the webUI
 
   Scenario: autocompletion of a pattern where the email of the existing user contains the pattern somewhere at the end but accounts medial search is disabled
-    Given these users have been created with default attributes and skeleton files but not initialized:
+    Given these users have been created with default attributes and large skeleton files but not initialized:
       | username | displayname | email        |
       | someone  | Some One    | de@oc.com.np |
     And user "autocomplete-test-user" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingInternalGroups1/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups1/shareWithGroups.feature
@@ -9,7 +9,7 @@ Feature: Sharing files and folders with internal groups
       | username |
       | Alice    |
       | Brian    |
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and large skeleton files
     And these groups have been created:
       | groupname |
       | grp1      |
@@ -169,7 +169,7 @@ Feature: Sharing files and folders with internal groups
   @mailhog @skipOnLDAP @skipOnOcV10.3
   Scenario: user should not get an email notification if the user is added to the group after the mail notification was sent
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "David" has been created with default attributes and skeleton files
+    And user "David" has been created with default attributes and large skeleton files
     And user "Carol" has logged in using the webUI
     And user "Carol" has shared file "lorem.txt" with group "grp1"
     And the user has opened the share dialog for file "lorem.txt"

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
@@ -13,7 +13,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | username |
       | Alice    |
       | Brian    |
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and large skeleton files
     And these groups have been created:
       | groupname |
       | grp1      |

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -9,7 +9,7 @@ Feature: Sharing files and folders with internal groups
       | username |
       | Alice    |
       | Brian    |
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and large skeleton files
 
   Scenario Outline: sharing  files and folder with an internal problematic group name
     Given these groups have been created:

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -6,7 +6,7 @@ Feature: Sharing files and folders with internal users
 
   @smokeTest
   Scenario: share a file & folder with another internal user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -23,7 +23,7 @@ Feature: Sharing files and folders with internal users
 
   Scenario: share a folder with other user and then it should be listed on Shared with Others page
     Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has shared file "lorem.txt" with user "Alice"
     And user "Brian" has shared file "simple-folder" with user "Alice"
     And user "Brian" has logged in using the webUI
@@ -33,7 +33,7 @@ Feature: Sharing files and folders with internal users
 
   Scenario: share two file with same name but different paths
     Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has shared file "lorem.txt" with user "Alice"
     And user "Brian" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
@@ -43,7 +43,7 @@ Feature: Sharing files and folders with internal users
     And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
 
   Scenario: user shares the file/folder with another internal user and delete the share with user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -57,7 +57,7 @@ Feature: Sharing files and folders with internal users
 
   @skipOnOcV10.3 @skipOnOcV10.4
   Scenario Outline: user shares a file with another user with unusual usernames
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And these users have been created without skeleton files:
       | username   |
       | <username> |
@@ -306,7 +306,7 @@ Feature: Sharing files and folders with internal users
     Then 2 public link shares with name "Public link" should be visible on the webUI
 
   Scenario Outline: user with unusual username shares a file & folder with another internal user
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username   |
       | Alice      |
       | <username> |

--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
@@ -4,7 +4,7 @@ Feature: misc scenarios on sharing with internal users
   @skipOnFIREFOX
   Scenario: share a file with another internal user who overwrites and unshares the file
     Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has logged in using the webUI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user shares file "new-lorem.txt" with user "Alice" using the webUI
@@ -23,7 +23,7 @@ Feature: misc scenarios on sharing with internal users
 
   Scenario: share a folder with another internal user who uploads, overwrites and deletes files
     Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with user "Alice" using the webUI
@@ -51,7 +51,7 @@ Feature: misc scenarios on sharing with internal users
 
   Scenario: share a folder with another internal user who unshares the folder
     Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has logged in using the webUI
     When the user renames folder "simple-folder" to "new-simple-folder" using the webUI
     And the user shares folder "new-simple-folder" with user "Alice" using the webUI
@@ -68,7 +68,7 @@ Feature: misc scenarios on sharing with internal users
 
   @skipOnMICROSOFTEDGE @skipOnOcV10.3
   Scenario: share a folder with another internal user and prohibit deleting
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -83,7 +83,7 @@ Feature: misc scenarios on sharing with internal users
   @skipOnFIREFOX
   Scenario: share a folder with other user and then it should be listed on Shared with You for other user
     Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has moved file "lorem.txt" to "ipsum.txt"
     And user "Brian" has moved file "simple-folder" to "new-simple-folder"
     And user "Brian" has shared file "ipsum.txt" with user "Alice"
@@ -99,7 +99,7 @@ Feature: misc scenarios on sharing with internal users
       | username |
       | Alice    |
       | Carol    |
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and large skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"
     And user "Alice" has been added to group "grp1"
     And the administrator has browsed to the admin sharing settings page
@@ -112,7 +112,7 @@ Feature: misc scenarios on sharing with internal users
       | username |
       | Alice    |
       | Carol    |
-    And user "Brian" has been created with default attributes and skeleton files
+    And user "Brian" has been created with default attributes and large skeleton files
     And group "grp1" has been created
     And user "Alice" has created folder "new-folder"
     And user "Alice" has been added to group "grp1"
@@ -122,7 +122,7 @@ Feature: misc scenarios on sharing with internal users
     Then user "Alice" should not be able to share folder "new-folder" with user "Carol" using the sharing API
 
   Scenario: member of a blacklisted from sharing group tries to re-share a file received as a share
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Carol    |
@@ -160,7 +160,7 @@ Feature: misc scenarios on sharing with internal users
       | Alice    |
       | Brian    |
       | David    |
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and large skeleton files
     And group "grp1" has been created
     And user "Alice" has been added to group "grp1"
     And user "Carol" has created folder "/common"
@@ -190,7 +190,7 @@ Feature: misc scenarios on sharing with internal users
 
   Scenario: user tries to share a file from a group which is blacklisted from sharing using webUI from files page
     Given group "grp1" has been created
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has been added to group "grp1"
     And the administrator has enabled exclude groups from sharing
     And the administrator has browsed to the admin sharing settings page
@@ -202,7 +202,7 @@ Feature: misc scenarios on sharing with internal users
 
   Scenario: user tries to re-share a file from a group which is blacklisted from sharing using webUI from shared with you page
     Given group "grp1" has been created
-    And these users have been created with default attributes and skeleton files:
+    And these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -223,7 +223,7 @@ Feature: misc scenarios on sharing with internal users
   @mailhog
   Scenario: user should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and large skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
     And user "Alice" has shared file "lorem.txt" with user "Brian"
@@ -238,7 +238,7 @@ Feature: misc scenarios on sharing with internal users
   @mailhog @skipOnOcV10.3
   Scenario: user should get and error message when trying to send notification by email to a user who has not setup their email
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and large skeleton files
     And these users have been created without skeleton files:
       | username | password |
       | Brian    | 1234     |
@@ -253,7 +253,7 @@ Feature: misc scenarios on sharing with internal users
   @mailhog @skipOnOcV10.3
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and large skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
     And user "Alice" has shared file "lorem.txt" with user "Brian"
@@ -267,7 +267,7 @@ Feature: misc scenarios on sharing with internal users
   @skipOnOcV10.3
   Scenario: user should not be able to send notification by email when allow share mail notification has been disabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "no"
-    And user "Alice" has been created with default attributes and skeleton files
+    And user "Alice" has been created with default attributes and large skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
     And user "Alice" has shared file "lorem.txt" with user "Brian"
@@ -294,7 +294,7 @@ Feature: misc scenarios on sharing with internal users
 
   @issue-35787 @skipOnOcV10
   Scenario: share a skeleton file after changing its content to a user before the user has logged in
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -311,7 +311,7 @@ Feature: misc scenarios on sharing with internal users
       | username |
       | Alice    |
       | Brian    |
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and large skeleton files
     And the administrator has changed the display name of user "Alice" to "USER"
     And the administrator has changed the display name of user "Brian" to "USER"
     And parameter "user_additional_info_field" of app "core" has been set to "id"

--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsersOc10Issue35787.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsersOc10Issue35787.feature
@@ -3,7 +3,7 @@ Feature: misc scenarios on sharing with internal users
 
   @issue-35787 @notToImplementOnOCIS
   Scenario: share a skeleton file after changing its content to a user before the user has logged in
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
@@ -9,7 +9,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | username |
       | Alice    |
       | Brian    |
-    And user "Carol" has been created with default attributes and skeleton files
+    And user "Carol" has been created with default attributes and large skeleton files
 
   Scenario: expiration date is disabled for sharing with users, user shares with another user
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"

--- a/tests/acceptance/features/webUISharingInternalUsers2/webUIShareDetails.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/webUIShareDetails.feature
@@ -6,7 +6,7 @@ Feature: WebUI share details for shares created using internal users
 
   @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -19,7 +19,7 @@ Feature: WebUI share details for shares created using internal users
 
   @skipOnOcV10.3
   Scenario: sharing indicator of items inside a shared folder two levels down
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -35,7 +35,7 @@ Feature: WebUI share details for shares created using internal users
 
   @skipOnOcV10.3
   Scenario: sharing indicator of items inside a re-shared folder
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
     And these users have been created without skeleton files:
@@ -52,7 +52,7 @@ Feature: WebUI share details for shares created using internal users
 
   @skipOnOcV10.3
   Scenario: no sharing indicator of items inside a not shared folder
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
     And user "Alice" has logged in using the webUI
@@ -99,7 +99,7 @@ Feature: WebUI share details for shares created using internal users
 
   @skipOnOcV10.3
   Scenario: sharing indicator for file uploaded inside a shared folder
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -112,7 +112,7 @@ Feature: WebUI share details for shares created using internal users
 
   @skipOnOcV10.3
   Scenario: sharing indicator for folder created inside a shared folder
-    Given these users have been created with default attributes and skeleton files:
+    Given these users have been created with default attributes and large skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/webUISharingPublic1/permissionsShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic1/permissionsShareByPublicLink.feature
@@ -8,7 +8,7 @@ Feature: Share by public link
     Given user "Alice" has been created with default attributes and without skeleton files
 
   Scenario: creating a public link with read & write permissions makes it possible to delete files via the link
-    Given user "Brian" has been created with default attributes and skeleton files
+    Given user "Brian" has been created with default attributes and large skeleton files
     And user "Brian" has logged in using the webUI
     When the user creates a new public link for folder "simple-folder" using the webUI with
       | permission | read-write |

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -72,7 +72,7 @@ Feature: Creation of tags for the files and folders
 
   @files_sharing-app-required
   Scenario: Add tags on skeleton file before sharing
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | Brian    |
       | Carol    |

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -5,7 +5,7 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     And the following files have been deleted
       | name          |

--- a/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinFilesFolders.feature
@@ -5,7 +5,7 @@ Feature: files and folders exist in the trashbin after being deleted
   So that I can recover data easily
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinRestore.feature
@@ -5,7 +5,7 @@ Feature: Restore deleted files/folders
   So that I can recover accidentally deleted files/folders in ownCloud
 
   Background:
-    Given user "Alice" has been created with default attributes and skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -6,7 +6,7 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username       |
       | brand-new-user |
     And user "brand-new-user" has logged in using the webUI
@@ -25,7 +25,7 @@ Feature: Locks
     But file "data.tar.gz" should not be marked as locked on the webUI
 
   Scenario: setting a lock shows the display name of a user in the locking details
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
     Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties
@@ -38,7 +38,7 @@ Feature: Locks
 
   @skipOnOcV10 @issue-34315
   Scenario: setting a lock shows the current display name of a user in the locking details
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
     Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties
@@ -51,7 +51,7 @@ Feature: Locks
     And file "data.zip" should be marked as locked by user "An ordinary name" in the locks tab of the details panel on the webUI
 
   Scenario: setting a lock shows the display name of a user in the locking details (user has set email address)
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username               | displayname   | email       |
       | user-with-display-name | My fancy name | mail@oc.org |
     Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties
@@ -63,7 +63,7 @@ Feature: Locks
     And file "data.zip" should be marked as locked by user "My fancy name (mail@oc.org)" in the locks tab of the details panel on the webUI
 
   Scenario: setting a lock shows the user name of a user in the locking details (user has set email address)
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username        | email       |
       | user-with-email | mail@oc.org |
     Given user "user-with-email" has locked folder "simple-folder" setting the following properties
@@ -93,7 +93,7 @@ Feature: Locks
 
   @skipOnOcV10 @issue-33867 @files_sharing-app-required
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-with-others page
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | receiver |
     And user "brand-new-user" has locked folder "simple-folder" setting the following properties
@@ -136,7 +136,7 @@ Feature: Locks
 
   @skipOnOcV10 @issue-33867 @files_sharing-app-required
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-with-you page
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | sharer   |
     And user "sharer" has locked folder "simple-folder" setting the following properties
@@ -162,7 +162,7 @@ Feature: Locks
 
   @files_sharing-app-required
   Scenario: lock set on a shared file shows the lock information for all involved users
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username  |
       | sharer    |
       | receiver  |
@@ -217,7 +217,7 @@ Feature: Locks
 
   @files_sharing-app-required
   Scenario Outline: decline locked folder
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | sharer   |
     And user "sharer" has created folder "/to-share-folder"
@@ -236,7 +236,7 @@ Feature: Locks
 
   @files_sharing-app-required
   Scenario Outline: accept previously declined locked folder
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | sharer   |
     And user "sharer" has created folder "/to-share-folder"
@@ -257,7 +257,7 @@ Feature: Locks
 
   @files_sharing-app-required
   Scenario Outline: accept previously declined locked folder but create a folder with same name in between
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | sharer   |
     And user "sharer" has created folder "/to-share-folder"
@@ -280,7 +280,7 @@ Feature: Locks
 
   @files_sharing-app-required
   Scenario Outline: creating a subfolder structure that is the same as the structure of a declined & locked share
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | sharer   |
     And user "sharer" has created folder "/parent"
@@ -304,7 +304,7 @@ Feature: Locks
 
   @files_sharing-app-required
   Scenario Outline: unsharing a locked file/folder
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | sharer   |
     And user "sharer" has locked file "lorem.txt" setting the following properties

--- a/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue33867.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue33867.feature
@@ -6,14 +6,14 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username       |
       | brand-new-user |
     And user "brand-new-user" has logged in using the webUI
 
   @issue-33867 @files_sharing-app-required
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-with-you page
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | sharer   |
     And user "sharer" has locked folder "simple-folder" setting the following properties
@@ -64,7 +64,7 @@ Feature: Locks
 
   @issue-33867 @files_sharing-app-required
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-with-you page
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username |
       | sharer   |
     And user "sharer" has locked folder "simple-folder" setting the following properties

--- a/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue34315.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue34315.feature
@@ -6,14 +6,14 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username       |
       | brand-new-user |
     And user "brand-new-user" has logged in using the webUI
 
   @skipOnOcV10 @issue-34315
   Scenario: setting a lock shows the current display name of a user in the locking details
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
     Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -6,7 +6,7 @@ Feature: Unlock locked files and folders
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username       |
       | brand-new-user |
     And user "brand-new-user" has logged in using the webUI
@@ -19,7 +19,7 @@ Feature: Unlock locked files and folders
     Then folder "simple-folder" should not be marked as locked on the webUI
 
   Scenario: unlocking by webDAV after the display name has been changed deletes the lock symbols at the correct files/folders
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username               | displayname   |
       | user-with-display-name | My fancy name |
     Given user "user-with-display-name" has locked folder "simple-folder" setting the following properties
@@ -114,7 +114,7 @@ Feature: Unlock locked files and folders
   # Pgsql and Oracle database can have different sorting, so allow this scenario to be skipped on those
   @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql @skipOnDbOracle
   Scenario: deleting the first one of multiple shared locks on the webUI
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username  |
       | receiver1 |
       | receiver2 |
@@ -155,7 +155,7 @@ Feature: Unlock locked files and folders
   # Pgsql and Oracle database can have different sorting, so allow this scenario to be skipped on those
   @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql @skipOnDbOracle
   Scenario: deleting the second one of multiple shared locks on the webUI
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username  |
       | receiver1 |
       | receiver2 |
@@ -196,7 +196,7 @@ Feature: Unlock locked files and folders
   # Pgsql and Oracle database can have different sorting, so allow this scenario to be skipped on those
   @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql @skipOnDbOracle
   Scenario: deleting the last one of multiple shared locks on the webUI
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username  |
       | receiver1 |
       | receiver2 |
@@ -235,7 +235,7 @@ Feature: Unlock locked files and folders
 
   @files_sharing-app-required @skipOnLDAP @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: deleting a lock that was created by an other user
-    Given these users have been created with skeleton files:
+    Given these users have been created with large skeleton files:
       | username  |
       | receiver1 |
     And user "brand-new-user" has shared file "/lorem.txt" with user "receiver1"


### PR DESCRIPTION
## Description
name the used skeleton explicitly in the feature description, don't rely on guessing anymore

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes owncloud/QA/issues/652

## Motivation and Context
working towards owncloud/QA/issues/628
generally speaking the person reading the feature file should understand what happens and should not need to know what "magic" happens in the background

## How Has This Been Tested?
- :robot: in this repo and on ocis: https://github.com/owncloud/ocis/pull/1703

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
