### PR TITLE
[Tests-Only] used skeleton files more wisely on favorites and main part of API tests

### DIFF
--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -2,7 +2,7 @@
 Feature: caldav
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @caldav
   Scenario: Accessing a not existing calendar of another user

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -2,7 +2,7 @@
 Feature: carddav
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @carddav
   Scenario: Accessing a not existing addressbook of another user

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -266,6 +266,7 @@ Feature: checksums
   @issue-ocis-reva-196
   Scenario Outline: Uploading a file with MD5 checksum overwriting an existing file
     Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "some data" to "textfile0.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
     Then as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     And the content of file "/textfile0.txt" for user "Alice" should be:
@@ -282,6 +283,7 @@ Feature: checksums
   @issue-ocis-reva-196
   Scenario Outline: Uploading a file with SHA1 checksum overwriting an existing file
     Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "some data" to "textfile0.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f" using the WebDAV API
     Then as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     And the content of file "/textfile0.txt" for user "Alice" should be:
@@ -297,12 +299,12 @@ Feature: checksums
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
   @issue-ocis-reva-196
-  Scenario Outline: Uploading a file with invalid SHA1 checksum overwriting an existing file
+ Scenario Outline: Uploading a file with invalid SHA1 checksum overwriting an existing file
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:f005ba11f005ba11f005ba11f005ba11f005ba11" using the WebDAV API
-    Then as user "Brian" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:0c1d334e686d1039c9ead0dbc047f02dbf696be8 MD5:d991cd854c53729d066c6ed5e34bcda3 ADLER32:8685092b"
-    And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:f005ba11f005ba11f005ba11f005ba11f005ba11" using the WebDAV API
+    Then as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:2052377dec0724bda0d57aeab67fa819278b7f74 MD5:096e350e9ff1339a997a14145f9fc4b9 ADLER32:7d5a0921"
+    And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
       | dav_version |
       | old         |
@@ -311,25 +313,25 @@ Feature: checksums
   @issue-ocis-reva-56
   Scenario: Upload overwriting a file with new chunking and correct checksum
     Given using new DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
-    When user "Brian" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Brian" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
-    And user "Brian" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
-    And user "Brian" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "Alice" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
     Then the HTTP status code should be "204"
-    And the content of file "/textfile0.txt" for user "Brian" should be "BBBBBCCCCC"
+    And the content of file "/textfile0.txt" for user "Alice" should be "BBBBBCCCCC"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
   @issue-ocis-reva-56
   Scenario: Upload overwriting a file with new chunking and invalid checksum
     Given using new DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
-    When user "Brian" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Brian" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
-    And user "Brian" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
-    And user "Brian" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:f005ba11" using the WebDAV API
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
+    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
+    And user "Alice" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:f005ba11" using the WebDAV API
     Then the HTTP status code should be "400"
-    And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
 
   @issue-ocis-reva-214
   Scenario Outline: Uploading a file with checksum should work for file with special characters

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -3,33 +3,30 @@ Feature: quota
 
   Background:
     Given using OCS API version "1"
+    And user "Alice" has been created with default attributes and without skeleton files
 
 	# Owner
 
   Scenario: Uploading a file as owner having enough quota
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And the quota of user "Alice" has been set to "10 MB"
+    Given the quota of user "Alice" has been set to "10 MB"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
 
   @smokeTest
   Scenario: Uploading a file as owner having insufficient quota
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And the quota of user "Alice" has been set to "20 B"
+    Given the quota of user "Alice" has been set to "20 B"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
     Then as "Alice" the files uploaded to "/testquota.txt" with all mechanisms should not exist
 
   Scenario: Overwriting a file as owner having enough quota
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Alice" has uploaded file with content "test" to "/testquota.txt"
+    Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "10 MB"
     When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
   Scenario: Overwriting a file as owner having insufficient quota
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Alice" has uploaded file with content "test" to "/testquota.txt"
+    Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "20 B"
     When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
@@ -39,10 +36,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Uploading a file in received folder having enough quota
-    Given these users have been created with default attributes and small skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
+    Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "20 B"
@@ -52,10 +46,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Uploading a file in received folder having insufficient quota
-    Given these users have been created with default attributes and small skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
+    Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "10 MB"
@@ -66,10 +57,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Overwriting a file in received folder having enough quota
-    Given these users have been created with default attributes and small skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
+    Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
@@ -80,10 +68,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Overwriting a file in received folder having insufficient quota
-    Given these users have been created with default attributes and small skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
+    Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
@@ -97,10 +82,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Overwriting a received file having enough quota
-    Given these users have been created with default attributes and small skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
+    Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
     And the quota of user "Brian" has been set to "20 B"
@@ -110,10 +92,7 @@ Feature: quota
 
   @files_sharing-app-required
   Scenario: Overwriting a received file having insufficient quota
-    Given these users have been created with default attributes and small skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
+    Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
     And the quota of user "Brian" has been set to "10 MB"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiFavorites
  - apiMain

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
