### PR TITLE
fix: use trusted domains to verify the signature

### DIFF
--- a/changelog/unreleased/38465
+++ b/changelog/unreleased/38465
@@ -1,0 +1,7 @@
+Bugfix: Use trusted domains to compute the signature of signed urls
+
+All configured trusted domains are used when computing the signature of a
+signed url. The server has no real true understanding for which domain the
+request is sent. Especially in proxy scenarios this is a must have.
+
+https://github.com/owncloud/core/pull/38465

--- a/tests/lib/Security/SignedUrl/VerifierTest.php
+++ b/tests/lib/Security/SignedUrl/VerifierTest.php
@@ -34,13 +34,15 @@ class VerifierTest extends TestCase {
 	 * @param bool $isUrlValid
 	 * @param string $method
 	 * @param string $url
+	 * @param bool $expired
 	 */
-	public function testSignedUrl(bool $isSignedUrl, bool $isUrlValid, string $method, string $url): void {
+	public function testSignedUrl(bool $isSignedUrl, bool $isUrlValid, string $method, string $url, bool $expired = false): void {
 		$r = new Request($method, $url);
 		$r->setAbsoluteUrl($url);
 		$config = $this->createMock(IConfig::class);
 		$config->method('getUserValue')->willReturn('1234567890');
-		$v = new Verifier($r, $config, new \DateTime('2019-05-14T11:01:58.135Z', null));
+		$now = $expired ? new \DateTime('2020-05-14T11:01:58.135Z', null) : new \DateTime('2019-05-14T11:01:58.135Z', null);
+		$v = new Verifier($r, $config, $now);
 		if ($isSignedUrl) {
 			self::assertTrue($v->isSignedRequest());
 			self::assertEquals('alice', $v->getUrlCredential());
@@ -58,6 +60,7 @@ class VerifierTest extends TestCase {
 			'invalid signature' => [true, false, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b'],
 			'different algo' => [true, false, 'post', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Algo=PBKDF2/5-SHA512&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
 			'unsupported algo' => [true, false, 'post', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Algo=PBKDF2/x-SHA512&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
+			'expired' => [true, false, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6', true],
 		];
 	}
 }

--- a/tests/lib/Security/SignedUrl/VerifierTest.php
+++ b/tests/lib/Security/SignedUrl/VerifierTest.php
@@ -29,18 +29,20 @@ use Test\TestCase;
 class VerifierTest extends TestCase {
 
 	/**
-	 * @dataProvider providesUrls
+	 * @dataProvider provider
 	 * @param bool $isSignedUrl
 	 * @param bool $isUrlValid
 	 * @param string $method
 	 * @param string $url
 	 * @param bool $expired
+	 * @param array $trustedDomains
 	 */
-	public function testSignedUrl(bool $isSignedUrl, bool $isUrlValid, string $method, string $url, bool $expired = false): void {
+	public function testSignedUrl(bool $isSignedUrl, bool $isUrlValid, string $method, string $url, bool $expired = false, array $trustedDomains = ['cloud.example.net']): void {
 		$r = new Request($method, $url);
 		$r->setAbsoluteUrl($url);
 		$config = $this->createMock(IConfig::class);
 		$config->method('getUserValue')->willReturn('1234567890');
+		$config->method('getSystemValue')->willReturn($trustedDomains);
 		$now = $expired ? new \DateTime('2020-05-14T11:01:58.135Z', null) : new \DateTime('2019-05-14T11:01:58.135Z', null);
 		$v = new Verifier($r, $config, $now);
 		if ($isSignedUrl) {
@@ -52,15 +54,31 @@ class VerifierTest extends TestCase {
 		}
 	}
 
-	public function providesUrls(): array {
-		return [
-			'valid url' => [true, true, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
-			'no signature' => [false, false, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET'],
-			'wrong method' => [true, false, 'post', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
-			'invalid signature' => [true, false, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b'],
-			'different algo' => [true, false, 'post', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Algo=PBKDF2/5-SHA512&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
-			'unsupported algo' => [true, false, 'post', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Algo=PBKDF2/x-SHA512&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'],
-			'expired' => [true, false, 'get', 'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6', true],
-		];
+	public function provider(): \Generator {
+		yield 'valid url' => [true, true, 'get',
+			'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'];
+
+		yield 'no signature' => [false, false, 'get',
+			'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET'];
+
+		yield 'wrong method' => [true, false, 'post',
+			'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'];
+
+		yield 'invalid signature' => [true, false, 'get',
+			'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b'];
+
+		yield 'different algo' => [true, false, 'post',
+			'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Algo=PBKDF2/5-SHA512&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'];
+
+		yield 'unsupported algo' => [true, false, 'post',
+			'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Algo=PBKDF2/x-SHA512&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6'];
+
+		yield 'expired' => [true, false, 'get',
+			'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6', true];
+
+		yield 'not trusted domain' => [true, false, 'get',
+			'http://cloud.example.net/?OC-Credential=alice&OC-Date=2019-05-14T11%3A01%3A58.135Z&OC-Expires=1200&OC-Verb=GET&OC-Signature=f9e53a1ee23caef10f72ec392c1b537317491b687bfdd224c782be197d9ca2b6', false, [
+			'cloud.example.com'
+		]];
 	}
 }


### PR DESCRIPTION
## Description
In some setups (mainly proxied setups) we cannot rely on the given host and protocol.
In addition to make sure that signed urls work for each and every trusted domain we need to loop all trusted domains.

## Motivation and Context
Support more complex setups ...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
