### PR TITLE
[Tests-Only] used small skeleton directory more wisely on API share create special features

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
@@ -2,13 +2,14 @@
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.3
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" shares folder "/FOLDER" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
@@ -26,6 +27,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | user       |
@@ -51,6 +53,7 @@ Feature: a default expiration date can be specified for shares with users or gro
   Scenario Outline: sharing with default expiration date not enabled, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | user       |
@@ -77,6 +80,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | user       |
@@ -104,6 +108,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | user       |
@@ -129,6 +134,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     When user "Alice" shares folder "/FOLDER" with group "grp1" using the sharing API
@@ -150,6 +156,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | group      |
@@ -177,6 +184,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | group      |
@@ -205,6 +213,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | group      |
@@ -234,6 +243,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | group      |
@@ -261,6 +271,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     Then the fields of the last response to user "Alice" sharing with user "Brian" should include
       | share_type  | user           |
@@ -281,6 +292,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |
@@ -303,6 +315,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     Then the fields of the last response to user "Alice" sharing with user "Brian" should include
       | share_type  | user           |
@@ -324,6 +337,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |
@@ -346,6 +360,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" with permissions "read,share" using the sharing API
     And the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "40"
     And user "Alice" gets the info of the last share using the sharing API
@@ -363,6 +378,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" with permissions "read,share" using the sharing API
     And the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "15"
     And user "Alice" gets the info of the last share using the sharing API
@@ -381,6 +397,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
     Then the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_type  | group          |
@@ -403,6 +420,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | group         |
@@ -427,6 +445,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
     Then the fields of the last response to user "Alice" sharing with group "grp1" should include
       | share_type  | group          |
@@ -450,6 +469,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | group         |
@@ -474,6 +494,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with group "grp1" with permissions "read,share" using the sharing API
     And the administrator sets parameter "shareapi_expire_after_n_days_group_share" of app "core" to "40"
     And user "Alice" gets the info of the last share using the sharing API
@@ -495,6 +516,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with group "grp1" with permissions "read,share" using the sharing API
     And the administrator sets parameter "shareapi_expire_after_n_days_group_share" of app "core" to "15"
     And user "Alice" gets the info of the last share using the sharing API
@@ -515,6 +537,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" shares file "FOLDER" with group "grp1" with permissions "read,share" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Alice" should include
@@ -532,6 +555,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" shares file "/FOLDER" with user "Brian" with permissions "read,share" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Alice" should include
@@ -549,6 +573,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -569,6 +594,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "2"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -595,6 +621,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt     |
       | shareType          | user              |
@@ -626,6 +653,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -651,6 +679,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -676,6 +705,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -698,6 +728,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "0"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |
@@ -719,6 +750,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "1"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareReceivedInMultipleWays.feature
@@ -2,22 +2,23 @@
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   Scenario Outline: Creating a new share with user who already received a share through their group
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has shared file "welcome.txt" with group "grp1"
-    When user "Alice" shares file "/welcome.txt" with user "Brian" using the sharing API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    When user "Alice" shares file "/textfile0.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "Brian" should include
       | share_with             | %username%        |
       | share_with_displayname | %displayname%     |
-      | file_target            | /welcome.txt      |
-      | path                   | /welcome.txt      |
+      | file_target            | /textfile0.txt      |
+      | path                   | /textfile0.txt      |
       | permissions            | share,read,update |
       | uid_owner              | %username%        |
       | displayname_owner      | %displayname%     |
@@ -33,17 +34,18 @@ Feature: share resources where the sharee receives the share in multiple ways
   @issue-ocis-reva-243
   Scenario Outline: Share of folder and sub-folder to same user - core#20645
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp4" has been created
     And user "Brian" has been added to group "grp4"
+    And user "ALice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     And user "Alice" shares folder "/PARENT/CHILD" with group "grp4" using the sharing API
     Then user "Brian" should see the following elements
-      | /FOLDER/                 |
       | /PARENT/                 |
       | /PARENT/parent.txt       |
