### PR TITLE
[Tests-Only] used small skeletons more wisely on share management test features

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
@@ -3,13 +3,13 @@ Feature: sharing
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
 
   @smokeTest
   @skipOnEncryptionType:user-keys @issue-32322
   Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -61,6 +61,7 @@ Feature: sharing
   Scenario Outline: Creating a share of a file with a user and asking for various permission combinations
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" with permissions <requested_permissions> using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -144,6 +145,7 @@ Feature: sharing
   Scenario Outline: Creating a share of a file with a group, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -264,6 +266,7 @@ Feature: sharing
   Scenario Outline: user shares a file with file name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "Alice" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -279,6 +282,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "Alice" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -292,6 +296,7 @@ Feature: sharing
   Scenario Outline: user shares a folder with folder name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "Alice" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/textfile0.txt"
     When user "Alice" shares folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" with user "Brian" using the sharing API
@@ -308,6 +313,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "Alice" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/textfile0.txt"
     When user "Alice" shares folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" with group "grp1" using the sharing API
@@ -414,6 +420,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with group "grp1"
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "<ocs_status_code>"
@@ -511,6 +518,7 @@ Feature: sharing
       | username |
       | Brian    |
       | Carol    |
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has shared file "textfile0.txt" with user "Carol"
     And the administrator has deleted user "Brian" using the provisioning API

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
@@ -1,16 +1,18 @@
 @api @files_sharing-app-required @notToImplementOnOCIS
 Feature: sharing
 
-  Scenario Outline: Delete all group shares
-    Given these users have been created with default attributes and small skeleton files:
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
-    And using OCS API version "<ocs_api_version>"
+
+  Scenario Outline: Delete all group shares
+    Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has shared file "textfile0.txt" with group "grp1"
-    And user "Brian" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has shared file "fileToShare.txt" with group "grp1"
     When user "Alice" deletes the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -22,10 +24,9 @@ Feature: sharing
 
   @smokeTest
   Scenario Outline: delete a share
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
-    And using OCS API version "<ocs_api_version>"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has shared file "fileToShare.txt" with user "Brian"
     When user "Alice" deletes the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -37,10 +38,6 @@ Feature: sharing
 
   Scenario: orphaned shares
     Given using OCS API version "1"
-    And these users have been created with default attributes and without skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
     And user "Alice" has created folder "/common"
     And user "Alice" has created folder "/common/sub"
     And user "Alice" has shared folder "/common/sub" with user "Brian"
@@ -51,10 +48,9 @@ Feature: sharing
   @smokeTest @files_trashbin-app-required
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
-    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has moved file "/fileToShare.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with user "Brian"
     When user "Brian" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -66,11 +62,9 @@ Feature: sharing
   @files_trashbin-app-required
   Scenario: deleting a folder out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has created folder "/shared/sub"
-    And user "Alice" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "shared/sub/shared_file.txt"
     And user "Alice" has shared folder "/shared" with user "Brian"
     When user "Brian" deletes folder "/shared/sub" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -86,11 +80,11 @@ Feature: sharing
     And group "grp1" has been created
     And these users have been created with default attributes and without skeleton files:
       | username |
-      | Alice    |
-      | Brian    |
-    And user "Carol" has been created with default attributes and small skeleton files
+      | Carol    |
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Carol" has created folder "/PARENT"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
     And user "Carol" has shared file "/PARENT/parent.txt" with group "grp1"
     And user "Carol" has stored etag of element "/PARENT"
     And user "Brian" has stored etag of element "/"
@@ -101,10 +95,8 @@ Feature: sharing
 
   Scenario: sharee of a read-only share folder tries to delete the shared folder
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
-    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "shared/shared_file.txt"
     And user "Alice" has shared folder "shared" with user "Brian" with permissions "read"
     When user "Brian" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -112,10 +104,8 @@ Feature: sharing
 
   Scenario: sharee of a upload-only shared folder tries to delete a file in the shared folder
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
-    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "shared/shared_file.txt"
     And user "Alice" has shared folder "shared" with user "Brian" with permissions "create"
     When user "Brian" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -123,10 +113,6 @@ Feature: sharing
 
   Scenario: sharee of an upload-only shared folder tries to delete their file in the folder
     Given using OCS API version "1"
-    And these users have been created with default attributes and without skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
     And user "Alice" has created folder "/shared"
     And user "Alice" has shared folder "shared" with user "Brian" with permissions "create"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "shared/textfile.txt" using the WebDAV API
