### PR TITLE
when creating self group-reshare do not share to self

### DIFF
--- a/changelog/unreleased/38581
+++ b/changelog/unreleased/38581
@@ -1,0 +1,11 @@
+Bugfix: Creating self group-reshare should not not share to self
+
+In a scenario where resharing with group that user belongs to, 
+permissions and attributes were incorrectly handled in share mount logic when 
+permissions for that share got adjusted, or that share got again reshared to another user 
+that again reshared with prior user. 
+This bugfix prevents creation of self share mount in root folder of the user
+
+
+https://github.com/owncloud/core/pull/38581
+https://github.com/owncloud/enterprise/issues/4382

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2992,6 +2992,23 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then user :user should be able to create folder :destination
+	 *
+	 * @param string $user
+	 * @param string $destination
+	 *
+	 * @return void
+	 */
+	public function userShouldBeAbleToCreateFolder($user, $destination) {
+		$this->userHasCreatedFolder($user, $destination);
+		$this->asFileOrFolderShouldExist(
+			$user,
+			"folder",
+			$destination
+		);
+	}
+
+	/**
 	 * Old style chunking upload
 	 *
 	 * @When user :user uploads the following :total chunks to :file with old chunking and using the WebDAV API

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -369,8 +369,7 @@ Feature: Sharing files and folders with internal groups
     Then as "Alice" folder "/simple-folder" should exist
     And user "Alice" should be able to upload file "filesForUpload/textfile.txt" to "simple-folder/textfile.txt"
     And as "Alice" folder "/simple-empty-folder" should not exist
-    When user "Alice" has created folder "/simple-empty-folder"
-    Then as "Alice" folder "/simple-empty-folder" should exist
+    And user "Alice" should be able to create folder "/simple-empty-folder"
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
   Scenario: Reshare with group that user is member of should allow for downgrading and upgrading permissions

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -11,6 +11,7 @@ Feature: Sharing files and folders with internal groups
       | Brian    |
       | Carol    |
     And user "Carol" has created folder "simple-folder"
+    And user "Carol" has created folder "simple-folder/simple-empty-folder"
 
   Scenario Outline: sharing  files and folder with an internal problematic group name
     Given these groups have been created:
@@ -349,3 +350,55 @@ Feature: Sharing files and folders with internal groups
       | uid_owner   | Carol          |
       | share_with  | grp2           |
       | permissions | 7              |
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
+  Scenario: Reshare with group that user is member of should not create mount in the root folder of resharer
+    Given these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
+    And user "Alice" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has been added to group "grp2"
+    And user "Brian" has been added to group "grp2"
+    And user "Carol" has shared folder "/simple-folder" with group "grp1"
+    And user "Alice" has logged in using the webUI
+    When the user shares folder "simple-folder" with group "grp2" using the webUI
+    And the user opens folder "simple-folder" using the webUI
+    And the user shares folder "simple-empty-folder" with group "grp2" using the webUI
+    Then as "Alice" folder "/simple-folder" should exist
+    And user "Alice" should be able to upload file "filesForUpload/textfile.txt" to "simple-folder/textfile.txt"
+    And as "Alice" folder "/simple-empty-folder" should not exist
+    When user "Alice" has created folder "/simple-empty-folder"
+    Then as "Alice" folder "/simple-empty-folder" should exist
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
+  Scenario: Reshare with group that user is member of should allow for downgrading and upgrading permissions
+    Given these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
+    And user "Alice" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has been added to group "grp2"
+    And user "Brian" has been added to group "grp2"
+    And user "Carol" has shared folder "/simple-folder" with group "grp1"
+    And user "Alice" has logged in using the webUI
+    When the user shares folder "simple-folder" with group "grp2" using the webUI
+    And the user sets the sharing permissions of group "grp2" for "simple-folder" using the webUI to
+      | edit   | no |
+      | create | no |
+    And the user opens folder "simple-folder" using the webUI
+    And the user shares folder "simple-empty-folder" with group "grp2" using the webUI
+    And the user sets the sharing permissions of group "grp2" for "simple-empty-folder" using the webUI to
+      | edit   | no |
+      | create | no |
+    And the user sets the sharing permissions of group "grp2" for "simple-empty-folder" using the webUI to
+      | edit   | yes |
+      | create | yes |
+    Then user "Alice" should be able to upload file "filesForUpload/textfile.txt" to "simple-folder/textfile.txt"
+    And as "Alice" folder "/simple-empty-folder" should not exist
+    And as "Brian" folder "/simple-folder" should exist
+    And as "Brian" folder "/simple-empty-folder" should exist
+    And user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "simple-folder/textfile.txt"
+    And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "simple-empty-folder/textfile.txt"


### PR DESCRIPTION
fixes https://github.com/owncloud/enterprise/issues/4382
related https://github.com/owncloud/core/pull/38542

This PR solved the issue where user is resharing with group that himself belongs to, and where further resharing or increasing permissions is not possible due to self-share with reduced permission

- [x] manual tests
- [x] add unit and integration tests