-      | /PARENT%20(2)/           |
-      | /PARENT%20(2)/parent.txt |
       | /CHILD/                  |
       | /CHILD/child.txt         |
     And the OCS status code should be "<ocs_status_code>"

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareWhenExcludedFromSharing.feature
@@ -2,16 +2,18 @@
 Feature: cannot share resources when in a group that is excluded from sharing
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/fileToShare.txt"
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
-    And user "Brian" has moved file "welcome.txt" to "fileToShare.txt"
     When user "Brian" shares file "fileToShare.txt" with user "Alice" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
@@ -23,15 +25,16 @@ Feature: cannot share resources when in a group that is excluded from sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a file with a group
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
-    And group "grp1" has been created
-    And group "grp2" has been created
+    And these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp2"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
-    And user "Brian" has moved file "welcome.txt" to "fileToShare.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/fileToShare.txt"
     When user "Brian" shares file "fileToShare.txt" with group "grp2" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
@@ -43,7 +46,6 @@ Feature: cannot share resources when in a group that is excluded from sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a folder with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -60,7 +62,6 @@ Feature: cannot share resources when in a group that is excluded from sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a folder with a group
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp0" has been created
     And group "grp1" has been created
     And user "Alice" has been added to group "grp0"

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
@@ -2,13 +2,14 @@
 Feature: shares are received in the default folder for received shares
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario Outline: Do not allow sharing of the entire share_folder
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "<share_folder>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" shares folder "/FOLDER" with user "Brian" using the sharing API
     And user "Brian" unshares folder "ReceivedShares/FOLDER" using the WebDAV API
     And user "Brian" shares folder "/ReceivedShares" with user "Alice" using the sharing API

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupAndUserWithSameName.feature
@@ -2,7 +2,8 @@
 Feature: sharing works when a username and group name are the same
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
 
   @skipOnLDAP @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: creating a new share with user and a group having same name
@@ -12,7 +13,6 @@ Feature: sharing works when a username and group name are the same
       | Carol    |
     And group "Brian" has been created
     And user "Carol" has been added to group "Brian"
-    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     And user "Alice" has shared file "randomfile.txt" with group "Brian"
     When user "Alice" shares file "randomfile.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "100"
@@ -32,7 +32,6 @@ Feature: sharing works when a username and group name are the same
       | Carol    |
     And group "Brian" has been created
     And user "Carol" has been added to group "Brian"
-    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     And user "Alice" has shared file "randomfile.txt" with user "Brian"
     When user "Alice" shares file "randomfile.txt" with group "Brian" using the sharing API
     Then the OCS status code should be "100"
@@ -52,7 +51,6 @@ Feature: sharing works when a username and group name are the same
       | Carol    |
     And group "Brian" has been created
     And user "Carol" has been added to group "Brian"
-    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     And user "Alice" has shared file "randomfile.txt" with group "Brian"
     When user "Alice" shares file "randomfile.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "100"
@@ -72,7 +70,6 @@ Feature: sharing works when a username and group name are the same
       | Carol    |
     And group "Brian" has been created
     And user "Carol" has been added to group "Brian"
-    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     And user "Alice" has shared file "randomfile.txt" with user "Brian"
     When user "Alice" shares file "randomfile.txt" with group "Brian" using the sharing API
     Then the OCS status code should be "100"

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupCaseSensitive.feature
@@ -2,7 +2,10 @@
 Feature: share with groups, group names are case-sensitive
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 2" to "/textfile2.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 3" to "/textfile3.txt"
 
   @skipOnLDAP @issue-ldap-250
   Scenario Outline: group names are case-sensitive, sharing with groups with different upper and lower case names
@@ -21,15 +24,15 @@ Feature: share with groups, group names are case-sensitive
     When user "Alice" shares file "textfile1.txt" with group "<group_id1>" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the content of file "textfile1.txt" for user "Brian" should be "ownCloud test text file 1" plus end-of-line
+    And the content of file "textfile1.txt" for user "Brian" should be "ownCloud test text file 1"
     When user "Alice" shares folder "textfile2.txt" with group "<group_id2>" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the content of file "textfile2.txt" for user "Carol" should be "ownCloud test text file 2" plus end-of-line
+    And the content of file "textfile2.txt" for user "Carol" should be "ownCloud test text file 2"
     When user "Alice" shares folder "textfile3.txt" with group "<group_id3>" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the content of file "textfile3.txt" for user "David" should be "ownCloud test text file 3" plus end-of-line
