### PR TITLE
[tests-only] send occ commands in bulk to the testing app

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -204,6 +204,34 @@ function remote_occ() {
 }
 
 # @param $1 admin authentication string username:password
+# @param $2 occ url (without /bulk appendix)
+# @param $3 commands
+# exists with 1 and sets $REMOTE_OCC_STDERR if any of the occ commands returned a non-zero code
+function remote_bulk_occ() {
+	if [ "${TEST_OCIS}" == "true" ] || [ "${TEST_REVA}" == "true" ]
+	then
+		return 0
+	fi
+	CURL_OCC_RESULT=`curl -k -s -u $1 $2/bulk -d "${3}"`
+	COUNT_RESULTS=`echo ${CURL_OCC_RESULT} | xmllint --xpath "ocs/data/element/code" - | wc -l`
+
+	RETURN=0
+	REMOTE_OCC_STDERR=""
+	for ((n=1;n<=${COUNT_RESULTS};n++))
+	do
+		EXIT_CODE=`echo ${CURL_OCC_RESULT} | xmllint --xpath "string((ocs/data/element/code)[${n}])" -`
+		if [ ${EXIT_CODE} -ne 0 ]
+		then
+			REMOTE_OCC_STDERR+=`echo ${CURL_OCC_RESULT} | xmllint --xpath "string((ocs/data/element/stdErr)[${n}])" - | xargs`
+			REMOTE_OCC_STDERR+="\n"
+			RETURN=1
+		fi
+
+	done
+	return ${RETURN}
+}
+
+# @param $1 admin authentication string username:password
 # @param $2 occ url
 # @param $3 directory to create, relative to the server's root
 # sets $REMOTE_OCC_STDOUT and $REMOTE_OCC_STDERR from returned xml data
@@ -951,6 +979,7 @@ SETTINGS+=("system;;skeletondirectory;;")
 # Set various settings
 for URL in ${OCC_URL} ${OCC_FED_URL}
 do
+  declare SETTINGS_CMDS='['
 	for i in "${!SETTINGS[@]}"
 	do
 		PREVIOUS_IFS=${IFS}
@@ -967,14 +996,17 @@ do
 			TYPE_STRING=" --type ${SETTING[4]}"
 		fi
 
-		remote_occ ${ADMIN_AUTH} ${URL} "config:${SETTING[0]}:set ${SETTING[1]} ${SETTING[2]} --value=${SETTING[3]}${TYPE_STRING}"
-		if [ $? -ne 0 ]
+		SETTINGS_CMDS+="{\"command\": \"config:${SETTING[0]}:set ${SETTING[1]} ${SETTING[2]} --value=${SETTING[3]}${TYPE_STRING}\"},"
+	done
+	SETTINGS_CMDS=${SETTINGS_CMDS%?} # removes the last comma
+	SETTINGS_CMDS+="]"
+	remote_bulk_occ ${ADMIN_AUTH} ${URL} "${SETTINGS_CMDS}"
+	if [ $? -ne 0 ]
 		then
-			echo -e "Could not set ${SETTING[2]} on ${URL}. Result:\n'${REMOTE_OCC_STDERR}'"
+			echo -e "Could not set some settings on ${URL}. Result:\n${REMOTE_OCC_STDERR}"
 			teardown
 			exit 1
 		fi
-	done
 done
 
 #set the skeleton folder


### PR DESCRIPTION
## Description
send occ commands that happen in the setup phase of the tests in bulk to save some time

## Related Issue
- Fixes #38428 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
define invalid settings and see if `run.sh` stops

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
