### PR TITLE
[Tests-Only] used skeleton files more wisely on api share reshare features

### DIFF
--- a/tests/acceptance/features/apiShareReshareToRoot1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot1/reShare.feature
@@ -2,13 +2,16 @@
 Feature: sharing
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Carol" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Carol    |
 
   @smokeTest
   Scenario Outline: User is not allowed to reshare file when reshare permission is not given
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions "read,update"
     When user "Brian" shares file "/textfile0.txt" with user "Carol" with permissions "read,update" using the sharing API
     Then the OCS status code should be "404"
@@ -22,6 +25,7 @@ Feature: sharing
 
   Scenario Outline: User is not allowed to reshare folder when reshare permission is not given
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read,update"
     When user "Brian" shares folder "/FOLDER" with user "Carol" with permissions "read,update" using the sharing API
     Then the OCS status code should be "404"
@@ -36,6 +40,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: User is allowed to reshare file with the same permissions
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions "share,read"
     When user "Brian" shares file "/textfile0.txt" with user "Carol" with permissions "share,read" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -48,6 +53,7 @@ Feature: sharing
 
   Scenario Outline: User is allowed to reshare folder with the same permissions
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "share,read"
     When user "Brian" shares folder "/FOLDER" with user "Carol" with permissions "share,read" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -60,6 +66,7 @@ Feature: sharing
 
   Scenario Outline: User is allowed to reshare file with less permissions
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions "share,update,read"
     When user "Brian" shares file "/textfile0.txt" with user "Carol" with permissions "share,read" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -72,6 +79,7 @@ Feature: sharing
 
   Scenario Outline: User is allowed to reshare folder with less permissions
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "share,update,read"
     When user "Brian" shares folder "/FOLDER" with user "Carol" with permissions "share,read" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -84,6 +92,7 @@ Feature: sharing
 
   Scenario Outline: User is not allowed to reshare file and set more permissions bits
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions <received_permissions>
     When user "Brian" shares file "/textfile0.txt" with user "Carol" with permissions <reshare_permissions> using the sharing API
     Then the OCS status code should be "404"
@@ -109,6 +118,7 @@ Feature: sharing
 
   Scenario Outline: User is allowed to reshare file and set create (4) or delete (8) permissions bits, which get ignored
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions <received_permissions>
     When user "Brian" shares file "/textfile0.txt" with user "Carol" with permissions <reshare_permissions> using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
@@ -146,6 +156,7 @@ Feature: sharing
 
   Scenario Outline: User is not allowed to reshare folder and set more permissions bits
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has shared folder "/PARENT" with user "Brian" with permissions <received_permissions>
     When user "Brian" shares folder "/PARENT" with user "Carol" with permissions <reshare_permissions> using the sharing API
     Then the OCS status code should be "404"
@@ -183,6 +194,7 @@ Feature: sharing
 
   Scenario Outline: User is not allowed to reshare folder and add delete permission bit (8)
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has shared folder "/PARENT" with user "Brian" with permissions <received_permissions>
     When user "Brian" shares folder "/PARENT" with user "Carol" with permissions <reshare_permissions> using the sharing API
     Then the OCS status code should be "404"
@@ -209,6 +221,7 @@ Feature: sharing
 
   Scenario Outline: Reshare a file with same name as a deleted file
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has deleted file "textfile0.txt"
     And user "Alice" has uploaded file with content "ownCloud new test text file 0" to "/textfile0.txt"
@@ -225,6 +238,7 @@ Feature: sharing
 
   Scenario Outline: Reshare a folder with same name as a deleted folder
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Alice" has deleted folder "PARENT"
     And user "Alice" has created folder "/PARENT"
@@ -240,6 +254,7 @@ Feature: sharing
 
   Scenario Outline: Reshare a folder with same name as a deleted file
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has deleted file "textfile0.txt"
     And user "Alice" has created folder "/textfile0.txt"

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareChain.feature
@@ -2,16 +2,19 @@
 Feature: resharing can be done on a reshared resource
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   Scenario: Reshared files can be still accessed if a user in the middle removes it.
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "David" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has moved file "/textfile0.txt" to "/textfile0_shared.txt"
     And user "Brian" has shared file "textfile0_shared.txt" with user "Carol"
     And user "Carol" has shared file "textfile0_shared.txt" with user "David"
     When user "Brian" deletes file "/textfile0_shared.txt" using the WebDAV API