+    And the content of file "textfile3.txt" for user "David" should be "ownCloud test text file 3"
     Examples:
       | ocs_api_version | group_id1            | group_id2            | group_id3            | ocs_status_code |
       | 1               | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | 100             |
@@ -56,7 +59,7 @@ Feature: share with groups, group names are case-sensitive
       | path        | /textfile1.txt    |
       | permissions | share,read,update |
       | uid_owner   | %username%        |
-    And the content of file "textfile1.txt" for user "Brian" should be "ownCloud test text file 1" plus end-of-line
+    And the content of file "textfile1.txt" for user "Brian" should be "ownCloud test text file 1"
     When user "Alice" shares file "textfile2.txt" with group "<group_id2>" using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -2,20 +2,23 @@
 Feature: cannot share resources outside the group when share with membership groups is enabled
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
+    And group "grp0" has been created
+    And user "Alice" has been added to group "grp0"
 
   Scenario Outline: sharer should not be able to share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
-    And group "grp0" has been created
     And group "grp1" has been created
-    And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "PARENT"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Brian" folder "/PARENT (2)" should not exist
+    And as "Brian" folder "/PARENT" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |
@@ -23,14 +26,11 @@ Feature: cannot share resources outside the group when share with membership gro
 
   Scenario Outline: sharer should be able to share a folder to a user who is not member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
-    And group "grp0" has been created
-    And user "Alice" has been added to group "grp0"
+    And user "Alice" has created folder "PARENT"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Brian" folder "/PARENT (2)" should exist
+    And as "Brian" folder "/PARENT" should exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -38,15 +38,12 @@ Feature: cannot share resources outside the group when share with membership gro
 
   Scenario Outline: sharer should be able to share a folder to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
-    And group "grp0" has been created
-    And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp0"
+    And user "Alice" has created folder "PARENT"
     When user "Alice" shares folder "/PARENT" with group "grp0" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Brian" folder "/PARENT (2)" should exist
+    And as "Brian" folder "/PARENT" should exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -54,16 +51,13 @@ Feature: cannot share resources outside the group when share with membership gro
 
   Scenario Outline: sharer should not be able to share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
-    And group "grp0" has been created
     And group "grp1" has been created
-    And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Brian" file "/textfile0 (2).txt" should not exist
+    And as "Brian" file "/textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |
@@ -71,15 +65,12 @@ Feature: cannot share resources outside the group when share with membership gro
 
   Scenario Outline: sharer should be able to share a file to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
-    And group "grp0" has been created
-    And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp0"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/textfile0.txt" with group "grp0" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Brian" file "/textfile0 (2).txt" should exist
+    And as "Brian" file "/textfile0.txt" should exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -87,14 +78,11 @@ Feature: cannot share resources outside the group when share with membership gro
 
   Scenario Outline: sharer should be able to share a file to a user who is not a member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
-    And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
-    And group "grp0" has been created
-    And user "Alice" has been added to group "grp0"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/textfile0.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Brian" file "/textfile0 (2).txt" should exist
+    And as "Brian" file "/textfile0.txt" should exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
@@ -2,7 +2,7 @@
 Feature: share resources with a disabled user
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   Scenario Outline: Creating a new share with a disabled user
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
@@ -2,7 +2,7 @@
 Feature: share resources with a disabled user - current oC10 behavior for issue-32068
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @issue-32068
   Scenario: Creating a new share with a disabled user

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithInvalidPermissions.feature
@@ -2,36 +2,52 @@
 Feature: cannot share resources with invalid permissions
 
   Background:
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
-    And user "Alice" has created folder "/PARENT"
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
-  Scenario Outline: Cannot create a share of a file or folder with invalid permissions
+  Scenario Outline: Cannot create a share of a file with invalid permissions
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
-      | path        | <item>        |
+      | path        | textfile0.txt |
       | shareWith   | Brian         |
       | shareType   | user          |
       | permissions | <permissions> |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Brian" entry "<item>" should not exist
