### PR TITLE
[tests-only] Prepare required resources rather than using skeleton director on API WebDav lock tests

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -2,10 +2,11 @@
 Feature: there can be only one exclusive lock on a resource
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   Scenario Outline: a second lock cannot be set on a folder when its exclusively locked
     Given using <dav-path> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | exclusive |
     When user "Alice" locks file "textfile0.txt" using the WebDAV API setting the following properties
@@ -21,6 +22,9 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: if a parent resource is exclusively locked a child resource cannot be locked again
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | exclusive |
     When user "Alice" locks folder "PARENT/CHILD" using the WebDAV API setting the following properties
@@ -36,6 +40,9 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: if a parent resource is exclusively locked with depth 0 a child resource can be locked again
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | exclusive |
       | depth     | 0         |
@@ -53,6 +60,9 @@ Feature: there can be only one exclusive lock on a resource
   @skipOnOcV10 @issue-34358
   Scenario Outline: if a child resource is exclusively locked a parent resource cannot be locked again
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | exclusive |
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
@@ -68,6 +78,9 @@ Feature: there can be only one exclusive lock on a resource
 
   Scenario Outline: if a child resource is exclusively locked a parent resource can be locked with depth 0
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | exclusive |
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
@@ -85,7 +98,9 @@ Feature: there can be only one exclusive lock on a resource
   @files_sharing-app-required
   Scenario Outline: a share receiver cannot lock a resource exclusively locked by itself
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has locked file "textfile0 (2).txt" setting the following properties
       | lockscope | exclusive |
@@ -104,7 +119,9 @@ Feature: there can be only one exclusive lock on a resource
   @files_sharing-app-required
   Scenario Outline: a share receiver cannot lock a resource exclusively locked by the owner
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | exclusive |
@@ -123,7 +140,9 @@ Feature: there can be only one exclusive lock on a resource
   @files_sharing-app-required
   Scenario Outline: a share owner cannot lock a resource exclusively locked by a share receiver
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has locked file "textfile0 (2).txt" setting the following properties
       | lockscope | exclusive |

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
@@ -3,7 +3,10 @@ Feature: there can be only one exclusive lock on a resource
 
   @issue-34358
   Scenario Outline: if a child resource is exclusively locked a parent resource cannot be locked again
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And using <dav-path> DAV path
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | exclusive |

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -2,11 +2,12 @@
 Feature: lock folders
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: upload to a locked folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/FOLDER/textfile.txt" using the WebDAV API
@@ -21,6 +22,8 @@ Feature: lock folders
 
   Scenario Outline: upload to a subfolder of a locked folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/CHILD/textfile.txt" using the WebDAV API
@@ -36,6 +39,7 @@ Feature: lock folders
   @smokeTest
   Scenario Outline: create folder in a locked folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" creates folder "/FOLDER/new-folder" using the WebDAV API
@@ -50,6 +54,8 @@ Feature: lock folders
 
   Scenario Outline: create folder in a subfolder of a locked folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" creates folder "/PARENT/CHILD/new-folder" using the WebDAV API
@@ -64,6 +70,8 @@ Feature: lock folders
 
   Scenario Outline: Move file out of a locked folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" moves file "/PARENT/parent.txt" to "/parent.txt" using the WebDAV API
@@ -79,6 +87,9 @@ Feature: lock folders
 
   Scenario Outline: Move file out of a locked sub folder one level higher into locked parent folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" moves file "/PARENT/CHILD/child.txt" to "/PARENT/child.txt" using the WebDAV API
