### PR TITLE
[tests-only] Pin php-cs-fixer to 2.18.3

### DIFF
--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+      "friendsofphp/php-cs-fixer": "2.18.3",
       "owncloud/coding-standard": "^2.0"
     }
   }


### PR DESCRIPTION
## Description
Pin the version of php-cs-fixer used in CI so that it passes. That will unblock CI.

Then we can sort out what to do about the new version 2.18.4

## Related Issue
Part of issue #28563


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
