### PR TITLE
[Tests-Only]Added test for request to edit non-existing user by authorized admin

### DIFF
--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -21,3 +21,13 @@ Feature: auth
       | /ocs/v2.php/apps/files_sharing/api/v1/shares/123 |
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
+
+  @issue-38423 @skipOnOcV10
+  Scenario: Request to edit non-existing user by authorized admin gets unauthorized in http response
+    Given user "another-admin" has been added to group "admin"
+    When user "another-admin" requests these endpoints with "PUT" including body "doesnotmatter" about user "non-existing"
+      | endpoint                                         |
+      | /ocs/v1.php/cloud/users/%username%               |
+      | /ocs/v2.php/cloud/users/%username%               |
+    Then the HTTP status code of responses on all endpoints should be "200"
+    And the OCS status code of responses on all endpoints should be "101"

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuthOc10Issue38423.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuthOc10Issue38423.feature
@@ -1,0 +1,13 @@
+@api @files_sharing-app-required @notToImplementOnOCIS
+#When this issue is fixed, please delete this file and use the one from ocsPUTAuth.feature
+Feature: current oC10 behavior for issue-38423
+
+  Scenario: Request to edit non-existing user by authorized admin gets unauthorized in http response
+      Given user "another-admin" has been created with default attributes and without skeleton files
+      And user "another-admin" has been added to group "admin"
+      When user "another-admin" requests these endpoints with "PUT" including body "doesnotmatter" about user "non-existing"
+        | endpoint                                         |
+        | /ocs/v1.php/cloud/users/%username%               |
+        | /ocs/v2.php/cloud/users/%username%               |
+      Then the HTTP status code of responses on all endpoints should be "401"
+      And the OCS status code of responses on all endpoints should be "997"


### PR DESCRIPTION
## Description
Request to edit non-existing user by authorized (admin) user sends HTTP status code 401 (unauthorized)

## Related Issue
- Demonstrates https://github.com/owncloud/core/issues/38423

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
