### PR TITLE
[tests-only] Process unexpected passes for test suites that contain dash in the name

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -473,7 +473,7 @@ function run_behat_tests() {
 				# Match lines that have [someSuite/someName.feature:n] - the part inside the
 				# brackets is the suite, feature and line number of the expected failure.
 				# Else ignore the line.
-				if [[ "${SUITE_SCENARIO}" =~ \[([a-zA-Z0-9]+/[a-zA-Z0-9]+\.feature:[0-9]+)] ]]; then
+				if [[ "${SUITE_SCENARIO}" =~ \[([a-zA-Z0-9-]+/[a-zA-Z0-9-]+\.feature:[0-9]+)] ]]; then
 				  SUITE_SCENARIO="${BASH_REMATCH[1]}"
 				else
 				  continue


### PR DESCRIPTION
## Description
Add a dash `-` to the characters that appear in suite and feature file names.

## How Has This Been Tested?
Local test by creating a local expected-failures file, using it for apiProvisioning-v1 suite.
Before this change the unexpected passes were not reported.
After the change the unexpected passes are reported.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
