### PR TITLE
[tests-only] prepare required resources rather than using skeleton files in API federation test features

### DIFF
--- a/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
@@ -4,9 +4,11 @@ Feature: propagation of etags between federated and local server
   Background:
     Given using OCS API version "1"
     And using server "REMOTE"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "PARENT"
 
   Scenario: Overwrite a federated shared folder as sharer propagates etag for recipient
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"

--- a/tests/acceptance/features/apiFederationToRoot1/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federated.feature
@@ -3,13 +3,14 @@ Feature: federated
 
   Background:
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Federate share a file with another server
     Given using OCS API version "<ocs-api-version>"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -35,7 +36,10 @@ Feature: federated
 
   @smokeTest
   Scenario Outline: Federate share a file with local server
-    Given using OCS API version "<ocs-api-version>"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And using server "LOCAL"
+    And using OCS API version "<ocs-api-version>"
     When user "Alice" from server "REMOTE" shares "/textfile0.txt" with user "Brian" from server "LOCAL" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -60,7 +64,10 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Remote sharee can see the pending share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
     Then the OCS status code should be "<ocs-status>"
@@ -81,8 +88,11 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Remote sharee requests information of only one share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" retrieves the information of the last federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
@@ -95,7 +105,7 @@ Feature: federated
       | name        | /textfile0.txt           |
       | owner       | %username%               |
       | user        | %username%               |
-      | mountpoint  | /textfile0 (2).txt       |
+      | mountpoint  | /textfile0.txt       |
       | accepted    | 1                        |
       | type        | file                     |
       | permissions | share,read,update,delete |
@@ -106,7 +116,10 @@ Feature: federated
 
   @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
   Scenario Outline: Remote sharee requests information of only one share before accepting it
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" retrieves the information of the last pending federated cloud share using the sharing API
     Then the HTTP status code should be "200"
@@ -147,7 +160,9 @@ Feature: federated
       | 2               | 404        | 404         |
 
   Scenario Outline: accept a pending remote share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" from server "LOCAL" accepts the last pending share using the sharing API
     Then the OCS status code should be "<ocs-status>"
@@ -158,13 +173,15 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Reshare a federated shared file
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
     And user "Carol" has been created with default attributes and small skeleton files
     And using OCS API version "<ocs-api-version>"
     When user "Brian" creates a share using the sharing API with settings
-      | path        | /textfile0 (2).txt |
+      | path        | /textfile0.txt |
       | shareType   | user               |
       | shareWith   | Carol              |
       | permissions | share,read,update  |
@@ -176,7 +193,7 @@ Feature: federated
       | item_source            | A_STRING           |
       | share_type             | user               |
       | file_source            | A_STRING           |
-      | path                   | /textfile0 (2).txt |
+      | path                   | /textfile0.txt |
       | permissions            | share,read,update  |
       | stime                  | A_NUMBER           |
       | storage                | A_STRING           |
@@ -191,11 +208,12 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a federated shared file as recipient - local server shares - remote server receives
-    Given user "Brian" from server "LOCAL" has shared "/textfile0.txt" with user "Alice" from server "REMOTE"
+    Given user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Brian" from server "LOCAL" has shared "/textfile0.txt" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
     And using OCS API version "<ocs-api-version>"
-    When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/textfile0.txt" for user "Brian" on server "LOCAL" should be "BLABLABLA" plus end-of-line
     Examples:
@@ -204,10 +222,13 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a federated shared file as recipient - remote server shares - local server receives
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
-    When user "Brian" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0 (2).txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/textfile0.txt" for user "Alice" on server "REMOTE" should be "BLABLABLA" plus end-of-line
     Examples:
@@ -216,11 +237,12 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
-    Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
+    Given user "Brian" has created folder "PARENT"
+    And user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
     And using OCS API version "<ocs-api-version>"
-    When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/PARENT/textfile0.txt" for user "Brian" on server "LOCAL" should be "BLABLABLA" plus end-of-line
     Examples:
@@ -229,10 +251,13 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
-    Given user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
-    When user "Brian" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/PARENT/textfile0.txt" for user "Alice" on server "REMOTE" should be "BLABLABLA" plus end-of-line
     Examples:
