### PR TITLE
[Tests-Only] used skeleton files more wisely on api share operations to features

### DIFF
--- a/tests/acceptance/features/apiShareOperationsToRoot/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/accessToShare.feature
@@ -2,10 +2,12 @@
 Feature: sharing
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
+    And user "Brian" has uploaded file with content "some data" to "/textfile0.txt"
 
   @smokeTest
   Scenario Outline: Sharee can see the share
@@ -23,6 +25,8 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Sharee can see the filtered share
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Brian" has uploaded file with content "some data" to "/textfile1.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has shared file "textfile1.txt" with user "Brian"
     When user "Brian" gets all the shares shared with him that are received as file "textfile1 (2).txt" using the provisioning API
@@ -37,6 +41,8 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Sharee can't see the share that is filtered out
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Brian" has uploaded file with content "some data" to "/textfile1.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has shared file "textfile1.txt" with user "Brian"
     When user "Brian" gets all the shares shared with him that are received as file "textfile0 (2).txt" using the provisioning API

--- a/tests/acceptance/features/apiShareOperationsToRoot/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/changingFilesShare.feature
@@ -2,10 +2,12 @@
 Feature: sharing
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
   @smokeTest
   Scenario Outline: moving a file into a share as recipient
@@ -58,7 +60,7 @@ Feature: sharing
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
-    And user "Alice" has moved file "welcome.txt" to "share1/welcome.txt"
+    And user "Alice" has moved file "textfile0.txt" to "share1/welcome.txt"
     And user "Alice" has shared folder "/share1" with user "Brian"
     And user "Alice" has shared folder "/share2" with user "Brian"
     When user "Brian" moves file "share1/welcome.txt" to "share2/welcome.txt" using the WebDAV API
@@ -73,7 +75,7 @@ Feature: sharing
     And user "Alice" has created folder "share2"
     And user "Alice" has shared folder "/share1" with user "Brian"
     And user "Alice" has shared folder "/share2" with user "Brian"
-    When user "Brian" moves file "welcome.txt" to "share1/welcome.txt" using the WebDAV API
+    When user "Brian" moves file "textfile0.txt" to "share1/welcome.txt" using the WebDAV API
     Then as "Brian" file "share1/welcome.txt" should exist
     And as "Alice" file "share1/welcome.txt" should exist
     When user "Brian" moves file "share1/welcome.txt" to "share2/welcome.txt" using the WebDAV API
@@ -82,8 +84,11 @@ Feature: sharing
 
   Scenario: Move files between shares by different users
     Given the administrator has enabled DAV tech_preview
-    And user "Carol" has been created with default attributes and small skeleton files
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Brian" has created folder "/PARENT"
+    And user "Carol" has created folder "/PARENT"
+    And user "Alice" has moved file "textfile0.txt" to "PARENT/welcome.txt"
     And user "Alice" has shared folder "/PARENT" with user "Carol"
     And user "Brian" has shared folder "/PARENT" with user "Carol"
     When user "Carol" moves file "PARENT (2)/welcome.txt" to "PARENT (3)/welcome.txt" using the WebDAV API

--- a/tests/acceptance/features/apiShareOperationsToRoot/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/gettingShares.feature
@@ -2,10 +2,11 @@
 Feature: sharing
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
 
   @smokeTest
   Scenario Outline: getting all shares of a user using that user
@@ -36,7 +37,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: getting all shares of a file
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Carol    |
       | David    |
@@ -56,12 +57,12 @@ Feature: sharing
   @smokeTest
   Scenario Outline: getting all shares of a file with reshares
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Carol    |
       | David    |
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Brian" has shared file "textfile0 (2).txt" with user "Carol"
+    And user "Brian" has shared file "textfile0.txt" with user "Carol"
     When user "Alice" gets all the shares with reshares from the file "textfile0.txt" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -77,10 +78,10 @@ Feature: sharing
   Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has been added to group "grp1"
     And user "Carol" has created folder "/shared"
