### PR TITLE
 Fix regression that occurred after #38375

### DIFF
--- a/changelog/unreleased/38375
+++ b/changelog/unreleased/38375
@@ -10,3 +10,5 @@ decrypted due to a wrong signature.
 This issue is now fixed, and the backup copy can be restored normally.
 
 https://github.com/owncloud/core/pull/38375
+https://github.com/owncloud/core/pull/38452
+https://github.com/owncloud/encryption/issues/244

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -801,7 +801,8 @@ class Encryption extends Wrapper {
 				if ($preserveMtime) {
 					$this->touch($targetInternalPath, $sourceStorage->filemtime($sourceInternalPath));
 				}
-				if (\substr($targetInternalPath, 0, \strlen('files_trashbin/')) !== 'files_trashbin/') {
+				if ($sourceStorage->getOwner($sourceInternalPath) === $this->uid
+					|| \substr($targetInternalPath, 0, \strlen('files_trashbin/')) !== 'files_trashbin/') {
 					// 1. user1 moves file from home storage to admins's shared folder
 					// 2. user2 grabs the file from admin's shared folder to his own home storage
 					// Admin has a broken copy in his trashbin, which is caused by a wrong encrypted


### PR DESCRIPTION
## Description
Fix regression that occurred after #38375

This pr allows updating the encrypted version, if session uid is the same as the target storage owner. This reduces possible side effects outside of the defined scenario here 
https://github.com/owncloud/core/blob/862513d3e6900cd639bfa26a622704b8804cc3cc/lib/private/Files/Storage/Wrapper/Encryption.php#L805-L809

and fix the related regression  https://github.com/owncloud/encryption/issues/244. 

## Related Issue
- Fixes https://github.com/owncloud/encryption/issues/244

## Motivation and Context

## How Has This Been Tested?
Manually tested with failing acceptance tests and #38375 scenarios.
Also tested in encrpytion repo to ensure regression fixed. Related PR: https://github.com/owncloud/encryption/pull/247.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
