### PR TITLE
[Tests-Only]Removed unused with/and skeleton files step from core

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -380,7 +380,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has been created with default attributes and (small|large|)\s?skeleton files$/
+	 * @Given /^user "([^"]*)" has been created with default attributes and (small|large)\s?skeleton files$/
 	 *
 	 * @param string $user
 	 * @param string $skeletonType
@@ -1083,7 +1083,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^these users have been created with ?(default attributes and|) (small|large|)\s?skeleton files ?(but not initialized|):$/
+	 * @Given /^these users have been created with ?(default attributes and|) (small|large)\s?skeleton files ?(but not initialized|):$/
 	 *
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"


### PR DESCRIPTION
## Description
Since the old `with/and skeleton files` steps in the core are all replaced by `small/large skeleton files`, we can now completely remove the `with/and skeleton files` step from the context file as well

## Related Issue
- part of https://github.com/owncloud/QA/issues/655

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