@@ -137,13 +123,13 @@ Feature: sharing
   Scenario Outline: A Group share recipient tries to delete the share
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Alice" has been created with default attributes and small skeleton files
     And these users have been created with default attributes and without skeleton files:
       | username |
-      | Brian    |
       | Carol    |
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
     And user "Alice" has shared entry "<entry_to_share>" with group "grp1"
     When user "Brian" deletes the last share using the sharing API
     Then the OCS status code should be "404"
@@ -160,8 +146,8 @@ Feature: sharing
 
   Scenario Outline: An individual share recipient tries to delete the share
     Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
     And user "Alice" has shared entry "<entry_to_share>" with user "Brian"
     When user "Brian" deletes the last share using the sharing API
     Then the OCS status code should be "404"
@@ -176,13 +162,9 @@ Feature: sharing
       | /PARENT            | 2               | 404              | PARENT         |
 
   Scenario Outline: delete a share with wrong authentication
-    Given these users have been created with default attributes and without skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
-    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
-    And using OCS API version "<ocs_api_version>"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has shared file "fileToShare.txt" with user "Brian"
     When user "Brian" tries to delete the last share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/excludeGroupFromReceivingShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/excludeGroupFromReceivingShares.feature
@@ -5,7 +5,7 @@ Feature: Exclude groups from receiving shares
   So that users do not mistakenly share with groups they should not e.g. huge meta groups
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -18,21 +18,23 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: user cannot share with a group that is excluded from receiving shares but can share with other groups
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
-    And user "Alice" shares file "welcome.txt" with group "grp1" using the sharing API
+    And user "Alice" shares file "fileToShare.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status message should be "The group is blacklisted for sharing"
-    And as "Brian" file "/welcome (2).txt" should not exist
+    And as "Brian" file "/fileToShare.txt" should not exist
     When user "Alice" shares folder "PARENT" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status message should be "The group is blacklisted for sharing"
-    And as "Brian" folder "/PARENT (2)" should not exist
-    When user "Alice" shares file "welcome.txt" with group "grp2" using the sharing API
+    And as "Brian" folder "/PARENT" should not exist
+    When user "Alice" shares file "fileToShare.txt" with group "grp2" using the sharing API
     And user "Alice" shares folder "PARENT" with group "grp2" using the sharing API
-    Then as "David" file "/welcome (2).txt" should exist
-    And as "David" folder "/PARENT (2)" should exist
+    Then as "David" file "/fileToShare.txt" should exist
+    And as "David" folder "/PARENT" should exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -40,21 +42,24 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: exclude multiple groups from receiving shares stops the user to share with any of them
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     And group "grp3" has been created
     And user "Brian" has been added to group "grp3"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
     And the administrator adds group "grp2" to the exclude groups from receiving shares list using the occ command
     And the administrator adds group "grp3" to the exclude groups from receiving shares list using the occ command
-    And user "Alice" shares file "welcome.txt" with group "grp1" using the sharing API
+    And user "Alice" shares file "fileToShare.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status message should be "The group is blacklisted for sharing"
-    And as "Brian" file "/welcome (2).txt" should not exist
+    And as "Brian" file "/fileToShare.txt" should not exist
     When user "Alice" shares folder "PARENT" with group "grp2" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status message should be "The group is blacklisted for sharing"
-    And as "Brian" folder "/PARENT (2)" should not exist
+    And as "Brian" folder "/PARENT" should not exist
     When user "Alice" shares folder "PARENT/CHILD" with group "grp3" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
@@ -67,23 +72,25 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: user cannot reshare a received share with a group that is excluded from receiving shares but can share with other groups
     Given using OCS API version "<ocs_api_version>"
-    And user "Carol" has shared file "textfile0.txt" with user "Alice"
+    And user "Carol" has created folder "PARENT"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Carol" has shared file "fileToShare.txt" with user "Alice"
     And user "Carol" has shared folder "PARENT" with user "Alice"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
