### PR TITLE
[tests-only] prepare required resources rather than using skeleton directories in API WebDav move, operations and preview features 

### DIFF
--- a/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
@@ -6,28 +6,30 @@ Feature: users cannot move (rename) a file to a blacklisted name
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And the administrator has enabled async operations
 
   Scenario: rename a file to a filename that is banned by default
-    When user "Alice" moves file "/welcome.txt" asynchronously to "/.htaccess" using the WebDAV API
+    When user "Alice" moves file "/textfile0.txt" asynchronously to "/.htaccess" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "Alice" should see the following elements
-      | /welcome.txt |
+      | /textfile0.txt |
 
   Scenario: rename a file to a banned filename
     When the administrator updates system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json" using the occ command
-    And user "Alice" moves file "/welcome.txt" asynchronously to "/blacklisted-file.txt" using the WebDAV API
+    And user "Alice" moves file "/textfile0.txt" asynchronously to "/blacklisted-file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "Alice" should see the following elements
-      | /welcome.txt |
+      | /textfile0.txt |
 
   @skipOnOcV10.3
   Scenario: rename a file to a filename that matches (or not) blacklisted_files_regex
+    Given user "Alice" has created folder "FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
-    Given the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
-    When user "Alice" moves file "/welcome.txt" asynchronously to these filenames using the webDAV API then the results should be as listed
+    And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
+    When user "Alice" moves file "/textfile0.txt" asynchronously to these filenames using the webDAV API then the results should be as listed
       | filename                               | http-code | exists |
       | .ext                                   | 403       | no     |
       | filename.ext                           | 403       | no     |

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
@@ -6,28 +6,31 @@ Feature: users cannot move (rename) a file to or into an excluded directory
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And the administrator has enabled async operations
 
   Scenario: rename a file to an excluded directory name
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
-    And user "Alice" moves file "/welcome.txt" asynchronously to "/.github" using the WebDAV API
+    And user "Alice" moves file "/textfile0.txt" asynchronously to "/.github" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "Alice" should see the following elements
       | /welcome.txt |
 
   Scenario: rename a file to an excluded directory name inside a parent directory
+    Given user "Alice" has created folder "FOLDER"
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
-    And user "Alice" moves file "/welcome.txt" asynchronously to "/FOLDER/.github" using the WebDAV API
+    And user "Alice" moves file "/textfile0.txt" asynchronously to "/FOLDER/.github" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "Alice" should see the following elements
-      | /welcome.txt |
+      | /textfile0.txt |
 
   @skipOnOcV10.3
   Scenario: rename a file to a filename that matches (or not) excluded_directories_regex
+    Given user "Alice" has created folder "FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
-    Given the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
+    And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
     When user "Alice" moves file "/welcome.txt" asynchronously to these filenames using the webDAV API then the results should be as listed
       | filename                                   | http-code | exists |
       | endswith.bad                               | 403       | no     |

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
@@ -38,8 +38,9 @@ Feature: users cannot move (rename) a folder to a blacklisted name
   @skipOnOcV10.3
   Scenario Outline: rename a folder to a folder name that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
+    And user "Brian" has created folder "/FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
     And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
@@ -6,7 +6,7 @@ Feature: users cannot move (rename) a folder to or into an excluded directory
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   Scenario Outline: Rename a folder to an excluded directory name
     Given using <dav_version> DAV path
@@ -24,6 +24,7 @@ Feature: users cannot move (rename) a folder to or into an excluded directory
   Scenario Outline: Rename a folder to an excluded directory name inside a parent directory
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/testshare"
+    And user "Alice" has created folder "/FOLDER"
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "Alice" moves folder "/testshare" to "/FOLDER/.github" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -38,6 +39,7 @@ Feature: users cannot move (rename) a folder to or into an excluded directory
   Scenario Outline: rename a folder to a folder name that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/testshare"
+    And user "Alice" has created folder "/FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
     And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -6,16 +6,18 @@ Feature: move (rename) file
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Moving a file
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     When user "Alice" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And the content of file "/FOLDER/textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "/FOLDER/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
       | dav_version |
       | old         |
@@ -24,11 +26,13 @@ Feature: move (rename) file
   @smokeTest
   Scenario Outline: Moving and overwriting a file
     Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     When user "Alice" moves file "/textfile0.txt" to "/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the following headers should match these regular expressions for user "Alice"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And the content of file "/textfile1.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "/textfile1.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
       | dav_version |
       | old         |
@@ -36,10 +40,11 @@ Feature: move (rename) file
 
   Scenario Outline: Moving (renaming) a file to be only different case
     Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     When user "Alice" moves file "/textfile0.txt" to "/TextFile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/textfile0.txt" should not exist
-    And the content of file "/TextFile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "/TextFile0.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
       | dav_version |
       | old         |
@@ -48,10 +53,12 @@ Feature: move (rename) file
   @smokeTest
   Scenario Outline: Moving (renaming) a file to a file with only different case to an existing file
     Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     When user "Alice" moves file "/textfile1.txt" to "/TextFile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