@@ -94,6 +105,7 @@ Feature: lock folders
 
   Scenario Outline: lockdiscovery of a locked folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
     And user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -3,11 +3,16 @@ Feature: persistent-locking in case of a public link
 
   Background:
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
 
   @skipOnOcV10 @smokeTest @issue-36064
   Scenario Outline: Uploading a file into a locked public folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share of folder "FOLDER" with change permission
     When user "Alice" locks folder "FOLDER" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -2,7 +2,10 @@
 Feature: LOCKDISCOVERY for public links
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
 
   Scenario Outline: lockdiscovery root of public link when root is locked
     Given user "Alice" has created a public link share of folder "PARENT" with change permission

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
@@ -4,11 +4,16 @@ Feature: persistent-locking in case of a public link
 
   Background:
     Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file child" to "PARENT/CHILD/child.txt"
 
   @smokeTest @issue-36064
   Scenario Outline: Uploading a file into a locked public folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share of folder "FOLDER" with change permission
     When user "Alice" locks folder "FOLDER" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
@@ -60,7 +65,7 @@ Feature: persistent-locking in case of a public link
       | lockscope | <lock-scope> |
     When the public uploads file "parent.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
-    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent" plus end-of-line
+    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
     Examples:
       | public-webdav-api-version | lock-scope |
       | old                       | shared     |
@@ -89,7 +94,7 @@ Feature: persistent-locking in case of a public link
     And the public uploads file "CHILD/child.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "changed text"
-    But the content of file "/PARENT/CHILD/child.txt" for user "Alice" should be "ownCloud test text file child" plus end-of-line
+    But the content of file "/PARENT/CHILD/child.txt" for user "Alice" should be "ownCloud test text file child"
     Examples:
       | public-webdav-api-version | lock-scope |
       | old                       | shared     |

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -2,11 +2,13 @@
 Feature: actions on a locked item are possible if the token is sent with the request
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: rename a file in a locked folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" moves file "/PARENT/parent.txt" to "/PARENT/renamed-file.txt" sending the locktoken of folder "PARENT" using the WebDAV API
@@ -23,6 +25,9 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @smokeTest
   Scenario Outline: move a file into a locked folder
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" moves file "/PARENT/parent.txt" to "/FOLDER/moved-file.txt" sending the locktoken of folder "FOLDER" using the WebDAV API
@@ -39,6 +44,10 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @smokeTest
   Scenario Outline: move a file into a locked folder is impossible when using the wrong token
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
@@ -57,11 +66,13 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @skipOnOcV10 @issue-34338 @files_sharing-app-required
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
-    When user "Brian" moves file "PARENT (2)/parent.txt" to "PARENT (2)/renamed-file.txt" sending the locktoken of file "PARENT" of user "Alice" using the WebDAV API
+    When user "Brian" moves file "PARENT/parent.txt" to "PARENT/renamed-file.txt" sending the locktoken of file "PARENT" of user "Alice" using the WebDAV API
     Then the HTTP status code should be "423"
     And as "Alice" file "/PARENT/parent.txt" should exist
     But as "Alice" file "/PARENT/renamed-file.txt" should not exist
@@ -75,6 +86,8 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @files_sharing-app-required
   Scenario Outline: public cannot overwrite a file in a folder locked by the owner even when sending the locktoken
     Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
     And user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
@@ -82,7 +95,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
     Then the HTTP status code should be "423"
     When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "Alice" using the new public WebDAV API
     Then the HTTP status code should be "412"
-    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent" plus end-of-line
+    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
     Examples:
       | lock-scope |
       | shared     |
@@ -91,7 +104,9 @@ Feature: actions on a locked item are possible if the token is sent with the req
   @skipOnOcV10 @issue-34360 @files_sharing-app-required
   Scenario Outline: two users having both a shared lock can use the resource
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "some data" to "textfile0.txt"
+    And user "Brian" has uploaded file with content "some data" to "textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
@@ -3,13 +3,17 @@ Feature: actions on a locked item are possible if the token is sent with the req
 
   @issue-34338 @files_sharing-app-required
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
     And using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
