### PR TITLE
[tests-only] skip password-reset test on user-keys encryption

### DIFF
--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -54,6 +54,7 @@ Feature: edit users
     And the user attributes returned by the API should include
       | quota definition | 12 MB |
 
+  @skipOnEncryptionType:user-keys
   Scenario Outline: Admin resets user password with special characters
     Given user "brand-new-user" has been deleted
     When the administrator creates user "brand-new-user" password "%alt1%" group "brand-new-group" using the occ command


### PR DESCRIPTION
## Description
I recently adjusted the test scenario so it does not rely on the skeleton files. But this is a test about the admin resetting the password of a user. In the case of user-keys encryption that cannot work and is not expected to work - the user will not be able to see their previous files if their password gets reset like is done in this test scenario.

https://github.com/owncloud/core/pull/38446/files#diff-53fa600b0414e0e01e3dfb3493745cfb87757ab1ece833db21d0f06ed8619c14

Skip the scenario when testing user-keys encryption.

Note: the test used to work "by luck" because the user was created with skeleton files, the admin reset the password before the user ever did anything, then the test test accessed a skeleton file. The user got initialized after the password had already been changed, and so their skeleton files got initialized with the new password already in effect.

## Related Issue
- Fixes https://github.com/owncloud/encryption/issues/249


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
