### PR TITLE
[Tests-Only] Adds API tests for counting number of etag elements in response of a versioned file

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -420,3 +420,13 @@ Feature: dav-versions
     Given user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"
     When user "Alice" gets the number of versions of file "textfile0.txt"
     Then the number of versions should be "0"
+
+  @issue-ocis-1234
+  Scenario: the number of etag elements in response changes according to version of the file
+    Given user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 1" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 2" to "textfile0.txt"
+    When user "Alice" gets the number of versions of file "textfile0.txt"
+    Then the HTTP status code should be "207"
+    And the number of etag elements in the response should be "2"
+    And the number of versions should be "2"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -449,6 +449,31 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then the number of etag elements in the response should be :number
+	 *
+	 * @param int $number
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theNumberOfEtagElementInTheResponseShouldBe($number) {
+		$resXml = $this->getResponseXmlObject();
+		if ($resXml === null) {
+			$resXml = HttpRequestHelper::getResponseXml(
+				$this->getResponse(),
+				__METHOD__
+			);
+		}
+		$xmlPart = $resXml->xpath("//d:getetag");
+		$actualNumber = \count($xmlPart);
+		Assert::assertEquals(
+			$number,
+			$actualNumber,
+			"Expected number of etag elements was '$number', but got '$actualNumber'"
+		);
+	}
+
+	/**
 	 * @Given /^the administrator has (enabled|disabled) async operations$/
 	 *
 	 * @param string $enabledOrDisabled


### PR DESCRIPTION
## Description
Adds API tests for counting number of etag elements  in response of a versioned file

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Demonstrates  https://github.com/owncloud/ocis/issues/1234

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/1708

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