-    When user "Brian" moves file "PARENT (2)/parent.txt" to "PARENT (2)/renamed-file.txt" sending the locktoken of file "PARENT" of user "Alice" using the WebDAV API
+    When user "Brian" moves file "PARENT/parent.txt" to "PARENT/renamed-file.txt" sending the locktoken of file "PARENT" of user "Alice" using the WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should not exist
     But as "Alice" file "/PARENT/renamed-file.txt" should exist

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
@@ -3,9 +3,13 @@ Feature: actions on a locked item are possible if the token is sent with the req
 
   @issue-34360 @files_sharing-app-required
   Scenario Outline: two users having both a shared lock can use the resource
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
     And using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    And user "Brian" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |
@@ -13,12 +17,12 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | lockscope | shared |
     When user "Alice" uploads file with content "from user 0" to "textfile0.txt" sending the locktoken of file "textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "423"
-    And the content of file "textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
-    And the content of file "textfile0 (2).txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
+    And the content of file "textfile0 (2).txt" for user "Brian" should be "ownCloud test text file 0"
     When user "Brian" uploads file with content "from user 1" to "textfile0 (2).txt" sending the locktoken of file "textfile0 (2).txt" using the WebDAV API
     Then the HTTP status code should be "423"
-    And the content of file "textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
-    And the content of file "textfile0 (2).txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
+    And the content of file "textfile0 (2).txt" for user "Brian" should be "ownCloud test text file 0"
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesOc10Issue36064.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesOc10Issue36064.feature
@@ -3,12 +3,15 @@ Feature: lock should propagate correctly if a share is reshared
 
   @issue-36064
   Scenario Outline: public uploads to a reshared share that was locked by original owner
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
       | Carol    |
     And the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "PARENT"
+    And user "Brian" has created folder "PARENT"
+    And user "Carol" has created folder "PARENT"
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
     And user "Carol" has created a public link share of folder "PARENT (2)" with change permission

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
@@ -2,11 +2,14 @@
 Feature: lock should propagate correctly if a share is reshared
 
   Background:
-    Given these users have been created with default attributes and small skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
       | Carol    |
+    And user "Alice" has created folder "PARENT"
+    And user "Brian" has created folder "PARENT"
+    And user "Carol" has created folder "PARENT"
 
   Scenario Outline: upload to a share that was locked by owner
     Given using <dav-path> DAV path
@@ -30,6 +33,9 @@ Feature: lock should propagate correctly if a share is reshared
 
   Scenario Outline: upload overwriting to a share that was locked by owner
     Given using <dav-path> DAV path
+    And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
+    And user "Brian" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
+    And user "Carol" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
     And user "Alice" has locked folder "PARENT" setting the following properties
@@ -40,7 +46,7 @@ Feature: lock should propagate correctly if a share is reshared
     Then the HTTP status code should be "423"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/parent.txt" using the WebDAV API
     Then the HTTP status code should be "423"
-    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent" plus end-of-line
+    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -5,11 +5,14 @@ Feature: lock should propagate correctly if a share is reshared
     Given the administrator has enabled DAV tech_preview
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And these users have been created with default attributes and small skeleton files:
+    And these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
       | Brian    |
       | Carol    |
+    And user "Alice" has created folder "PARENT"
+    And user "Brian" has created folder "PARENT"
+    And user "Carol" has created folder "PARENT"
 
   Scenario Outline: upload to a share that was locked by owner
     Given using <dav-path> DAV path
@@ -35,6 +38,9 @@ Feature: lock should propagate correctly if a share is reshared
 
   Scenario Outline: upload overwriting to a share that was locked by owner
     Given using <dav-path> DAV path
+    And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
+    And user "Brian" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
+    And user "Carol" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has shared folder "Shares/PARENT" with user "Carol"
@@ -47,7 +53,7 @@ Feature: lock should propagate correctly if a share is reshared
     Then the HTTP status code should be "423"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/parent.txt" using the WebDAV API
     Then the HTTP status code should be "423"
