### PR TITLE
[tests-only] added comment in tests for encoded filename

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
@@ -8,6 +8,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     When user "Alice" uploads file with checksum "<checksum>" to the last created TUS Location with offset "0" and content "12345" using the TUS protocol on the WebDAV API
     Then the HTTP status code should be "204"
@@ -24,6 +25,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     When user "Alice" uploads file with checksum "MD5 827ccb0eea8a706c4c34a16891f84e7b" to the last created TUS Location with offset "0" and content "12345" using the TUS protocol on the WebDAV API
     And user "Alice" requests the checksum of "/textFile.txt" via propfind
@@ -38,6 +40,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     And user "Alice" has uploaded file with checksum "MD5 827ccb0eea8a706c4c34a16891f84e7b" to the last created TUS Location with offset "0" and content "12345" using the TUS protocol on the WebDAV API
     When user "Alice" downloads file "/textFile.txt" using the WebDAV API
@@ -47,11 +50,12 @@ Feature: checksums
       | old         |
       | new         |
 
-    
+
   Scenario Outline: Uploading a file with incorrect checksum should not work
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     When user "Alice" uploads file with checksum "<incorrect_checksum>" to the last created TUS Location with offset "0" and content "12345" using the TUS protocol on the WebDAV API
     Then the HTTP status code should be "406"
@@ -67,7 +71,8 @@ Feature: checksums
   Scenario Outline: Uploading a chunked file with correct checksum should work
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
-      | Upload-Length   | 10                         |
+      | Upload-Length   | 10                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
     And user "Alice" sends a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API
@@ -82,7 +87,8 @@ Feature: checksums
   Scenario Outline: Uploading a chunked file with correct checksum should return the checksum in the propfind
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
-      | Upload-Length   | 10                         |
+      | Upload-Length   | 10                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     And user "Alice" has uploaded a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
     And user "Alice" has uploaded a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API
@@ -97,7 +103,8 @@ Feature: checksums
   Scenario Outline: Uploading a chunked file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
-      | Upload-Length   | 10                         |
+      | Upload-Length   | 10                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     And user "Alice" has uploaded a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
     And user "Alice" has uploaded a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API
@@ -108,11 +115,12 @@ Feature: checksums
       | old         |
       | new         |
 
-    
+
   Scenario Outline: Uploading second chunk of file with incorrect checksum should not work
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
-      | Upload-Length   | 10                         |
+      | Upload-Length   | 10                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546799" using the TUS protocol on the WebDAV API
     And user "Alice" sends a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 781e5e245d69b566979b86e28d23f2c7" using the TUS protocol on the WebDAV API

--- a/tests/acceptance/features/apiWebdavUploadTUS/creationWithUplaodExtension.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/creationWithUplaodExtension.feature
@@ -10,6 +10,7 @@ Feature: tests of the creation extension see https://tus.io/protocols/resumable-
       | Upload-Length   | 100                             |
       | Tus-Resumable   | 1.0.0                           |
       | Content-Type    | application/offset+octet-stream |
+      #    dGVzdC50eHQ= is the base64 encode of test.txt
       | Upload-Metadata | filename dGVzdC50eHQ=           |
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions
@@ -20,6 +21,7 @@ Feature: tests of the creation extension see https://tus.io/protocols/resumable-
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: creating a new resource and upload data in multiple bytes using creation with upload extension
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavUploadTUS/lowLevelCreationExtension.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/lowLevelCreationExtension.feature
@@ -8,6 +8,7 @@ Feature: low level tests of the creation extension see https://tus.io/protocols/
     Given using <dav_version> DAV path
     When user "Alice" creates a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 100                                           |
+      #    d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg== is the base64 encode of world_domination_plan.pdf
       | Upload-Metadata | filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg== |
       | Tus-Resumable   | 1.0.0                                         |
     Then the HTTP status code should be "201"
@@ -19,10 +20,12 @@ Feature: low level tests of the creation extension see https://tus.io/protocols/
       | old         |
       | new         |
 
