### PR TITLE
[docs-only] Fixup changelogs edited in PR 38524

### DIFF
--- a/changelog/unreleased/38462
+++ b/changelog/unreleased/38462
@@ -1,4 +1,3 @@
-Change: Update icewind/streams from 0.7.2 to 0.7.4
+Change: Update icewind/streams from 0.7.2 to 0.7.3
 
 https://github.com/owncloud/core/pull/38462
-https://github.com/owncloud/core/pull/38524

--- a/changelog/unreleased/38462-3
+++ b/changelog/unreleased/38462-3
@@ -1,4 +1,3 @@
-Change: Update icewind/streams from 0.7.2 to 0.7.4 in files_external
+Change: Update icewind/streams from 0.7.2 to 0.7.3 in files_external
 
 https://github.com/owncloud/core/pull/38462
-https://github.com/owncloud/core/pull/38524

--- a/changelog/unreleased/38462-4
+++ b/changelog/unreleased/38462-4
@@ -1,4 +1,3 @@
-Change: Update icewind/smb from 3.2.7 to 3.4.0 in files_external
+Change: Update icewind/smb from 3.2.7 to 3.3.1 in files_external
 
 https://github.com/owncloud/core/pull/38462
-https://github.com/owncloud/core/pull/38524

--- a/changelog/unreleased/38524
+++ b/changelog/unreleased/38524
@@ -1,0 +1,3 @@
+Change: Update icewind/streams from 0.7.3 to 0.7.4
+
+https://github.com/owncloud/core/pull/38524

--- a/changelog/unreleased/38524-3
+++ b/changelog/unreleased/38524-3
@@ -1,0 +1,3 @@
+Change: Update icewind/streams from 0.7.3 to 0.7.4 in files_external
+
+https://github.com/owncloud/core/pull/38524

--- a/changelog/unreleased/38524-4
+++ b/changelog/unreleased/38524-4
@@ -1,0 +1,3 @@
+Change: Update icewind/smb from 3.3.1 to 3.4.0 in files_external
+
+https://github.com/owncloud/core/pull/38524


### PR DESCRIPTION
While sorting out changelogs for the dependabot PR #38524 I edited existing changelogs related to `icewind/smb` and `icewind/.streams` - usually I do that when multiple patch bumps of the same dependency are in the "unreleased" changelog folder. That reduces the length of the changelog - every individual patch bump does not need a separate changelog entry.

But I see that there was a code-freeze last night. So what I did is not appropriate, because the patch release bumps in PR #38524 will not end up in 10.7.0 release.

This PR puts those changelog entries into separate changelog files.

I tried some local rebase of the `release-10.7.0` branch with these changes, and it does not generate conflicts, and the files in `changelog/10.7.0_2021-03-15` end up being correct for 10.7.0. So I think that this makes things good again.