-    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent" plus end-of-line
+    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -2,7 +2,10 @@
 Feature: set timeouts of LOCKS
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
 
   @skipOnOcV10.3 @skipOnOcV10.4
   Scenario Outline: do not set timeout on folder and check the default timeout

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
@@ -2,12 +2,20 @@
 Feature: set timeouts of LOCKS on shares
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
+    And user "Brian" has created folder "PARENT"
+    And user "Brian" has created folder "PARENT/CHILD"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
 
 
   Scenario Outline: as owner set timeout on folder as receiver check it
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
@@ -40,7 +48,6 @@ Feature: set timeouts of LOCKS on shares
 
   Scenario Outline: as share receiver set timeout on folder as owner check it
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     When user "Brian" locks folder "PARENT (2)" using the WebDAV API setting the following properties
       | lockscope | shared    |

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -5,12 +5,20 @@ Feature: set timeouts of LOCKS on shares
     Given the administrator has enabled DAV tech_preview
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
+    And user "Brian" has created folder "PARENT"
+    And user "Brian" has created folder "PARENT/CHILD"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
 
 
   Scenario Outline: as owner set timeout on folder as receiver check it
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
@@ -44,7 +52,6 @@ Feature: set timeouts of LOCKS on shares
 
   Scenario Outline: as share receiver set timeout on folder as owner check it
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     When user "Brian" locks folder "Shares/PARENT" using the WebDAV API setting the following properties

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
@@ -3,7 +3,7 @@ Feature: independent locks
   Make sure all locks are independent and don't interact with other items that have the same name
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
 
   Scenario Outline: locking a folder does not lock other items with the same name in other parts of the file system

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
@@ -2,11 +2,14 @@
 Feature: UNLOCK locked items
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: unlock a single lock set by the user itself
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks the last created lock of folder "PARENT" using the WebDAV API
@@ -22,6 +25,7 @@ Feature: UNLOCK locked items
 
   Scenario Outline: unlock one of multiple locks set by the user itself
     Given using <dav-path> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | shared |
     And user "Alice" has locked file "textfile0.txt" setting the following properties
@@ -35,6 +39,9 @@ Feature: UNLOCK locked items
 
   Scenario Outline: unlocking a file that was locked by the user locking the folder above is not possible
     Given using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
     When user "Alice" unlocks file "PARENT/CHILD/child.txt" with the last created lock of folder "PARENT/CHILD" using the WebDAV API
@@ -49,7 +56,9 @@ Feature: UNLOCK locked items
 
   @skipOnOcV10 @issue-34302 @files_sharing-app-required @skipOnOcV10.3
   Scenario Outline: as public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
-    Given user "Alice" has created a public link share of folder "PARENT" with change permission
+    Given user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
+    And user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     When the public unlocks file "/parent.txt" with the last created lock of file "PARENT/parent.txt" of user "Alice" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
@@ -3,7 +3,9 @@ Feature: UNLOCK locked items
 
   @issue-34302 @files_sharing-app-required @skipOnOcV10.3
   Scenario Outline: as public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
@@ -2,12 +2,16 @@
 Feature: UNLOCK locked items (sharing)
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
 
 
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
@@ -25,7 +29,8 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a file in a share locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has created folder "PARENT"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
@@ -43,18 +48,19 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a shared folder locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
-    When user "Brian" unlocks folder "PARENT (2)" with the last created lock of folder "PARENT" of user "Alice" using the WebDAV API
+    When user "Brian" unlocks folder "PARENT" with the last created lock of folder "PARENT" of user "Alice" using the WebDAV API
     Then the HTTP status code should be "403"
     And 3 locks should be reported for folder "PARENT" of user "Alice" by the WebDAV API
     And 2 locks should be reported for folder "PARENT/CHILD" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
-    And 3 locks should be reported for folder "PARENT (2)" of user "Brian" by the WebDAV API
-    And 2 locks should be reported for folder "PARENT (2)/CHILD" of user "Brian" by the WebDAV API
-    And 1 locks should be reported for file "PARENT (2)/parent.txt" of user "Brian" by the WebDAV API
+    And 3 locks should be reported for folder "PARENT" of user "Brian" by the WebDAV API
+    And 2 locks should be reported for folder "PARENT/CHILD" of user "Brian" by the WebDAV API
+    And 1 locks should be reported for file "PARENT/parent.txt" of user "Brian" by the WebDAV API
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |
@@ -65,7 +71,6 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlock a shared file
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has locked file "parent.txt" setting the following properties
       | lockscope | <lock-scope> |