+    And as "Brian" entry "/textfile0.txt" should not exist
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code | item          | permissions |
-      | 1               | 400             | 200              | textfile0.txt | 0           |
-      | 2               | 400             | 400              | textfile0.txt | 0           |
-      | 1               | 400             | 200              | PARENT        | 0           |
-      | 2               | 400             | 400              | PARENT        | 0           |
-      | 1               | 404             | 200              | textfile0.txt | 32          |
-      | 2               | 404             | 404              | textfile0.txt | 32          |
-      | 1               | 404             | 200              | PARENT        | 32          |
-      | 2               | 404             | 404              | PARENT        | 32          |
+      | ocs_api_version | ocs_status_code | http_status_code | permissions |
+      | 1               | 400             | 200              | 0           |
+      | 2               | 400             | 400              | 0           |
+      | 1               | 404             | 200              | 32          |
+      | 2               | 404             | 404              | 32          |
+
+
+  Scenario Outline: Cannot create a share of a folder with invalid permissions
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    When user "Alice" creates a share using the sharing API with settings
+      | path        | PARENT        |
+      | shareWith   | Brian         |
+      | shareType   | user          |
+      | permissions | <permissions> |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "<http_status_code>"
+    And as "Brian" entry "PARENT" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code | http_status_code | permissions |
+      | 1               | 400             | 200              | 0           |
+      | 2               | 400             | 400              | 0           |
+      | 1               | 404             | 200              | 32          |
+      | 2               | 404             | 404              | 32          |
 
   @issue-ocis-reva-45 @issue-ocis-reva-243
   Scenario Outline: Cannot create a share of a file with a user with only create permission
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareWith   | Brian         |
@@ -48,7 +64,7 @@ Feature: cannot share resources with invalid permissions
   @issue-ocis-reva-45 @issue-ocis-reva-243
   Scenario Outline: Cannot create a share of a file with a user with only (create,delete) permission
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareWith   | Brian         |
@@ -67,9 +83,9 @@ Feature: cannot share resources with invalid permissions
   @issue-ocis-reva-34
   Scenario Outline: Cannot create a share of a file with a group with only create permission
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareWith   | grp1          |
@@ -86,9 +102,9 @@ Feature: cannot share resources with invalid permissions
   @issue-ocis-reva-34
   Scenario Outline: Cannot create a share of a file with a group with only (create,delete) permission
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareWith   | grp1          |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
@@ -4,13 +4,16 @@ Feature: a default expiration date can be specified for shares with users or gro
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   @skipOnOcV10.3
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" shares folder "/FOLDER" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
@@ -30,7 +33,7 @@ Feature: a default expiration date can be specified for shares with users or gro
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares with expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | user       |
@@ -58,7 +61,7 @@ Feature: a default expiration date can be specified for shares with users or gro
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date not enabled, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | user       |
@@ -87,7 +90,7 @@ Feature: a default expiration date can be specified for shares with users or gro
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | user       |
@@ -115,7 +118,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | user       |
@@ -141,9 +144,9 @@ Feature: a default expiration date can be specified for shares with users or gro
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" shares folder "/FOLDER" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
@@ -163,9 +166,9 @@ Feature: a default expiration date can be specified for shares with users or gro
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares with expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | group      |
@@ -193,9 +196,9 @@ Feature: a default expiration date can be specified for shares with users or gro
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date not enabled for groups, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | group      |
@@ -224,9 +227,9 @@ Feature: a default expiration date can be specified for shares with users or gro
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | group      |
@@ -254,9 +257,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "/FOLDER"
     When user "Alice" creates a share using the sharing API with settings
       | path        | /FOLDER    |
       | shareType   | group      |
@@ -284,7 +287,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then the fields of the last response to user "Alice" sharing with user "Brian" should include
@@ -305,7 +308,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |
@@ -328,7 +331,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then the fields of the last response to user "Alice" sharing with user "Brian" should include
@@ -350,7 +353,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |
@@ -373,7 +376,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" with permissions "read,share" using the sharing API
     And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     And the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "40"
@@ -391,7 +394,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" with permissions "read,share" using the sharing API
     And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     And the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "15"
@@ -408,9 +411,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
     And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then the fields of the last response to user "Alice" sharing with group "grp1" should include
@@ -431,9 +434,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | group         |
@@ -456,9 +459,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
     And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then the fields of the last response to user "Alice" sharing with group "grp1" should include