@@ -241,16 +266,19 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a federated shared file as recipient using old chunking
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
-    When user "Brian" uploads the following "3" chunks to "/textfile0 (2).txt" with old chunking and using the WebDAV API
+    When user "Brian" uploads the following "3" chunks to "/textfile0.txt" with old chunking and using the WebDAV API
       | number | content |
       | 1      | AAAAA   |
       | 2      | BBBBB   |
       | 3      | CCCCC   |
     Then the HTTP status code should be "201"
-    And the content of file "/textfile0 (2).txt" for user "Brian" should be "AAAAABBBBBCCCCC"
+    And the content of file "/textfile0.txt" for user "Brian" should be "AAAAABBBBBCCCCC"
     And the content of file "/textfile0.txt" for user "Alice" on server "REMOTE" should be "AAAAABBBBBCCCCC"
     Examples:
       | ocs-api-version | ocs-status |
@@ -258,16 +286,19 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient using old chunking
-    Given user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
-    When user "Brian" uploads the following "3" chunks to "/PARENT (2)/textfile0.txt" with old chunking and using the WebDAV API
+    When user "Brian" uploads the following "3" chunks to "/PARENT/textfile0.txt" with old chunking and using the WebDAV API
       | number | content |
       | 1      | AAAAA   |
       | 2      | BBBBB   |
       | 3      | CCCCC   |
     Then the HTTP status code should be "201"
-    And the content of file "/PARENT (2)/textfile0.txt" for user "Brian" should be "AAAAABBBBBCCCCC"
+    And the content of file "/PARENT/textfile0.txt" for user "Brian" should be "AAAAABBBBBCCCCC"
     And the content of file "/PARENT/textfile0.txt" for user "Alice" on server "REMOTE" should be "AAAAABBBBBCCCCC"
     Examples:
       | ocs-api-version | ocs-status |
@@ -275,14 +306,17 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Remote sharee deletes an accepted federated share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "Brian" should not see the following elements
-      | /textfile0%20(2).txt |
+      | /textfile0.txt |
     When user "Brian" gets the list of federated cloud shares using the sharing API
     Then the response should contain 0 entries
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
@@ -294,14 +328,17 @@ Feature: federated
 
   @issue-31276 @skipOnOcV10
   Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last federated cloud share with password "invalid" using the sharing API
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should see the following elements
-      | /textfile0%20(2).txt |
+      | /textfile0.txt |
     When user "Brian" gets the list of federated cloud shares using the sharing API
     Then the fields of the last response about user "Alice" sharing with user "Brian" should include
       | id          | A_STRING                 |
@@ -311,7 +348,7 @@ Feature: federated
       | name        | /textfile0.txt           |
       | owner       | %username%               |
       | user        | %username%               |
-      | mountpoint  | /textfile0 (2).txt       |
+      | mountpoint  | /textfile0.txt       |
       | accepted    | 1                        |
       | type        | file                     |
       | permissions | share,delete,update,read |
@@ -323,13 +360,16 @@ Feature: federated
       | 2               |
 
   Scenario Outline: Remote sharee deletes a pending federated share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last pending federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "Brian" should not see the following elements
-      | /textfile0%20(2).txt |
+      | /textfile0.txt |
     When user "Brian" gets the list of federated cloud shares using the sharing API
     Then the response should contain 0 entries
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
@@ -341,13 +381,16 @@ Feature: federated
 
   @issue-31276 @skipOnOcV10
   Scenario Outline: Remote sharee tries to delete a pending federated share sending wrong password
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last pending federated cloud share with password "invalid" using the sharing API
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"
     And user "Brian" should not see the following elements
-      | /textfile0%20(2).txt |
+      | /textfile0.txt |
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
     Then the fields of the last response about user "Alice" sharing with user "Brian" should include
       | id          | A_STRING                                   |
@@ -367,8 +410,7 @@ Feature: federated
       | 2               |
 
   Scenario Outline: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
-    Given using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
+    Given using OCS API version "<ocs-api-version>"
     When user "UNAUTHORIZED_USER" requests shared secret using the federation API
     Then the HTTP status code should be "<http-status>"
     Then the OCS status code should be "403"
@@ -379,31 +421,34 @@ Feature: federated
 
   @skipOnLDAP
   Scenario: Upload file to received federated share while quota is set on home storage