-    And user "Alice" shares file "textfile0 (2).txt" with group "grp1" using the sharing API
+    And user "Alice" shares file "fileToShare.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status message should be "The group is blacklisted for sharing"
-    And as "Brian" file "/textfile0 (2).txt" should not exist
-    When user "Alice" shares folder "PARENT (2)" with group "grp1" using the sharing API
+    And as "Brian" file "/fileToShare.txt" should not exist
+    When user "Alice" shares folder "PARENT" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status message should be "The group is blacklisted for sharing"
-    And as "Brian" folder "/PARENT (2)" should not exist
-    When user "Alice" shares file "textfile0 (2).txt" with group "grp2" using the sharing API
-    And user "Alice" shares folder "PARENT (2)" with group "grp2" using the sharing API
-    Then as "David" file "/textfile0 (2).txt" should exist
-    And as "David" folder "/PARENT (2)" should exist
+    And as "Brian" folder "/PARENT" should not exist
+    When user "Alice" shares file "fileToShare.txt" with group "grp2" using the sharing API
+    And user "Alice" shares folder "PARENT" with group "grp2" using the sharing API
+    Then as "David" file "/fileToShare.txt" should exist
+    And as "David" folder "/PARENT" should exist
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -91,15 +98,17 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: sharing with a user that is part of a group that is excluded from receiving shares still works
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
-    And user "Alice" shares file "welcome.txt" with user "Brian" using the sharing API
+    And user "Alice" shares file "fileToShare.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     When user "Alice" shares folder "PARENT" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    Then as "Brian" file "/welcome (2).txt" should exist
-    And as "Brian" folder "/PARENT (2)" should exist
+    Then as "Brian" file "/fileToShare.txt" should exist
+    And as "Brian" folder "/PARENT" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -107,17 +116,19 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: sharing with a user that is part of a group that is excluded from receiving shares using an other group works
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     And group "grp3" has been created
     And user "Brian" has been added to group "grp3"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
-    And user "Alice" shares file "welcome.txt" with group "grp3" using the sharing API
+    And user "Alice" shares file "fileToShare.txt" with group "grp3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     When user "Alice" shares folder "PARENT" with group "grp3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    Then as "Brian" file "/welcome (2).txt" should exist
-    And as "Brian" folder "/PARENT (2)" should exist
+    Then as "Brian" file "/welcome.txt" should exist
+    And as "Brian" folder "/PARENT" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -125,15 +136,17 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: a user that is part of a group that is excluded from receiving shares still can initiate shares
     Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has created folder "PARENT"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
-    And user "Brian" shares file "welcome.txt" with user "Carol" using the sharing API
+    And user "Brian" shares file "fileToShare.txt" with user "Carol" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And user "Brian" shares folder "PARENT" with user "Carol" using the sharing API
+    When user "Brian" shares folder "PARENT" with user "Carol" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    Then as "Carol" file "/welcome (2).txt" should exist
-    And as "Carol" folder "/PARENT (2)" should exist
+    And as "Carol" file "/fileToShare.txt" should exist
+    And as "Carol" folder "/PARENT" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -5,13 +5,13 @@ Feature: sharing
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
 
   @smokeTest
   @skipOnEncryptionType:user-keys @issue-32322
   Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -70,6 +70,7 @@ Feature: sharing
   Scenario Outline: Creating a share of a file with a user and asking for various permission combinations
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" shares file "textfile0.txt" with user "Brian" with permissions <requested_permissions> using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -159,6 +160,7 @@ Feature: sharing
   Scenario Outline: Creating a share of a file with a group, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -292,6 +294,7 @@ Feature: sharing
   Scenario Outline: user shares a file with file name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "Alice" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -311,6 +314,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt"
     When user "Alice" shares file "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -328,6 +332,7 @@ Feature: sharing
   Scenario Outline: user shares a folder with folder name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "Alice" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/textfile0.txt"
     When user "Alice" shares folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" with user "Brian" using the sharing API
@@ -348,6 +353,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has created folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog"
     And user "Alice" has moved file "textfile0.txt" to "aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog/textfile0.txt"
     When user "Alice" shares folder "/aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog" with group "grp1" using the sharing API
@@ -472,6 +478,7 @@ Feature: sharing
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with group "grp1"
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/shares"
     Then the OCS status code should be "<ocs_status_code>"
@@ -586,6 +593,7 @@ Feature: sharing
   Scenario Outline: Creating a share of a renamed file
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" moves file "textfile0.txt" to "renamed.txt" using the WebDAV API
     When user "Alice" shares file "renamed.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -617,6 +625,7 @@ Feature: sharing
       | username |
       | Brian    |
       | Carol    |
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has shared file "textfile0.txt" with user "Carol"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
@@ -669,6 +678,7 @@ Feature: sharing
   Scenario Outline: Sharing a same file twice to the same group is not possible
     Given using OCS API version "<ocs-api-version>"
     And group "grp1" has been created
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
     When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
     Then the HTTP status code should be "<http-status>"

--- a/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -88,11 +88,13 @@ Feature: sharing
   @smokeTest
   Scenario: unshare from self
     And group "grp1" has been created
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Carol    |
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Carol" has created folder "PARENT"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Carol" has shared file "/PARENT/parent.txt" with group "grp1"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Carol"
     And user "Carol" has stored etag of element "/PARENT"

