### PR TITLE
[Tests-Only] used small skeletons more wisely on API public link share features

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
@@ -2,7 +2,7 @@
 Feature: accessing a public link share
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
 
@@ -29,8 +29,9 @@ Feature: accessing a public link share
   @skipOnOcV10.3
   Scenario: Access to the preview of password protected public shared file inside a folder without providing the password is not allowed
     Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
-    And user "Alice" has moved file "textfile0.txt" to "FOLDER/textfile0.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "FOLDER/textfile0.txt"
     And user "Alice" has created a public link share with settings
       | path        | /FOLDER   |
       | permissions | change    |
@@ -42,8 +43,9 @@ Feature: accessing a public link share
 
   Scenario: Access to the preview of public shared file inside a folder without password
     Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
-    And user "Alice" has moved file "textfile0.txt" to "FOLDER/textfile0.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "FOLDER/textfile0.txt"
     And user "Alice" has created a public link share with settings
       | path        | /FOLDER |
       | permissions | change  |

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -3,20 +3,21 @@
 Feature: changing a public link share
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
 
 
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    When the public deletes file "welcome.txt" from the last public share using the old public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
-    And as "Alice" file "PARENT/welcome.txt" <should-or-not> exist
+    And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
     Examples:
       | permissions               | http-status-code | should-or-not |
       | read,update,create        | 403              | should        |
@@ -25,13 +26,12 @@ Feature: changing a public link share
   @issue-ocis-reva-292
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    When the public deletes file "welcome.txt" from the last public share using the new public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the new public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
-    And as "Alice" file "PARENT/welcome.txt" <should-or-not> exist
+    And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
     Examples:
       | permissions               | http-status-code | should-or-not |
       | read,update,create        | 403              | should        |
@@ -84,7 +84,6 @@ Feature: changing a public link share
 
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
@@ -95,7 +94,6 @@ Feature: changing a public link share
   @issue-ocis-reva-292
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
@@ -106,7 +104,6 @@ Feature: changing a public link share
 
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
@@ -116,7 +113,6 @@ Feature: changing a public link share
 
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
@@ -127,48 +123,44 @@ Feature: changing a public link share
 
   Scenario: Public cannot delete file through publicly shared link with password using an invalid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "welcome.txt" from the last public share using the password "invalid" and old public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the password "invalid" and old public WebDAV API
     Then the HTTP status code should be "401"
-    And as "Alice" file "PARENT/welcome.txt" should exist
+    And as "Alice" file "PARENT/parent.txt" should exist
 
   Scenario: Public cannot delete file through publicly shared link with password using an invalid password with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "welcome.txt" from the last public share using the password "invalid" and new public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the password "invalid" and new public WebDAV API
     Then the HTTP status code should be "401"
-    And as "Alice" file "PARENT/welcome.txt" should exist
+    And as "Alice" file "PARENT/parent.txt" should exist
 
 
   Scenario: Public can delete file through publicly shared link with password using the valid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "welcome.txt" from the last public share using the password "newpasswd" and old public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the password "newpasswd" and old public WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" file "PARENT/welcome.txt" should not exist
+    And as "Alice" file "PARENT/parent.txt" should not exist
 
   Scenario: Public can delete file through publicly shared link with password using the valid password with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "welcome.txt" from the last public share using the password "newpasswd" and new public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the password "newpasswd" and new public WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" file "PARENT/welcome.txt" should not exist
+    And as "Alice" file "PARENT/parent.txt" should not exist
 
 
   Scenario: Public tries to rename a file in a password protected share using an invalid password with the old public WebDAV API
@@ -220,7 +212,6 @@ Feature: changing a public link share
 
   Scenario: Public tries to upload to a password protected public share using an invalid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
@@ -231,7 +222,6 @@ Feature: changing a public link share
 
   Scenario: Public tries to upload to a password protected public share using an invalid password with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
@@ -243,7 +233,6 @@ Feature: changing a public link share
 
   Scenario: Public tries to upload to a password protected public share using the valid password with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
@@ -254,7 +243,6 @@ Feature: changing a public link share
 
   Scenario: Public tries to upload to a password protected public share using the valid password with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