-    Then the content of file "/textfile0_shared.txt" for user "Carol" should be "ownCloud test text file 0" plus end-of-line
-    And the content of file "/textfile0_shared.txt" for user "David" should be "ownCloud test text file 0" plus end-of-line
+    Then the content of file "/textfile0_shared.txt" for user "Carol" should be "ownCloud test text file 0"
+    And the content of file "/textfile0_shared.txt" for user "David" should be "ownCloud test text file 0"

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareDisabled.feature
@@ -2,13 +2,16 @@
 Feature: resharing can be disabled
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   @smokeTest
   Scenario Outline: resharing a file is not allowed when allow resharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions "share,update,read"
     And parameter "shareapi_allow_resharing" of app "core" has been set to "no"
     When user "Brian" shares file "/textfile0.txt" with user "Carol" with permissions "share,update,read" using the sharing API
@@ -23,6 +26,7 @@ Feature: resharing can be disabled
   Scenario Outline: ordinary sharing is allowed when allow resharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_resharing" of app "core" has been set to "no"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares file "/textfile0.txt" with user "Brian" with permissions "share,update,read" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareSubfolder.feature
@@ -2,8 +2,10 @@
 Feature: a subfolder of a received share can be reshared
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   @smokeTest
   Scenario Outline: User is allowed to reshare a sub-folder with the same permissions

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -2,20 +2,23 @@
 Feature: resharing a resource with an expiration date
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   Scenario Outline: User should not be able to re-share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
     When user "Brian" shares folder "/PARENT" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Carol" folder "/PARENT (2)" should not exist
+    And as "Carol" folder "/PARENT" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |
@@ -24,14 +27,15 @@ Feature: resharing a resource with an expiration date
   Scenario Outline: User should not be able to re-share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian"
     When user "Brian" shares folder "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
-    And as "Carol" folder "/textfile0 (2).txt" should not exist
+    And as "Carol" folder "/textfile0.txt" should not exist
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 403             | 200              |

--- a/tests/acceptance/features/apiShareReshareToRoot3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot3/reShareUpdate.feature
@@ -2,9 +2,11 @@
 Feature: sharing
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Carol" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Carol    |
 
   Scenario Outline: Update of reshare can reduce permissions
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareReshareToRoot3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot3/reShareWithExpiryDate.feature
@@ -2,8 +2,11 @@
 Feature: resharing a resource with an expiration date
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
   @skipOnOcV10.3
   Scenario Outline: User should be able to set expiration while resharing a file with user

--- a/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
@@ -4,13 +4,16 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Carol" has been created with default attributes and without skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Carol    |
 
   @smokeTest
   Scenario Outline: User is not allowed to reshare file when reshare permission is not given
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions "read,update"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     When user "Brian" shares file "/Shares/textfile0.txt" with user "Carol" with permissions "read,update" using the sharing API
@@ -26,6 +29,7 @@ Feature: sharing
 
   Scenario Outline: User is not allowed to reshare folder when reshare permission is not given
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read,update"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" shares folder "/Shares/FOLDER" with user "Carol" with permissions "read,update" using the sharing API
@@ -42,6 +46,7 @@ Feature: sharing
   @smokeTest
   Scenario Outline: User is allowed to reshare file with the same permissions
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions "share,read"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     When user "Brian" shares file "/Shares/textfile0.txt" with user "Carol" with permissions "share,read" using the sharing API
@@ -58,6 +63,7 @@ Feature: sharing
 
   Scenario Outline: User is allowed to reshare folder with the same permissions
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "share,read"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" shares folder "/Shares/FOLDER" with user "Carol" with permissions "share,read" using the sharing API
@@ -74,6 +80,7 @@ Feature: sharing
 
   Scenario Outline: User is allowed to reshare file with less permissions
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions "share,update,read"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     When user "Brian" shares file "/Shares/textfile0.txt" with user "Carol" with permissions "share,read" using the sharing API
@@ -90,6 +97,7 @@ Feature: sharing
 
   Scenario Outline: User is allowed to reshare folder with less permissions
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "share,update,read"
     And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
     When user "Brian" shares folder "/Shares/FOLDER" with user "Carol" with permissions "share,read" using the sharing API
