### PR TITLE
[Tests-Only]Skip intermittent etag propagation tests on ocis on oc storage

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
@@ -48,7 +48,7 @@ Feature: propagation of etags when restoring a file or folder from trash
       | old         |
       | new         |
 
-
+  @skipOnOcis-OC-Storage
   Scenario Outline: restoring a folder to its original location changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"


### PR DESCRIPTION
## Description
This PR skips the intermittent etagPropagation tests on ocis on oc storage.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