--- a/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
@@ -7,7 +7,7 @@ Feature: Exclude groups from receiving shares
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -20,8 +20,10 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: user cannot share with a group that is excluded from receiving shares but can share with other groups
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
-    And user "Alice" shares file "welcome.txt" with group "grp1" using the sharing API
+    And user "Alice" shares file "fileToShare.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status message should be "The group is blacklisted for sharing"
@@ -31,11 +33,11 @@ Feature: Exclude groups from receiving shares
     And the HTTP status code should be "<http_status_code>"
     And the OCS status message should be "The group is blacklisted for sharing"
     And the sharing API should report to user "Brian" that no shares are in the pending state
-    When user "Alice" shares file "welcome.txt" with group "grp2" using the sharing API
+    When user "Alice" shares file "fileToShare.txt" with group "grp2" using the sharing API
     And user "Alice" shares folder "PARENT" with group "grp2" using the sharing API
-    And user "David" accepts share "/welcome.txt" offered by user "Alice" using the sharing API
+    And user "David" accepts share "/fileToShare.txt" offered by user "Alice" using the sharing API
     And user "David" accepts share "/PARENT" offered by user "Alice" using the sharing API
-    Then as "David" file "/Shares/welcome.txt" should exist
+    Then as "David" file "/Shares/fileToShare.txt" should exist
     And as "David" folder "/Shares/PARENT" should exist
     Examples:
       | ocs_api_version | http_status_code |
@@ -46,10 +48,13 @@ Feature: Exclude groups from receiving shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp3" has been created
     And user "Brian" has been added to group "grp3"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
     And the administrator adds group "grp2" to the exclude groups from receiving shares list using the occ command
     And the administrator adds group "grp3" to the exclude groups from receiving shares list using the occ command
-    And user "Alice" shares file "welcome.txt" with group "grp1" using the sharing API
+    And user "Alice" shares file "fileToShare.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     And the OCS status message should be "The group is blacklisted for sharing"
@@ -71,6 +76,8 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: user cannot reshare a received share with a group that is excluded from receiving shares but can share with other groups
     Given using OCS API version "<ocs_api_version>"
+    And user "Carol" has created folder "PARENT"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Carol" has shared file "textfile0.txt" with user "Alice"
     And user "Alice" has accepted share "/textfile0.txt" offered by user "Carol"
     And user "Carol" has shared folder "PARENT" with user "Alice"
@@ -99,16 +106,18 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: sharing with a user that is part of a group that is excluded from receiving shares still works
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
-    And user "Alice" shares file "welcome.txt" with user "Brian" using the sharing API
+    And user "Alice" shares file "fileToShare.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     When user "Alice" shares folder "PARENT" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When user "Brian" accepts share "/welcome.txt" offered by user "Alice" using the sharing API
+    When user "Brian" accepts share "/fileToShare.txt" offered by user "Alice" using the sharing API
     And user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
-    Then as "Brian" file "/Shares/welcome.txt" should exist
+    Then as "Brian" file "/Shares/fileToShare.txt" should exist
     And as "Brian" folder "/Shares/PARENT" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -119,16 +128,18 @@ Feature: Exclude groups from receiving shares
     Given using OCS API version "<ocs_api_version>"
     And group "grp3" has been created
     And user "Brian" has been added to group "grp3"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
-    And user "Alice" shares file "welcome.txt" with group "grp3" using the sharing API
+    And user "Alice" shares file "fileToShare.txt" with group "grp3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     When user "Alice" shares folder "PARENT" with group "grp3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When user "Brian" accepts share "/welcome.txt" offered by user "Alice" using the sharing API
+    When user "Brian" accepts share "/fileToShare.txt" offered by user "Alice" using the sharing API
     And user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
-    Then as "Brian" file "/Shares/welcome.txt" should exist
+    Then as "Brian" file "/Shares/fileToShare.txt" should exist
     And as "Brian" folder "/Shares/PARENT" should exist
     Examples:
       | ocs_api_version | ocs_status_code |
@@ -137,16 +148,18 @@ Feature: Exclude groups from receiving shares
 
   Scenario Outline: a user that is part of a group that is excluded from receiving shares still can initiate shares
     Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has created folder "PARENT"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When the administrator adds group "grp1" to the exclude groups from receiving shares list using the occ command