@@ -288,21 +276,19 @@ Feature: changing a public link share
 
   Scenario: Public cannot delete a file in uploadwriteonly public link share with the old public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public deletes file "welcome.txt" from the last public share using the old public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the old public WebDAV API
     Then the HTTP status code should be "403"
-    And as "Alice" file "PARENT/welcome.txt" should exist
+    And as "Alice" file "PARENT/parent.txt" should exist
 
   @issue-ocis-reva-292
   Scenario: Public cannot delete a file in uploadwriteonly public link share with the new public WebDAV API
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has moved file "welcome.txt" to "PARENT/welcome.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public deletes file "welcome.txt" from the last public share using the new public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the new public WebDAV API
     Then the HTTP status code should be "403"
-    And as "Alice" file "PARENT/welcome.txt" should exist
+    And as "Alice" file "PARENT/parent.txt" should exist

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -3,7 +3,7 @@
 Feature: create a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1) using the old public WebDAV API
@@ -187,6 +187,7 @@ Feature: create a public link share
   Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | PARENT |
@@ -218,6 +219,7 @@ Feature: create a public link share
   Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | PARENT |
@@ -248,6 +250,7 @@ Feature: create a public link share
 
   Scenario Outline: Creating a new public link share of a folder, with a password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | PARENT   |
@@ -279,6 +282,7 @@ Feature: create a public link share
   @issue-ocis-reva-292
   Scenario Outline: Creating a new public link share of a folder, with a password using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | PARENT   |
@@ -310,14 +314,15 @@ Feature: create a public link share
   @smokeTest @issue-ocis-reva-294
   Scenario Outline: Getting the share information of public link share from the OCS API does not expose sensitive information
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
-      | path     | welcome.txt |
+      | path     | randomfile.txt |
       | password | %public%    |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | file_target            | /welcome.txt   |
-      | path                   | /welcome.txt   |
+      | file_target            | /randomfile.txt   |
+      | path                   | /randomfile.txt   |
       | item_type              | file           |
       | share_type             | public_link    |
       | permissions            | read           |
@@ -331,13 +336,14 @@ Feature: create a public link share
 
   Scenario Outline: Getting the share information of passwordless public-links hides credential placeholders
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
-      | path | welcome.txt |
+      | path | randomfile.txt |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | file_target | /welcome.txt |
-      | path        | /welcome.txt |
+      | file_target | /randomfile.txt |
+      | path        | /randomfile.txt |
       | item_type   | file         |
       | share_type  | public_link  |
       | permissions | read         |
@@ -731,7 +737,9 @@ Feature: create a public link share
 
   @issue-ocis-reva-199
   Scenario: Deleting a folder that has been publicly shared
-    Given user "Alice" has created a public link share with settings
+    Given user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
+    And user "Alice" has created a public link share with settings
       | path        | PARENT |
       | permissions | read   |
     When user "Alice" deletes folder "PARENT" using the WebDAV API
@@ -741,6 +749,8 @@ Feature: create a public link share
   @issue-ocis-reva-292
   Scenario: try to download from a public share that has upload only permissions
     Given the administrator has enabled DAV tech_preview
+    Given user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
     And user "Alice" has created a public link share with settings
       | path        | PARENT          |
       | permissions | uploadwriteonly |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue36442.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue36442.feature
@@ -3,7 +3,7 @@
 Feature: create a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @issue-36442
   Scenario Outline: Creating a public link share with read+create permissions defaults to read permissions when public upload disabled globally

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
@@ -3,7 +3,7 @@
 Feature: create a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @issue-37605
   Scenario: Get the mtime of a file inside a folder shared by public link using new webDAV version

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
@@ -4,7 +4,7 @@ Feature: create a public link share when share_folder is set to Shares
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario Outline: Creating a new public link share of a file gives the correct response

--- a/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
@@ -2,11 +2,12 @@
 Feature: multilinksharing
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Creating three public shares of a folder
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path         | FOLDER      |
       | password     | %public%    |
@@ -44,6 +45,7 @@ Feature: multilinksharing
 
   Scenario Outline: Creating three public shares of a file
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has created a public link share with settings
       | path        | textfile0.txt |
       | password    | %public%      |
@@ -78,6 +80,7 @@ Feature: multilinksharing
 
   Scenario Outline: Check that updating password doesn't remove name of links
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path         | FOLDER      |
       | password     | %public%    |