+
   Scenario Outline: creating a new upload resource without upload length
     Given using <dav_version> DAV path
     When user "Alice" creates a new TUS resource on the WebDAV API with these headers:
       | Tus-Resumable   | 1.0.0                                         |
+      #    d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg== is the base64 encode of world_domination_plan.pdf
       | Upload-Metadata | filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg== |
     Then the HTTP status code should be "412"
     And the following headers should not be set

--- a/tests/acceptance/features/apiWebdavUploadTUS/lowLevelUpload.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/lowLevelUpload.feature
@@ -9,6 +9,7 @@ Feature: low level tests for upload of chunks
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                    |
+      #    ZmlsZS50eHQ= is the base64 encode of file.txt
       | Upload-Metadata | filename ZmlsZS50eHQ= |
     When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "123" using the WebDAV API
     And user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "000" using the WebDAV API
@@ -24,6 +25,7 @@ Feature: low level tests for upload of chunks
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                    |
+      #    ZmlsZS50eHQ= is the base64 encode of file.txt
       | Upload-Metadata | filename ZmlsZS50eHQ= |
     When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "123" using the WebDAV API
     And user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "000" using the WebDAV API
@@ -40,6 +42,7 @@ Feature: low level tests for upload of chunks
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                    |
+      #    ZmlsZS50eHQ= is the base64 encode of file.txt
       | Upload-Metadata | filename ZmlsZS50eHQ= |
     When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "123" using the WebDAV API
     And user "Alice" sends a chunk to the last created TUS Location with offset "3" and data "4567890" using the WebDAV API
@@ -56,6 +59,7 @@ Feature: low level tests for upload of chunks
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                    |
+      #    ZmlsZS50eHQ= is the base64 encode of file.txt
       | Upload-Metadata | filename ZmlsZS50eHQ= |
     When user "Alice" sends a chunk to the last created TUS Location with offset "1" and data "123" using the WebDAV API
     Then the HTTP status code should be "409"

--- a/tests/acceptance/features/apiWebdavUploadTUS/optionsRequest.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/optionsRequest.feature
@@ -16,6 +16,7 @@ Feature: OPTIONS request
       | Tus-Extension          | creation,creation-with-upload,checksum |
       | Tus-Checksum-Algorithm | md5,sha1,adler32                       |
 
+
   Scenario: send OPTIONS request to webDav endpoints using the TUS protocol without any authentication
     When a user requests these endpoints with "OPTIONS" with body "doesnotmatter" and no authentication about user "Alice"
       | endpoint                          |
@@ -28,6 +29,7 @@ Feature: OPTIONS request
       | Tus-Extension          | creation,creation-with-upload,checksum |
       | Tus-Checksum-Algorithm | md5,sha1,adler32                       |
 
+
   Scenario: send OPTIONS request to webDav endpoints using the TUS protocol with valid username and wrong password
     When user "Alice" requests these endpoints with "OPTIONS" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                          |
@@ -39,6 +41,7 @@ Feature: OPTIONS request
       | Tus-Version            | 1.0.0                                  |
       | Tus-Extension          | creation,creation-with-upload,checksum |
       | Tus-Checksum-Algorithm | md5,sha1,adler32                       |
+
 
   Scenario: send OPTIONS requests to webDav endpoints using valid password and username of different user
     Given user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
@@ -28,6 +28,7 @@ Feature: upload file
       | new         | /?fi=le&%#2 . txt |
       | new         | /# %ab ab?=ed     |
 
+
   Scenario Outline: upload a file into a folder and check download content
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<folder_name>"
@@ -60,6 +61,7 @@ Feature: upload file
       | old         |
       | new         |
 
+
   Scenario Outline: Upload 1 byte chunks with TUS
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "0123456789" in 10 chunks to "/myChunkedFile.txt" using the TUS protocol on the WebDAV API
@@ -68,6 +70,7 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: Upload to overwriting a file
     Given using <dav_version> DAV path