-    And user "Brian" shares file "welcome.txt" with user "Carol" using the sharing API
+    And user "Brian" shares file "fileToShare.txt" with user "Carol" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And user "Brian" shares folder "PARENT" with user "Carol" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    When user "Carol" accepts share "/welcome.txt" offered by user "Brian" using the sharing API
+    When user "Carol" accepts share "/fileToShare.txt" offered by user "Brian" using the sharing API
     And user "Carol" accepts share "/PARENT" offered by user "Brian" using the sharing API
-    Then as "Carol" file "/Shares/welcome.txt" should exist
+    Then as "Carol" file "/Shares/fileToShare.txt" should exist
     And as "Carol" folder "/Shares/PARENT" should exist
     Examples:
       | ocs_api_version | ocs_status_code |

--- a/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
@@ -7,7 +7,7 @@ Feature: accept/decline shares coming from internal users
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -15,10 +15,26 @@ Feature: accept/decline shares coming from internal users
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "FOLDER"
+    And user "Brian" has created folder "PARENT"
+    And user "Brian" has created folder "FOLDER"
+    And user "Carol" has created folder "PARENT"
+    And user "Carol" has created folder "FOLDER"
+    And user "Alice" has uploaded file with content "ownCloud text file 0" to "/textfile0.txt"
+    And user "Brian" has uploaded file with content "ownCloud text file 0" to "/textfile0.txt"
+    And user "Carol" has uploaded file with content "ownCloud text file 0" to "/textfile0.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file parent" to "/PARENT/parent.txt"
+    And user "Brian" has uploaded file with content "ownCloud test text file parent" to "/PARENT/parent.txt"
+    And user "Carol" has uploaded file with content "ownCloud test text file parent" to "/PARENT/parent.txt"
 
   @smokeTest
   Scenario Outline: share a file & folder with another internal user with different permissions when auto accept is enabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Brian" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file with content "ownCloud test text file child" to "/PARENT/CHILD/child.txt"
+    And user "Brian" has uploaded file with content "ownCloud test text file child" to "/PARENT/CHILD/child.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | PARENT        |
       | shareType   | user          |
@@ -39,7 +55,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT (2)/       |
       | /textfile0 (2).txt |
     And  the downloaded content when downloading file "/PARENT (2)/CHILD/child.txt" for user "Brian" with range "bytes=19-28" should be "file child"
-    And  the downloaded content when downloading file "/textfile0 (2).txt" for user "Brian" with range "bytes=14-24" should be "text file 0"
+    And  the downloaded content when downloading file "/textfile0 (2).txt" for user "Brian" with range "bytes=14-24" should be "file 0"
     Examples:
       | permissions |
       | read        |
@@ -74,6 +90,12 @@ Feature: accept/decline shares coming from internal users
 
   Scenario Outline: share a file & folder with internal group with different permissions when auto accept is enabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Brian" has created folder "PARENT/CHILD"
+    And user "Carol" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file with content "ownCloud test text file child" to "/PARENT/CHILD/child.txt"
+    And user "Brian" has uploaded file with content "ownCloud test text file child" to "/PARENT/CHILD/child.txt"
+    And user "Carol" has uploaded file with content "ownCloud test text file child" to "/PARENT/CHILD/child.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | PARENT        |
       | shareType   | group         |
@@ -105,7 +127,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT (2)/       |
       | /textfile0 (2).txt |
     And  the downloaded content when downloading file "/PARENT (2)/CHILD/child.txt" for user "Carol" with range "bytes=19-28" should be "file child"
-    And  the downloaded content when downloading file "/textfile0 (2).txt" for user "Carol" with range "bytes=14-24" should be "text file 0"
+    And  the downloaded content when downloading file "/textfile0 (2).txt" for user "Carol" with range "bytes=14-24" should be "file 0"
     Examples:
       | permissions |
       | read        |
@@ -549,7 +571,8 @@ Feature: accept/decline shares coming from internal users
 
   Scenario: user accepts shares received from multiple users with the same name when auto-accept share is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-    And user "David" has been created with default attributes and small skeleton files
+    And user "David" has been created with default attributes and without skeleton files
+    And user "David" has created folder "/PARENT"
     And user "Brian" has shared folder "/PARENT" with user "Alice"
     And user "Carol" has shared folder "/PARENT" with user "Alice"
     When user "Alice" accepts share "/PARENT" offered by user "Brian" using the sharing API
@@ -621,6 +644,9 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/FOLDER (2)/abc.txt" for user "Carol" should be "uploaded content"
 
   Scenario: user shares files in a group with matching file-names for every users involved in sharing
