### PR TITLE
[Tests-Only]Add tests to create tags with names in lower and upper case and assert they are displayed differently

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -52,6 +52,8 @@ class DetailsDialog extends OwncloudPage {
 	];
 	private $tabSwitchBtnXpath = "//li[@data-tabid='%s']";
 	private $tagsContainer = "//div[@class='systemTagsInputFieldContainer']";
+	private $tagList = "//span[@class='system-tag-list-item']";
+	private $tagSearchChoiceXpath = "//li[@class='select2-search-choice']" . "//span[@class='label']";
 
 	private $tagsInputXpath = "//li[@class='select2-search-field']//input";
 
@@ -443,6 +445,24 @@ class DetailsDialog extends OwncloudPage {
 	}
 
 	/**
+	 * Get tag list items from the tag list
+	 *
+	 * @return NodeElement[]
+	 */
+	public function getTagsListItems() {
+		return $this->findAll("xpath", $this->getTagsListXpath());
+	}
+
+	/**
+	 * Get tag items from the tag input field
+	 *
+	 * @return NodeElement[]
+	 */
+	public function getTagsItemsFromTagInputField() {
+		return $this->findAll("xpath", $this->getTagsInputFieldItemsXpath());
+	}
+
+	/**
 	 * Add a tag on the files in the details dialog
 	 *
 	 * @param string $tagName
@@ -551,6 +571,24 @@ class DetailsDialog extends OwncloudPage {
 	 */
 	public function getTagsDropDownResultsXpath() {
 		return $this->tagsDropDownResultXpath;
+	}
+
+	/**
+	 * Returns xpath of the tag list
+	 *
+	 * @return string
+	 */
+	public function getTagsListXpath() {
+		return $this->tagList;
+	}
+
+	/**
+	 * Returns xpath of the tag search choices in the tag input field
+	 *
+	 * @return string
+	 */
+	public function getTagsInputFieldItemsXpath() {
+		return $this->tagSearchChoiceXpath;
 	}
 
 	/**

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -21,6 +21,44 @@ Feature: Creation of tags for the files and folders
       | Top Secret   | normal |
       | Confidential | normal |
 
+  Scenario: Create new tags in lowercase and uppercase
+    Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
+    When the user browses directly to display the details of file "randomfile.txt" in folder "/"
+    And the user switches to the "tags" tab in the details panel using the webUI
+    And the user adds a tag "Top Secret Uppercase" to the file using the webUI
+    And the user adds a tag "confidential lowercase" to the file using the webUI
+    Then the following tags should be displayed in the tag list in the webUI
+      | name                   |
+      | Top Secret Uppercase   |
+      | confidential lowercase |
+    And the following tags should be displayed in the tag input field in the webUI
+      | name                   |
+      | Top Secret Uppercase   |
+      | confidential lowercase |
+    And file "/randomfile.txt" should have the following tags for user "Alice"
+      | name                   | type   |
+      | Top Secret Uppercase   | normal |
+      | confidential lowercase | normal |
+
+  Scenario: Create new tags with same name in lowercase and uppercase
+    Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
+    When the user browses directly to display the details of file "randomfile.txt" in folder "/"
+    And the user switches to the "tags" tab in the details panel using the webUI
+    And the user adds a tag "Top Secret" to the file using the webUI
+    And the user adds a tag "top secret" to the file using the webUI
+    Then the following tags should be displayed in the tag list in the webUI
+      | name       |
+      | Top Secret |
+      | top secret |
+    And the following tags should be displayed in the tag input field in the webUI
+      | name       |
+      | Top Secret |
+      | top secret |
+    And file "/randomfile.txt" should have the following tags for user "Alice"
+      | name       | type   |
+      | Top Secret | normal |
+      | top secret | normal |
+
   Scenario: Create a new tag that does not exist for a file in a folder
     Given user "Alice" has created folder "a-folder"
     And user "Alice" has uploaded file with content "some content" to "/a-folder/randomfile.txt"


### PR DESCRIPTION
## Description
This PR adds test scenarios to create tags with names in lowercase and in uppercase and asserts that these created tags are displayed accordingly. 

## Related Issue
- Fixes https://github.com/owncloud/core/issues/38499
- Can be merged after rebasing with https://github.com/owncloud/core/pull/38498

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
