### PR TITLE
feat: add config parameter to redeclare same site cookie setup

### DIFF
--- a/changelog/unreleased/38458
+++ b/changelog/unreleased/38458
@@ -1,0 +1,7 @@
+Enhancement: Add config parameter 'http.cookie.samesite'
+
+Allows to relax ownClouds same site cookie settings.
+Possible values: Strict, Lax or None
+Setting the same site cookie to none is necessary in case of OpenID Connect.
+
+https://github.com/owncloud/core/pull/38458

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -266,6 +266,15 @@ $CONFIG = [
 'csrf.disabled' => false,
 
 /**
+ * Allows to relax ownClouds same site cookie settings.
+ *
+ * Possible values: Strict, Lax or None
+ * Setting the same site cookie to none is necessary in case of OpenID Connect.
+ */
+
+'http.cookie.samesite' => 'strict',
+
+/**
  * Define the directory where the skeleton files are located
  * These files will be copied to the data directory of new users.
  * Leave this directory empty if you do not want to copy any skeleton files.

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -266,10 +266,12 @@ $CONFIG = [
 'csrf.disabled' => false,
 
 /**
- * Allows to relax ownClouds same site cookie settings.
+ * Define how to relax same site cookie settings
  *
  * Possible values: Strict, Lax or None
- * Setting the same site cookie to none is necessary in case of OpenID Connect.
+ * Setting the same site cookie to None is necessary in case of OpenID Connect.
+ * For more information about the impact of the values see:
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values
  */
 
 'http.cookie.samesite' => 'strict',

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -47,19 +47,16 @@ use OCP\Security\ISecureRandom;
  * @package OC\Session
  */
 class CryptoWrapper {
-	const COOKIE_NAME = 'oc_sessionPassphrase';
+	public const COOKIE_NAME = 'oc_sessionPassphrase';
 
 	/** @var ISession */
 	protected $session;
 
-	/** @var \OCP\Security\ICrypto */
+	/** @var ICrypto */
 	protected $crypto;
 
 	/** @var ISecureRandom */
 	protected $random;
-
-	/** @var IConfig  */
-	private $config;
 
 	/** @var string  */
 	private $passphrase;
@@ -75,7 +72,6 @@ class CryptoWrapper {
 								ISecureRandom $random,
 								IRequest $request) {
 		$this->crypto = $crypto;
-		$this->config = $config;
 		$this->random = $random;
 
 		if ($request->getCookie(self::COOKIE_NAME) !== null) {
@@ -93,13 +89,14 @@ class CryptoWrapper {
 				if (\version_compare(PHP_VERSION, '7.3.0') === -1) {
 					\setcookie(self::COOKIE_NAME, $this->passphrase, 0, $webRoot, '', $secureCookie, true);
 				} else {
+					$samesite = $config->getSystemValue('http.cookie.samesite', 'strict');
 					$options = [
 						"expires" => 0,
 						"path" => $webRoot,
 						"domain" => '',
 						"secure" => $secureCookie,
 						"httponly" => true,
-						"samesite" => 'strict'
+						"samesite" => $samesite
 					];
 
 					\setcookie(self::COOKIE_NAME, $this->passphrase, $options);


### PR DESCRIPTION
## Description
In case of openid redirect the cookie samesite strict or lax are not working.

Use:
```php
<?php
$CONFIG = [
        "http.cookie.samesite" => "None",
```

to choose a different setup

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4191

## How Has This Been Tested?
- http://openid-azure.owncloud.works/

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