-    Given user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
     And as user "Alice" on server "REMOTE" the files uploaded to "/PARENT/testquota.txt" with all mechanisms should exist
 
   @skipOnLDAP
   Scenario: Upload file to received federated share while quota is set on remote storage - local server shares - remote server receives
-    Given using server "LOCAL"
-    And the quota of user "Brian" has been set to "20 B"
+    Given the quota of user "Brian" has been set to "20 B"
+    And user "Brian" has created folder "PARENT"
     And user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
 
   @skipOnLDAP
   Scenario: Upload file to received federated share while quota is set on remote storage - remote server shares - local server receives
     Given using server "REMOTE"
     And the quota of user "Alice" has been set to "20 B"
+    And user "Alice" has created folder "PARENT"
     And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT (2)/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
 
   Scenario Outline: share of a folder to a remote user who already has a folder with the same name

--- a/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
@@ -3,9 +3,11 @@ Feature: current oC10 behavior for issue-31276
 
   Background:
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
 
   @issue-31276
   Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password

--- a/tests/acceptance/features/apiFederationToRoot2/federatedOc10Issue35839.feature
+++ b/tests/acceptance/features/apiFederationToRoot2/federatedOc10Issue35839.feature
@@ -3,9 +3,13 @@ Feature: current oC10 behavior for issue-35839
 
   Background:
     Given using server "REMOTE"
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
     And using server "LOCAL"
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
 
   @issue-35839
   Scenario: "Auto accept from trusted servers" enabled with remote server

--- a/tests/acceptance/features/apiFederationToShares1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederationToShares1/etagPropagation.feature
@@ -6,11 +6,12 @@ Feature: propagation of etags between federated and local server
     And using server "REMOTE"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And using server "LOCAL"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "PARENT"
 
   Scenario: Overwrite a federated shared folder as sharer propagates etag for recipient
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"

--- a/tests/acceptance/features/apiFederationToShares1/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares1/federated.feature
@@ -5,15 +5,16 @@ Feature: federated
     Given using server "REMOTE"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And using server "LOCAL"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario Outline: Federate share a file with another server
     Given using OCS API version "<ocs-api-version>"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -40,6 +41,8 @@ Feature: federated
   @smokeTest
   Scenario Outline: Federate share a file with local server
     Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     When user "Alice" from server "REMOTE" shares "/textfile0.txt" with user "Brian" from server "LOCAL" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -64,7 +67,10 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Remote sharee can see the pending share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
     Then the OCS status code should be "<ocs-status>"
@@ -85,8 +91,11 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Remote sharee requests information of only one share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" retrieves the information of the last federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
@@ -110,7 +119,10 @@ Feature: federated
 
   @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
   Scenario Outline: Remote sharee requests information of only one share before accepting it
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" retrieves the information of the last pending federated cloud share using the sharing API
     Then the HTTP status code should be "200"
@@ -151,7 +163,9 @@ Feature: federated
       | 2               | 404        | 404         |
 
   Scenario Outline: accept a pending remote share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" from server "LOCAL" accepts the last pending share using the sharing API
     Then the OCS status code should be "<ocs-status>"
@@ -162,7 +176,9 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Reshare a federated shared file
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
     And user "Carol" has been created with default attributes and small skeleton files
@@ -195,7 +211,8 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a federated shared file as recipient - local server shares - remote server receives
-    Given user "Brian" from server "LOCAL" has shared "/textfile0.txt" with user "Alice" from server "REMOTE"
+    Given user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Brian" from server "LOCAL" has shared "/textfile0.txt" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
     And using OCS API version "<ocs-api-version>"
@@ -208,8 +225,11 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a federated shared file as recipient - remote server shares - local server receives
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" uploads file "filesForUpload/file_to_overwrite.txt" to "/Shares/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
@@ -220,7 +240,8 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
-    Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
+    Given user "Brian" has created folder "PARENT"
+    And user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
     And using OCS API version "<ocs-api-version>"
@@ -233,8 +254,11 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
-    Given user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" uploads file "filesForUpload/file_to_overwrite.txt" to "/Shares/PARENT/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
@@ -245,8 +269,11 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a federated shared file as recipient using old chunking
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" uploads the following "3" chunks to "/Shares/textfile0.txt" with old chunking and using the WebDAV API
       | number | content |
