### PR TITLE
[Tests-Only] used skeleton files more wisely on api tags, translation and trashbin test features

### DIFF
--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -4,7 +4,7 @@ Feature: Assign tags to file/folder
   So that I can organize the files/folders easily
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiTags/assignTagsGroup.feature
+++ b/tests/acceptance/features/apiTags/assignTagsGroup.feature
@@ -3,7 +3,7 @@ Feature: Title of your feature
   I want to use this template for my feature file
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   Scenario: User can assign tags when in the tag's groups
     Given group "grp1" has been created

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -5,7 +5,7 @@ Feature: Creation of tags
   So that I could categorize my files
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -4,7 +4,7 @@ Feature: Deletion of tags
   I want to delete the tags that are already created
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario: Deleting a normal tag as regular user should work

--- a/tests/acceptance/features/apiTags/editTags.feature
+++ b/tests/acceptance/features/apiTags/editTags.feature
@@ -4,7 +4,7 @@ Feature: Editing the tags
   I want to be able to change the tags I have created
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Renaming a normal tag as regular user should work

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -2,7 +2,7 @@
 Feature: tags
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -4,7 +4,7 @@ Feature: Unassigning tags from file/folder
   I want to be able to remove tags from file/folder
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |

--- a/tests/acceptance/features/apiTranslation/translation.feature
+++ b/tests/acceptance/features/apiTranslation/translation.feature
@@ -5,12 +5,13 @@ Feature: translate messages in api response to preferred language
   So that I can see and understand the response messages in my language
 
   Scenario Outline: user tries to get non existing share and uses some preferred language
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
+      | Alice    |
       | Brian    |
       | Carol    |
     And using <dav_version> DAV path
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Brian" has shared file "textfile0.txt" with user "Carol"
     When user "Alice" gets the info of the last share in language "<language>" using the sharing API
     Then the OCS status code should be "404"

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -141,7 +141,8 @@ Feature: files and folders exist in the trashbin after being deleted
   @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
-    And user "testtrashbin100" has been created with default attributes and small skeleton files
+    And user "testtrashbin100" has been created with default attributes and without skeleton files
+    And user "testtrashbin100" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin100" has deleted file "/textfile1.txt"
     When user "Brian" tries to list the trashbin content for user "testtrashbin100"
@@ -157,7 +158,9 @@ Feature: files and folders exist in the trashbin after being deleted
   @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
-    And user "testtrashbin101" has been created with default attributes and small skeleton files
+    And user "testtrashbin101" has been created with default attributes and without skeleton files
+    And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin101" has deleted file "/textfile0.txt"
     And user "testtrashbin101" has deleted file "/textfile2.txt"
@@ -175,7 +178,9 @@ Feature: files and folders exist in the trashbin after being deleted
   @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
-    And user "testtrashbin102" has been created with default attributes and small skeleton files
+    And user "testtrashbin102" has been created with default attributes and without skeleton files
+    And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin102" has deleted file "/textfile0.txt"
     And user "testtrashbin102" has deleted file "/textfile2.txt"
@@ -199,6 +204,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @smokeTest
   Scenario Outline: Get trashbin content with wrong password
     Given using <dav-path> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" tries to list the trashbin content for user "Alice" using password "invalid"
     Then the HTTP status code should be "401"
@@ -213,6 +219,7 @@ Feature: files and folders exist in the trashbin after being deleted
   @smokeTest
   Scenario Outline: Get trashbin content without password
     Given using <dav-path> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" tries to list the trashbin content for user "Alice" using password ""
     Then the HTTP status code should be "401"
@@ -261,7 +268,7 @@ Feature: files and folders exist in the trashbin after being deleted
   Scenario Outline: deleting a folder moves all its content to the trashbin
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/new-folder"
-    And user "Alice" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/new-folder/new-file.txt"
     When user "Alice" deletes folder "/new-folder/" using the WebDAV API
     Then as "Alice" the file with original path "/new-folder/new-file.txt" should exist in the trashbin
     Then as "Alice" the folder with original path "/new-folder/" should exist in the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -39,9 +39,9 @@ Feature: using trashbin together with sharing
 
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
-    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has uploaded file with content "to delete" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with user "Brian"
     And user "Brian" has moved file "/shared" to "/renamed_shared"
     And user "Brian" has deleted file "/renamed_shared/shared_file.txt"
@@ -66,6 +66,7 @@ Feature: using trashbin together with sharing
     And user "Brian" has created folder "shareFolderParent"
     And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
     And as "Alice" folder "/shareFolderParent" should exist
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "403"
@@ -84,6 +85,7 @@ Feature: using trashbin together with sharing
     And user "Brian" has created folder "shareFolderParent"
     And user "Brian" has created folder "shareFolderParent/shareFolderChild"
     And user "Brian" has shared folder "shareFolderParent" with user "Alice" with permissions "read"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And as "Alice" folder "/shareFolderParent/shareFolderChild" should exist
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -43,7 +43,7 @@ Feature: using trashbin together with sharing
 
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with user "Brian"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiTags
  - apiTranslation
  - apiTrashbin

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
