### PR TITLE
[tests-only] Skip new subadmin tests on old oC10

### DIFF
--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -21,7 +21,7 @@ Feature: get subadmin groups
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
 
-
+  @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: admin tries to get subadmin groups of a user which does not exist
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
@@ -30,7 +30,7 @@ Feature: get subadmin groups
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @issue-owncloud-sdk-658
+  @issue-owncloud-sdk-658 @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: subadmin gets groups where he/she is subadmin
     Given user "Alice" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -21,7 +21,7 @@ Feature: get subadmin groups
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 
-
+  @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: admin tries to get subadmin groups of a user which does not exist
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
@@ -30,7 +30,7 @@ Feature: get subadmin groups
     And the HTTP status code should be "404"
     And the API should not return any data
 
-  @issue-owncloud-sdk-658
+  @issue-owncloud-sdk-658 @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: subadmin gets groups where he/she is subadmin
     Given user "Alice" has been created with default attributes and small skeleton files
     And group "brand-new-group" has been created


### PR DESCRIPTION
## Description
These test scenarios were added or adjusted in #38330 and #38281 
They are not expected to pass against old oC10 releases, so skip in that case.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