@@ -262,8 +289,11 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient using old chunking
-    Given user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" uploads the following "3" chunks to "/Shares/PARENT/textfile0.txt" with old chunking and using the WebDAV API
       | number | content |
@@ -279,8 +309,11 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Remote sharee deletes an accepted federated share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
@@ -298,8 +331,11 @@ Feature: federated
 
   @issue-31276 @skipOnOcV10
   Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last federated cloud share with password "invalid" using the sharing API
     Then the OCS status code should be "401"
@@ -327,7 +363,10 @@ Feature: federated
       | 2               |
 
   Scenario Outline: Remote sharee deletes a pending federated share
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last pending federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
@@ -345,7 +384,10 @@ Feature: federated
 
   @issue-31276 @skipOnOcV10
   Scenario Outline: Remote sharee tries to delete a pending federated share sending wrong password
-    Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
+    And using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last pending federated cloud share with password "invalid" using the sharing API
     Then the OCS status code should be "401"
@@ -383,7 +425,9 @@ Feature: federated
 
   @skipOnLDAP
   Scenario: Upload file to received federated share while quota is set on home storage
-    Given user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/Shares/PARENT/testquota.txt" with all mechanisms using the WebDAV API
@@ -394,6 +438,7 @@ Feature: federated
   Scenario: Upload file to received federated share while quota is set on remote storage - local server shares - remote server receives
     Given using server "LOCAL"
     And the quota of user "Brian" has been set to "20 B"
+    And user "Brian" has created folder "PARENT"
     And user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
@@ -404,6 +449,7 @@ Feature: federated
   Scenario: Upload file to received federated share while quota is set on remote storage - remote server shares - local server receives
     Given using server "REMOTE"
     And the quota of user "Alice" has been set to "20 B"
+    And user "Alice" has created folder "PARENT"
     And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"

--- a/tests/acceptance/features/apiFederationToShares2/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares2/federated.feature
@@ -5,15 +5,18 @@ Feature: federated
     Given using server "REMOTE"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has been created with default attributes and without skeleton files
     And using server "LOCAL"
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
-    And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
 
   @issue-35839 @skipOnOcV10
   Scenario: "Auto accept from trusted servers" enabled with remote server
-    Given the trusted server list is cleared
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
+    And using server "LOCAL"
+    And the trusted server list is cleared
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     When the administrator adds url "%remote_server%" as trusted server using the testing API
     And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
@@ -23,7 +26,10 @@ Feature: federated
 
   @issue-35839 @skipOnOcV10
   Scenario: "Auto accept from trusted servers" disabled with remote server
-    Given the trusted server list is cleared
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
+    And the trusted server list is cleared
+    And using server "LOCAL"
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
     When the administrator adds url "%remote_server%" as trusted server using the testing API
     And user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
@@ -35,6 +41,8 @@ Feature: federated
     Given the trusted server list is cleared
     And using server "LOCAL"
     And parameter "autoAddServers" of app "federation" has been set to "1"
+    And using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
     When user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
@@ -42,7 +50,10 @@ Feature: federated
     And url "%remote_server%" should be a trusted server
 
   Scenario: Federated share with "Auto add server" disabled
-    Given the trusted server list is cleared
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
+    And using server "LOCAL"
+    And the trusted server list is cleared
     And parameter "autoAddServers" of app "federation" has been set to "0"
     When user "Alice" from server "REMOTE" shares "/textfile1.txt" with user "Brian" from server "LOCAL" using the sharing API
     And user "Brian" from server "LOCAL" has accepted the last pending share
@@ -52,7 +63,10 @@ Feature: federated
 
   @issue-35839 @skipOnOcV10
   Scenario: enable "Add server automatically" once a federated share was created successfully
-    Given using server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
+    And using server "LOCAL"
     And parameter "autoAddServers" of app "federation" has been set to "1"
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     When user "Alice" from server "REMOTE" shares "/textfile0.txt" with user "Brian" from server "LOCAL" using the sharing API
@@ -64,7 +78,10 @@ Feature: federated
 
   @issue-35839 @skipOnOcV10
   Scenario: disable "Add server automatically" once a federated share was created successfully
