### PR TITLE
[tests-only] Remove skeletondirectory

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -14,7 +14,7 @@ Feature: add user
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
-    And user "brand-new-user" should be able to access a skeleton file
+    And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
 
   @skipOnOcV10.3
   Scenario: admin creates a user with special characters in the username
@@ -32,7 +32,7 @@ Feature: add user
       | username |
       | a@-+_.b  |
       | a space  |
-    And the following users should be able to access a skeleton file
+    And the following users should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
       | username |
       | a@-+_.b  |
       | a space  |
@@ -59,7 +59,7 @@ Feature: add user
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should belong to group "brand-new-group"
-    And user "brand-new-user" should be able to access a skeleton file
+    And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
 
   Scenario: admin creates a user and specifies a password with special characters
     When the administrator sends a user creation request for the following users with password using the provisioning API
@@ -74,7 +74,7 @@ Feature: add user
       | brand-new-user1 |
       | brand-new-user2 |
       | brand-new-user3 |
-    And the following users should be able to access a skeleton file
+    And the following users should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
       | username        |
       | brand-new-user1 |
       | brand-new-user2 |
@@ -93,7 +93,7 @@ Feature: add user
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
-    And user "brand-new-user" should be able to access a skeleton file
+    And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
 
   Scenario Outline: admin creates a user with username that contains capital letters
     When the administrator sends a user creation request for user "<display-name>" password "%alt1%" using the provisioning API
@@ -147,7 +147,7 @@ Feature: add user
       | 123      |
       | -123     |
       | 0.0      |
-    And the following users should be able to access a skeleton file
+    And the following users should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
       | username |
       | user-1   |
       | null     |

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -14,7 +14,7 @@ Feature: add user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
-    And user "brand-new-user" should be able to access a skeleton file
+    And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
 
   @skipOnOcV10.3
   Scenario Outline: admin creates a user with special characters in the username
@@ -23,7 +23,7 @@ Feature: add user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "<username>" should exist
-    And user "<username>" should be able to access a skeleton file
+    And user "<username>" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
     Examples:
       | username |
       | a@-+_.b  |
@@ -51,7 +51,7 @@ Feature: add user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should belong to group "brand-new-group"
-    And user "brand-new-user" should be able to access a skeleton file
+    And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
 
   Scenario Outline: admin creates a user and specifies a password with special characters
     Given user "brand-new-user" has been deleted
@@ -59,7 +59,7 @@ Feature: add user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
-    And user "brand-new-user" should be able to access a skeleton file
+    And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
     Examples:
       | password                     | comment                               |
       | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters                    |
@@ -79,7 +79,7 @@ Feature: add user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
-    And user "brand-new-user" should be able to access a skeleton file
+    And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
 
   Scenario Outline: admin creates a user with username that contains capital letters
     When the administrator sends a user creation request for user "<display-name>" password "%alt1%" using the provisioning API
@@ -112,7 +112,7 @@ Feature: add user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
     And user "<username>" should exist