@@ -480,9 +483,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | group         |
@@ -505,9 +508,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with group "grp1" with permissions "read,share" using the sharing API
     And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     And the administrator sets parameter "shareapi_expire_after_n_days_group_share" of app "core" to "40"
@@ -527,9 +530,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "30"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with group "grp1" with permissions "read,share" using the sharing API
     And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     And the administrator sets parameter "shareapi_expire_after_n_days_group_share" of app "core" to "15"
@@ -548,9 +551,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" shares file "FOLDER" with group "grp1" with permissions "read,share" using the sharing API
     And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
@@ -568,8 +571,8 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
-    When user "Alice" shares file "/FOLDER" with user "Brian" with permissions "read,share" using the sharing API
+    And user "Alice" has created folder "FOLDER"
+    When user "Alice" shares folder "/FOLDER" with user "Brian" with permissions "read,share" using the sharing API
     And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Alice" should include
@@ -586,7 +589,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -607,7 +610,7 @@ Feature: a default expiration date can be specified for shares with users or gro
   Scenario Outline: sharing with default expiration date enforced for users, user shares with different time format
     Given using OCS API version "2"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -636,7 +639,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt     |
       | shareType          | user              |
@@ -668,7 +671,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -694,7 +697,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -720,7 +723,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path               | textfile0.txt |
       | shareType          | user          |
@@ -743,7 +746,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "0"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |
@@ -765,7 +768,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "1"
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
@@ -4,26 +4,29 @@ Feature: share resources where the sharee receives the share in multiple ways
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   Scenario Outline: Creating a new share with user who already received a share through their group
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has shared file "welcome.txt" with group "grp1"
-    And user "Brian" has accepted share "/welcome.txt" offered by user "Alice"
-    When user "Alice" shares file "/welcome.txt" with user "Brian" using the sharing API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Alice" shares file "/textfile0.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When user "Brian" accepts share "/welcome.txt" offered by user "Alice" using the sharing API
+    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "Brian" should include
       | share_with             | %username%              |
       | share_with_displayname | %displayname%           |
-      | file_target            | /Shares/welcome (2).txt |
-      | path                   | /Shares/welcome (2).txt |
+      | file_target            | /Shares/textfile0 (2).txt |
+      | path                   | /Shares/textfile0 (2).txt |
       | permissions            | share,read,update       |
       | uid_owner              | %username%              |
       | displayname_owner      | %displayname%           |
@@ -39,9 +42,12 @@ Feature: share resources where the sharee receives the share in multiple ways
   @issue-ocis-reva-243
   Scenario Outline: Share of folder and sub-folder to same user - core#20645
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and small skeleton files
     And group "grp4" has been created
     And user "Brian" has been added to group "grp4"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created folder "/PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     And user "Alice" shares folder "/PARENT/CHILD" with group "grp4" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -53,11 +59,8 @@ Feature: share resources where the sharee receives the share in multiple ways
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And user "Brian" should see the following elements
-      | /FOLDER/                  |
       | /Shares/PARENT/           |
       | /Shares/PARENT/parent.txt |
-      | /PARENT/                  |
-      | /PARENT/parent.txt        |
       | /Shares/CHILD/            |
       | /Shares/CHILD/child.txt   |
     Examples:
@@ -68,7 +71,6 @@ Feature: share resources where the sharee receives the share in multiple ways
   @issue-ocis-reva-243
   Scenario Outline: sharing subfolder when parent already shared
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Alice" has created folder "/test"
     And user "Alice" has created folder "/test/sub"
@@ -88,7 +90,6 @@ Feature: share resources where the sharee receives the share in multiple ways
   @issue-ocis-reva-243
   Scenario Outline: sharing subfolder when parent already shared with group of sharer
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     And user "Alice" has created folder "/test"
@@ -109,10 +110,7 @@ Feature: share resources where the sharee receives the share in multiple ways
   @issue-ocis-reva-243
   Scenario Outline: multiple users share a file with the same name but different permissions to a user
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and without skeleton files:
-      | username |
-      | Brian    |
-      | Carol    |
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has uploaded file with content "First data" to "/randomfile.txt"
     And user "Carol" has uploaded file with content "Second data" to "/randomfile.txt"
     When user "Brian" shares file "randomfile.txt" with user "Alice" with permissions "read" using the sharing API
