### PR TITLE
fix: require search param to not be empty

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -165,6 +165,11 @@ class ShareesController extends OCSController {
 	protected function getUsers($search) {
 		$this->result['users'] = $this->result['exact']['users'] = $users = [];
 
+		if (\strlen(\trim($search)) === 0 && $this->userSearch->getSearchMinLength() > 0) {
+			$this->result['users'] = [];
+			return;
+		}
+
 		$userGroups = [];
 		if ($this->shareWithGroupOnly || $this->shareeEnumerationGroupMembers) {
 			// Search in all the groups this user is part of
@@ -295,6 +300,11 @@ class ShareesController extends OCSController {
 	 */
 	protected function getGroups($search) {
 		$this->result['groups'] = $this->result['exact']['groups'] = [];
+
+		if (\strlen(\trim($search)) === 0 && $this->userSearch->getSearchMinLength() > 0) {
+			$this->result['groups'] = [];
+			return;
+		}
 
 		$groups = $this->groupManager->search($search, $this->limit, $this->offset, 'sharing');
 		$groupIds = \array_map(function (IGroup $group) {

--- a/changelog/unreleased/38489
+++ b/changelog/unreleased/38489
@@ -1,0 +1,5 @@
+Bugfix: Fix behavior for user search at the API level
+
+The 'user.search_min_length' restriction could be circumvented when accessing the API directly.
+
+https://github.com/owncloud/core/pull/38489


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Before listing users or groups as share recipients we check if the search parameter is empty and if it is empty we return an empty list. This prevents a users to circumvent the 'user.search_min_length' restriction.

The better fix would be to change the `isSearchable` method in lib/public/Util/UserSearch.php. This would require many changes though since this method is being used at the Manager level and some users of the managers expect the old behavior. Ideally the `isSearchable` call would be moved to the controller / API level.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4456

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally:
- via curl against the sharees api
- in the browser via webui

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
