### PR TITLE
if source and target owners are different, check quota on move

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2259,6 +2259,10 @@
 							OC.Notification.show(t('files', 'Could not move "{file}" because either the file or the target are locked.',
 								{file: fileName, message: result.message}), {type: 'error'}
 							);
+						} else if (status === 507) {
+							OC.Notification.show(t('files', 'Not enough free space',
+								{file: fileName, message: result.message}), {type: 'error'}
+							);
 						} else if (result != null && typeof result.message !== "undefined") {
 							OC.Notification.show(t('files', 'Could not move "{file}": {message}',
 								{file: fileName, message: result.message}), {type: 'error'}

--- a/changelog/unreleased/38591
+++ b/changelog/unreleased/38591
@@ -1,0 +1,7 @@
+Bugfix: Check quota on the necessary move operations
+
+When encryption is active, a move operation between two different storages was
+leading to a broken copy on target storage if the target has not enough quota.
+This data loss problem has been resolved.
+
+https://github.com/owncloud/core/pull/38591

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -26,6 +26,7 @@ default:
         - FilesVersionsContext:
         - OccContext:
         - TransferOwnershipContext:
+        - TrashbinContext:
 
     apiAuth:
       paths:

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -5,7 +5,7 @@ Feature: quota
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-	# Owner
+    # Owner
 
   Scenario: Uploading a file as owner having enough quota
     Given the quota of user "Alice" has been set to "10 MB"
@@ -99,4 +99,92 @@ Feature: quota
     And the quota of user "Alice" has been set to "20 B"
     When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
+    And the content of file "/testquota.txt" for user "Alice" should be "test"
+
+
+  Scenario: User with zero quota cannot upload a file
+    Given the quota of user "Alice" has been set to "0 B"
+    When user "Alice" uploads file with content "uploaded content" to "testquota.txt" using the WebDAV API
+    Then the HTTP status code should be "507"
+    And the DAV exception should be "Sabre\DAV\Exception\InsufficientStorage"
+
+
+  Scenario: User with zero quota can create a folder
+    Given the quota of user "Alice" has been set to "0 B"
+    When user "Alice" creates folder "testQuota" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" folder "testQuota" should exist
+
+
+  Scenario: user cannot create file on shared folder by a user with zero quota
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Brian" has been created with default attributes and without skeleton files
+    And the quota of user "Brian" has been set to "0 B"
+    And the quota of user "Alice" has been set to "10 MB"
+    And user "Brian" has created folder "shareFolder"
+    And user "Brian" has shared file "/shareFolder" with user "Alice"
+    And user "Alice" has accepted share "/shareFolder" offered by user "Brian"
+    When user "Alice" uploads file with content "uploaded content" to "/Shares/shareFolder/newTextFile.txt" using the WebDAV API
+    Then the HTTP status code should be "507"
+    And the DAV exception should be "Sabre\DAV\Exception\InsufficientStorage"
+    And as "Brian" file "/shareFolder/newTextFile.txt" should not exist
+
+
+  Scenario: share receiver with 0 quota should not be able to move file from shared folder to home folder
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Brian" has been created with default attributes and without skeleton files
+    And the quota of user "Brian" has been set to "0 B"
+    And the quota of user "Alice" has been set to "10 MB"
+    And user "Alice" has uploaded file with content "test" to "/testquota.txt"
+    And user "Alice" has shared file "/testquota.txt" with user "Brian"
+    And user "Brian" has accepted share "/testquota.txt" offered by user "Alice"
+    When user "Brian" moves file "/Shares/testquota.txt" to "/testquota.txt" using the WebDAV API
+    Then the HTTP status code should be "507"
+    And the DAV exception should be "Sabre\DAV\Exception\InsufficientStorage"
+
+
+  Scenario: sharer should be able to upload to a folder shared with user having zero quota
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Brian" has been created with default attributes and without skeleton files
+    And the quota of user "Brian" has been set to "0 B"
+    And the quota of user "Alice" has been set to "10 MB"
+    And user "Alice" has created folder "shareFolder"
+    And user "Alice" has uploaded file with content "test" to "/shareFolder/testquota.txt"
+    And user "Alice" has shared file "/shareFolder" with user "Brian"
+    And user "Brian" has accepted share "/shareFolder" offered by user "Alice"
+    When user "Alice" moves file "/shareFolder/testquota.txt" to "/testquota.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testquota.txt" for user "Alice" should be "test"
+    And as "Brian" file "/Shares/testquota" should not exist
+
+
+  Scenario: share receiver with 0 quota should be able to upload on shared folder
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Brian" has been created with default attributes and without skeleton files
+    And the quota of user "Brian" has been set to "0 B"
+    And the quota of user "Alice" has been set to "10 MB"
+    And user "Alice" has created folder "shareFolder"
+    And user "Alice" has shared file "/shareFolder" with user "Brian"
+    And user "Brian" has accepted share "/shareFolder" offered by user "Alice"
+    When user "Brian" uploads file with content "uploaded content" to "/Shares/shareFolder/newTextFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/shareFolder/newTextFile.txt" for user "Alice" should be "uploaded content"
+
+
+  Scenario: User should retain their old files even if their quota is set to 0
+    Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
+    And the quota of user "Alice" has been set to "0 B"
+    Then the content of file "/testquota.txt" for user "Alice" should be "test"
+
+
+  Scenario: User should be able to restore their deleted file when their quota is set to zero
+    Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
+    And user "Alice" has deleted file "/testquota.txt"
+    And the quota of user "Alice" has been set to "0 B"
+    When user "Alice" restores the file with original path "/testquota.txt" to "/testquota.txt" using the trashbin API
+    Then the HTTP status code should be "201"
     And the content of file "/testquota.txt" for user "Alice" should be "test"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2425,6 +2425,9 @@ trait WebDav {
 		$this->response = $this->makeDavRequest(
 			$user, "PUT", $destination, [], $content
 		);
+		$this->setResponseXml(
+			HttpRequestHelper::parseResponseAsXml($this->response)
+		);
 		$this->lastUploadDeleteTime = \time();
 		return $this->response->getHeader('oc-fileid');
 	}


### PR DESCRIPTION
## Description
If source and target owners are different, check free space in dav quota plugin

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4427

## Motivation and Context
Fixing bugs

## How Has This Been Tested?
Manually tested below scenarios
- Create two users `user1` and `user2`
- Set quota for `user1` to unlimited, `user2` to 0
- Share a folder from `user1` to `user2`
- Upload a file from `user1` to shared folder, it should be successful
- `user1` moves the uploaded file to home folder, it should be successful
- Upload a file from `user1` to shared folder again, it should be successful
- When `user2` moves file to home folder, it should not be succesful and `user2` should show `Not enough free space` notification

Tried same scenario for chunked files also.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
