### PR TITLE
[tests-only] added comment in tests for encoded filename

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
@@ -136,6 +136,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     And user "Alice" has uploaded a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
     And user "Alice" has uploaded a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API
@@ -157,6 +158,7 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
       | Upload-Length   | 10                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     And user "Alice" has uploaded a chunk to the last created TUS Location with offset "0" and data "01234" with checksum "MD5 4100c4d44da9177247e44a5fc1546778" using the TUS protocol on the WebDAV API
     And user "Alice" has uploaded a chunk to the last created TUS Location with offset "5" and data "56789" with checksum "MD5 099ebea48ea9666a7da2177267983138" using the TUS protocol on the WebDAV API

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature
@@ -251,14 +251,16 @@ Feature: upload file to shared folder
   Scenario Outline: Sharer uploads a file with checksum and as a sharee overwrites the shared file with new data and correct checksum
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
-      | Upload-Length   | 16                                     |
+      | Upload-Length   | 16                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     And user "Alice" has uploaded file with checksum "SHA1 c1dab0c0864b6ac9bdd3743a1408d679f1acd823" to the last created TUS Location with offset "0" and content "original content" using the TUS protocol on the WebDAV API
     And user "Alice" has shared file "/textFile.txt" with user "Brian"
     And user "Brian" has accepted share "/textFile.txt" offered by user "Alice"
    When user "Brian" overwrites recently shared file with offset "0" and data "overwritten content" with checksum "SHA1 fe990d2686a0fc86004efc31f5bf2475a45d4905" using the TUS protocol on the WebDAV API with these headers:
-      | Upload-Length   | 19                         |
-      | Upload-Metadata | filename L1NoYXJlcy90ZXh0RmlsZS50eHQ= |
+     | Upload-Length   | 19                                    |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of /Shares/textFile.txt
+     | Upload-Metadata | filename L1NoYXJlcy90ZXh0RmlsZS50eHQ= |
     Then the content of file "/textFile.txt" for user "Alice" should be "overwritten content"
     Examples:
       | dav_version |
@@ -269,13 +271,15 @@ Feature: upload file to shared folder
   Scenario Outline: Sharer uploads a file with checksum and as a sharee overwrites the shared file with new data and invalid checksum
     Given using <dav_version> DAV path
     And user "Alice" has created a new TUS resource on the WebDAV API with these headers:
-      | Upload-Length   | 16                                     |
+      | Upload-Length   | 16                        |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of textFile.txt
       | Upload-Metadata | filename dGV4dEZpbGUudHh0 |
     And user "Alice" has uploaded file with checksum "SHA1 c1dab0c0864b6ac9bdd3743a1408d679f1acd823" to the last created TUS Location with offset "0" and content "original content" using the TUS protocol on the WebDAV API
     And user "Alice" has shared file "/textFile.txt" with user "Brian"
     And user "Brian" has accepted share "/textFile.txt" offered by user "Alice"
     When user "Brian" overwrites recently shared file with offset "0" and data "overwritten content" with checksum "SHA1 fe990d2686a0fc86004efc31f5bf2475a45d4906" using the TUS protocol on the WebDAV API with these headers:
-      | Upload-Length   | 19                         |
+      | Upload-Length   | 19                                    |
+      #    dGV4dEZpbGUudHh0 is the base64 encode of /Shares/textFile.txt
       | Upload-Metadata | filename L1NoYXJlcy90ZXh0RmlsZS50eHQ= |
     Then the HTTP status code should be "406"
     And the content of file "/textFile.txt" for user "Alice" should be "original content"


### PR DESCRIPTION
## Description
This PR adds comment above the Upload-Metadata header in TUS tests, to state what is the actual name of this file so that tests are more understandable and readable for https://github.com/owncloud/core/pull/38492.

## Related Issue
- https://github.com/owncloud/ocis/issues/1798

## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
