### PR TITLE
[Tests-Only] used skeleton files more wisely on api share update to and share notifications to features

### DIFF
--- a/tests/acceptance/features/apiShareUpdateToRoot/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToRoot/updateShare.feature
@@ -3,7 +3,7 @@ Feature: sharing
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Allow modification of reshare
@@ -27,11 +27,13 @@ Feature: sharing
 
   Scenario Outline: keep group permissions in sync
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
-    And user "Brian" has moved file "/textfile0 (2).txt" to "/FOLDER/textfile0.txt"
+    And user "Brian" has created folder "FOLDER"
+    And user "Brian" has moved file "/textfile0.txt" to "/FOLDER/textfile0.txt"
     When user "Alice" updates the last share using the sharing API with
       | permissions | read |
     Then the OCS status code should be "<ocs_status_code>"
@@ -58,6 +60,7 @@ Feature: sharing
   Scenario Outline: Cannot set permissions to zero
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with group "grp1"
     When user "Alice" updates the last share using the sharing API with
       | permissions | 0 |
@@ -71,6 +74,7 @@ Feature: sharing
   Scenario Outline: Cannot update a share of a file with a user to have only create and/or delete permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     When user "Alice" updates the last share using the sharing API with
       | permissions | <permissions> |
@@ -92,6 +96,7 @@ Feature: sharing
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
     When user "Alice" updates the last share using the sharing API with
       | permissions | <permissions> |
@@ -170,10 +175,11 @@ Feature: sharing
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Carol" has created folder "/FOLDER"
     And user "Carol" has shared folder "/FOLDER" with group "grp1"
     And user "Carol" has updated the last share with
       | permissions | read |
@@ -191,7 +197,8 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-    When user "Alice" shares file "/welcome.txt" with group "grp1" using the sharing API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -202,6 +209,7 @@ Feature: sharing
   Scenario Outline: Editing share permission of existing share is forbidden when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When user "Alice" updates the last share using the sharing API with
@@ -226,6 +234,7 @@ Feature: sharing
   Scenario Outline: Deleting group share is allowed when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When user "Alice" deletes the last share using the sharing API
@@ -244,6 +253,7 @@ Feature: sharing
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |
@@ -272,6 +282,7 @@ Feature: sharing
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has created a share with settings
       | path        | textfile0.txt |
       | shareType   | user          |

--- a/tests/acceptance/features/apiShareUpdateToRoot/updateShareOc10Issue37217.feature
+++ b/tests/acceptance/features/apiShareUpdateToRoot/updateShareOc10Issue37217.feature
@@ -4,7 +4,8 @@ Feature: sharing
   @issue-37217
   Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Allow modification of reshare
@@ -32,11 +32,13 @@ Feature: sharing
   @issue-ocis-reva-194 @issue-ocis-reva-243
   Scenario Outline: keep group permissions in sync
     Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    And user "Brian" has created folder "/FOLDER"
     And user "Brian" has moved file "/Shares/textfile0.txt" to "/FOLDER/textfile0.txt"
     When user "Alice" updates the last share using the sharing API with
       | permissions | read |
@@ -65,6 +67,7 @@ Feature: sharing
   Scenario Outline: Cannot set permissions to zero
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has shared folder "/FOLDER" with group "grp1"
     When user "Alice" updates the last share using the sharing API with
       | permissions | 0 |
@@ -79,6 +82,7 @@ Feature: sharing
   Scenario Outline: Cannot update a share of a file with a user to have only create and/or delete permission
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     When user "Alice" updates the last share using the sharing API with
@@ -102,6 +106,7 @@ Feature: sharing
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     When user "Alice" updates the last share using the sharing API with
@@ -234,10 +239,11 @@ Feature: sharing
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
-    And user "Carol" has been created with default attributes and small skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Carol" has created folder "/FOLDER"
     And user "Carol" has shared folder "/FOLDER" with group "grp1"
     And user "Brian" has accepted share "/FOLDER" offered by user "Carol"
     And user "Carol" has updated the last share with
@@ -257,7 +263,8 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-    When user "Alice" shares file "/welcome.txt" with group "grp1" using the sharing API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -269,6 +276,7 @@ Feature: sharing
   Scenario Outline: Editing share permission of existing share is forbidden when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When user "Alice" updates the last share using the sharing API with
@@ -294,6 +302,7 @@ Feature: sharing
   Scenario Outline: Deleting group share is allowed when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with group "grp1"
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When user "Alice" deletes the last share using the sharing API
@@ -313,6 +322,7 @@ Feature: sharing
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" creates a share using the sharing API with settings
       | path        | textfile0.txt |
       | shareType   | user          |
@@ -341,6 +351,7 @@ Feature: sharing
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has created a share with settings
       | path        | textfile0.txt |
       | shareType   | user          |
@@ -368,6 +379,7 @@ Feature: sharing
   Scenario Outline: Sharer deletes file uploaded with upload-only permission by sharee to a shared folder
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/FOLDER"
     And user "Alice" has created a share with settings
       | path        | FOLDER |
       | shareType   | user   |

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShareOc10Issue37217.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShareOc10Issue37217.feature
@@ -6,12 +6,13 @@ Feature: sharing
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has created a share with settings
       | path        | textfile0.txt |
       | shareType   | user          |

--- a/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
@@ -8,7 +8,7 @@ Feature: Display notifications when receiving a share
     Given app "notifications" has been enabled
     And using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -18,10 +18,12 @@ Feature: Display notifications when receiving a share
       | grp1      |
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "PARENT"
 
   @smokeTest
   Scenario: share to user sends notification
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     And user "Alice" shares file "/textfile0.txt" with user "Brian" using the sharing API
     Then user "Brian" should have 2 notifications
@@ -35,6 +37,7 @@ Feature: Display notifications when receiving a share
 
   Scenario: share to group sends notification to every member
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
     And user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then user "Brian" should have 2 notifications

--- a/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
@@ -9,7 +9,7 @@ Feature: Display notifications when receiving a share
     And app "notifications" has been enabled
     And using OCS API version "1"
     And using new DAV path
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
@@ -19,10 +19,12 @@ Feature: Display notifications when receiving a share
       | grp1      |
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "PARENT"
 
   @smokeTest
   Scenario: share to user sends notification
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     And user "Alice" shares file "/textfile0.txt" with user "Brian" using the sharing API
     Then user "Brian" should have 2 notifications
@@ -36,6 +38,7 @@ Feature: Display notifications when receiving a share
 
   Scenario: share to group sends notification to every member
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
     And user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
     Then user "Brian" should have 2 notifications


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiShareUpdateToRoot
  - apiShareUpdateToShares
  - apiSharingNotificationsToRoot
  - apiSharingNotificationsToShares

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