@@ -106,6 +114,7 @@ Feature: sharing
 
   Scenario Outline: User is not allowed to reshare file and set more permissions bits
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions <received_permissions>
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     When user "Brian" shares file "/Shares/textfile0.txt" with user "Carol" with permissions <reshare_permissions> using the sharing API
@@ -134,6 +143,7 @@ Feature: sharing
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: User is allowed to reshare file and set create (4) or delete (8) permissions bits, which get ignored
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian" with permissions <received_permissions>
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     When user "Brian" shares file "/Shares/textfile0.txt" with user "Carol" with permissions <reshare_permissions> using the sharing API
@@ -175,6 +185,7 @@ Feature: sharing
 
   Scenario Outline: User is not allowed to reshare folder and set more permissions bits
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has shared folder "/PARENT" with user "Brian" with permissions <received_permissions>
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     When user "Brian" shares folder "/Shares/PARENT" with user "Carol" with permissions <reshare_permissions> using the sharing API
@@ -214,6 +225,7 @@ Feature: sharing
 
   Scenario Outline: User is not allowed to reshare folder and add delete permission bit (8)
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has shared folder "/PARENT" with user "Brian" with permissions <received_permissions>
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     When user "Brian" shares folder "/Shares/PARENT" with user "Carol" with permissions <reshare_permissions> using the sharing API
@@ -242,6 +254,7 @@ Feature: sharing
 
   Scenario Outline: Reshare a file with same name as a deleted file
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     And user "Alice" has deleted file "textfile0.txt"
@@ -259,6 +272,7 @@ Feature: sharing
 
   Scenario Outline: Reshare a folder with same name as a deleted folder
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Alice" has deleted folder "PARENT"
@@ -276,6 +290,7 @@ Feature: sharing
 
   Scenario Outline: Reshare a folder with same name as a deleted file
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     And user "Alice" has deleted file "/textfile0.txt"

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
@@ -4,12 +4,15 @@ Feature: resharing can be done on a reshared resource
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   Scenario: Reshared files can be still accessed if a user in the middle removes it.
     Given user "Carol" has been created with default attributes and without skeleton files
     And user "David" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     And user "Brian" has moved file "/Shares/textfile0.txt" to "/textfile0_shared.txt"
@@ -18,5 +21,5 @@ Feature: resharing can be done on a reshared resource
     And user "Carol" has shared file "/Shares/textfile0_shared.txt" with user "David"
     And user "David" has accepted share "/textfile0.txt" offered by user "Carol"
     When user "Brian" deletes file "/textfile0_shared.txt" using the WebDAV API
-    Then the content of file "/Shares/textfile0_shared.txt" for user "Carol" should be "ownCloud test text file 0" plus end-of-line
-    And the content of file "/Shares/textfile0_shared.txt" for user "David" should be "ownCloud test text file 0" plus end-of-line
+    Then the content of file "/Shares/textfile0_shared.txt" for user "Carol" should be "ownCloud test text file 0"
+    And the content of file "/Shares/textfile0_shared.txt" for user "David" should be "ownCloud test text file 0"

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
@@ -4,8 +4,11 @@ Feature: resharing can be disabled
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
   @smokeTest
   Scenario Outline: resharing a file is not allowed when allow resharing has been disabled

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
@@ -4,8 +4,10 @@ Feature: a subfolder of a received share can be reshared
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   @smokeTest
   Scenario Outline: User is allowed to reshare a sub-folder with the same permissions

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -4,15 +4,18 @@ Feature: resharing a resource with an expiration date
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
 
   Scenario Outline: User should not be able to re-share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     When user "Brian" shares folder "/Shares/PARENT" with group "grp1" using the sharing API
@@ -27,9 +30,10 @@ Feature: resharing a resource with an expiration date
   Scenario Outline: User should not be able to re-share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     When user "Brian" shares folder "/Shares/textfile0.txt" with group "grp1" using the sharing API

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
@@ -4,9 +4,11 @@ Feature: sharing
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Carol" has been created with default attributes and without skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+      | Carol    |
 
   Scenario Outline: Update of reshare can reduce permissions
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
@@ -4,8 +4,11 @@ Feature: resharing a resource with an expiration date
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
   @skipOnOcV10.3
   Scenario Outline: User should be able to set expiration while resharing a file with user

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
@@ -4,8 +4,11 @@ Feature: resharing a resource with an expiration date
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
   @skipOnOcV10.3 @issue-37013
   Scenario Outline: reshare extends the received expiry date up to the default by default


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiShareReshareToRoot1
  - apiShareReshareToRoot2
  - apiShareReshareToRoot3
  - apiShareReshareToShares1
  - apiShareReshareToShares2
  - apiShareReshareToShares3

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