@@ -79,6 +82,7 @@ Feature: upload file
       | old         |
       | new         |
 
+
   Scenario Outline: upload a file and no version is available
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "/upload.txt" using the TUS protocol on the WebDAV API
@@ -87,6 +91,7 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: upload a file twice and versions are available
     Given using <dav_version> DAV path
@@ -99,6 +104,7 @@ Feature: upload file
       | old         |
       | new         |
 
+
   Scenario Outline: upload a file in chunks with TUS and no version is available
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "0123456789" in 10 chunks to "/myChunkedFile.txt" using the TUS protocol on the WebDAV API
@@ -107,6 +113,7 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: upload a twice file in chunks with TUS and versions are available
     Given using <dav_version> DAV path
@@ -118,6 +125,7 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: upload a file with invalid-name
     Given using <dav_version> DAV path
@@ -141,11 +149,13 @@ Feature: upload file
       | new         | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
       | new         | "my\\file"              | bXkMaWxl                     |
 
+
   Scenario Outline: upload a file using the resource URL of another user
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     When user "Brian" sends a chunk to the last created TUS Location with offset "0" and data "12345" using the WebDAV API
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToNonExistingFolder.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToNonExistingFolder.feature
@@ -19,6 +19,7 @@ Feature: upload file
       | old         |
       | new         |
 
+
   Scenario Outline: attempt to upload a file into a non-existent folder
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "/nonExistentFolder/textfile.txt" using the TUS protocol on the WebDAV API
@@ -28,6 +29,7 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: attempt to upload a file into a non-existent folder within correctly received share
     Given using <dav_version> DAV path
@@ -42,6 +44,7 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: attempt to upload a file into a non-existent folder within correctly received read only share
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
@@ -10,6 +10,7 @@ Feature: upload file to shared folder
       | Alice    |
       | Brian    |
 
+
   Scenario Outline: Uploading file to a received share folder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/FOLDER"
@@ -22,6 +23,7 @@ Feature: upload file to shared folder
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: Uploading file to a user read/write share folder works
     Given using <dav_version> DAV path
@@ -36,6 +38,7 @@ Feature: upload file to shared folder
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: Uploading a file into a group share as share receiver
     Given using <dav_version> DAV path
@@ -52,6 +55,7 @@ Feature: upload file to shared folder
       | old         |
       | new         |
 
+
   Scenario Outline: Overwrite file to a received share folder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/FOLDER"
@@ -65,6 +69,7 @@ Feature: upload file to shared folder
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: attempt to upload a file into a folder within correctly received read only share
     Given using <dav_version> DAV path
@@ -86,6 +91,7 @@ Feature: upload file to shared folder
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                                     |
+      #    L0ZPTERFUi90ZXh0RmlsZS50eHQ= is the base64 encode of /FOLDER/textFile.txt
       | Upload-Metadata | filename L0ZPTERFUi90ZXh0RmlsZS50eHQ= |
     And user "Alice" has uploaded file with checksum "SHA1 8cb2237d0679ca88db6464eac60da96345513964" to the last created TUS Location with offset "0" and content "12345" using the TUS protocol on the WebDAV API
     When user "Brian" requests the checksum of "/Shares/FOLDER/textFile.txt" via propfind
@@ -103,6 +109,7 @@ Feature: upload file to shared folder
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                                     |
+      #    L0ZPTERFUi90ZXh0RmlsZS50eHQ= is the base64 encode of /FOLDER/textFile.txt
       | Upload-Metadata | filename L0ZPTERFUi90ZXh0RmlsZS50eHQ= |
     And user "Alice" has uploaded file with checksum "SHA1 8cb2237d069ca88db6464eac60da96345513964" to the last created TUS Location with offset "0" and content "12345" using the TUS protocol on the WebDAV API
     When user "Brian" downloads file "/Shares/FOLDER/textFile.txt" using the WebDAV API