+    Given user "Alice" has uploaded file with content "ownCloud text file 1" to "/textfile1.txt"
+    And user "Brian" has uploaded file with content "ownCloud text file 1" to "/textfile1.txt"
+    And user "Carol" has uploaded file with content "ownCloud text file 1" to "/textfile1.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     And user "Alice" shares file "/textfile1.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "100"
@@ -699,7 +725,7 @@ Feature: accept/decline shares coming from internal users
 
   @issue-ocis-765
   Scenario: shares exist after restoring already shared file to a previous version
-    And user "Alice" has uploaded file with content "Test Content." to "/toShareFile.txt"
+    Given user "Alice" has uploaded file with content "Test Content." to "/toShareFile.txt"
     And user "Alice" has uploaded file with content "Content Test Updated." to "/toShareFile.txt"
     And user "Alice" has shared file "/toShareFile.txt" with user "Brian"
     When user "Alice" restores version index "1" of file "/toShareFile.txt" using the WebDAV API

--- a/tests/acceptance/features/apiShareManagementToRoot/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/disableSharing.feature
@@ -5,7 +5,7 @@ Feature: sharing
   So that ownCloud users cannot share file or folder
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -24,6 +24,7 @@ Feature: sharing
 
   Scenario Outline: user tries to share a folder with another user when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/FOLDER"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
     Then user "Alice" should not be able to share folder "/FOLDER" with user "Brian" using the sharing API
     And the OCS status code should be "404"
@@ -48,6 +49,7 @@ Feature: sharing
 
   Scenario Outline: user tries to share a folder with group when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/FOLDER"
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
@@ -73,6 +75,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: user tries to create public link share of a folder when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/FOLDER"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
     Then user "Alice" should not be able to create a public link share of folder "/FOLDER" using the sharing API
     And the OCS status code should be "404"
@@ -99,7 +102,7 @@ Feature: sharing
   Scenario Outline: user shares a file with user who is in their group when sharing outside the group has been restricted
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -115,7 +118,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp2" has been created
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp2"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -144,7 +147,7 @@ Feature: sharing
   Scenario Outline: user who is a member of a group tries to share a file in the group when group sharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
     When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"

--- a/tests/acceptance/features/apiShareManagementToRoot/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/mergeShare.feature
@@ -3,7 +3,7 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
@@ -3,7 +3,7 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareOc10Issue30325.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareOc10Issue30325.feature
@@ -3,7 +3,7 @@ Feature: sharing - current oC10 behavior for issue-30325
 
   Background:
     Given using OCS API version "1"
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
@@ -9,7 +9,7 @@ Feature: accept/decline shares coming from internal users
     And auto-accept shares has been disabled
     And using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -17,9 +17,20 @@ Feature: accept/decline shares coming from internal users
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
+    And user "Brian" has created folder "PARENT"
+    And user "Brian" has created folder "FOLDER"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
 
   @smokeTest
   Scenario: share a file & folder with another internal group when auto accept is disabled
+    Given user "Carol" has created folder "FOLDER"
+    And user "Carol" has created folder "PARENT"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
     And user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "100"
@@ -296,8 +307,10 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/Shares/testfile (2) (2).txt" for user "Carol" should be "First file"
 
   Scenario: user accepts shares received from multiple users with the same name when auto-accept share is disabled
-    Given user "David" has been created with default attributes and small skeleton files
+    Given user "David" has been created with default attributes and without skeleton files
+    And user "David" has created folder "PARENT"
     And user "Brian" has shared folder "/PARENT" with user "Alice"
+    And user "Carol" has created folder "PARENT"
     And user "Carol" has shared folder "/PARENT" with user "Alice"
     And user "Alice" has created folder "Shares"
     And user "Alice" has created folder "Shares/PARENT"
@@ -342,6 +355,8 @@ Feature: accept/decline shares coming from internal users
   Scenario: user shares folder in a group with matching folder-name for every users involved
     Given user "Alice" uploads file with content "uploaded content" to "/PARENT/abc.txt" using the WebDAV API
     And user "Alice" uploads file with content "uploaded content" to "/FOLDER/abc.txt" using the WebDAV API
+    And user "Carol" has created folder "PARENT"
+    And user "Carol" has created folder "FOLDER"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
     And user "Alice" shares folder "/FOLDER" with group "grp1" using the sharing API
     Then the OCS status code should be "100"
