### PR TITLE
[tests-only] prepare required resources rather than using skeleton dirs in API webdav properties and upload test features

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -49,7 +49,7 @@ Feature: copy file
   @issue-ocis-reva-11
   Scenario Outline: Copying a file to a folder with no permissions
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
     And user "Brian" has created a share with settings
       | path        | testshare |
@@ -69,8 +69,9 @@ Feature: copy file
   @issue-ocis-reva-11
   Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
+    And user "Brian" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     And user "Brian" has created a share with settings
       | path        | testshare |
       | shareType   | user      |

--- a/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
@@ -6,7 +6,7 @@ Feature: get quota
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   Scenario Outline: Retrieving folder quota when no quota is set
     Given using <dav_version> DAV path
@@ -21,7 +21,7 @@ Feature: get quota
   Scenario Outline: Retrieving folder quota when quota is set
     Given using <dav_version> DAV path
     When the administrator sets the quota of user "Alice" to "10 MB" using the provisioning API
-    Then as user "Alice" folder "/" should contain a property "d:quota-available-bytes" with value "10485406"
+    Then as user "Alice" folder "/" should contain a property "d:quota-available-bytes" with value "10485597"
     Examples:
       | dav_version |
       | old         |
@@ -30,7 +30,7 @@ Feature: get quota
   @files_sharing-app-required
   Scenario Outline: Retrieving folder quota of shared folder with quota when no quota is set for recipient
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been given unlimited quota
     And the quota of user "Brian" has been set to "10 MB"
     And user "Brian" has created folder "/testquota"
@@ -42,7 +42,7 @@ Feature: get quota
     When user "Alice" gets the following properties of folder "/testquota" using the WebDAV API
       | propertyName            |
       | d:quota-available-bytes |
-    Then the single response should contain a property "d:quota-available-bytes" with value "10485406"
+    Then the single response should contain a property "d:quota-available-bytes" with value "10485597"
     Examples:
       | dav_version |
       | old         |
@@ -55,7 +55,7 @@ Feature: get quota
     When user "Alice" gets the following properties of folder "/" using the WebDAV API
       | propertyName            |
       | d:quota-available-bytes |
-    Then the single response should contain a property "d:quota-available-bytes" with value "577"
+    Then the single response should contain a property "d:quota-available-bytes" with value "768"
     Examples:
       | dav_version |
       | old         |
@@ -64,14 +64,25 @@ Feature: get quota
   @files_sharing-app-required
   Scenario Outline: Retrieving folder quota when quota is set and a file was received
     Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
     And the quota of user "Brian" has been set to "1 KB"
     And user "Alice" has uploaded file "/Alice.txt" of size 93 bytes
     And user "Alice" has shared file "Alice.txt" with user "Brian"
     When user "Brian" gets the following properties of folder "/" using the WebDAV API
       | propertyName            |
       | d:quota-available-bytes |
-    Then the single response should contain a property "d:quota-available-bytes" with value "670"
+    Then the single response should contain a property "d:quota-available-bytes" with value "861"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @smokeTest
+  Scenario Outline: Retrieving folder quota when quota is set for a user initialized with skeleton files
+    Given user "Brian" has been created with default attributes and small skeleton files
+    And using <dav_version> DAV path
+    When the administrator sets the quota of user "Brian" to "10 MB" using the provisioning API
+    Then as user "Brian" folder "/" should contain a property "d:quota-available-bytes" with value "10485406"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
@@ -6,7 +6,7 @@ Feature: upload file using new chunking
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
     And the administrator has enabled async operations
@@ -63,7 +63,8 @@ Feature: upload file using new chunking
       | dav |
 
   Scenario: Upload chunked file overwriting existing file using async MOVE
-    Given user "Alice" has copied file "/textfile0.txt" to "/existingFile.txt"
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" has copied file "/textfile0.txt" to "/existingFile.txt"
     When user "Alice" uploads the following chunks asynchronously to "/existingFile.txt" with new chunking and using the WebDAV API
       | number | content |
       | 1      | AAAAA   |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
@@ -6,7 +6,7 @@ Feature: users cannot upload a file to a blacklisted name
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @issue-ocis-reva-15
   Scenario Outline: upload a file to a filename that is banned by default
@@ -35,6 +35,7 @@ Feature: users cannot upload a file to a blacklisted name
   @issue-ocis-reva-54
   Scenario Outline: upload a file to a filename that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
     And the administrator has updated system config key "blacklisted_files_regex" with value '[".*\\.ext$","^bannedfilename\\..+","containsbannedstring"]' and type "json"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
@@ -6,7 +6,7 @@ Feature: users cannot upload a file to a blacklisted name using new chunking
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
     And the administrator has enabled async operations

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
@@ -6,7 +6,7 @@ Feature: users cannot upload a file to or into an excluded directory
 
   Background:
     Given using OCS API version "1"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @issue-ocis-reva-54
   Scenario Outline: upload a file to an excluded directory name