-    And the content of file "/TextFile0.txt" for user "Alice" should be "ownCloud test text file 1" plus end-of-line
+    And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
+    And the content of file "/TextFile0.txt" for user "Alice" should be "ownCloud test text file 1"
     Examples:
       | dav_version |
       | old         |
@@ -59,10 +66,13 @@ Feature: move (rename) file
 
   Scenario Outline: Moving (renaming) a file to a file in a folder with only different case to an existing file
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     When user "Alice" moves file "/textfile1.txt" to "/PARENT/Parent.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent" plus end-of-line
-    And the content of file "/PARENT/Parent.txt" for user "Alice" should be "ownCloud test text file 1" plus end-of-line
+    And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
+    And the content of file "/PARENT/Parent.txt" for user "Alice" should be "ownCloud test text file 1"
     Examples:
       | dav_version |
       | old         |
@@ -165,7 +175,8 @@ Feature: move (rename) file
   @files_sharing-app-required
   Scenario Outline: Moving a file to a shared folder with no permissions
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
       | path        | testshare |
@@ -184,14 +195,16 @@ Feature: move (rename) file
   @files_sharing-app-required
   Scenario Outline: Moving a file to overwrite a file in a shared folder with no permissions
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
+    And user "Brian" has uploaded file with content "Welcome to ownCloud" to "fileToCopy.txt"
     And user "Brian" has created a share with settings
       | path        | testshare |
       | shareType   | user      |
       | permissions | read      |
       | shareWith   | Alice     |
-    And user "Brian" has copied file "/welcome.txt" to "/testshare/overwritethis.txt"
+    And user "Brian" has copied file "/fileToCopy.txt" to "/testshare/overwritethis.txt"
     When user "Alice" moves file "/textfile0.txt" to "/testshare/overwritethis.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     And the downloaded content when downloading file "/testshare/overwritethis.txt" for user "Alice" with range "bytes=0-6" should be "Welcome"
@@ -202,7 +215,8 @@ Feature: move (rename) file
 
   Scenario Outline: move file into a not-existing folder
     Given using <dav_version> DAV path
-    When user "Alice" moves file "/welcome.txt" to "/not-existing/welcome.txt" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToMove.txt"
+    When user "Alice" moves file "/fileToMove.txt" to "/not-existing/welcome.txt" using the WebDAV API
     Then the HTTP status code should be "409"
     Examples:
       | dav_version |
@@ -212,7 +226,8 @@ Feature: move (rename) file
   @issue-ocis-reva-211
   Scenario Outline: rename a file into an invalid filename
     Given using <dav_version> DAV path
-    When user "Alice" moves file "/welcome.txt" to "/a\\a" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToRename.txt"
+    When user "Alice" moves file "/fileToRename.txt" to "/a\\a" using the WebDAV API
     Then the HTTP status code should be "400"
     Examples:
       | dav_version |
@@ -221,6 +236,8 @@ Feature: move (rename) file
 
   Scenario Outline: Checking file id after a move
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has stored id of file "/textfile0.txt"
     When user "Alice" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt" using the WebDAV API
     Then user "Alice" file "/FOLDER/textfile0.txt" should have the previously stored id
@@ -234,7 +251,7 @@ Feature: move (rename) file
   @files_sharing-app-required
   Scenario Outline: Checking file id after a move between received shares
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/folderA"
     And user "Alice" has created folder "/folderB"
     And user "Alice" has shared folder "/folderA" with user "Brian"
@@ -258,37 +275,39 @@ Feature: move (rename) file
   @issue-ocis-reva-211
   Scenario Outline: Renaming a file to a path with extension .part should not be possible
     Given using <dav_version> DAV path
-    When user "Alice" moves file "/welcome.txt" to "/welcome.part" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToRename.txt"
+    When user "Alice" moves file "/fileToRename.txt" to "/welcome.part" using the WebDAV API
     Then the HTTP status code should be "400"
     And the DAV exception should be "OCA\DAV\Connector\Sabre\Exception\InvalidPath"
     And the DAV message should be "Can`t upload files with extension .part because these extensions are reserved for internal use."
     And the DAV reason should be "Can`t upload files with extension .part because these extensions are reserved for internal use."
     And user "Alice" should see the following elements
-      | /welcome.txt |
+      | /fileToRename.txt |
     But user "Alice" should not see the following elements
-      | /welcome.part |
+      | /fileToRename.part |
     Examples:
       | dav_version |
       | old         |
       | new         |
 
   Scenario: renaming to a file with special characters
+    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     When user "Alice" moves the following file using the WebDAV API
       | source         | destination   |
       | /textfile0.txt | *a@b#c$e%f&g* |
       | /textfile1.txt | 1 2 3##.##    |
     Then the HTTP status code of responses on all endpoints should be "201"
-    And the content of the following files for user "Alice" should be the following plus end-of-line
-      | filename       | content                   |
-      | *a@b#c$e%f&g*  | ownCloud test text file 0 |
-      | 1 2 3##.##     | ownCloud test text file 1 |
+    And the content of file "*a@b#c$e%f&g*" for user "Alice" should be "ownCloud test text file 0"
+    And the content of file "1 2 3##.##" for user "Alice" should be "ownCloud test text file 1"
 
   @issue-ocis-reva-265
   #after fixing the issues merge this Scenario into the one above
   Scenario Outline: renaming to a file with question mark in its name