@@ -376,6 +391,10 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/Shares/FOLDER/abc.txt" for user "Carol" should be "uploaded content"
 
   Scenario: user shares files in a group with matching file-names for every users involved in sharing
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     And user "Alice" shares file "/textfile1.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "100"
@@ -415,6 +434,7 @@ Feature: accept/decline shares coming from internal users
       | /Shares/textfile0.txt |
 
   Scenario: user shares file in a group with matching filename when auto accept is disabled
+    Given user "Carol" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
@@ -9,24 +9,28 @@ Feature: accept/decline shares coming from internal users to the Shares folder
     And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
 
   Scenario: When accepting a share of a file, the received file is accessible
-    Given user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
     When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    Then the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+    Then the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0"
 
   Scenario: When accepting a share of a folder, the received folder is accessible
-    Given user "Alice" has shared file "/PARENT" with user "Brian"
+    Given user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
+    And user "Alice" has shared file "/PARENT" with user "Brian"
     When user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
-    Then the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line
+    Then the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent"
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: When accepting a share of a file, the response is valid
-    Given user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
     When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -42,11 +46,13 @@ Feature: accept/decline shares coming from internal users to the Shares folder
       | mimetype               | text/plain            |
       | storage_id             | ANY_VALUE             |
       | share_type             | user                  |
-    And the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0"
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario: When accepting a share of a folder, the response is valid
-    Given user "Alice" has shared file "/PARENT" with user "Brian"
+    Given user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
+    And user "Alice" has shared file "/PARENT" with user "Brian"
     When user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
@@ -62,4 +68,4 @@ Feature: accept/decline shares coming from internal users to the Shares folder
       | mimetype               | httpd/unix-directory |
       | storage_id             | ANY_VALUE            |
       | share_type             | user                 |
-    And the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line
+    And the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent"

--- a/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using OCS API version "1"
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using OCS API version "1"
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -100,7 +100,8 @@ Feature: sharing
     But as "Brian" file "/myFolder/fileInside" should exist
 
   Scenario: receiver renames a received folder share to a different name on the same folder
-    Given user "Alice" has shared folder "PARENT" with user "Brian"
+    Given user "Alice" has created folder "PARENT"
+    And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -108,9 +109,10 @@ Feature: sharing
     But as "Alice" folder "myFolder" should not exist
 
   Scenario: receiver renames a received file share to different name on the same folder
-    Given user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
-    When user "Brian" moves file "/Shares/textfile0.txt" to "/Shares/newFile.txt" using the WebDAV API
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has shared file "fileToShare.txt" with user "Brian"
+    And user "Brian" has accepted share "/fileToShare.txt" offered by user "Alice"
+    When user "Brian" moves file "/Shares/fileToShare.txt" to "/Shares/newFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "/Shares/newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
@@ -118,15 +120,17 @@ Feature: sharing
   Scenario: receiver renames a received file share to different name on the same folder for group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has shared file "textfile0.txt" with group "grp1"
-    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
-    When user "Brian" moves file "/Shares/textfile0.txt" to "/Shares/newFile.txt" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has shared file "fileToShare.txt" with group "grp1"
+    And user "Brian" has accepted share "/fileToShare.txt" offered by user "Alice"
+    When user "Brian" moves file "/Shares/fileToShare.txt" to "/Shares/newFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "/Shares/newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
 
   Scenario: receiver renames a received folder share to different name on the same folder for group sharing
     Given group "grp1" has been created
+    And user "Alice" has created folder "PARENT"
     And user "Brian" has been added to group "grp1"
     And user "Alice" has shared folder "PARENT" with group "grp1"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
@@ -138,15 +142,17 @@ Feature: sharing
   Scenario: receiver renames a received file share with read,update,share permissions in group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has shared file "textfile0.txt" with group "grp1" with permissions "read,update,share"
-    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
-    When user "Brian" moves folder "/Shares/textfile0.txt" to "newFile.txt" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has shared file "fileToShare.txt" with group "grp1" with permissions "read,update,share"
+    And user "Brian" has accepted share "/fileToShare.txt" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/fileToShare.txt" to "newFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
 
   Scenario: receiver renames a received folder share with share, read, change permissions in group sharing
     Given group "grp1" has been created
+    And user "Alice" has created folder "PARENT"
     And user "Brian" has been added to group "grp1"
     And user "Alice" has shared folder "PARENT" with group "grp1" with permissions "share,read,change"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
@@ -158,15 +164,17 @@ Feature: sharing
   Scenario: receiver tries to rename a received file share with share, read permissions in group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