@@ -143,10 +141,7 @@ Feature: share resources where the sharee receives the share in multiple ways
   @issue-ocis-reva-243
   Scenario Outline: multiple users share a folder with the same name to a user
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and without skeleton files:
-      | username |
-      | Brian    |
-      | Carol    |
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/zzzfolder"
     And user "Brian" has created folder "zzzfolder/Brian"
     And user "Carol" has created folder "/zzzfolder"
@@ -179,10 +174,7 @@ Feature: share resources where the sharee receives the share in multiple ways
   @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP
   Scenario Outline: share with a group and then add a user to that group that already has a file with the shared name
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and without skeleton files:
-      | username |
-      | Brian    |
-      | Carol    |
+    And user "Carol" has been created with default attributes and without skeleton files
     And these groups have been created:
       | groupname |
       | grp1      |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareWhenExcludedFromSharing.feature
@@ -4,16 +4,16 @@ Feature: cannot share resources when in a group that is excluded from sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
 
   Scenario Outline: user who is excluded from sharing tries to share a file with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and small skeleton files
-    And group "grp1" has been created
-    And user "Brian" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
-    And user "Brian" has moved file "welcome.txt" to "fileToShare.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/fileToShare.txt"
     When user "Brian" shares file "fileToShare.txt" with user "Alice" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
@@ -27,15 +27,12 @@ Feature: cannot share resources when in a group that is excluded from sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a file with a group
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
-    And group "grp1" has been created
     And group "grp2" has been created
-    And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp2"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
-    And user "Brian" has moved file "welcome.txt" to "fileToShare.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/fileToShare.txt"
     When user "Brian" shares file "fileToShare.txt" with group "grp2" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
@@ -49,9 +46,6 @@ Feature: cannot share resources when in a group that is excluded from sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a folder with another user
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
-    And group "grp1" has been created
-    And user "Brian" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp1"]'
     And user "Brian" has created folder "folderToShare"
@@ -68,11 +62,8 @@ Feature: cannot share resources when in a group that is excluded from sharing
 
   Scenario Outline: user who is excluded from sharing tries to share a folder with a group
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp0" has been created
-    And group "grp1" has been created
     And user "Alice" has been added to group "grp0"
-    And user "Brian" has been added to group "grp1"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And parameter "shareapi_exclude_groups_list" of app "core" has been set to '["grp0"]'
     And user "Alice" has created folder "folderToShare"

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
@@ -4,12 +4,13 @@ Feature: shares are received in the default folder for received shares
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario Outline: Do not allow sharing of the entire share_folder
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" shares folder "/FOLDER" with user "Brian" using the sharing API
     And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
     And user "Brian" unshares folder "Shares/FOLDER" using the WebDAV API

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
@@ -4,7 +4,7 @@ Feature: sharing works when a username and group name are the same
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnLDAP @skipOnOcV10.3.0 @skipOnOcV10.3.1
   Scenario: creating a new share with user and a group having same name

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
@@ -4,7 +4,10 @@ Feature: share with groups, group names are case-sensitive
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 2" to "/textfile2.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 3" to "/textfile3.txt"
 
   @skipOnLDAP @issue-ldap-250
   Scenario Outline: group names are case-sensitive, sharing with groups with different upper and lower case names
@@ -26,21 +29,21 @@ Feature: share with groups, group names are case-sensitive
     When user "Brian" accepts share "/textfile1.txt" offered by user "Alice" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the content of file "/Shares/textfile1.txt" for user "Brian" should be "ownCloud test text file 1" plus end-of-line
-    When user "Alice" shares folder "textfile2.txt" with group "<group_id2>" using the sharing API
+    And the content of file "/Shares/textfile1.txt" for user "Brian" should be "ownCloud test text file 1"
+    When user "Alice" shares file "textfile2.txt" with group "<group_id2>" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     When user "Carol" accepts share "/textfile2.txt" offered by user "Alice" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the content of file "/Shares/textfile2.txt" for user "Carol" should be "ownCloud test text file 2" plus end-of-line
-    When user "Alice" shares folder "textfile3.txt" with group "<group_id3>" using the sharing API
+    And the content of file "/Shares/textfile2.txt" for user "Carol" should be "ownCloud test text file 2"
+    When user "Alice" shares file "textfile3.txt" with group "<group_id3>" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     When user "David" accepts share "/textfile3.txt" offered by user "Alice" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the content of file "/Shares/textfile3.txt" for user "David" should be "ownCloud test text file 3" plus end-of-line
+    And the content of file "/Shares/textfile3.txt" for user "David" should be "ownCloud test text file 3"
     Examples:
       | ocs_api_version | group_id1            | group_id2            | group_id3            | ocs_status_code |
       | 1               | case-sensitive-group | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | 100             |
