### PR TITLE
[tests-only]TUS tests for chunking with checksum

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
@@ -60,3 +60,33 @@ Feature: checksums
       | new         | MD5 827ccb0eea8a706c4c34a16891f84e7a          |
       | old         | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
       | new         | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
+
+  Scenario Outline: Uploading a chunked file with correct checksum should work
+    Given using <dav_version> DAV path
+    When user "Alice" uploads file with content "0123456789" in 2 chunks to "/myChecksumFile.txt" with checksum "MD5:781e5e245d69b566979b86e28d23f2c7" using the TUS protocol on the WebDAV API
+    Then the HTTP status code should be "200"
+    And the content of file "/myChecksumFile.txt" for user "Alice" should be "0123456789"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: Uploading a chunked file with correct checksum should return the checksum in the propfind
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "0123456789" in 2 chunks to "/myChecksumFile.txt" with checksum "MD5:781e5e245d69b566979b86e28d23f2c7" using the TUS protocol on the WebDAV API
+    When user "Alice" requests the checksum of "/myChecksumFile.txt" via propfind
+    Then the webdav checksum should match "SHA1:87acec17cd9dcd20a716cc2cf67417b71c8a7016 MD5:781e5e245d69b566979b86e28d23f2c7 ADLER32:0aff020e"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: Uploading a chunked file with checksum should return the checksum in the download header
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "0123456789" in 2 chunks to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e" using the TUS protocol on the WebDAV API
+    When user "Alice" downloads file "/myChecksumFile.txt" using the WebDAV API
+    Then the header checksum should match "SHA1:87acec17cd9dcd20a716cc2cf67417b71c8a7016"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
@@ -63,9 +63,13 @@ Feature: checksums
 
   Scenario Outline: Uploading a chunked file with correct checksum should work
     Given using <dav_version> DAV path
-    When user "Alice" uploads file with content "0123456789" in 2 chunks to "/myChecksumFile.txt" with checksum "MD5:781e5e245d69b566979b86e28d23f2c7" using the TUS protocol on the WebDAV API
-    Then the HTTP status code should be "200"
-    And the content of file "/myChecksumFile.txt" for user "Alice" should be "0123456789"
+    And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
+      | Upload-Length   | 10                         |
+      | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
+    When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
+    And user "Alice" sends a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API
+    Then the HTTP status code should be "204"
+    And the content of file "/textFile.txt" for user "Alice" should be "0123456789"
     Examples:
       | dav_version |
       | old         |
@@ -73,8 +77,12 @@ Feature: checksums
 
   Scenario Outline: Uploading a chunked file with correct checksum should return the checksum in the propfind
     Given using <dav_version> DAV path
-    And user "Alice" has uploaded file with content "0123456789" in 2 chunks to "/myChecksumFile.txt" with checksum "MD5:781e5e245d69b566979b86e28d23f2c7" using the TUS protocol on the WebDAV API
-    When user "Alice" requests the checksum of "/myChecksumFile.txt" via propfind
+    And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
+      | Upload-Length   | 10                         |
+      | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
+    And user "Alice" has uploaded a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
+    And user "Alice" has uploaded a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API
+    When user "Alice" requests the checksum of "/textFile.txt" via propfind
     Then the webdav checksum should match "SHA1:87acec17cd9dcd20a716cc2cf67417b71c8a7016 MD5:781e5e245d69b566979b86e28d23f2c7 ADLER32:0aff020e"
     Examples:
       | dav_version |
@@ -83,9 +91,27 @@ Feature: checksums
 
   Scenario Outline: Uploading a chunked file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
-    And user "Alice" has uploaded file with content "0123456789" in 2 chunks to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e" using the TUS protocol on the WebDAV API
-    When user "Alice" downloads file "/myChecksumFile.txt" using the WebDAV API
+    And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
+      | Upload-Length   | 10                         |
+      | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
+    And user "Alice" has uploaded a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
+    And user "Alice" has uploaded a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API
+    When user "Alice" downloads file "/textFile.txt" using the WebDAV API
     Then the header checksum should match "SHA1:87acec17cd9dcd20a716cc2cf67417b71c8a7016"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  Scenario Outline: Uploading second chunk of file with incorrect checksum should not work