-    And user "Carol" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Carol" has uploaded file "/filesForUpload/textfile.txt" to "/shared/shared_file.txt"
     And user "Carol" has shared folder "/shared" with user "Brian"
     And user "Brian" has shared folder "/shared" with group "grp1"
     When user "Carol" gets all the shares shared with him using the sharing API
@@ -96,6 +97,7 @@ Feature: sharing
   Scenario Outline: Get a share with a user that didn't receive the share
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
+    And user "Carol" has uploaded file "/filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     When user "Carol" gets the info of the last share using the sharing API
     Then the OCS status code should be "404"
@@ -108,28 +110,28 @@ Feature: sharing
   @skipOnLDAP
   Scenario: Share of folder to a group, remove user from that group
     Given using OCS API version "1"
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And group "group0" has been created
     And user "Brian" has been added to group "group0"
     And user "Carol" has been added to group "group0"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has moved file "textfile0.txt" to "PARENT/parent.txt"
     And user "Alice" has shared folder "/PARENT" with group "group0"
     When the administrator removes user "Carol" from group "group0" using the provisioning API
     Then user "Brian" should see the following elements
-      | /FOLDER/                 |
       | /PARENT/                 |
       | /PARENT/parent.txt       |
-      | /PARENT%20(2)/           |
-      | /PARENT%20(2)/parent.txt |
     And user "Carol" should see the following elements
-      | /FOLDER/           |
+      | textfile0.txt        |
+    But user "Carol" should not see the following elements
       | /PARENT/           |
       | /PARENT/parent.txt |
-    But user "Carol" should not see the following elements
-      | /PARENT%20(2)/           |
-      | /PARENT%20(2)/parent.txt |
 
   Scenario Outline: getting all the shares inside the folder
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has moved file "textfile0.txt" to "PARENT/parent.txt"
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     When user "Alice" gets all the shares inside the folder "PARENT" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"

--- a/tests/acceptance/features/apiShareOperationsToRoot/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/uploadToShare.feature
@@ -2,22 +2,23 @@
 Feature: sharing
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
 
   Scenario: Uploading file to a user read-only share folder does not work
-    Given user "Brian" has been created with default attributes and small skeleton files
+    Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
       | permissions | read   |
       | shareWith   | Brian  |
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
 
   Scenario Outline: Uploading file to a group read-only share folder does not work
     Given using <dav-path> DAV path
-    Given user "Brian" has been created with default attributes and small skeleton files
+    Given user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -25,7 +26,7 @@ Feature: sharing
       | shareType   | group  |
       | permissions | read   |
       | shareWith   | grp1   |
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/FOLDER/textfile.txt" should not exist
     Examples:
@@ -35,13 +36,13 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a user upload-only share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
       | permissions | create |
       | shareWith   | Brian  |
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
@@ -58,7 +59,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group upload-only share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -66,7 +67,7 @@ Feature: sharing
       | shareType   | group  |
       | permissions | create |
       | shareWith   | grp1   |
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
@@ -84,13 +85,13 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Uploading file to a user read/write share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
       | permissions | change |
       | shareWith   | Brian  |
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
     """
@@ -105,7 +106,7 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group read/write share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -113,7 +114,7 @@ Feature: sharing
       | shareType   | group  |
       | permissions | change |
       | shareWith   | grp1   |
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/textfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/textfile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/textfile.txt" for user "Alice" should be:
     """
@@ -129,9 +130,9 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Check quota of owners parent directory of a shared file
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And the quota of user "Brian" has been set to "0"
-    And user "Alice" has moved file "/welcome.txt" to "/myfile.txt"
+    And user "Alice" has uploaded file with content "some data" to "myfile.txt"
     And user "Alice" has shared file "myfile.txt" with user "Brian"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -150,14 +151,14 @@ Feature: sharing
 
   Scenario Outline: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
       | permissions | change |
       | shareWith   | Brian  |
     And the quota of user "Alice" has been set to "0"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