+    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     When user "Alice" moves file "/textfile0.txt" to "/<renamed_file>" using the WebDAV API
     Then the HTTP status code should be "201"
-    And the content of file "/<renamed_file>" for user "Alice" should be "ownCloud test text file 0" plus end-of-line
+    And the content of file "/<renamed_file>" for user "Alice" should be "ownCloud test text file 0"
     Examples:
       | renamed_file  |
       | #oc ab?cd=ef# |
@@ -318,6 +337,7 @@ Feature: move (rename) file
   @smokeTest
   Scenario Outline: user tries to move a file that doesnt exist into a folder
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" moves file "/doesNotExist.txt" to "/FOLDER/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "404"
     And as "Alice" file "/FOLDER/textfile0.txt" should not exist
@@ -339,6 +359,7 @@ Feature: move (rename) file
 
   Scenario Outline: Moving a hidden file
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded the following files with content "hidden file"
       | path                    |
       | .hidden_file101         |

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
@@ -6,12 +6,13 @@ Feature: users cannot move (rename) a file to a blacklisted name
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
 
   @issue-ocis-reva-211
   Scenario Outline: rename a file to a filename that is banned by default
     Given using <dav_version> DAV path
-    When user "Alice" moves file "/welcome.txt" to "/.htaccess" using the WebDAV API
+    When user "Alice" moves file "/textfile0.txt" to "/.htaccess" using the WebDAV API
     Then the HTTP status code should be "403"
     Examples:
       | dav_version |
@@ -22,7 +23,7 @@ Feature: users cannot move (rename) a file to a blacklisted name
   Scenario Outline: rename a file to a banned filename
     Given using <dav_version> DAV path
     When the administrator updates system config key "blacklisted_files" with value '["blacklisted-file.txt",".htaccess"]' and type "json" using the occ command
-    And user "Alice" moves file "/welcome.txt" to "/blacklisted-file.txt" using the WebDAV API
+    And user "Alice" moves file "/textfile0.txt" to "/blacklisted-file.txt" using the WebDAV API
     Then the HTTP status code should be "403"
     Examples:
       | dav_version |
@@ -32,10 +33,11 @@ Feature: users cannot move (rename) a file to a blacklisted name
   @skipOnOcV10.3
   Scenario Outline: rename a file to a filename that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
     And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"
-    When user "Alice" moves file "/welcome.txt" to these filenames using the webDAV API then the results should be as listed
+    When user "Alice" moves file "/textfile0.txt" to these filenames using the webDAV API then the results should be as listed
       | filename                               | http-code | exists |
       | .ext                                   | 403       | no     |
       | filename.ext                           | 403       | no     |

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
@@ -6,12 +6,13 @@ Feature: users cannot move (rename) a file to or into an excluded directory
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
 
   Scenario Outline: rename a file to an excluded directory name
     Given using <dav_version> DAV path
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
-    And user "Alice" moves file "/welcome.txt" to "/.github" using the WebDAV API
+    And user "Alice" moves file "/textfile0.txt" to "/.github" using the WebDAV API
     Then the HTTP status code should be "403"
     Examples:
       | dav_version |
@@ -20,8 +21,9 @@ Feature: users cannot move (rename) a file to or into an excluded directory
 
   Scenario Outline: rename a file to an excluded directory name inside a parent directory
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
-    And user "Alice" moves file "/welcome.txt" to "/FOLDER/.github" using the WebDAV API
+    And user "Alice" moves file "/textfile0.txt" to "/FOLDER/.github" using the WebDAV API
     Then the HTTP status code should be "403"
     Examples:
       | dav_version |
@@ -31,6 +33,7 @@ Feature: users cannot move (rename) a file to or into an excluded directory
   @skipOnOcV10.3
   Scenario Outline: rename a file to a filename that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
     And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"

--- a/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
+++ b/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature
@@ -24,9 +24,10 @@ Feature: refuse access
 
   Scenario Outline: A disabled user cannot use webdav
     Given using <dav_version> DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" has been disabled
-    When user "Alice" downloads file "/welcome.txt" using the WebDAV API
+    When user "Alice" downloads file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "401"
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiWebdavOperations/search.feature
+++ b/tests/acceptance/features/apiWebdavOperations/search.feature
@@ -5,7 +5,7 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given user "Alice" has been created with default attributes and small skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/just-a-folder"
     And user "Alice" has created folder "/फनी näme"
     And user "Alice" has created folder "/upload folder"
@@ -44,6 +44,7 @@ Feature: Search
 
   Scenario Outline: search for entries by only some letters from the middle of the entry name
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
     When user "Alice" searches for "ol" using the WebDAV API
     Then the HTTP status code should be "207"
     And the search result should contain "4" entries


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiWebdavMove1
  - apiWebdavMove2
  - apiWebdavOperations
  - apiWebdavPreviews

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