+    Given using <dav_version> DAV path
+    And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
+      | Upload-Length   | 10                         |
+      | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
+    When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546799" using the TUS protocol on the WebDAV API
+    And user "Alice" sends a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 781e5e245d69b566979b86e28d23f2c7" using the TUS protocol on the WebDAV API
+    Then the HTTP status code should be "409"
+    And as "Alice" file "textFile.txt" should not exist
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -381,42 +381,33 @@ class TUSContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads file with content :content in :noOfChunks chunks to :destination with checksum :checksum using the TUS protocol on the WebDAV API
+	 * @When user :user sends a chunk to the last created TUS Location with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user
-	 * @param string $content
-	 * @param int $noOfChunks
-	 * @param string $destination
+	 * @param string $offset
+	 * @param string $data
 	 * @param string $checksum
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userUploadsChunkFileWithChecksum($user, $content, $noOfChunks, $destination, $checksum) {
-		$tmpfname = $this->writeDataToTempFile($content);
-
-		$this->userUploadsUsingTusAFileTo(
-			$user, \basename($tmpfname), $destination, [], $noOfChunks, null, $checksum
-		);
+	public function userUploadsChunkFileWithChecksum($user, $offset, $data, $checksum) {
+		$this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
 	}
 
 	/**
-	 * @Given user :user has uploaded file with content :content in :noOfChunks chunks to :destination with checksum :checksum using the TUS protocol on the WebDAV API
+	 * @Given user :user has uploaded a chunk to the last created TUS Location with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API
 	 *
 	 * @param string $user
-	 * @param string $content
-	 * @param int $noOfChunks
-	 * @param string $destination
+	 * @param string $offset
+	 * @param string $data
 	 * @param string $checksum
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userHasUploadedChunkFileWithChecksum($user, $content, $noOfChunks, $destination, $checksum) {
-		$tmpfname = $this->writeDataToTempFile($content);
-
-		$this->userUploadsUsingTusAFileTo(
-			$user, \basename($tmpfname), $destination, [], $noOfChunks, null, $checksum
-		);
+	public function userHasUploadedChunkFileWithChecksum($user, $offset, $data, $checksum) {
+		$this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
+		$this->featureContext->theHTTPStatusCodeShouldBe(204, "");
 	}
 }

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -135,6 +135,7 @@ class TUSContext implements Context {
 	 *                               Don't Base64 encode the value.
 	 * @param int    $noOfChunks
 	 * @param int $bytes
+	 * @param string $checksum
 	 *
 	 * @return void
 	 * @throws ConnectionException
@@ -147,7 +148,8 @@ class TUSContext implements Context {
 		string $destination,
 		array $uploadMetadata = [],
 		int $noOfChunks = 1,
-		int $bytes = null
+		int $bytes = null,
+		string $checksum = ''
 	) {
 		$user = $this->featureContext->getActualUsername($user);
 		$password = $this->featureContext->getUserPassword($user);
@@ -161,6 +163,13 @@ class TUSContext implements Context {
 			];
 			$headers = \array_merge($headers, $creationWithUploadHeader);
 		}
+		if ($checksum != '') {
+			$checksumHeader = [
+				'Upload-Checksum' => $checksum
+			];
+			$headers = \array_merge($headers, $checksumHeader);
+		}
+
 		$client = new Client(
 			$this->featureContext->getBaseUrl(),
 			['verify' => false,
@@ -349,6 +358,7 @@ class TUSContext implements Context {
 	) {
 		$this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $content, $checksum);
 	}
+
 	/**
 	 * @Given user :user has uploaded file with checksum :checksum to the last created TUS Location with offset :offset and content :content using the TUS protocol on the WebDAV API
 	 *
@@ -368,5 +378,45 @@ class TUSContext implements Context {
 	) {
 		$this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $content, $checksum);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "");
+	}
+
+	/**
+	 * @When user :user uploads file with content :content in :noOfChunks chunks to :destination with checksum :checksum using the TUS protocol on the WebDAV API
+	 *
+	 * @param string $user
+	 * @param string $content
+	 * @param int $noOfChunks
+	 * @param string $destination
+	 * @param string $checksum
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userUploadsChunkFileWithChecksum($user, $content, $noOfChunks, $destination, $checksum) {
+		$tmpfname = $this->writeDataToTempFile($content);
+
+		$this->userUploadsUsingTusAFileTo(
+			$user, \basename($tmpfname), $destination, [], $noOfChunks, null, $checksum
+		);
+	}
+
+	/**
+	 * @Given user :user has uploaded file with content :content in :noOfChunks chunks to :destination with checksum :checksum using the TUS protocol on the WebDAV API
+	 *
+	 * @param string $user
+	 * @param string $content
+	 * @param int $noOfChunks
+	 * @param string $destination
+	 * @param string $checksum
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userHasUploadedChunkFileWithChecksum($user, $content, $noOfChunks, $destination, $checksum) {
+		$tmpfname = $this->writeDataToTempFile($content);
+
+		$this->userUploadsUsingTusAFileTo(
+			$user, \basename($tmpfname), $destination, [], $noOfChunks, null, $checksum
+		);
 	}
 }


### PR DESCRIPTION
## Description
This PR adds test for TUS chunking with checksum.

## Related Issue
- https://github.com/owncloud/ocis/issues/1754
- https://github.com/owncloud/ocis/issues/1599

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
