### PR TITLE
[full-ci] Enable streaming for propfind

### DIFF
--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -62,5 +62,6 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 $event = new \OCP\SabrePluginEvent($server);
 \OC::$server->getEventDispatcher()->dispatch('OCA\DAV\Connector\Sabre::authInit', $event);
 
+\Sabre\DAV\Server::$streamMultiStatus = true;
 // And off we go!
 $server->exec();

--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -38,11 +38,14 @@ class Capabilities implements ICapability {
 	}
 
 	public function getCapabilities() {
-		$cap =  [
+		$cap = [
 			'dav' => [
 				'chunking' => '1.0',
 				'reports' => [
 					'search-files',
+				],
+				'propfind' => [
+					'depth_infinity' => $this->config->getSystemValue('dav.propfind.depth_infinity', true),
 				]
 			]
 		];

--- a/apps/dav/tests/unit/CapabilitiesTest.php
+++ b/apps/dav/tests/unit/CapabilitiesTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace OCA\DAV\Tests\Unit;
+
+use OCA\DAV\Capabilities;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+/**
+ * @author Jan Ackermann <jackermann@owncloud.com>
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+class CapabilitiesTest extends TestCase {
+
+	/** @var IConfig| MockObject */
+	protected $config;
+
+	/** @var Capabilities */
+	protected $capabilities;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->capabilities = new Capabilities($this->config);
+	}
+
+	public function testGetCapabilities() {
+		$this->config->expects($this->exactly(2))
+			->method('getSystemValue')
+			->withConsecutive(['dav.propfind.depth_infinity'], ['dav.enable.async'])
+			->willReturn(true, true);
+
+		$result = $this->capabilities->getCapabilities();
+		$this->assertEquals($result['dav']['chunking'], '1.0');
+		$this->assertEquals($result['dav']['reports'][0], 'search-files');
+		$this->assertEquals($result['dav']['trashbin'], '1.0');
+		$this->assertEquals($result['dav']['propfind']['depth_infinity'], true);
+		$this->assertEquals($result['async'], '1.0');
+	}
+}

--- a/changelog/unreleased/38583
+++ b/changelog/unreleased/38583
@@ -1,0 +1,9 @@
+Change: Enable streaming for propfind requests
+
+Propfind requests will now be streamed to reduce memory usage
+with large responses.
+Additionally, the new config `dav.propfind.depth_infinity` has been
+added to tell clients whether `depth=infinity` is allowed for
+propfind requests. It defaults to true. 
+
+https://github.com/owncloud/core/pull/38583

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1658,6 +1658,15 @@ $CONFIG = [
 'dav.enable.async' => false,
 
 /**
+ * Allow propfind depth infinity
+ *
+ * With this setting that defaults to true, propfind requests will now be streamed to reduce memory usage
+ * with large responses. It tells the clients whether `depth=infinity` is allowed for propfind requests.
+ * For details see: https://datatracker.ietf.org/doc/html/rfc4918#section-10.2
+ */
+'dav.propfind.depth_infinity' => true,
+
+/**
  * Show the grace period popup
  * Decide whether show or not the grace period popup. There is no change in the
  * behaviour of the grace period.

--- a/tests/acceptance/features/apiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/apiWebdavOperations/propfind.feature
@@ -7,9 +7,17 @@ Feature: PROPFIND
     When user "Alice" requests "/remote.php/dav/files" with "PROPFIND" using basic auth
     Then the HTTP status code should be "405"
 
-  Scenario: PROPFIND to "/remote.php/dav/files" with depth header
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: PROPFIND to "/remote.php/dav/files" with depth header
     Given user "Alice" has been created with default attributes and without skeleton files
-    When user "Alice" requests "/remote.php/dav/files" with "PROPFIND" using basic auth and with headers
-      | header | value |
-      | depth  | 0     |
-    Then the HTTP status code should be "207"
+    And the administrator has set depth_infinity_allowed to <depth_infinity_allowed>
+    When user "Alice" requests "/remote.php/dav/files/alice" with "PROPFIND" using basic auth and with headers
+      | header | value   |
+      | depth  | <depth> |
+    Then the HTTP status code should be "<http_status>"
+  Examples:
+      | depth_infinity_allowed | depth    | http_status |
+      | 1                      | 0        | 207         |
+      | 1                      | infinity | 207         |
+      | 0                      | 0        | 207         |
+      | 0                      | infinity | 412         |

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -939,6 +939,20 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @When the administrator has set depth_infinity_allowed to :depth_infinity_allowed
+	 *
+	 * @param int $depth_infinity_allowed
+	 *
+	 * @return void
+	 */
+	public function theAdministratorHasSetDepthInfinityAllowedTo($depth_infinity_allowed) {
+		$this->addSystemConfigKeyUsingTheOccCommand(
+			"dav.propfind.depth_infinity",
+			$depth_infinity_allowed
+		);
+	}
+
+	/**
 	 * @Given the administrator has set the mail smtpmode to :smtpmode
 	 *
 	 * @param string $smtpmode


### PR DESCRIPTION
## Description
Propfind requests will now be streamed to reduce memory usage with large responses.
Additionally, the new config `dav.propfind.depth_infinity` has been added to tell clients whether `depth=infinity` is allowed for propfind requests. It defaults to true. 

https://github.com/owncloud/core/pull/36336 reloaded
Fixes https://github.com/owncloud/core/issues/14531

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket raised:  https://github.com/owncloud/docs/issues/4127
- [x] Changelog item