@@ -83,7 +88,6 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a shared file locked by the receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has locked file "parent.txt" setting the following properties
       | lockscope | <lock-scope> |
@@ -101,14 +105,13 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a file in a share that was locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
-    And user "Brian" has locked file "PARENT (2)/parent.txt" setting the following properties
+    And user "Brian" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
-    When user "Alice" unlocks file "PARENT/parent.txt" with the last created lock of file "PARENT (2)/parent.txt" of user "Brian" using the WebDAV API
+    When user "Alice" unlocks file "PARENT/parent.txt" with the last created lock of file "PARENT/parent.txt" of user "Brian" using the WebDAV API
     Then the HTTP status code should be "403"
     And 1 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
-    And 1 locks should be reported for file "PARENT (2)/parent.txt" of user "Brian" by the WebDAV API
+    And 1 locks should be reported for file "PARENT/parent.txt" of user "Brian" by the WebDAV API
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |
@@ -119,18 +122,19 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a shared folder locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has shared folder "PARENT" with user "Brian"
-    And user "Brian" has locked folder "PARENT (2)" setting the following properties
+    And user "Brian" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
-    When user "Alice" unlocks folder "PARENT" with the last created lock of folder "PARENT (2)" of user "Brian" using the WebDAV API
+    When user "Alice" unlocks folder "PARENT" with the last created lock of folder "PARENT" of user "Brian" using the WebDAV API
     Then the HTTP status code should be "403"
     And 3 locks should be reported for folder "PARENT" of user "Alice" by the WebDAV API
     And 2 locks should be reported for folder "PARENT/CHILD" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
-    And 3 locks should be reported for folder "PARENT (2)" of user "Brian" by the WebDAV API
-    And 2 locks should be reported for folder "PARENT (2)/CHILD" of user "Brian" by the WebDAV API
-    And 1 locks should be reported for file "PARENT (2)/parent.txt" of user "Brian" by the WebDAV API
+    And 3 locks should be reported for folder "PARENT" of user "Brian" by the WebDAV API
+    And 2 locks should be reported for folder "PARENT/CHILD" of user "Brian" by the WebDAV API
+    And 1 locks should be reported for file "PARENT/parent.txt" of user "Brian" by the WebDAV API
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -5,12 +5,16 @@ Feature: UNLOCK locked items (sharing)
     Given the administrator has enabled DAV tech_preview
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
 
 
   Scenario Outline: as share receiver unlocking a shared file locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
@@ -29,7 +33,6 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a file in a share locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has locked file "PARENT/parent.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
@@ -48,7 +51,8 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlocking a shared folder locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "PARENT" with user "Brian"
@@ -71,7 +75,6 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as share receiver unlock a shared file
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Alice"
     And user "Brian" has locked file "Shares/parent.txt" setting the following properties
@@ -90,7 +93,6 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a shared file locked by the receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared file "PARENT/parent.txt" with user "Brian"
     And user "Brian" has accepted share "/PARENT/parent.txt" offered by user "Alice"
     And user "Brian" has locked file "Shares/parent.txt" setting the following properties
@@ -109,7 +111,6 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a file in a share that was locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has locked file "Shares/PARENT/parent.txt" setting the following properties
@@ -128,7 +129,8 @@ Feature: UNLOCK locked items (sharing)
 
   Scenario Outline: as owner unlocking a shared folder locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has locked folder "Shares/PARENT" setting the following properties


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiWebdavLocks
  - apiWebdavLocks2
  - apiWebdavLocks3
  - apiWebdavLocksUnlock

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
