### PR TITLE
feat: add samesite cookie attribute to session cookie

### DIFF
--- a/changelog/10.7.0_2021-03-08/38458
+++ b/changelog/10.7.0_2021-03-08/38458
@@ -5,3 +5,4 @@ Possible values: Strict, Lax or None
 Setting the same site cookie to none is necessary in case of OpenID Connect.
 
 https://github.com/owncloud/core/pull/38458
+https://github.com/owncloud/core/pull/38477

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -274,7 +274,7 @@ $CONFIG = [
  * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values
  */
 
-'http.cookie.samesite' => 'strict',
+'http.cookie.samesite' => 'Strict',
 
 /**
  * Define the directory where the skeleton files are located

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -89,7 +89,7 @@ class CryptoWrapper {
 				if (\version_compare(PHP_VERSION, '7.3.0') === -1) {
 					\setcookie(self::COOKIE_NAME, $this->passphrase, 0, $webRoot, '', $secureCookie, true);
 				} else {
-					$samesite = $config->getSystemValue('http.cookie.samesite', 'strict');
+					$samesite = $config->getSystemValue('http.cookie.samesite', 'Strict');
 					$options = [
 						"expires" => 0,
 						"path" => $webRoot,

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -173,6 +173,11 @@ class Internal extends Session {
 			//try to set the session lifetime
 			$sessionLifeTime = self::getSessionLifeTime();
 			@\ini_set('session.gc_maxlifetime', (string)$sessionLifeTime);
+
+			if (\version_compare(PHP_VERSION, '7.3.0') !== -1) {
+				$samesite = \OC::$server->getConfig()->getSystemValue('http.cookie.samesite', 'Strict');
+				\ini_set('session.cookie_samesite', $samesite);
+			}
 		}
 		\session_start();
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
to decrypt oc_sessionPassphrase we need to have the session cookie samesite attribute to be set the same

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Extends #38458

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
the passphrase cookie should have the same samesite attribute as the oc_sessionPassphrase cookie. If they are different it's not possible to decrypt oc_sessionPassphrase in cases like a iframe because the passphrase then is unknown.



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manual in teams

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
