### PR TITLE
Fix expiration date

### DIFF
--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -1153,10 +1153,10 @@ class ApiTest extends TestCase {
 		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'yes');
 
 		$dateWithinRange = new \DateTime();
-		$dateWithinRange->setTime(0, 0, 0);
+		$dateWithinRange->setTime(23, 59, 0);
 		$dateWithinRange->add(new \DateInterval('P5D'));
 		$dateOutOfRange = new \DateTime();
-		$dateOutOfRange->setTime(0, 0, 0);
+		$dateOutOfRange->setTime(23, 59, 0);
 		$dateOutOfRange->add(new \DateInterval('P8D'));
 
 		// update expire date to a valid value
@@ -1533,7 +1533,7 @@ class ApiTest extends TestCase {
 		$this->assertEquals($url, $data['url']);
 
 		$share = $this->shareManager->getShareById('ocinternal:'.$data['id']);
-		$date->setTime(0, 0, 0);
+		$date->setTime(23, 59, 0);
 		$this->assertEquals($date, $share->getExpirationDate());
 
 		$this->shareManager->deleteShare($share);

--- a/changelog/unreleased/38540
+++ b/changelog/unreleased/38540
@@ -1,0 +1,6 @@
+Bugfix: Expire shares not before the end of the day
+
+Shares will expire now at the end of the day. This was a bit undeterministic before, depending on the background job execution time. Now it will not expire during the day but at the first possible moment in time after the end of the day. The exact expiration time will still depend on the scheduling of the background job.
+
+
+https://github.com/owncloud/core/pull/38540

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -430,11 +430,11 @@ class Manager implements IManager {
 
 		if ($expirationDate !== null) {
 			// Set the expiration date to just the date at "zero" time in the day
-			$expirationDate->setTime(0, 0, 0, 0);
+			$expirationDate->setTime(23, 59, 0, 0);
 
 			// Get the current date in the same timezone, and at "zero" time in the day
 			$date = new \DateTime('now', new DateTimeZone($expirationDate->getTimezone()->getName()));
-			$date->setTime(0, 0, 0, 0);
+			$date->setTime(23, 59, 0, 0);
 
 			if ($date > $expirationDate) {
 				$message = $this->l->t('Expiration date is in the past');
@@ -473,7 +473,7 @@ class Manager implements IManager {
 			// If expiredate is empty and it is a new share, set a default one if there is a default
 			if ($this->isNewShare($share) && $expirationDate === null && $thereIsDefault) {
 				$expirationDate = new \DateTime();
-				$expirationDate->setTime(0, 0, 0);
+				$expirationDate->setTime(23, 59, 0);
 				$expirationDate->add(new \DateInterval('P'.$defaultDays.'D'));
 			}
 
@@ -482,7 +482,7 @@ class Manager implements IManager {
 			}
 
 			$date = new \DateTime();
-			$date->setTime(0, 0, 0);
+			$date->setTime(23, 59, 0);
 			$date->add(new \DateInterval('P' . $defaultDays . 'D'));
 			if ($date < $expirationDate) {
 				$message = $this->l->t('Cannot set expiration date more than %s days in the future', [$defaultDays]);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1029,7 +1029,7 @@ class ManagerTest extends \Test\TestCase {
 	 */
 	public function testValidateExpirationDateToday() {
 		$today = new \DateTime();
-		$today->setTime(0, 0, 0);
+		$today->setTime(23, 59, 0);
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($today);
 
@@ -1083,7 +1083,7 @@ class ManagerTest extends \Test\TestCase {
 			]));
 
 		$expected = new \DateTime();
-		$expected->setTime(0, 0, 0);
+		$expected->setTime(23, 59, 0);
 		$expected->add(new \DateInterval('P3D'));
 		$this->invokePrivate($this->manager, 'validateExpirationDate', [$share]);
 		$this->assertNotNull($share->getExpirationDate());
@@ -1120,10 +1120,10 @@ class ManagerTest extends \Test\TestCase {
 		// Expire date in the past
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P2D'));
-		$future->setTime(0, 0, 0);
+		$future->setTime(23, 59, 0);
 
 		$expected = clone $future;
-		$future->setTime(1, 2, 3);
+		$future->setTime(23, 59, 3);
 
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($future);
@@ -1150,7 +1150,7 @@ class ManagerTest extends \Test\TestCase {
 		$date->add(new \DateInterval('P5D'));
 
 		$expected = clone $date;
-		$expected->setTime(0, 0, 0);
+		$expected->setTime(23, 59, 0);
 
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($date);
@@ -1184,7 +1184,7 @@ class ManagerTest extends \Test\TestCase {
 	public function testvalidateExpirationDateNoDateDefault() {
 		$future = new \DateTime();
 		$future->add(new \DateInterval('P3D'));
-		$future->setTime(0, 0, 0);
+		$future->setTime(23, 59, 0);
 
 		$expected = clone $future;
 
@@ -1211,7 +1211,7 @@ class ManagerTest extends \Test\TestCase {
 	public function testValidateExpirationDateHookModification() {
 		$nextWeek = new \DateTime();
 		$nextWeek->add(new \DateInterval('P7D'));
-		$nextWeek->setTime(0, 0, 0);
+		$nextWeek->setTime(23, 59, 0);
 
 		$save = clone $nextWeek;
 
@@ -1238,7 +1238,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$nextWeek = new \DateTime();
 		$nextWeek->add(new \DateInterval('P7D'));
-		$nextWeek->setTime(0, 0, 0);
+		$nextWeek->setTime(23, 59, 0);
 
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($nextWeek);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description

Shares will expire now at the end of the day. This was a bit undeterministic before, depending on the background job execution time. Now it will not expire during the day but at the first possible moment in time after the end of the day. The exact expiration time will still depend on the scheduling of the background job.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4454
- Fixes https://github.com/owncloud/enterprise/issues/4324

## Motivation and Context

The expiration of shares was a bit undeterministic before

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- manually
- Ci

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
