### PR TITLE
Disable sharing on files_external if auth mechanism is not compatible

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -26,8 +26,8 @@ var MOUNT_OPTIONS_DROPDOWN_TEMPLATE =
 	'		<input id="mountOptionsPreviews" name="previews" type="checkbox" value="true" checked="checked"/>' +
 	'		<label for="mountOptionsPreviews">{{t "files_external" "Enable previews"}}</label>' +
 	'	</div>' +
-	'	<div class="optionRow">' +
-	'		<input id="mountOptionsSharing" name="enable_sharing" type="checkbox" value="true"/>' +
+	'	<div class="optionRow" title="{{mountOptionsSharingTitle}}">' +
+	'		<input id="mountOptionsSharing" name="enable_sharing" type="checkbox" value="true" {{#if sharingDisabled}}disabled{{/if}}/>' +
 	'		<label for="mountOptionsSharing">{{t "files_external" "Enable sharing"}}</label>' +
 	'	</div>' +
 	'	<div class="optionRow">' +
@@ -487,8 +487,9 @@ MountOptionsDropdown.prototype = {
 	 * @param {Object} $container container
 	 * @param {Object} mountOptions mount options
 	 * @param {Array} visibleOptions enabled mount options
+	 * @param {GlobalStorageConfig} storageConfig
 	 */
-	show: function($container, mountOptions, visibleOptions) {
+	show: function($container, mountOptions, visibleOptions, storageConfig) {
 		if (MountOptionsDropdown._last) {
 			MountOptionsDropdown._last.hide();
 		}
@@ -499,8 +500,12 @@ MountOptionsDropdown.prototype = {
 			MountOptionsDropdown._template = template;
 		}
 
+		var sharingDisabled = storageConfig.authMechanism === 'password::sessioncredentials';
+
 		var $el = $(template({
 			mountOptionsEncodingLabel: t('files_external', 'Compatibility with Mac NFD encoding (slow)'),
+			mountOptionsSharingTitle: sharingDisabled ? t('files_external', 'Sharing cannot be enabled due to the chosen authentication method') : '',
+			sharingDisabled: sharingDisabled,
 		}));
 		this.$el = $el;
 
@@ -1371,7 +1376,7 @@ MountConfigListView.prototype = _.extend({
 			visibleOptions.push('enable_sharing');
 		}
 
-		dropDown.show($toggle, storage.mountOptions || [], visibleOptions);
+		dropDown.show($toggle, storage.mountOptions || [], visibleOptions, storage);
 		$('body').on('mouseup.mountOptionsDropdown', function(event) {
 			var $target = $(event.target);
 			if ($toggle.has($target).length) {

--- a/changelog/unreleased/38483
+++ b/changelog/unreleased/38483
@@ -1,0 +1,9 @@
+Enhancement: UI improvement external storage
+
+When selecting external storage and set the auth mechanism
+to 'Log-in credentials, save in session', the 'Enable sharing' option in
+the mount options dropdown will be disabled and a tooltip will show up due to
+incompatibility.
+
+https://github.com/owncloud/core/pull/38483
+https://github.com/owncloud/enterprise/issues/4444


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
If we set up external storage and choose the auth mechanism 'Log-in credentials, save in session' sharing is not possible, to show this to the user, the checkbox will be disabled and a hint due a tooltip will be shown

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4444

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/26169327/110444653-93191180-80bd-11eb-9706-1cc37b58b37f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
