### PR TITLE
[10.7] [tests-only] removed phpstan skip

### DIFF
--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1395,7 +1395,6 @@ class OC_Util {
 		}
 		// Zend Opcache
 		if (\function_exists('accelerator_reset')) {
-			/* @phpstan-ignore-next-line */
 			accelerator_reset();
 		}
 		// Opcache (PHP >= 5.5)


### PR DESCRIPTION
Backport #38550 to `release-10.7.0`

A new release of `phpstan` https://github.com/phpstan/phpstan/releases/tag/0.12.82 is improved and no longer reports this code as a problem.

We removed the `phpstan-ignore-next-line` annotation in `master`. We need to remove it in `release-10.7.0` also, so that CI will pass here.