### PR TITLE
fix moving an encrypted file to an unencrypted storage

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -701,6 +701,8 @@ class Encryption extends Wrapper {
 			}
 
 			$cacheInformation['encryptedVersion'] = $encryptedVersion;
+		} else {
+			$cacheInformation['encryptedVersion'] = 0;
 		}
 
 		// in case of a rename we need to manipulate the source cache because
@@ -711,7 +713,7 @@ class Encryption extends Wrapper {
 			 * incremented version of source file, for the destination file.
 			 */
 			$encryptedVersion = $sourceStorage->getCache()->get($sourceInternalPath)['encryptedVersion'];
-			if ($this->encryptionManager->isEnabled()) {
+			if ($this->encryptionManager->isEnabled() && $isEncrypted) {
 				$cacheInformation['encryptedVersion'] = $encryptedVersion + 1;
 			}
 			$sourceStorage->getCache()->put($sourceInternalPath, $cacheInformation);

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -802,6 +802,7 @@ class EncryptionTest extends Storage {
 
 		$expectedCachePut = [
 			'encrypted' => $expectedEncrypted,
+			'encryptedVersion' => 0
 		];
 		if ($expectedEncrypted === true) {
 			$expectedCachePut['encryptedVersion'] = 12345;


### PR DESCRIPTION
Mark a file as unencrypted when moving it from an encrypted storage to an unencrypted storage.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/encryption/issues/256
- Fixes https://github.com/owncloud/encryption/issues/257

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