@@ -23,6 +23,7 @@ Feature: users cannot upload a file to or into an excluded directory
   @issue-ocis-reva-54
   Scenario Outline: upload a file to an excluded directory name inside a parent directory
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "Alice" uploads file with content "uploaded content" to "/FOLDER/.github" using the WebDAV API
     Then the HTTP status code should be "403"
@@ -37,6 +38,7 @@ Feature: users cannot upload a file to or into an excluded directory
   @issue-ocis-reva-54
   Scenario Outline: upload a file to a filename that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
+    And user "Alice" has created folder "FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
     And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
@@ -6,7 +6,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
 
   Background:
     Given using new DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And the owncloud log level has been set to debug
     And the owncloud log has been cleared
     And the administrator has enabled async operations
@@ -22,6 +22,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
     And as "Alice" file "/.github" should not exist
 
   Scenario: Upload to an excluded directory name inside a parent directory using new chunking and async MOVE
+    Given user "Alice" has created folder "FOLDER"
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to a blacklisted name using new chunking
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   Scenario: Upload a file to a filename that is banned by default using new chunking
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to a blacklisted name using old chunking
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnOcV10 @issue-36645
   Scenario: Upload a file to a filename that is banned by default using old chunking

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunkingOc10Issue36645.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunkingOc10Issue36645.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to a blacklisted name using old chunking
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @issue-36645
   Scenario: Upload a file to a filename that is banned by default using old chunking

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   Scenario: Upload a file to an excluded directory name using new chunking
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
@@ -20,6 +20,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
     And as "Alice" file ".github" should not exist
 
   Scenario: Upload a file to an excluded directory name inside a parent directory using new chunking
+    Given user "Alice" has created folder "FOLDER"
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to or into an excluded directory using old c
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnOcV10 @issue-36645
   Scenario: Upload a file to an excluded directory name using old chunking
@@ -18,6 +18,7 @@ Feature: users cannot upload a file to or into an excluded directory using old c
 
   @skipOnOcV10 @issue-36645
   Scenario: Upload a file to an excluded directory name inside a parent directory using old chunking
+    Given user "Alice" has created folder "FOLDER"
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "Alice" uploads file "filesForUpload/textfile.txt" to "/FOLDER/.github" in 3 chunks using the WebDAV API
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunkingOc10Issue36645.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunkingOc10Issue36645.feature
@@ -7,7 +7,7 @@ Feature: users cannot upload a file to or into an excluded directory using old c
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @issue-36645
   Scenario: Upload a file to an excluded directory name using old chunking
@@ -19,6 +19,7 @@ Feature: users cannot upload a file to or into an excluded directory using old c
 
   @issue-36645
   Scenario: Upload a file to an excluded directory name inside a parent directory using old chunking
+    Given user "Alice" has created folder "FOLDER"
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
     And user "Alice" uploads file "filesForUpload/textfile.txt" to "/FOLDER/.github" in 3 chunks using the WebDAV API
     Then the HTTP status code should be "507"

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -7,7 +7,7 @@ Feature: upload file using new chunking
   Background:
     Given using OCS API version "1"
     And using new DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
 
   Scenario: Upload chunked file asc with new chunking
@@ -59,7 +59,8 @@ Feature: upload file using new chunking
 
 
   Scenario: Checking file id after a move overwrite using new chunking endpoint
-    Given the owncloud log level has been set to debug
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And the owncloud log level has been set to debug
     And the owncloud log has been cleared
     And user "Alice" has copied file "/textfile0.txt" to "/existingFile.txt"
     And user "Alice" has stored id of file "/existingFile.txt"

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
@@ -7,7 +7,7 @@ Feature: upload file using old chunking
   Background:
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnOcV10 @issue-36115
   Scenario: Upload chunked file asc
@@ -41,7 +41,8 @@ Feature: upload file using old chunking
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "AAAAABBBBBCCCCC"
 
   Scenario: Checking file id after a move overwrite using old chunking endpoint
-    Given the owncloud log level has been set to debug
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And the owncloud log level has been set to debug
     And the owncloud log has been cleared
     And user "Alice" has copied file "/textfile0.txt" to "/existingFile.txt"
     And user "Alice" has stored id of file "/existingFile.txt"

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunkingOc10Issue36115.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunkingOc10Issue36115.feature
@@ -8,7 +8,7 @@ Feature: upload file using old chunking
   Scenario: Upload chunked file asc
     Given using OCS API version "1"
     And using old DAV path
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     When user "Alice" uploads the following "3" chunks to "/myChunkedFile.txt" with old chunking and using the WebDAV API
       | number | content |
       | 1      | AAAAA   |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiWebdavProperties1
  - apiWebdavProperties2
  - apiWebdavUpload1
  - apiWebdavUpload2
  - apiWebdavUploadTUS

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