@@ -107,6 +110,7 @@ Feature: multilinksharing
 
   Scenario: Deleting a file deletes also its public links
     Given using OCS API version "1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has created a public link share with settings
       | path        | textfile0.txt |
       | password    | %public%      |
@@ -127,6 +131,7 @@ Feature: multilinksharing
 
   Scenario Outline: Deleting one public link share of a file doesn't affect the rest
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has created a public link share with settings
       | path        | textfile0.txt |
       | password    | %public%      |
@@ -159,6 +164,7 @@ Feature: multilinksharing
 
   Scenario: Overwriting a file doesn't remove its public shares
     Given using OCS API version "1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has created a public link share with settings
       | path        | textfile0.txt |
       | password    | %public%      |
@@ -180,6 +186,7 @@ Feature: multilinksharing
   @issue-ocis-reva-335
   Scenario: Renaming a folder doesn't remove its public shares
     Given using OCS API version "1"
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path         | FOLDER      |
       | password     | %public%    |

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
@@ -6,8 +6,10 @@ Feature: reshare as public link
   So that I can give controlled access to others
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username  |
+      | Alice     |
+      | Brian     |
 
   Scenario Outline: creating a public link from a share with read permission only is not allowed
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -5,8 +5,10 @@ Feature: reshare as public link
   So that I can give controlled access to others
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username  |
+      | Alice     |
+      | Brian     |
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
 

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
@@ -5,8 +5,10 @@ Feature: reshare as public link
   So that I can give controlled access to others
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username  |
+      | Alice     |
+      | Brian     |
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
 

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -3,11 +3,12 @@ Feature: update a public link share
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @issue-37653 @skipOnOcV10
   Scenario Outline: API responds with a full set of parameters when owner changes the expireDate of a public share
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" updates the last share using the sharing API with
@@ -47,6 +48,7 @@ Feature: update a public link share
   @smokeTest @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" updates the last share using the sharing API with
@@ -79,6 +81,7 @@ Feature: update a public link share
   @issue-product-295 @skipOnOcV10
   Scenario Outline: API responds with a full set of parameters when owner renames the file with a public link
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" has moved folder "/FOLDER" to "/RENAMED_FOLDER"
@@ -149,6 +152,7 @@ Feature: update a public link share
   @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" updates the last share using the sharing API with
@@ -181,6 +185,7 @@ Feature: update a public link share
   @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its password and getting its info
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" updates the last share using the sharing API with
@@ -212,6 +217,7 @@ Feature: update a public link share
   @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its permissions and getting its info
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" updates the last share using the sharing API with
@@ -243,6 +249,7 @@ Feature: update a public link share
   @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its permissions to view download and upload and getting its info
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" updates the last share using the sharing API with
@@ -274,6 +281,7 @@ Feature: update a public link share
   @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating publicUpload option and getting its info
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" updates the last share using the sharing API with
@@ -458,6 +466,9 @@ Feature: update a public link share
   Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the old public API
     Given the administrator has enabled DAV tech_preview
     And using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
@@ -480,6 +491,9 @@ Feature: update a public link share
   Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the new public API
     Given the administrator has enabled DAV tech_preview
     And using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
@@ -502,6 +516,10 @@ Feature: update a public link share
   Scenario Outline: Updating share permissions from read to change allows public to delete files using the old public API
     Given the administrator has enabled DAV tech_preview
     And using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT |
       | permissions | read    |
@@ -526,6 +544,10 @@ Feature: update a public link share
   Scenario Outline: Updating share permissions from read to change allows public to delete files using the new public API
     Given the administrator has enabled DAV tech_preview
     And using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT |
       | permissions | read    |

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShareOc10Issue37653.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShareOc10Issue37653.feature
@@ -3,11 +3,12 @@ Feature: update a public link share
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @issue-37653
   Scenario Outline: API responds with a full set of parameters when owner changes the expireDate of a public share
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | FOLDER |
     And user "Alice" updates the last share using the sharing API with

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -3,7 +3,8 @@
 Feature: upload to a public link share
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
 
   @smokeTest
   Scenario: Uploading same file to a public upload-only share multiple times via old API


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiSharePublicLink1
  - apiSharePublicLink2

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
