### PR TITLE
feat: add second cookie for samesite none

### DIFF
--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -99,6 +99,9 @@ class CryptoWrapper {
 						"httponly" => true,
 						"samesite" => 'strict'
 					]);
+					# legacy cookis for openid connect
+					# TODO: remove index.php if necessary ....
+					$webRoot .= 'index.php/apps/openidconnect/redirect';
 					\setcookie(self::LEGACY_COOKIE_NAME, $this->passphrase, [
 						"expires" => 0,
 						"path" => $webRoot,


### PR DESCRIPTION
## Description
Based on https://github.com/GoogleChromeLabs/samesite-examples/blob/master/php.md and https://web.dev/samesite-cookie-recipes/#handling-incompatible-clients

This PR introduces a leagcy cookie which fixes login issues with OpenID providers - e.g. Azure AD and PingID

## Related Issue
- Fixes owncloud/enterprise#4191

## How Has This Been Tested?
- openid-azure.owncloud.works
- make sure to be fully logged out - only when you see the ms login screen the issue is triggered at all 

## Screenshots (if appropriate):
The redirect from Azure AD only holds the legacy cookie .... as a result we are logged in ....
![Screenshot from 2021-03-02 10-23-00](https://user-images.githubusercontent.com/1005065/109626901-568b6a00-7b41-11eb-8ed4-e65d54fa335b.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
