### PR TITLE
Bump phpseclib/phpseclib from 2.0.30 to 3.0.3

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -34,7 +34,7 @@
 namespace OCA\Files_External\Lib\Storage;
 use Icewind\Streams\IteratorDirectory;
 use Icewind\Streams\RetryWrapper;
-use phpseclib\Net\SFTP\Stream;
+use phpseclib3\Net\SFTP\Stream;
 
 /**
 * Uses phpseclib's Net\SFTP class and the Net\SFTP\Stream stream wrapper to
@@ -124,7 +124,7 @@ class SFTP extends \OCP\Files\Storage\StorageAdapter {
 		}
 
 		$hostKeys = $this->readHostKeys();
-		$this->client = new \phpseclib\Net\SFTP($this->host, $this->port);
+		$this->client = new \phpseclib3\Net\SFTP($this->host, $this->port);
 
 		// The SSH Host Key MUST be verified before login().
 		$currentHostKey = $this->client->getServerPublicHostKey();

--- a/changelog/unreleased/38454
+++ b/changelog/unreleased/38454
@@ -1,0 +1,3 @@
+Change: Update phpseclib/phpseclib (2.0.30 => 3.0.3)
+
+https://github.com/owncloud/core/pull/38454

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": ">=7.2",
         "doctrine/dbal": "^2.10",
-        "phpseclib/phpseclib": "^2.0",
+        "phpseclib/phpseclib": "^3.0",
         "opis/closure": "^3.5",
         "bantu/ini-get-wrapper": "v1.0.1",
         "punic/punic": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5766e87e0d26cb65d36a2212db445cc2",
+    "content-hash": "0eb68d1ea846a45691c737085826b1a0",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1743,6 +1743,123 @@
             "time": "2020-11-07T02:01:34+00:00"
         },
         {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
+                "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6|^7|^8|^9",
+                "vimeo/psalm": "^1|^2|^3|^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2020-12-06T15:14:20+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
             "name": "patchwork/jsqueeze",
             "version": "v2.0.5",
             "source": {
@@ -2034,24 +2151,26 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.30",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "136b9ca7eebef78be14abf90d65c5e57b6bc5d36"
+                "reference": "7c751ea006577e4c2e83326d90c8b1e8c11b8ede"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/136b9ca7eebef78be14abf90d65c5e57b6bc5d36",
-                "reference": "136b9ca7eebef78be14abf90d65c5e57b6bc5d36",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/7c751ea006577e4c2e83326d90c8b1e8c11b8ede",
+                "reference": "7c751ea006577e4c2e83326d90c8b1e8c11b8ede",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
             },
             "require-dev": {
                 "phing/phing": "~2.7",
-                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
+                "phpunit/phpunit": "^5.7|^6.0|^9.4",
                 "squizlabs/php_codesniffer": "~2.0"
             },
             "suggest": {
@@ -2066,7 +2185,7 @@
                     "phpseclib/bootstrap.php"
                 ],
                 "psr-4": {
-                    "phpseclib\\": "phpseclib/"
+                    "phpseclib3\\": "phpseclib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2123,7 +2242,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/2.0.30"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.5"
             },
             "funding": [
                 {
@@ -2139,7 +2258,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-17T05:42:04+00:00"
+            "time": "2021-02-12T16:18:16+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -5224,12 +5343,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "640ff0b5dcacc0958534c8c0255b90697f3eb2a8"
+                "reference": "a6bfc5a1416f0dde1f53b7737b2cf983352737b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/640ff0b5dcacc0958534c8c0255b90697f3eb2a8",
-                "reference": "640ff0b5dcacc0958534c8c0255b90697f3eb2a8",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/a6bfc5a1416f0dde1f53b7737b2cf983352737b8",
+                "reference": "a6bfc5a1416f0dde1f53b7737b2cf983352737b8",
                 "shasum": ""
             },
             "conflict": {
@@ -5371,7 +5490,7 @@
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
-                "pimcore/pimcore": "<6.3",
+                "pimcore/pimcore": "<6.8.8",
                 "pocketmine/pocketmine-mp": "<3.15.4",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
                 "prestashop/contactform": ">1.0.1,<4.3",
@@ -5411,7 +5530,7 @@
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "simplito/elliptic-php": "<1.0.6",
                 "slim/slim": "<2.6",
-                "smarty/smarty": "<3.1.33",
+                "smarty/smarty": "<3.1.39",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
                 "spoonity/tcpdf": "<6.2.22",
@@ -5543,7 +5662,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-18T21:02:27+00:00"
+            "time": "2021-02-26T20:02:39+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/core/Command/Integrity/SignApp.php
+++ b/core/Command/Integrity/SignApp.php
@@ -25,8 +25,8 @@ namespace OC\Core\Command\Integrity;
 use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
 use OCP\IURLGenerator;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -96,13 +96,13 @@ class SignApp extends Command {
 			return null;
 		}
 
-		$rsa = new RSA();
-		$rsa->loadKey($privateKey);
+		/** @var RSA $rsa */
+		$rsa = RSA::load($privateKey)->withHash('sha1');
 		$x509 = new X509();
