### PR TITLE
[Tests-Only] used skeleton files more wisely on capabilites and comments part of API tests

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -728,7 +728,7 @@ Feature: capabilities
 
   Scenario: When in a group that is excluded from sharing, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
@@ -757,7 +757,7 @@ Feature: capabilities
 
   Scenario: When not in any group that is excluded from sharing, can_share is on
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created
@@ -786,7 +786,7 @@ Feature: capabilities
 
   Scenario: When in a group that is excluded from sharing and in another group, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And group "group1" has been created
     And group "hash#group" has been created
     And group "group-3" has been created

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -3,7 +3,7 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario: Getting info of comments using files endpoint
@@ -22,7 +22,8 @@ Feature: Comments
     And the single response should contain a property "oc:comments-href" with value "%a_comment_url%"
 
   Scenario: Getting info on comments for a folder using the endpoint
-    Given user "Alice" has commented with content "My first comment" on folder "/PARENT"
+    Given user "Alice" has created folder "/PARENT"
+    And user "Alice" has commented with content "My first comment" on folder "/PARENT"
     And user "Alice" should have the following comments on folder "/PARENT"
       | user  | comment          |
       | Alice | My first comment |
@@ -36,8 +37,8 @@ Feature: Comments
     And the single response should contain a property "oc:comments-href" with value "%a_comment_url%"
 
   Scenario: Getting more info about comments using REPORT method
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "myFileToComment.txt"
-    And user "Alice" has commented with content "My first comment" on file "myFileToComment.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
+    And user "Alice" has commented with content "My first comment" on file "/myFileToComment.txt"
     When user "Alice" gets all information about the comments on file "myFileToComment.txt" using the WebDAV REPORT API
     Then the following comment properties should be listed about user "Alice"
       | propertyName     | propertyValue    |
@@ -50,7 +51,7 @@ Feature: Comments
       | message          | My first comment |
 
   Scenario: Getting more info about comments using PROPFIND method
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "myFileToComment.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
     And user "Alice" has commented with content "My first comment" on file "myFileToComment.txt"
     When user "Alice" gets the following comment properties of file "myFileToComment.txt" using the WebDAV PROPFIND API
       | propertyName        |

--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -3,7 +3,7 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -68,6 +68,7 @@ Feature: Comments
     And user "Alice" should have 0 comments on file "/FOLDER_TO_SHARE"
 
   Scenario: Creating a comment on a folder belonging to myself
+    Given user "Alice" has created folder "/FOLDER"
     When user "Alice" comments with content "My first comment" on folder "/FOLDER" using the WebDAV API
     Then user "Alice" should have the following comments on folder "/FOLDER"
       | user  | comment          |

--- a/tests/acceptance/features/apiComments/deleteComments.feature
+++ b/tests/acceptance/features/apiComments/deleteComments.feature
@@ -3,10 +3,9 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
-      | Brian    |
 
   @smokeTest
   Scenario Outline: Deleting my own comments on a file belonging to myself
@@ -33,7 +32,8 @@ Feature: Comments
 
   @files_sharing-app-required
   Scenario: Deleting my own comments on a file shared by somebody else
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
     And user "Alice" has shared file "/myFileToComment.txt" with user "Brian"
     And user "Alice" has commented with content "File owner comment" on file "/myFileToComment.txt"
     And user "Brian" has commented with content "Sharee comment" on file "/myFileToComment.txt"
@@ -64,14 +64,11 @@ Feature: Comments
 
   @files_sharing-app-required
   Scenario: Deleting my own comments on a file shared by somebody else
-    Given user "Alice" has created folder "/FOLDER_TO_COMMENT"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/FOLDER_TO_COMMENT"
     And user "Alice" has shared folder "/FOLDER_TO_COMMENT" with user "Brian"
     And user "Alice" has commented with content "Folder owner comment" on folder "/FOLDER_TO_COMMENT"
     And user "Brian" has commented with content "Sharee comment" on folder "/FOLDER_TO_COMMENT"
-    And user "Brian" should have the following comments on folder "/FOLDER_TO_COMMENT"
-      | user  | comment              |
-      | Alice | Folder owner comment |
-      | Brian | Sharee comment       |
     When user "Brian" deletes the last created comment using the WebDAV API
     Then the HTTP status code should be "204"
     And user "Brian" should have 1 comments on folder "/FOLDER_TO_COMMENT"