-    Given using server "LOCAL"
+    Given using server "REMOTE"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
+    And using server "LOCAL"
     And the trusted server list is cleared
     And parameter "autoAddServers" of app "federation" has been set to "0"
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
@@ -90,6 +107,7 @@ Feature: federated
 
   Scenario Outline: federated share receiver sees the original content of a received file in multiple levels of folders
     Given using server "REMOTE"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/RandomFolder"
     And user "Alice" has uploaded file with content "thisContentIsVisible" to "/PARENT/RandomFolder/file-to-share"
     And user "Alice" from server "REMOTE" has shared "/PARENT/RandomFolder/file-to-share" with user "Brian" from server "LOCAL"
@@ -103,7 +121,8 @@ Feature: federated
       | 2               |
 
   Scenario Outline: remote federated share receiver adds files/folders in the federated share
-    Given user "Brian" has created folder "/PARENT/RandomFolder"
+    Given user "Brian" has created folder "/PARENT"
+    And user "Brian" has created folder "/PARENT/RandomFolder"
     And user "Brian" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
     And user "Brian" from server "LOCAL" has shared "/PARENT/RandomFolder" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
@@ -123,6 +142,7 @@ Feature: federated
 
   Scenario Outline: local federated share receiver adds files/folders in the federated share
     Given using server "REMOTE"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/RandomFolder"
     And user "Alice" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
     And user "Alice" from server "REMOTE" has shared "/PARENT/RandomFolder" with user "Brian" from server "LOCAL"
@@ -143,6 +163,7 @@ Feature: federated
 
   Scenario Outline: local federated share receiver deletes files/folders of the received share
     Given using server "REMOTE"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/RandomFolder"
     And user "Alice" has created folder "/PARENT/RandomFolder/sub-folder"
     And user "Alice" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
@@ -162,7 +183,8 @@ Feature: federated
       | 2               |
 
   Scenario Outline: remote federated share receiver deletes files/folders of the received share
-    Given user "Brian" has created folder "/PARENT/RandomFolder"
+    Given user "Brian" has created folder "/PARENT"
+    And user "Brian" has created folder "/PARENT/RandomFolder"
     And user "Brian" has created folder "/PARENT/RandomFolder/sub-folder"
     And user "Brian" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
     And user "Brian" from server "LOCAL" has shared "/PARENT/RandomFolder" with user "Alice" from server "REMOTE"
@@ -182,6 +204,7 @@ Feature: federated
 
   Scenario Outline: local federated share receiver renames files/folders of the received share
     Given using server "REMOTE"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/RandomFolder"
     And user "Alice" has created folder "/PARENT/RandomFolder/sub-folder"
     And user "Alice" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
@@ -203,7 +226,8 @@ Feature: federated
       | 2               |
 
   Scenario Outline: remote federated share receiver renames files/folders of the received share
-    Given user "Brian" has created folder "/PARENT/RandomFolder"
+    Given user "Brian" has created folder "/PARENT"
+    And user "Brian" has created folder "/PARENT/RandomFolder"
     And user "Brian" has created folder "/PARENT/RandomFolder/sub-folder"
     And user "Brian" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
     And user "Brian" from server "LOCAL" has shared "/PARENT/RandomFolder" with user "Alice" from server "REMOTE"
@@ -225,6 +249,7 @@ Feature: federated
 
   Scenario Outline: sharer modifies the share which was shared to the federated share receiver
     Given using server "REMOTE"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/RandomFolder"
     And user "Alice" has uploaded file with content "thisContentShouldBeChanged" to "/PARENT/RandomFolder/file-to-share"
     And user "Alice" from server "REMOTE" has shared "/PARENT/RandomFolder/file-to-share" with user "Brian" from server "LOCAL"
@@ -240,6 +265,7 @@ Feature: federated
 
   Scenario Outline: sharer adds files/folders in the share which was shared to the federated share receiver
     Given using server "REMOTE"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/RandomFolder"
     And user "Alice" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
     And user "Alice" from server "REMOTE" has shared "/PARENT/RandomFolder" with user "Brian" from server "LOCAL"
@@ -259,6 +285,7 @@ Feature: federated
 
   Scenario Outline: sharer deletes files/folders of the share which was shared to the federated share receiver
     Given using server "REMOTE"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/RandomFolder"
     And user "Alice" has created folder "/PARENT/RandomFolder/sub-folder"
     And user "Alice" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