-    And user "Alice" has shared file "textfile0.txt" with group "grp1" with permissions "share,read"
-    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
-    When user "Brian" moves file "/Shares/textfile0.txt" to "/newFile.txt" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has shared file "fileToShare.txt" with group "grp1" with permissions "share,read"
+    And user "Brian" has accepted share "/fileToShare.txt" offered by user "Alice"
+    When user "Brian" moves file "/Shares/fileToShare.txt" to "/newFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Brian" file "newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
 
   Scenario: receiver tries to rename a received folder share with share, read permissions in group sharing
     Given group "grp1" has been created
+    And user "Alice" has created folder "PARENT"
     And user "Brian" has been added to group "grp1"
     And user "Alice" has shared folder "PARENT" with group "grp1" with permissions "share,read"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
@@ -223,6 +231,7 @@ Feature: sharing
 
   Scenario: receiver moves file within a received folder to new folder
     Given user "Alice" has created folder "folderToShare"
+    And user "Brian" has created folder "FOLDER"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileToShare1.txt"
     And user "Alice" has uploaded file with content "thisIsAnotherFileInsideTheSharedFolder" to "/folderToShare/fileToShare2.txt"
     And user "Alice" has shared folder "folderToShare" with user "Brian" with permissions "share,read,change"

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -2,7 +2,7 @@
 Feature: sharees
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | sharee1  |
@@ -453,7 +453,7 @@ Feature: sharees
   @skipOnLDAP
   Scenario Outline: Enumerate only group members - only show partial results from member of groups
     Given using OCS API version "<ocs-api-version>"
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username | displayname |
       | another  | Another     |
     And user "Another" has been added to group "ShareeGroup2"
@@ -538,7 +538,7 @@ Feature: sharees
       | 2               | 200        | 200         |
 
   Scenario Outline: Search without exact match such that the search string matches the user getting the sharees
-    Given user "sharee2" has been created with default attributes and small skeleton files
+    Given user "sharee2" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | search   | sharee |
@@ -563,7 +563,7 @@ Feature: sharees
   @skipOnOcV10
   Scenario Outline: empty search for sharees when search min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
-    And user "sharee2" has been created with default attributes and small skeleton files
+    And user "sharee2" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | search   |      |
@@ -589,7 +589,7 @@ Feature: sharees
   @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario Outline: empty search for sharees when search min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
-    And user "sharee2" has been created with default attributes and small skeleton files
+    And user "sharee2" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | search   |      |
@@ -610,7 +610,7 @@ Feature: sharees
 
   Scenario Outline: search for sharees when search min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
-    And user "sharee2" has been created with default attributes and small skeleton files
+    And user "sharee2" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | search   | sh   |
@@ -635,7 +635,7 @@ Feature: sharees
 
   Scenario Outline: search for sharees with long name when search min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
-    And user "sharee2" has been created with default attributes and small skeleton files
+    And user "sharee2" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | search   | sharee |
@@ -660,7 +660,7 @@ Feature: sharees
   @skipOnOcV10
   Scenario Outline: search for sharees without search when min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
-    And user "sharee2" has been created with default attributes and small skeleton files
+    And user "sharee2" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | itemType | file |
@@ -685,7 +685,7 @@ Feature: sharees
   @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario Outline: search for sharees without search when min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
-    And user "sharee2" has been created with default attributes and small skeleton files
+    And user "sharee2" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | itemType | file |

--- a/tests/acceptance/features/apiSharees/shareesIssue38501.feature
+++ b/tests/acceptance/features/apiSharees/shareesIssue38501.feature
@@ -5,20 +5,22 @@ Feature: Test for issue owncloud/core 38501
   apiSharees/sharees.feature:519
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | sharee1  |
-    Given these users have been created with small skeleton files:
+      | sharee2  |
+    And these users have been created without skeleton files:
       | username | password  | displayname  | email |
       | sharee3  | %regular% | Sharee Three |       |
-    And group "ShareeGroup" has been created
-    And group "ShareeGroup2" has been created
+    And these groups have been created:
+      | groupname    |
+      | ShareeGroup  |
+      | ShareeGroup2 |
     And user "Alice" has been added to group "ShareeGroup2"
 
   Scenario Outline: empty search for sharees when search min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
-    And user "sharee2" has been created with default attributes and small skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | search   |      |
@@ -44,7 +46,6 @@ Feature: Test for issue owncloud/core 38501
 
   Scenario Outline: search for sharees without search when min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
-    And user "sharee2" has been created with default attributes and small skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "sharee1" gets the sharees using the sharing API with parameters
       | itemType | file |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiShareOperationsToRoot
  - apiShareOperationsToShares

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