@@ -86,6 +83,7 @@ Feature: Comments
   @files_sharing-app-required
   Scenario: deleting a user does not remove the comment
     Given user "Alice" has created folder "/FOLDER_TO_COMMENT"
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared folder "/FOLDER_TO_COMMENT" with user "Brian"
     And user "Brian" has commented with content "Comment from sharee" on folder "/FOLDER_TO_COMMENT"
     When the administrator deletes user "Brian" using the provisioning API
@@ -98,6 +96,6 @@ Feature: Comments
     Given user "Alice" has created folder "/FOLDER_TO_COMMENT"
     And user "Alice" has commented with content "Comment from owner" on folder "/FOLDER_TO_COMMENT"
     And user "Alice" has been deleted
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     When user "Alice" creates folder "/FOLDER_TO_COMMENT" using the WebDAV API
     Then user "Alice" should have 0 comments on folder "/FOLDER_TO_COMMENT"

--- a/tests/acceptance/features/apiComments/editComments.feature
+++ b/tests/acceptance/features/apiComments/editComments.feature
@@ -3,18 +3,17 @@ Feature: Comments
 
   Background:
     Given using new DAV path
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
-      | Brian    |
 
   @smokeTest
   Scenario Outline: Edit my own comments on a file belonging to myself
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
-    And user "Alice" has commented with content "File owner comment" on file "/myFileToComment.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Alice" has commented with content "File owner comment" on file "/textfile0.txt"
     When user "Alice" edits the last created comment with content "<comment>" using the WebDAV API
     Then the HTTP status code should be "207"
-    And user "Alice" should have the following comments on file "/myFileToComment.txt"
+    And user "Alice" should have the following comments on file "/textfile0.txt"
       | user  | comment   |
       | Alice | <comment> |
     Examples:
@@ -25,34 +24,36 @@ Feature: Comments
 
   @files_sharing-app-required
   Scenario: Edit my own comments on a file shared by someone with me
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
-    And user "Alice" has shared file "/myFileToComment.txt" with user "Brian"
-    And user "Brian" has commented with content "Sharee comment" on file "/myFileToComment.txt"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    And user "Brian" has commented with content "Sharee comment" on file "/textfile0.txt"
     When user "Brian" edits the last created comment with content "My edited comment" using the WebDAV API
     Then the HTTP status code should be "207"
-    And user "Brian" should have the following comments on file "/myFileToComment.txt"
+    And user "Brian" should have the following comments on file "/textfile0.txt"
       | user  | comment           |
       | Brian | My edited comment |
 
   @files_sharing-app-required
   Scenario: Editing comments of other users should not be possible
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
-    And user "Alice" has shared file "/myFileToComment.txt" with user "Brian"
-    And user "Brian" has commented with content "Sharee comment" on file "/myFileToComment.txt"
-    And user "Alice" should have the following comments on file "/myFileToComment.txt"
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    And user "Brian" has commented with content "Sharee comment" on file "/textfile0.txt"
+    And user "Alice" should have the following comments on file "/textfile0.txt"
       | user  | comment        |
       | Brian | Sharee comment |
     When user "Alice" edits the last created comment with content "Edit the comment of another user" using the WebDAV API
     Then the HTTP status code should be "403"
-    And user "Alice" should have the following comments on file "/myFileToComment.txt"
+    And user "Alice" should have the following comments on file "/textfile0.txt"
       | user  | comment        |
       | Brian | Sharee comment |
 
   Scenario: Edit my own comments on a folder belonging to myself
-    Given user "Alice" has created folder "/FOLDER_TO_COMMENT"
-    And user "Alice" has commented with content "Folder owner comment" on folder "/FOLDER_TO_COMMENT"
+    Given user "Alice" has created folder "FOLDER"
+    And user "Alice" has commented with content "Folder owner comment" on folder "/FOLDER"
     When user "Alice" edits the last created comment with content "My edited comment" using the WebDAV API
     Then the HTTP status code should be "207"
-    And user "Alice" should have the following comments on folder "/FOLDER_TO_COMMENT"
+    And user "Alice" should have the following comments on folder "/FOLDER"
       | user  | comment           |
       | Alice | My edited comment |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiComments
  - apiCapabilities

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
