### PR TITLE
Do not remove federated share on CURLE errors, provide improved notification in UI and exception handling

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1707,7 +1707,8 @@
 			if (status === 500) {
 				// Go home
 				this.changeDirectory('/');
-				OC.Notification.show(t('files', 'This directory is unavailable, please check the logs or contact the administrator'),
+				OC.Notification.show(
+					t('files', 'Directory "{dir}" is unavailable, please contact the administrator', { dir:this.getCurrentDirectory() }),
 					{type: 'error'}
 				);
 				return false;
@@ -1718,7 +1719,8 @@
 				if (this.getCurrentDirectory() !== '/') {
 					this.changeDirectory('/');
 					// TODO: read error message from exception
-					OC.Notification.show(t('files', 'Storage is temporarily not available'),
+					OC.Notification.show(
+						t('files', 'Storage for "{dir}" is temporarily not available', { dir:this.getCurrentDirectory() }),
 						{type: 'error'}
 					);
 				}
@@ -1726,10 +1728,25 @@
 			}
 
 			if (status === 404) {
+				// check if shared file root
+				var currentDir = OC.basename(this.getCurrentDirectory());
+				var currentDirInfo = this.findFileEl(currentDir);
+				if (currentDirInfo.attr('data-mounttype') == 'shared-root') {
+					OC.Notification.show(t('files', 'Shared directory "{dir}" is not available, remove the share or contact it\'s owner to reshare.', { dir:this.getCurrentDirectory() }),
+						{type: 'error'}
+					);
+				} else {
+					OC.Notification.show(
+						t('files', 'Directory "{dir}" not found', { dir:this.getCurrentDirectory() }),
+						{type: 'error'}
+					);
+				}
+
 				// go back home
 				this.changeDirectory('/');
 				return false;
 			}
+
 			// aborted ?
 			if (status === 0){
 				return true;

--- a/changelog/unreleased/38474
+++ b/changelog/unreleased/38474
@@ -1,0 +1,8 @@
+Bugfix: Handle exceptions with inaccesible federated share 
+
+In a scenario federation share storage is inaccessible and returns connection timeouts, 
+federated share storage now does not return not found but storage not available. 
+Additionaly logging and notifications handling has been improved.
+
+https://github.com/owncloud/core/pull/38474
+https://github.com/owncloud/enterprise/issues/4311

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -248,7 +248,7 @@ class DAV extends Common {
 	 *
 	 * @throws ClientHttpException
 	 */
-	protected function propfind($path) {
+	protected function propfind($path, $strictNotFoundCheck=false) {
 		$path = $this->cleanPath($path);
 		$cachedResponse = $this->statCache->get($path);
 		// we either don't know it, or we know it exists but need more details
@@ -284,6 +284,9 @@ class DAV extends Common {
 						'Storage is not available due to the connection timeout to {hostName}',
 						['hostName' => $this->host]
 					);
+					if ($strictNotFoundCheck) {
+						throw new StorageNotAvailableException('Storage is not available due to the connection timeout');
+					}
 				} else {
 					$this->convertException($e, $path);
 				}

--- a/tests/lib/Files/Storage/DavTest.php
+++ b/tests/lib/Files/Storage/DavTest.php
@@ -1361,4 +1361,25 @@ class DavTest extends TestCase {
 
 		$this->instance->hasUpdated('some%dir', 1508496363);
 	}
+
+	public function testPropfindNotFoundOnCurlException() {
+		$exception = new \Exception("", \CURLE_COULDNT_CONNECT);
+		$this->davClient->expects($this->once())
+			->method('propfind')
+			->willThrowException($exception);
+
+		$response = $this->invokePrivate($this->instance, 'propfind', ['']);
+		$this->assertEquals(false, $response);
+	}
+
+	public function testPropfindStorageNotAvailableExceptionOnCurlExceptionWithStrictCheck() {
+		$this->expectException(\OCP\Files\StorageNotAvailableException::class);
+
+		$exception = new \Exception("", \CURLE_COULDNT_CONNECT);
+		$this->davClient->expects($this->once())
+			->method('propfind')
+			->willThrowException($exception);
+
+		$this->invokePrivate($this->instance, 'propfind', ['', true]);
+	}
 }


### PR DESCRIPTION
fixes:
- https://github.com/owncloud/enterprise/issues/4311 
-  implements "TODO" from https://github.com/owncloud/core/blob/v10.6.0/apps/files_sharing/lib/External/Storage.php#L238

problem:
currently (and without some sophisitcated implementation in the future) there is no clean way of deciding of state of federated share. Currently PROPFIND is send, and if 404 not found is returned, then availability of system by probing e.g. status.php endpoint is performed. If status check succeed, federated share is removed. However, customer with large federation setup reported that shares get falsely removed under certain conditions on the server (e.g. some maintenance).

usecase:
- there are two servers, fed1 and fed2. fed1 gets unavailable, user in fed2 removes federated share that he shared with fed1. fed1 never receives share removal. now fed1 becomes available, provide proper notification and log exception in the logs
- due to some maintenance work, server returns CURLE_COULDNT_CONNECT or CURLE_OPERATION_TIMEDOUT or NotFound. This indicated to fed share storage provider that it should "test remote". However, now for some reason all "status checks like status.php" succeed, and we should let the user in fed1 decide what to do with share, instead of blindly removing

to be done:
- [x] provide most basic notification
- [x] investigate further notifications
- [x] tests