### PR TITLE
improve systemtags UI for delete and fix case sensitivity problem

### DIFF
--- a/changelog/unreleased/38498
+++ b/changelog/unreleased/38498
@@ -1,0 +1,10 @@
+Enhancement: Improve systemtags UI for delete and fix case sensitivity problem
+
+Previously, a system tag could be deleted within the rename step.
+Now, users can delete tags directly from the system tags tab view dropdown menu.
+Also, inconsistency on tag name casing has been fixed.
+
+https://github.com/owncloud/core/pull/38498
+https://github.com/owncloud/core/issues/38494
+https://github.com/owncloud/core/issues/38495
+https://github.com/owncloud/core/issues/38496

--- a/core/css/systemtags.css
+++ b/core/css/systemtags.css
@@ -37,9 +37,11 @@
 .systemtags-select2-dropdown .select2-result-label .icon {
 	display: inline-block;
 	opacity: .5;
-}
-.systemtags-select2-dropdown .select2-result-label .icon.rename {
 	padding: 4px;
+}
+
+.systemtags-select2-dropdown .select2-result-label .icon:hover {
+	opacity: 1;
 }
 
 .systemtags-select2-dropdown .systemtags-actions {
@@ -73,6 +75,7 @@
 .systemtags-select2-container .select2-choices .select2-search-choice {
 	line-height: 20px;
 	padding-left: 5px;
+	text-transform: none;
 }
 
 .systemtags-select2-container .select2-choices .select2-search-choice.select2-locked .label {

--- a/core/js/systemtags/systemtagsinputfield.js
+++ b/core/js/systemtags/systemtagsinputfield.js
@@ -25,6 +25,7 @@
 		'{{#allowActions}}' +
 		'    <span class="systemtags-actions">' +
 		'        <a href="#" class="rename icon icon-rename" title="{{renameTooltip}}"></a>' +
+		'        <a href="#" class="delete icon icon-delete" title="{{deleteTooltip}}"></a>' +
 		'    </span>' +
 		'{{/allowActions}}' +
 		'</span>';
@@ -40,7 +41,6 @@
 		'<form class="systemtags-rename-form">' +
 		'    <label class="hidden-visually" for="{{cid}}-rename-input">{{renameLabel}}</label>' +
 		'    <input id="{{cid}}-rename-input" type="text" value="{{name}}">' +
-		'    <a href="#" class="delete icon icon-delete" title="{{deleteTooltip}}"></a>' +
 		'</form>';
 
 	/**
@@ -132,7 +132,6 @@
 			var $renameForm = $(this._renameFormTemplate({
 				cid: this.cid,
 				name: oldName,
-				deleteTooltip: t('core', 'Delete'),
 				renameLabel: t('core', 'Rename')
 			}));
 			$item.find('.label').after($renameForm);
@@ -151,7 +150,7 @@
 		/**
 		 * Event handler whenever the rename form has been submitted after
 		 * the user entered a new tag name.
-		 * This will submit the change to the server. 
+		 * This will submit the change to the server.
 		 *
 		 * @param {Object} ev event
 		 */
@@ -321,6 +320,7 @@
 
 			return this._resultTemplate(_.extend({
 				renameTooltip: t('core', 'Rename'),
+				deleteTooltip: t('core', 'Delete'),
 				allowActions: this._allowActions,
 				tagMarkup: this._isAdmin ? OC.SystemTags.getDescriptiveTag(data)[0].innerHTML : null,
 				isAdmin: this._isAdmin

--- a/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
+++ b/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
@@ -271,10 +271,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 			});
 			it('deletes model and submits change when clicking delete', function() {
 				var destroyStub = sinon.stub(OC.SystemTags.SystemTagModel.prototype, 'destroy');
-
-				expect($dropdown.find('.delete').length).toEqual(0);
-				$dropdown.find('.rename').mouseup();
-				// delete button appears
+				// delete button appears in tag actions
 				expect($dropdown.find('.delete').length).toEqual(1);
 				$dropdown.find('.delete').mouseup();
 

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -59,7 +59,7 @@ class DetailsDialog extends OwncloudPage {
 
 	private $tagsResultFromDropdownXpath = "//li[contains(@class, 'select2-result')]";
 	private $tagEditButtonInTagXpath = "//span[@class='systemtags-actions']//a[contains(@class, 'rename')]";
-	private $tagDeleteButtonInTagXpath = "//form[@class='systemtags-rename-form']//a";
+	private $tagDeleteButtonInTagXpath = "//span[@class='systemtags-actions']//a[contains(@class, 'delete')]";
 	private $tagsDropDownResultXpath = "//div[contains(@class, 'systemtags-select2-dropdown')]" .
 	"//ul[@class='select2-results']" .
 	"//span[@class='label']";
@@ -478,19 +478,7 @@ class DetailsDialog extends OwncloudPage {
 		foreach ($suggestions as $tag) {
 			if ($tag->getText() === $tagName) {
 				$tagContainer = $tag->getParent();
-				$editBtn = $tagContainer->find("xpath", $this->tagEditButtonInTagXpath);
-				$this->assertElementNotNull(
-					$editBtn,
-					__METHOD__ .
-					" xpath: $this->tagEditButtonInTagXpath" .
-					"could not find tag edit button"
-				);
-				$editBtn->focus();
-				$editBtn->click();
-
-				$deleteBtn = $this->find(
-					"xpath", $this->tagDeleteButtonInTagXpath
-				);
+				$deleteBtn = $tagContainer->find("xpath", $this->tagDeleteButtonInTagXpath);
 				$this->assertElementNotNull(
 					$deleteBtn,
 					__METHOD__ .


### PR DESCRIPTION
## Description
- Fix inconsistency on tag names #38494
- Allow users to delete a systemtag from dropdown list directly #38496 #38495 
- Add hover effect to rename icon in systemtags dropdown

## Related Issue
- Fixes #38494 
- Fixes #38496
- Fixes #38495 

## Motivation and Context
Improving UI experience for systemtags

## How Has This Been Tested?
- Tested manually
- Unit and acceptance tests are adjusted
## Screenshots (if appropriate):
![Screenshot from 2021-03-11 13-04-08](https://user-images.githubusercontent.com/14157973/110854957-c084db80-82c6-11eb-9c27-a53574bea4f7.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