@@ -70,7 +73,7 @@ Feature: share with groups, group names are case-sensitive
       | path        | /Shares/textfile1.txt |
       | permissions | share,read,update     |
       | uid_owner   | %username%            |
-    And the content of file "/Shares/textfile1.txt" for user "Brian" should be "ownCloud test text file 1" plus end-of-line
+    And the content of file "/Shares/textfile1.txt" for user "Brian" should be "ownCloud test text file 1"
     When user "Alice" shares file "textfile2.txt" with group "<group_id2>" using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -4,20 +4,21 @@ Feature: cannot share resources outside the group when share with membership gro
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   Scenario Outline: sharer should not be able to share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp0" has been created
     And group "grp1" has been created
     And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "PARENT"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Brian" folder "/PARENT (2)" should not exist
+    And as "Brian" folder "/PARENT" should not exist
     And as "Brian" folder "/Shares/PARENT" should not exist
     And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
@@ -28,9 +29,10 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a folder to a user who is not member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
+    And user "Alice" has created folder "PARENT"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
@@ -38,7 +40,7 @@ Feature: cannot share resources outside the group when share with membership gro
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" folder "/Shares/PARENT" should exist
-    But as "Brian" folder "/PARENT (2)" should not exist
+    But as "Brian" folder "/PARENT" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -47,10 +49,11 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a folder to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp0"
+    And user "Alice" has created folder "PARENT"
     When user "Alice" shares folder "/PARENT" with group "grp0" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
@@ -58,7 +61,7 @@ Feature: cannot share resources outside the group when share with membership gro
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" folder "/Shares/PARENT" should exist
-    But as "Brian" folder "/PARENT (2)" should not exist
+    But as "Brian" folder "/PARENT" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -67,15 +70,16 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should not be able to share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp0" has been created
     And group "grp1" has been created
     And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Brian" file "/textfile0 (2).txt" should not exist
+    And as "Brian" file "/textfile0.txt" should not exist
     And as "Brian" file "/Shares/textfile0.txt" should not exist
     And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
@@ -86,10 +90,11 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a file to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
     And user "Brian" has been added to group "grp0"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/textfile0.txt" with group "grp0" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
@@ -97,7 +102,7 @@ Feature: cannot share resources outside the group when share with membership gro
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" file "/Shares/textfile0.txt" should exist
-    But as "Brian" file "/textfile0 (2).txt" should not exist
+    But as "Brian" file "/textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -106,9 +111,10 @@ Feature: cannot share resources outside the group when share with membership gro
   Scenario Outline: sharer should be able to share a file to a user who is not a member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp0" has been created
     And user "Alice" has been added to group "grp0"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/textfile0.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
@@ -116,7 +122,7 @@ Feature: cannot share resources outside the group when share with membership gro
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" file "/Shares/textfile0.txt" should exist
-    But as "Brian" file "/textfile0 (2).txt" should not exist
+    But as "Brian" file "/textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature
@@ -4,13 +4,14 @@ Feature: share resources with a disabled user
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
   Scenario Outline: Creating a new share with a disabled user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
-    When user "Alice" shares file "welcome.txt" with user "Brian" using the sharing API
+    When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "401"
     Examples:
@@ -22,7 +23,7 @@ Feature: share resources with a disabled user
     Given using OCS API version "2"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
-    When user "Alice" shares file "welcome.txt" with user "Brian" using the sharing API
+    When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "997"
     #And the OCS status code should be "401"
     And the HTTP status code should be "401"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiShareCreateSpecialToRoot1
  - apiShareCreateSpecialToRoot2
  - apiShareCreateSpecialToShares1
  - apiShareCreateSpecialToShares2

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
