### PR TITLE
[tests-only] Adds API tests for sharing a same file twice to the same group

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -664,3 +664,17 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+  @issue-ocis-1710
+  Scenario Outline: Sharing a same file twice to the same group is not possible
+    Given using OCS API version "<ocs-api-version>"
+    And group "grp1" has been created
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
+    Then the HTTP status code should be "<http-status>"
+    And the OCS status code should be "403"
+    And the OCS status message should be "Path already shared with this group"
+    Examples:
+      | ocs-api-version | http-status |
+      | 1               | 200         |
+      | 2               | 403         |


### PR DESCRIPTION

## Description
Adds API tests for sharing a same file twice to the same group

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Demonstrates https://github.com/owncloud/ocis/issues/1710

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