@@ -278,6 +305,7 @@ Feature: federated
 
   Scenario Outline: sharer renames files/folders of the share which was shared to the federated share receiver
     Given using server "REMOTE"
+    And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/RandomFolder"
     And user "Alice" has created folder "/PARENT/RandomFolder/sub-folder"
     And user "Alice" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
@@ -298,7 +326,8 @@ Feature: federated
       | 2               |
 
   Scenario Outline: sharer unshares the federated share and the receiver no longer sees the files/folders
-    Given user "Brian" has created folder "/PARENT/RandomFolder"
+    Given user "Brian" has created folder "/PARENT"
+    And user "Brian" has created folder "/PARENT/RandomFolder"
     And user "Brian" has uploaded file with content "thisContentShouldBeVisible" to "/PARENT/RandomFolder/file-to-share"
     And user "Brian" from server "LOCAL" has shared "/PARENT/RandomFolder" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
@@ -313,7 +342,8 @@ Feature: federated
       | 2               |
 
   Scenario Outline: federated share receiver can move the location of the received share and changes are correctly seen at both ends
-    Given user "Brian" has created folder "/PARENT/RandomFolder"
+    Given user "Brian" has created folder "/PARENT"
+    And user "Brian" has created folder "/PARENT/RandomFolder"
     And user "Brian" has uploaded file with content "thisContentIsVisible" to "PARENT/RandomFolder/file-to-share"
     And user "Brian" from server "LOCAL" has shared "/PARENT/RandomFolder" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
@@ -336,7 +366,8 @@ Feature: federated
       | 2               |
 
   Scenario Outline: federated sharer can move the location of the received share and changes are correctly seen at both ends
-    Given user "Brian" has created folder "/PARENT/RandomFolder"
+    Given user "Brian" has created folder "/PARENT"
+    And user "Brian" has created folder "/PARENT/RandomFolder"
     And user "Brian" has uploaded file with content "thisContentIsVisible" to "PARENT/RandomFolder/file-to-share"
     And user "Brian" from server "LOCAL" has shared "/PARENT/RandomFolder" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
@@ -487,6 +518,7 @@ Feature: federated
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -516,6 +548,7 @@ Feature: federated
   Scenario Outline: Federated sharing with default expiration date enabled but not enforced, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -531,6 +564,7 @@ Feature: federated
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -545,6 +579,7 @@ Feature: federated
   Scenario Outline: Federated sharing with default expiration date disabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "no"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -561,6 +596,7 @@ Feature: federated
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
     And user "Brian" updates the last share using the sharing API with
       | expireDate | +3 days |
@@ -579,6 +615,7 @@ Feature: federated
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Brian" from server "LOCAL" shares "/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
     And user "Brian" updates the last share using the sharing API with
       | expireDate | +10 days |
@@ -593,11 +630,11 @@ Feature: federated
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   Scenario Outline: User modifies expiration date for federated reshare of a file with another server with default expiration date
     Given using OCS API version "<ocs_api_version>"
-    And using server "LOCAL"
     And user "Carol" has been created with default attributes and without skeleton files
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Brian" has shared file "/textfile0.txt" with user "Carol" with permissions "read,update,share"
     And user "Carol" has accepted share "/textfile0.txt" offered by user "Brian"
     When user "Carol" from server "LOCAL" shares "/Shares/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API
@@ -616,11 +653,11 @@ Feature: federated
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   Scenario Outline: User modifies expiration date more than the default for federated reshare of a file
     Given using OCS API version "<ocs_api_version>"
-    And using server "LOCAL"
     And user "Carol" has been created with default attributes and without skeleton files
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "7"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Brian" has shared file "/textfile0.txt" with user "Carol" with permissions "read,update,share"
     And user "Carol" has accepted share "/textfile0.txt" offered by user "Brian"
     When user "Carol" from server "LOCAL" shares "/Shares/textfile0.txt" with user "Alice" from server "REMOTE" using the sharing API


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With this PR:
- skeleton file/folders are used more wisely on the following features suite
  - apiFederationToRoot1
  - apiFederationToRoot2
  - apiFederationToShares1
  - apiFederationToShares2

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