@@ -167,7 +168,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -176,7 +177,7 @@ Feature: sharing
       | permissions | change |
       | shareWith   | grp1   |
     And the quota of user "Alice" has been set to "0"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
@@ -186,14 +187,14 @@ Feature: sharing
 
   Scenario Outline: Uploading to a user shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
       | permissions | create |
       | shareWith   | Brian  |
     And the quota of user "Alice" has been set to "0"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
@@ -203,7 +204,7 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created a share with settings
@@ -212,7 +213,7 @@ Feature: sharing
       | permissions | create |
       | shareWith   | grp1   |
     And the quota of user "Alice" has been set to "0"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER (2)/myfile.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "FOLDER/myfile.txt" using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Alice" file "/FOLDER/myfile.txt" should not exist
     Examples:
@@ -222,7 +223,7 @@ Feature: sharing
 
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" creates folder "/READ_ONLY" using the WebDAV API
     And user "Alice" has created a share with settings
       | path        | /READ_ONLY |

--- a/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature
@@ -4,10 +4,11 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
 
   @smokeTest
   Scenario Outline: Sharee can see the share
@@ -26,6 +27,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Sharee can see the filtered share
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has shared file "textfile1.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
@@ -42,6 +44,7 @@ Feature: sharing
   @smokeTest @issue-ocis-reva-260
   Scenario Outline: Sharee can't see the share that is filtered out
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has shared file "textfile1.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"

--- a/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -15,6 +15,7 @@ Feature: sharing
     And user "Alice" has created folder "/shared"
     And user "Alice" has shared folder "/shared" with user "Brian"
     And user "Brian" has accepted share "/shared" offered by user "Alice"
+    And user "Brian" has uploaded file with content "some data" to "/textfile0.txt"
     When user "Brian" moves file "textfile0.txt" to "/Shares/shared/shared_file.txt" using the WebDAV API
     Then as "Brian" file "/Shares/shared/shared_file.txt" should exist
     And as "Alice" file "/shared/shared_file.txt" should exist
@@ -27,6 +28,7 @@ Feature: sharing
   Scenario Outline: moving a file out of a share as recipient creates a backup for the owner
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/shared"
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared file "/shared" with user "Brian"
     And user "Brian" has accepted share "/shared" offered by user "Alice"
@@ -45,6 +47,7 @@ Feature: sharing
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/shared"
     And user "Alice" has created folder "/shared/sub"
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
     And user "Alice" has shared file "/shared" with user "Brian"
     And user "Brian" has accepted share "/shared" offered by user "Alice"
@@ -64,27 +67,29 @@ Feature: sharing
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
-    And user "Alice" has moved file "welcome.txt" to "share1/welcome.txt"
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
+    And user "Alice" has moved file "textfile0.txt" to "share1/textfile0.txt"
     And user "Alice" has shared folder "/share1" with user "Brian"
     And user "Alice" has shared folder "/share2" with user "Brian"
     And user "Brian" has accepted share "/share1" offered by user "Alice"
     And user "Brian" has accepted share "/share2" offered by user "Alice"
-    When user "Brian" moves file "/Shares/share1/welcome.txt" to "/Shares/share2/welcome.txt" using the WebDAV API
-    Then as "Brian" file "/Shares/share1/welcome.txt" should not exist
-    But as "Brian" file "/Shares/share2/welcome.txt" should exist
-    And as "Alice" file "share1/welcome.txt" should not exist
-    But as "Alice" file "share2/welcome.txt" should exist
+    When user "Brian" moves file "/Shares/share1/textfile0.txt" to "/Shares/share2/textfile0.txt" using the WebDAV API
+    Then as "Brian" file "/Shares/share1/textfile0.txt" should not exist
+    But as "Brian" file "/Shares/share2/textfile0.txt" should exist
+    And as "Alice" file "share1/textfile0.txt" should not exist
+    But as "Alice" file "share2/textfile0.txt" should exist
 
 
   Scenario: Move files between shares by same user added by sharee
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
+    And user "Brian" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has shared folder "/share1" with user "Brian"
     And user "Alice" has shared folder "/share2" with user "Brian"
     And user "Brian" has accepted share "/share1" offered by user "Alice"
     And user "Brian" has accepted share "/share2" offered by user "Alice"