@@ -117,6 +124,7 @@ Feature: upload file to shared folder
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     And user "Alice" has uploaded file with checksum "SHA1 8cb2237d0679ca88db6464eac60da96345513964" to the last created TUS Location with offset "0" and content "12345" using the TUS protocol on the WebDAV API
     And user "Alice" has shared file "/textFile.txt" with user "Brian"
@@ -133,6 +141,7 @@ Feature: upload file to shared folder
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                         |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     And user "Alice" has uploaded file with checksum "SHA1 8cb2237d0679ca88db6464eac60da96345513964" to the last created TUS Location with offset "0" and content "12345" using the TUS protocol on the WebDAV API
     And user "Alice" has shared file "/textFile.txt" with user "Brian"
@@ -153,6 +162,7 @@ Feature: upload file to shared folder
     When user "Brian" creates a new TUS resource on the WebDAV API with these headers:
       | Tus-Resumable   | 1.0.0                                         |
       | Upload-Length   | 16                                            |
+      #    L1NoYXJlcy9GT0xERVIvdGV4dGZpbGUudHh0 is the base64 encode of /Shares/FOLDER/textFile.txt
       | Upload-Metadata | filename L1NoYXJlcy9GT0xERVIvdGV4dGZpbGUudHh0 |
     And user "Brian" uploads file with checksum "MD5 827ccb0eea8a706c4c34a16891f84e7b" to the last created TUS Location with offset "0" and content "uploaded content" using the TUS protocol on the WebDAV API
     Then as "Alice" file "/FOLDER/textFile.txt" should exist
@@ -171,6 +181,7 @@ Feature: upload file to shared folder
     When user "Brian" creates a new TUS resource on the WebDAV API with these headers:
       | Tus-Resumable   | 1.0.0                                         |
       | Upload-Length   | 16                                            |
+      #    L1NoYXJlcy9GT0xERVIvdGV4dGZpbGUudHh0 is the base64 encode of /Shares/FOLDER/textFile.txt
       | Upload-Metadata | filename L1NoYXJlcy9GT0xERVIvdGV4dGZpbGUudHh0 |
     And user "Brian" uploads file with checksum "MD5 827ccb0eea8a706c4c34a16891f84e8c" to the last created TUS Location with offset "0" and content "uploaded content" using the TUS protocol on the WebDAV API
     Then the HTTP status code should be "406"
@@ -188,6 +199,7 @@ Feature: upload file to shared folder
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 5                                     |
+      #    L0ZPTERFUi90ZXh0RmlsZS50eHQ= is the base64 encode of /FOLDER/textFile.txt
       | Upload-Metadata | filename L0ZPTERFUi90ZXh0RmlsZS50eHQ= |
     When user "Alice" uploads file with checksum "SHA1 8cb2237d0679ca88db6464eac60da96345513954" to the last created TUS Location with offset "0" and content "uploaded content" using the TUS protocol on the WebDAV API
     Then the HTTP status code should be "406"
@@ -203,6 +215,7 @@ Feature: upload file to shared folder
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     When user "Alice" sends a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
     And user "Alice" sends a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API
@@ -223,6 +236,7 @@ Feature: upload file to shared folder
     And user "Brian" creates a new TUS resource on the WebDAV API with these headers:
       | Tus-Resumable   | 1.0.0                                         |
       | Upload-Length   | 10                                            |
+      #    L1NoYXJlcy9GT0xERVIvdGV4dGZpbGUudHh0 is the base64 encode of /Shares/FOLDER/textFile.txt
       | Upload-Metadata | filename L1NoYXJlcy9GT0xERVIvdGV4dGZpbGUudHh0 |
     When user "Brian" sends a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
     And user "Brian" sends a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API


### PR DESCRIPTION
## Description
This PR adds comment above the `Upload-Metadata` header in TUS tests, to state what is the actual name of this file so that tests are more understandable and readable.

Also, added some extra line before some scenarios just to meet our standard practice of writing tests(Two lines gap between scenarios)
## Related Issue
- https://github.com/owncloud/ocis/issues/1798


## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