-    And user "<username>" should be able to access a skeleton file
+    And user "<username>" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
     Examples:
       | username |
       | user-1   |

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -173,14 +173,15 @@ class OccUsersGroupsContext implements Context {
 	public function theAdministratorCreatesUserPasswordGroupUsingTheOccCommand($username, $password, $group) {
 		$user = $this->featureContext->getActualUsername($username);
 		$cmd = "user:add $user  --password-from-env --group=$group";
+		$actualPassword = $this->featureContext->getActualPassword($password);
 		$this->occContext->invokingTheCommandWithEnvVariable(
 			$cmd,
 			'OC_PASS',
-			$this->featureContext->getActualPassword($password)
+			$actualPassword
 		);
 		$this->featureContext->addUserToCreatedUsersList(
 			$user,
-			$password,
+			$actualPassword,
 			null,
 			null,
 			$this->occContext->theOccCommandExitStatusWasSuccess()

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2138,6 +2138,27 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then the following users should be able to upload file :source to :destination
+	 *
+	 * @param string $source
+	 * @param string $destination
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function usersShouldBeAbleToUploadFileTo(
+		string $source, string $destination, TableNode $table
+	) {
+		$this->verifyTableNodeColumns($table, ["username"]);
+		$usernames = $table->getHash();
+		foreach ($usernames as $username) {
+			$actualUser = $this->getActualUsername($username["username"]);
+			$this->userUploadsAFileTo($actualUser, $source, $destination);
+			$this->asFileOrFolderShouldExist($actualUser, "file", $destination);
+		}
+	}
+
+	/**
 	 * @Then user :user should not be able to upload file :source to :destination
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/cliProvisioning/addUser.feature
+++ b/tests/acceptance/features/cliProvisioning/addUser.feature
@@ -13,7 +13,7 @@ Feature: add a user using the using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The user "%username%" was created successfully' about user "<username>"
     And user "<username>" should exist
-    And user "<username>" should be able to access a skeleton file
+    And user "<username>" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
     Examples:
       | username       |
       | brand-new-user |
@@ -28,7 +28,7 @@ Feature: add a user using the using the occ command
     And the command output should contain the text 'Display name set to "Brand New User"'
     And the command output should contain the text 'Email address set to "brand-new-user@example.com"'
     And user "brand-new-user" should exist
-    And user "brand-new-user" should be able to access a skeleton file
+    And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
     When the administrator retrieves the information of user "brand-new-user" using the provisioning API
     Then the user attributes returned by the API should include
       | displayname | Brand New User             |
@@ -60,7 +60,7 @@ Feature: add a user using the using the occ command
     Then the command should have been successful
     And the command output should contain the text 'The user "%username%" was created successfully' about user "brand-new-user"
     And user "brand-new-user" should exist
-    And user "brand-new-user" should be able to access a skeleton file
+    And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
     Examples:
       | password                     | comment                               |
       | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters                    |
@@ -82,7 +82,7 @@ Feature: add a user using the using the occ command
     And the command output should contain the text 'The user "%username%" was created successfully' about user "Brand-New-User"
     And user "Brand-New-User" should exist
     And user "brand-new-user" should exist
-    And user "Brand-New-User" should be able to access a skeleton file
+    And user "Brand-New-User" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
     And the display name of user "brand-new-user" should be "Brand-New-User"
 
   Scenario: admin tries to create an existing user but with username containing capital letters

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -57,12 +57,13 @@ Feature: edit users
   Scenario Outline: Admin resets user password with special characters
     Given user "brand-new-user" has been deleted
     When the administrator creates user "brand-new-user" password "%alt1%" group "brand-new-group" using the occ command
+    And user "brand-new-user" uploads file with content "some text" to "atextfile.txt" using the WebDAV API
     And the administrator resets the password of user "brand-new-user" to "<password>" using the occ command
     Then the command should have been successful
     And the command output should contain the text 'Successfully reset password for %username%' about user "brand-new-user"
     And user "brand-new-user" should exist
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "<password>" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password "%alt1%" should not be able to download file "textfile0.txt"
+    And the content of file "atextfile.txt" for user "brand-new-user" using password "<password>" should be "some text"
+    But user "brand-new-user" using password "%alt1%" should not be able to download file "atextfile.txt"
     Examples:
       | password                     | comment                               |
       | !@#$%^&*()-_+=[]{}:;,.<>?~/\ | special characters                    |
@@ -73,7 +74,8 @@ Feature: edit users
   Scenario: admin creates a user and specifies an invalid password, containing just space
     Given user "brand-new-user" has been deleted
     When the administrator creates user "brand-new-user" password "%alt1%" group "brand-new-group" using the occ command
+    And user "Brand-New-User" uploads file with content "some text" to "/atextfile.txt" using the WebDAV API
     And the administrator resets the password of user "brand-new-user" to " " using the occ command
     Then the command should have failed with exit code 1
-    And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
-    But user "brand-new-user" using password " " should not be able to download file "textfile0.txt"
+    And the content of file "atextfile.txt" for user "brand-new-user" using password "%alt1%" should be "some text"
+    But user "brand-new-user" using password " " should not be able to download file "atextfile.txt"

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -978,22 +978,8 @@ do
 done
 
 #set the skeleton folder
-if [ -z "${SKELETON_DIR}" ]
+if [ -n "${SKELETON_DIR}" ]
 then
-	# calculate the correct skeleton folder
-	if [ "${RUNNING_API_TESTS}" = true ] || [ "${RUNNING_CLI_TESTS}" = true ]
-	then
-		# CLI tests use the apiSkeleton so that API-based "then" steps can be used
-		# to check the state of users after CLI commands
-		export SRC_SKELETON_DIR="apiSkeleton"
-	else
-		export SRC_SKELETON_DIR="webUISkeleton"
-	fi
-	for URL in ${TESTING_APP_URL} ${TESTING_APP_FED_URL}
-	do
-		curl -k -s -u ${ADMIN_AUTH} ${URL}testingskeletondirectory -d "directory=${SRC_SKELETON_DIR}" > /dev/null
-	done
-else
 	for URL in ${OCC_URL} ${OCC_FED_URL}
 	do
 		remote_occ ${ADMIN_AUTH} ${URL} "config:system:set skeletondirectory --value=${SKELETON_DIR}"


### PR DESCRIPTION
## Description
- remove the code in acceptance tests `run.sh` that automagically chooses "api" or "webui" skeleton
- adjust tests that were depending on some skeleton files existing "by default"

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/656

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