-    When user "Brian" moves file "welcome.txt" to "/Shares/share1/welcome.txt" using the WebDAV API
+    When user "Brian" moves file "textfile0.txt" to "/Shares/share1/welcome.txt" using the WebDAV API
     Then as "Brian" file "/Shares/share1/welcome.txt" should exist
     And as "Alice" file "share1/welcome.txt" should exist
     When user "Brian" moves file "/Shares/share1/welcome.txt" to "/Shares/share2/welcome.txt" using the WebDAV API
@@ -94,8 +99,11 @@ Feature: sharing
 
   Scenario: Move files between shares by different users
     Given the administrator has enabled DAV tech_preview
-    And user "Carol" has been created with default attributes and small skeleton files
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
+    And user "Alice" has created folder "/PARENT"
+    And user "Brian" has created folder "/PARENT"
+    And user "Alice" has moved file "textfile0.txt" to "PARENT/welcome.txt"
     And user "Alice" has shared folder "/PARENT" with user "Carol"
     And user "Brian" has shared folder "/PARENT" with user "Carol"
     And user "Carol" has accepted share "/PARENT" offered by user "Alice"

--- a/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -12,7 +12,7 @@ Feature: sharing
   @smokeTest @issue-ocis-reva-262
   Scenario Outline: getting all shares of a user using that user
     Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has moved file "/textfile0.txt" to "/file_to_share.txt"
+    And user "Alice" has uploaded file with content "some data" to "/file_to_share.txt"
     And user "Alice" has shared file "file_to_share.txt" with user "Brian"
     And user "Brian" has accepted share "/file_to_share.txt" offered by user "Alice"
     When user "Alice" gets all shares shared by him using the sharing API
@@ -27,6 +27,7 @@ Feature: sharing
   @issue-ocis-reva-65
   Scenario Outline: getting all shares of a user using another user
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     When the administrator gets all shares shared by him using the sharing API
@@ -41,10 +42,11 @@ Feature: sharing
   @smokeTest
   Scenario Outline: getting all shares of a file
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Carol    |
       | David    |
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has shared file "textfile0.txt" with user "Carol"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
@@ -63,10 +65,11 @@ Feature: sharing
   @smokeTest @issue-ocis-reva-243
   Scenario Outline: getting all shares of a file with reshares
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Carol    |
       | David    |
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     And user "Brian" has shared file "/Shares/textfile0.txt" with user "Carol"
@@ -86,10 +89,10 @@ Feature: sharing
   Scenario Outline: User's own shares reshared to him don't appear when getting "shared with me" shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has been added to group "grp1"
     And user "Carol" has created folder "/shared"
-    And user "Carol" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Carol" has uploaded file with content "some data" to "/shared/shared_file.txt"
     And user "Carol" has shared folder "/shared" with user "Brian"
     And user "Brian" has accepted share "/shared" offered by user "Carol"
     And user "Brian" has shared folder "/Shares/shared" with group "grp1"
@@ -107,7 +110,7 @@ Feature: sharing
   #after fixing all the issues merge this scenario with the one below
   Scenario Outline: getting share info of a share
     Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has moved file "/textfile0.txt" to "/file_to_share.txt"
+    And user "Alice" has uploaded file with content "some data" to "/file_to_share.txt"
     And user "Alice" has shared file "file_to_share.txt" with user "Brian"
     And user "Brian" has accepted share "/file_to_share.txt" offered by user "Alice"
     When user "Alice" gets the info of the last share using the sharing API
@@ -139,7 +142,7 @@ Feature: sharing
   #after fixing all the issues merge this scenario with the one above
   Scenario Outline: getting share info of a share
     Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has moved file "/textfile0.txt" to "/file_to_share.txt"
