### PR TITLE
Fix web rewrites for private and public links

### DIFF
--- a/changelog/unreleased/38600
+++ b/changelog/unreleased/38600
@@ -1,0 +1,5 @@
+Bugfix: Normalize web.baseUrl before using it
+
+`web.baseUrl` was used for rewriting private and public links to the new web UI without normalizing it. This leads to broken authentication if the `web.baseUrl` was configured with a trailing slash.
+
+https://github.com/owncloud/core/issues/38600

--- a/core/routes.php
+++ b/core/routes.php
@@ -103,6 +103,7 @@ $this->create('files.viewcontroller.showFile', '/f/{fileId}')->action(static fun
 		$webBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
 	}
 	if ($webBaseUrl) {
+		$webBaseUrl = \rtrim($webBaseUrl, '/');
 		$fileId = $urlParams['fileId'];
 		\OC_Response::redirect("$webBaseUrl/index.html#/f/$fileId");
 		return;
@@ -119,6 +120,7 @@ $this->create('files_sharing.sharecontroller.showShare', '/s/{token}')->action(s
 		$webBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
 	}
 	if ($webBaseUrl) {
+		$webBaseUrl = \rtrim($webBaseUrl, '/');
 		$token = $urlParams['token'];
 		\OC_Response::redirect("$webBaseUrl/index.html#/s/$token");
 		return;


### PR DESCRIPTION
## Description
The `web.baseUrl` was used without normalizing it first. This PR fixes it, thus preventing misconfiguration.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/38600

## Motivation and Context
Web deployment is error prone without it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment: manually by providing a `web.baseUrl` with a trailing slash. Happy to get pointers how to test this in an automated way.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item
