### PR TITLE
when resharing with group that user belongs permissions are most permissive already in mount provider

### DIFF
--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -158,6 +158,8 @@ class Application extends App {
 			return new MountProvider(
 				$server->getConfig(),
 				$server->getShareManager(),
+				$server->getUserManager(),
+				$server->getGroupManager(),
 				$server->getLogger()
 			);
 		});

--- a/changelog/unreleased/38542
+++ b/changelog/unreleased/38542
@@ -1,0 +1,9 @@
+Bugfix: Handle group reshare mount permissions and attributes correctly
+
+In a scenario where resharing with group that user belongs to, 
+permissions and attributes for the share mount now are restricted only to received shares.
+Outgoing self-share with group are ignored as this could lead to incorrect permissions/attributes
+
+
+https://github.com/owncloud/core/pull/38542
+https://github.com/owncloud/enterprise/issues/4382

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -347,3 +347,84 @@ Feature: Sharing files and folders with internal groups
       | uid_owner   | Carol          |
       | share_with  | grp2           |
       | permissions | 7              |
+
+  @skipOnOcV10.3
+  Scenario: Check share permissions and expiration date of a group and the member of the same group
+    Given these groups have been created:
+      | groupname |
+      | grp1      |
+    And user "Alice" has been added to group "grp1"
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has shared folder "/simple-folder" with user "Alice"
+    And user "Carol" has shared folder "/simple-folder" with group "grp1"
+    And user "Carol" has logged in using the webUI
+    When the user sets the sharing permissions of group "grp1" for "simple-folder" using the webUI to
+      | edit   | no |
+      | create | no |
+    And the user changes expiration date for share of group "grp1" to "+5 days" in the share dialog
+    Then the information for user "Brian" about the received share of folder "simple-folder" shared with a group should include
+      | share_type  | group          |
+      | file_target | /simple-folder |
+      | uid_owner   | Carol          |
+      | share_with  | grp1           |
+      | expiration  | +5 days        |
+      | permissions | 17             |
+    And the information for user "Alice" about the received share of folder "simple-folder" shared with a user should include
+      | share_type  | user           |
+      | file_target | /simple-folder |
+      | uid_owner   | Carol          |
+      | share_with  | Alice          |
+      | expiration  |                |
+      | permissions | 31             |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6
+  Scenario: mount for reshare with group should contain correct sharing permissions
+    Given these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
+    And user "Alice" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has been added to group "grp2"
+    And user "Brian" has been added to group "grp2"
+    And user "Carol" has shared folder "/simple-folder" with group "grp1"
+    And user "Alice" has logged in using the webUI
+    And the user shares file "simple-folder" with group "grp2" using the webUI without closing the share dialog
+    And the user sets the sharing permissions of group "grp2" for "simple-folder" using the webUI to
+      | edit   | no |
+      | create | no |
+    When the user opens folder "simple-folder" using the webUI
+    And the user shares file "simple-empty-folder" with group "grp2" using the webUI without closing the share dialog
+    And the user sets the sharing permissions of group "grp2" for "simple-empty-folder" using the webUI to
+      | edit   | no |
+      | create | no |
+    Then user "Alice" should be able to upload file "filesForUpload/textfile.txt" to "simple-folder/textfile.txt"
+    And user "Alice" should not be able to upload file "filesForUpload/textfile.txt" to "simple-empty-folder/textfile.txt"
+    And user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "simple-folder/textfile.txt"
+    And user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "simple-empty-folder/textfile.txt"
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6
+  Scenario: reshare with group should allow for downgrading and upgrading permissions
+    Given these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
+    And user "Alice" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has been added to group "grp2"
+    And user "Brian" has been added to group "grp2"
+    And user "Carol" has shared folder "/simple-folder" with group "grp1"
+    And user "Alice" has logged in using the webUI
+    And the user shares file "simple-folder" with group "grp2" using the webUI without closing the share dialog
+    And the user sets the sharing permissions of group "grp2" for "simple-folder" using the webUI to
+      | edit   | no |
+      | create | no |
+    When the user opens folder "simple-folder" using the webUI
+    And the user shares file "simple-empty-folder" with group "grp2" using the webUI without closing the share dialog
+    And the user sets the sharing permissions of group "grp2" for "simple-empty-folder" using the webUI to
+      | edit   | no |
+      | create | no |
+    And the user sets the sharing permissions of group "grp2" for "simple-empty-folder" using the webUI to
+      | edit   | yes |
+      | create | yes |
+    Then user "Alice" should be able to upload file "filesForUpload/textfile.txt" to "simple-empty-folder/textfile.txt"

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -992,6 +992,25 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
+	 * Supershare permissions should not be validated when user is share owner or shared by
+	 */
+	public function testValidatePermissionsOfShareOwnerOrShareBy() {
+		$file = $this->createMock(File::class);
+		$file->method('getPermissions')->willReturn(1);
+		$this->rootFolder->expects($this->never())->method('getUserFolder');
+		$share = $this->createShare(null, \OCP\Share::SHARE_TYPE_GROUP, $file, 'user2', 'user1', 'user0', 11, null, null);
+
+		try {
+			$this->invokePrivate($this->manager, 'validatePermissions', [$share]);
+			$thrown = false;
+		} catch (\Exception $e) {
+			$thrown = true;
+		}
+
+		$this->assertSame(false, $thrown);
+	}
+
+	/**
 	 */
 	public function testValidateExpirationDateInPast() {
 		$this->expectException(\OCP\Share\Exceptions\GenericShareException::class);


### PR DESCRIPTION
fixes https://github.com/owncloud/enterprise/issues/4382

This PR solved the issue where user is resharing with group that himself belongs to, and we should not check for more permissive permissions/attributes in supershare as these are most permissive already .

- [x] manual tests
- [ ] add unit and integration tests