+    And user "Alice" has uploaded file with content "some data" to "/file_to_share.txt"
     And user "Alice" has shared file "file_to_share.txt" with user "Brian"
     And user "Brian" has accepted share "/file_to_share.txt" offered by user "Alice"
     When user "Alice" gets the info of the last share using the sharing API
@@ -171,6 +174,7 @@ Feature: sharing
   Scenario Outline: Get a share with a user that didn't receive the share
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     When user "Carol" gets the info of the last share using the sharing API
     Then the OCS status code should be "404"
@@ -183,24 +187,19 @@ Feature: sharing
   @skipOnLDAP @issue-ocis-reva-194
   Scenario: Share of folder to a group, remove user from that group
     Given using OCS API version "1"
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And group "group0" has been created
     And user "Brian" has been added to group "group0"
     And user "Carol" has been added to group "group0"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
     And user "Alice" has shared folder "/PARENT" with group "group0"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Carol" has accepted share "/PARENT" offered by user "Alice"
     When the administrator removes user "Carol" from group "group0" using the provisioning API
     Then user "Brian" should see the following elements
-      | /FOLDER/                  |
-      | /PARENT/                  |
-      | /PARENT/parent.txt        |
       | /Shares/PARENT/           |
       | /Shares/PARENT/parent.txt |
-    And user "Carol" should see the following elements
-      | /FOLDER/           |
-      | /PARENT/           |
-      | /PARENT/parent.txt |
     But user "Carol" should not see the following elements
       | /Shares/PARENT/           |
       | /Shares/PARENT/parent.txt |
@@ -208,6 +207,8 @@ Feature: sharing
   @issue-ocis-reva-372
   Scenario Outline: getting all the shares inside the folder
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Alice"
     When user "Alice" gets all the shares inside the folder "PARENT" using the sharing API

--- a/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature
@@ -4,11 +4,12 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
 
   Scenario: Uploading file to a user read-only share folder does not work
-    Given user "Brian" has been created with default attributes and small skeleton files
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -22,9 +23,10 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group read-only share folder does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | group  |
@@ -42,7 +44,8 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a user upload-only share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -67,9 +70,10 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group upload-only share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | group  |
@@ -94,7 +98,8 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Uploading file to a user read/write share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -117,9 +122,10 @@ Feature: sharing
 
   Scenario Outline: Uploading file to a group read/write share folder works
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | group  |
@@ -142,9 +148,9 @@ Feature: sharing
   @smokeTest
   Scenario Outline: Check quota of owners parent directory of a shared file
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And the quota of user "Brian" has been set to "0"
-    And user "Alice" has moved file "/welcome.txt" to "/myfile.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/myfile.txt"
     And user "Alice" has shared file "myfile.txt" with user "Brian"
     And user "Brian" has accepted share "/myfile.txt" offered by user "Alice"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/myfile.txt" using the WebDAV API
@@ -166,6 +172,7 @@ Feature: sharing
   Scenario Outline: Uploading to a user shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -184,9 +191,10 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with read/write permission when the sharer has unsufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | group  |
@@ -205,7 +213,8 @@ Feature: sharing
 
   Scenario Outline: Uploading to a user shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |
@@ -224,9 +233,10 @@ Feature: sharing
 
   Scenario Outline: Uploading to a group shared folder with upload-only permission when the sharer has insufficient quota does not work
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | group  |
@@ -245,7 +255,7 @@ Feature: sharing
 
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" creates folder "/READ_ONLY" using the WebDAV API
     And user "Alice" has created a share with settings
       | path        | /READ_ONLY |
@@ -263,7 +273,8 @@ Feature: sharing
 
   Scenario Outline: Sharer can download file uploaded with different permission by sharee to a shared folder
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER        |
       | shareType   | user          |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiShareOperationsToRoot
  - apiShareOperationsToShares

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