-		$x509->loadX509($keyBundle);
-		$x509->setPrivateKey($rsa);
+		$certificate = $x509->loadX509($keyBundle);
+
 		try {
-			$this->checker->writeAppSignature($path, $x509, $rsa);
+			$this->checker->writeAppSignature($path, $certificate, $x509, $rsa);
 			$output->writeln('Successfully signed "'.$path.'"');
 		} catch (\Exception $e) {
 			$output->writeln('Error: ' . $e->getMessage());

--- a/core/Command/Integrity/SignCore.php
+++ b/core/Command/Integrity/SignCore.php
@@ -24,8 +24,9 @@ namespace OC\Core\Command\Integrity;
 
 use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\Common\AsymmetricKey;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -87,14 +88,13 @@ class SignCore extends Command {
 			return null;
 		}
 
-		$rsa = new RSA();
-		$rsa->loadKey($privateKey);
+		/** @var RSA $rsa */
+		$rsa = RSA::load($privateKey)->withHash('sha1');
 		$x509 = new X509();
-		$x509->loadX509($keyBundle);
-		$x509->setPrivateKey($rsa);
+		$certificate = $x509->loadX509($keyBundle);
 
 		try {
-			$this->checker->writeCoreSignature($x509, $rsa, $path);
+			$this->checker->writeCoreSignature($path, $certificate, $x509, $rsa);
 			$output->writeln('Successfully signed "core"');
 		} catch (\Exception $e) {
 			$output->writeln('Error: ' . $e->getMessage());

--- a/lib/private/Files/External/LegacyUtil.php
+++ b/lib/private/Files/External/LegacyUtil.php
@@ -21,7 +21,7 @@
 
 namespace OC\Files\External;
 
-use phpseclib\Crypt\AES;
+use phpseclib3\Crypt\AES;
 use \OCP\Files\External\IStorageConfig;
 use \OCP\Files\External\Backend\Backend;
 use \OCP\Files\StorageNotAvailableException;
@@ -309,7 +309,7 @@ class LegacyUtil {
 	 * @return AES
 	 */
 	private static function getCipher() {
-		$cipher = new AES(AES::MODE_CBC);
+		$cipher = new AES('cbc');
 		$cipher->setKey(\OC::$server->getConfig()->getSystemValue('passwordsalt', null));
 		return $cipher;
 	}

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -37,8 +37,8 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\ITempManager;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 
 /**
  * Class Checker handles the code signing using X.509 and RSA. ownCloud ships with
@@ -224,24 +224,28 @@ class Checker {
 	 * Creates the signature data
 	 *
 	 * @param array $hashes
-	 * @param X509 $certificate
+	 * @param array $certificate
 	 * @param RSA $privateKey
+	 * @param X509 $x509,
 	 * @return array
 	 */
 	private function createSignatureData(array $hashes,
-										 X509 $certificate,
-										 RSA $privateKey) {
+										 array $certificate,
+										 RSA $privateKey,
+										 X509 $x509) {
 		\ksort($hashes);
 
-		$privateKey->setSignatureMode(RSA::SIGNATURE_PSS);
-		$privateKey->setMGFHash('sha512');
-		$privateKey->setSaltLength(0);
+		$privateKey = $privateKey
+			->withMGFHash('sha512')
+			->withSaltLength(0)
+			->withPadding(RSA::SIGNATURE_PSS);
+
 		$signature = $privateKey->sign(\json_encode($hashes));
 
 		return [
 				'hashes' => $hashes,
 				'signature' => \base64_encode($signature),
-				'certificate' => $certificate->saveX509($certificate->currentCert),
+				'certificate' => $x509->saveX509($certificate),
 			];
 	}
 
@@ -249,12 +253,14 @@ class Checker {
 	 * Write the signature of the app in the specified folder
 	 *
 	 * @param string $path
-	 * @param X509 $certificate
+	 * @param array $certificate
+	 * @param X509 $x509
 	 * @param RSA $privateKey
 	 * @throws \Exception
 	 */
-	public function writeAppSignature($path,
-									  X509 $certificate,
+	public function writeAppSignature(string $path,
+									  array $certificate,
+									  X509 $x509,
 									  RSA $privateKey) {
 		$appInfoDir = $path . '/appinfo';
 		$this->fileAccessHelper->assertDirectoryExists($path);
@@ -262,7 +268,7 @@ class Checker {
 
 		$iterator = $this->getFolderIterator($path);
 		$hashes = $this->generateHashes($iterator, $path);
-		$signature = $this->createSignatureData($hashes, $certificate, $privateKey);
+		$signature = $this->createSignatureData($hashes, $certificate, $privateKey, $x509);
 		try {
 			$this->fileAccessHelper->file_put_contents(
 				$appInfoDir . '/signature.json',
@@ -279,21 +285,23 @@ class Checker {
 	/**
 	 * Write the signature of core
 	 *
-	 * @param X509 $certificate
-	 * @param RSA $rsa
 	 * @param string $path
+	 * @param array $certificate
+	 * @param X509 $x509
+	 * @param RSA $privateKey
 	 * @throws \Exception
 	 */
-	public function writeCoreSignature(X509 $certificate,
-									   RSA $rsa,
-									   $path) {
+	public function writeCoreSignature(string $path,
+									   array $certificate,
+									   X509 $x509,
+									   RSA $privateKey) {
 		$coreDir = $path . '/core';
 		$this->fileAccessHelper->assertDirectoryExists($path);
 		$this->fileAccessHelper->assertDirectoryExists($coreDir);
 
 		$iterator = $this->getFolderIterator($path, $path);
 		$hashes = $this->generateHashes($iterator, $path);
-		$signatureData = $this->createSignatureData($hashes, $certificate, $rsa);
+		$signatureData = $this->createSignatureData($hashes, $certificate, $privateKey, $x509);
 		try {
 			$this->fileAccessHelper->file_put_contents(
 				$coreDir . '/signature.json',
@@ -335,7 +343,7 @@ class Checker {
 		$certificate = $signatureData['certificate'];
 
 		// Check if certificate is signed by ownCloud Root Authority
-		$x509 = new \phpseclib\File\X509();
+		$x509 = new \phpseclib3\File\X509();
 		$rootCertificatePublicKey = $this->fileAccessHelper->file_get_contents($this->environmentHelper->getServerRoot().'/resources/codesigning/root.crt');
 		$x509->loadCA($rootCertificatePublicKey);
 		$loadedCertificate = $x509->loadX509($certificate);
@@ -346,7 +354,7 @@ class Checker {
 		// Check if the certificate has been revoked
 		$crlFileContent = $this->fileAccessHelper->file_get_contents($this->environmentHelper->getServerRoot().'/resources/codesigning/intermediate.crl.pem');
 		if ($crlFileContent && \strlen($crlFileContent) > 0) {
-			$crl = new \phpseclib\File\X509();
+			$crl = new \phpseclib3\File\X509();
 			$crl->loadCA($rootCertificatePublicKey);
 			$crl->loadCRL($crlFileContent);
 			if (!$crl->validateSignature()) {
@@ -369,12 +377,12 @@ class Checker {
 					"Certificate is not valid for required scope. (Requested: $certificateCN, current: CN=$cn)");
 		}
 
-		// Check if the signature of the files is valid
-		$rsa = new \phpseclib\Crypt\RSA();
-		$rsa->loadKey($x509->currentCert['tbsCertificate']['subjectPublicKeyInfo']['subjectPublicKey']);
-		$rsa->setSignatureMode(RSA::SIGNATURE_PSS);
-		$rsa->setSaltLength(0);
-		$rsa->setMGFHash('sha512');
+		$rsa = RSA::load($loadedCertificate['tbsCertificate']['subjectPublicKeyInfo']['subjectPublicKey'])
+			->withHash('sha1')
+			->withMGFHash('sha512')
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withSaltLength(0);
+
 		if (!$rsa->verify(\json_encode($expectedHashes), $signature)) {
 			throw new InvalidSignatureException('Signature could not get verified.');
 		}

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -24,8 +24,8 @@
 
 namespace OC\Security;
 
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Hash;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Crypt\Hash;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
 use OCP\IConfig;
@@ -41,6 +41,11 @@ use OCP\IConfig;
  * @package OC\Security
  */
 class Crypto implements ICrypto {
+	const CRYPT_MODE = 'cbc';
+	const CRYPT_METHOD = 'pbkdf2';
+	const CRYPT_HASH = 'sha1';
+	const SALT = 'phpseclib';
+
 	/** @var AES $cipher */
 	private $cipher;
 	/** @var int */
@@ -55,7 +60,7 @@ class Crypto implements ICrypto {
 	 * @param ISecureRandom $random
 	 */
 	public function __construct(IConfig $config, ISecureRandom $random) {
-		$this->cipher = new AES();
+		$this->cipher = new AES(self::CRYPT_MODE);
 		$this->config = $config;
 		$this->random = $random;
 	}
@@ -94,7 +99,7 @@ class Crypto implements ICrypto {
 		// https://github.com/owncloud/encryption/issues/215
 		$derived = \hash_hkdf('sha512', $password, 0);
 		list($password, $hmacKey) = \str_split($derived, 32);
-		$this->cipher->setPassword($password);
+		$this->cipher->setPassword($password, self::CRYPT_METHOD, self::CRYPT_HASH, self::SALT);
 
 		$iv = \random_bytes($this->ivLength);
 		$this->cipher->setIV($iv);
@@ -123,7 +128,7 @@ class Crypto implements ICrypto {
 		if (\sizeof($parts) === 4 && $parts[0] === 'v2') {
 			$derived = \hash_hkdf('sha512', $password, 0);
 			list($password, $hmacKey) = \str_split($derived, 32);
-			$this->cipher->setPassword($password);
+			$this->cipher->setPassword($password, self::CRYPT_METHOD, self::CRYPT_HASH, self::SALT);
 
 			$ciphertext = \hex2bin($parts[1]);
 			$iv = \hex2bin($parts[2]);
@@ -139,7 +144,7 @@ class Crypto implements ICrypto {
 		}
 
 		if (\sizeof($parts) === 3) {
-			$this->cipher->setPassword($password);
+			$this->cipher->setPassword($password, self::CRYPT_METHOD, self::CRYPT_HASH, self::SALT);
 			$ciphertext = \hex2bin($parts[0]);
 			$iv = $parts[1];
 			$hmac = \hex2bin($parts[2]);

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -30,8 +30,8 @@ use OC\Memcache\Redis;
 use OCP\App\IAppManager;
 use OCP\ICacheFactory;
 use OCP\IConfig;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 use Test\TestCase;
 
 /**
@@ -92,11 +92,11 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = \file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = \file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		/** @var RSA $rsa */
+		$rsa = RSA::load($rsaPrivateKey)->withHash('sha1');
 		$x509 = new X509();
-		$x509->loadX509($keyBundle);
-		$this->checker->writeAppSignature('NotExistingApp', $x509, $rsa);
+		$certificate = $x509->loadX509($keyBundle);
+		$this->checker->writeAppSignature('NotExistingApp', $certificate, $x509, $rsa);
 	}
 
 	/**
@@ -111,11 +111,11 @@ class CheckerTest extends TestCase {
 		;
 		$keyBundle = \file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = \file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		/** @var RSA $rsa */
+		$rsa = RSA::load($rsaPrivateKey)->withHash('sha1');
 		$x509 = new X509();
-		$x509->loadX509($keyBundle);
-		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
+		$certificate = $x509->loadX509($keyBundle);
+		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $certificate, $x509, $rsa);
 	}
 
 	public function testWriteAppSignature() {
@@ -143,11 +143,11 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = \file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = \file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		/** @var RSA $rsa */
+		$rsa = RSA::load($rsaPrivateKey)->withHash('sha1');
 		$x509 = new X509();
-		$x509->loadX509($keyBundle);
-		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
+		$certificate = $x509->loadX509($keyBundle);
+		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $certificate, $x509, $rsa);
 	}
 
 	public function testIgnoredAppSignatureWithoutSignatureData() {
@@ -588,11 +588,11 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = \file_get_contents(__DIR__ .'/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = \file_get_contents(__DIR__ .'/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		/** @var RSA $rsa */
+		$rsa = RSA::load($rsaPrivateKey)->withHash('sha1');
 		$x509 = new X509();
-		$x509->loadX509($keyBundle);
-		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/app/');
+		$certificate = $x509->loadX509($keyBundle);
+		$this->checker->writeCoreSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $certificate, $x509, $rsa);
 	}
 
 	public function testWriteCoreSignatureWithUnmodifiedHtaccess() {
@@ -624,11 +624,11 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = \file_get_contents(__DIR__ .'/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = \file_get_contents(__DIR__ .'/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		/** @var RSA $rsa */
+		$rsa = RSA::load($rsaPrivateKey)->withHash('sha1');
 		$x509 = new X509();
-		$x509->loadX509($keyBundle);
-		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessUnmodified/');
+		$certificate = $x509->loadX509($keyBundle);
+		$this->checker->writeCoreSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/htaccessUnmodified/', $certificate, $x509, $rsa);
 	}
 
 	public function testWriteCoreSignatureWithInvalidModifiedHtaccess() {
@@ -655,11 +655,11 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = \file_get_contents(__DIR__ .'/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = \file_get_contents(__DIR__ .'/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		/** @var RSA $rsa */
+		$rsa = RSA::load($rsaPrivateKey)->withHash('sha1');
 		$x509 = new X509();
-		$x509->loadX509($keyBundle);
-		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithInvalidModifiedContent/');
+		$certificate = $x509->loadX509($keyBundle);
+		$this->checker->writeCoreSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithInvalidModifiedContent/', $certificate, $x509, $rsa);
 	}
 
 	public function testWriteCoreSignatureWithValidModifiedHtaccessAndUserIni() {
@@ -696,11 +696,11 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = \file_get_contents(__DIR__ .'/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = \file_get_contents(__DIR__ .'/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		/** @var RSA $rsa */
+		$rsa = RSA::load($rsaPrivateKey)->withHash('sha1');
 		$x509 = new X509();
-		$x509->loadX509($keyBundle);
-		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithValidModifiedContent');
+		$certificate = $x509->loadX509($keyBundle);
+		$this->checker->writeCoreSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithValidModifiedContent', $certificate, $x509, $rsa);
 	}
 
 	public function testVerifyCoreSignatureWithoutSignatureData() {


### PR DESCRIPTION
## Description

Bumps [phpseclib/phpseclib](https://github.com/phpseclib/phpseclib) from 2.0.30 to 3.0.3.
- [Release notes](https://github.com/phpseclib/phpseclib/releases)
- [Changelog](https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md)
- [Commits](https://github.com/phpseclib/phpseclib/compare/2.0.30...3.0.3)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

This is the code from PR #38453 but squashed into 1 commit and with the changelog updated to have this PR number.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
