### PR TITLE
[tests-only] Added tests for overwriting file with checksum

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
@@ -246,3 +246,40 @@ Feature: upload file to shared folder
       | dav_version |
       | old         |
       | new         |
+
+
+  Scenario Outline: Sharer uploads a file with checksum and as a sharee overwrites the shared file with new data and correct checksum
+    Given using <dav_version> DAV path
+    And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
+      | Upload-Length   | 16                                     |
+      | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
+    And user "Alice" has uploaded file with checksum "SHA1 c1dab0c0864b6ac9bdd3743a1408d679f1acd823" to the last created TUS Location with offset "0" and content "original content" using the TUS protocol on the WebDAV API
+    And user "Alice" has shared file "/textFile.txt" with user "Brian"
+    And user "Brian" has accepted share "/textFile.txt" offered by user "Alice"
+   When user "Brian" overwrites recently shared file with offset "0" and data "overwritten content" with checksum "SHA1 fe990d2686a0fc86004efc31f5bf2475a45d4905" using the TUS protocol on the WebDAV API with these headers:
+      | Upload-Length   | 19                         |
+      | Upload-Metadata | filename L1NoYXJlcy90ZXh0RmlsZS50eHQ= |
+    Then the content of file "/textFile.txt" for user "Alice" should be "overwritten content"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: Sharer uploads a file with checksum and as a sharee overwrites the shared file with new data and invalid checksum
+    Given using <dav_version> DAV path
+    And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
+      | Upload-Length   | 16                                     |
+      | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
+    And user "Alice" has uploaded file with checksum "SHA1 c1dab0c0864b6ac9bdd3743a1408d679f1acd823" to the last created TUS Location with offset "0" and content "original content" using the TUS protocol on the WebDAV API
+    And user "Alice" has shared file "/textFile.txt" with user "Brian"
+    And user "Brian" has accepted share "/textFile.txt" offered by user "Alice"
+    When user "Brian" overwrites recently shared file with offset "0" and data "overwritten content" with checksum "SHA1 fe990d2686a0fc86004efc31f5bf2475a45d4906" using the TUS protocol on the WebDAV API with these headers:
+      | Upload-Length   | 19                         |
+      | Upload-Metadata | filename L1NoYXJlcy90ZXh0RmlsZS50eHQ= |
+    Then the HTTP status code should be "406"
+    And the content of file "/textFile.txt" for user "Alice" should be "original content"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -410,4 +410,23 @@ class TUSContext implements Context {
 		$this->sendsAChunkToTUSLocationWithOffsetAndData($user, $offset, $data, $checksum);
 		$this->featureContext->theHTTPStatusCodeShouldBe(204, "");
 	}
+
+	/**
+	 * @When user :user overwrites recently shared file with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API with these headers:
+	 * @When user :user overwrites existing file with offset :offset and data :data with checksum :checksum using the TUS protocol on the WebDAV API with these headers:
+	 *
+	 * @param string $user
+	 * @param string $offset
+	 * @param string $data
+	 * @param string $checksum
+	 * @param TableNode $headers Tus-Resumable: 1.0.0 header is added automatically
+	 *
+	 * @return void
+	 *
+	 * @throws Exception
+	 */
+	public function userOverwritesFileWithChecksum($user, $offset, $data, $checksum, TableNode $headers) {
+		$this->createNewTUSresource($user, $headers);
+		$this->userHasUploadedChunkFileWithChecksum($user, $offset, $data, $checksum);
+	}
 }


### PR DESCRIPTION
## Description
This PR adds tests for:

- Upload a file with chunking and correct checksum then overwrite the file with new data and checksum(correct / invalid)
- Upload a file with checksum then share it and as a sharee overwriting the shared file with new data and checksum(correct / invalid)

## Related Issue
- https://github.com/owncloud/ocis/issues/1789

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
