### PR TITLE
Configurable web rewrite

### DIFF
--- a/changelog/unreleased/38602
+++ b/changelog/unreleased/38602
@@ -1,0 +1,6 @@
+Bugfix: Don't rewrite private/public links when web app disabled
+
+When oc10 app is installed but disabled, we still showed the nav item and rewrote the URLs for private and public links.
+
+https://github.com/owncloud/core/issues/38602
+https://github.com/owncloud/core/pull/38603

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -481,7 +481,7 @@ $CONFIG = [
 /**
  * Define the Web base URL
  *
- * It's needed for the navigation item to the new ownCloud Web UI and for redirecting 
+ * It's needed for the navigation item to the new ownCloud Web UI and for redirecting
  * public and private links.
  */
 'web.baseUrl' => '',

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -480,14 +480,22 @@ $CONFIG = [
 
 /**
  * Define the Web base URL
- * If web.baseUrl is set, public and private links will be redirected to this url.
- * Web will handle these links accordingly.
+ *
+ * It's needed for the navigation item to the new ownCloud Web UI and for redirecting 
+ * public and private links.
+ */
+'web.baseUrl' => '',
+
+/**
+ * Rewrite private and public links to the new ownCloud Web UI (if available).
+ * If web.rewriteLinks is set to 'true', public and private links will be redirected to this url.
+ * The Web UI will handle these links accordingly.
  *
  * As an example, in case 'web.baseUrl' is set to 'http://web.example.com',
  * the shared link 'http://ocx.example.com/index.php/s/THoQjwYYMJvXMdW' will be redirected
  * by ownCloud to 'http://web.example.com/index.html#/s/THoQjwYYMJvXMdW'.
  */
-'web.baseUrl' => '',
+'web.rewriteLinks' => false,
 
 /**
  * Define clean URLs without `/index.php`

--- a/core/routes.php
+++ b/core/routes.php
@@ -102,7 +102,7 @@ $this->create('files.viewcontroller.showFile', '/f/{fileId}')->action(static fun
 		// Check the old phoenix.baseUrl system key to provide compatibility across the name change
 		$webBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
 	}
-	if ($webBaseUrl) {
+	if (isWebRewriteLinksEnabled()) {
 		$webBaseUrl = \rtrim($webBaseUrl, '/');
 		$fileId = $urlParams['fileId'];
 		\OC_Response::redirect("$webBaseUrl/index.html#/f/$fileId");
@@ -119,7 +119,7 @@ $this->create('files_sharing.sharecontroller.showShare', '/s/{token}')->action(s
 		// Check the old phoenix.baseUrl system key to provide compatibility across the name change
 		$webBaseUrl = \OC::$server->getConfig()->getSystemValue('phoenix.baseUrl', null);
 	}
-	if ($webBaseUrl) {
+	if (isWebRewriteLinksEnabled()) {
 		$webBaseUrl = \rtrim($webBaseUrl, '/');
 		$token = $urlParams['token'];
 		\OC_Response::redirect("$webBaseUrl/index.html#/s/$token");
@@ -145,3 +145,20 @@ $this->create('files_sharing.sharecontroller.downloadShare', '/s/{token}/downloa
 $this->create('heartbeat', '/heartbeat')->action(function () {
 	// do nothing
 });
+
+/**
+ * Asserts whether rewriting private and public links to the ownCloud Web UI is enabled.
+ *
+ * Since we have two different deployment modes - external or as oc10 app -
+ * we can't just decide based on whether or not the app is enabled. Only if it's
+ * installed at all, we return false on the disabled app.
+ *
+ * @return bool
+ */
+function isWebRewriteLinksEnabled(): bool {
+	if (\OC::$server->getAppManager()->isInstalled('web')
+		&& !\OC::$server->getAppManager()->isEnabledForUser('web')) {
+		return false;
+	}
+	return \OC::$server->getConfig()->getSystemValue('web.rewriteLinks', false);
+}

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -201,7 +201,7 @@ class NavigationManager implements INavigationManager {
 			$webIconKey = 'phoenix.icon';
 			$webIconLabel = 'phoenix.label';
 		}
-		if ($webBaseUrl) {
+		if ($webBaseUrl && !$this->suppressWebNavItem()) {
 			$iconPath = $this->config->getSystemValue($webIconKey, $this->urlGenerator->imagePath('core', 'apps/web.svg'));
 			$l = $this->l10nFac->get("core");
 			$label = $this->config->getSystemValue($webIconLabel, $l->t('New Design'));
@@ -213,6 +213,23 @@ class NavigationManager implements INavigationManager {
 				'order' => 99
 			]);
 		}
+	}
+
+	/**
+	 * Decides if the `Web` nav item should be hidden.
+	 *
+	 * Since we have two different deployment modes - external or as oc10 app -
+	 * we can't just decide based on whether or not the app is enabled. If it's
+	 * not installed at all we skip the `enabled` check and just rely on the
+	 * webBaseUrl being configured or not.
+	 *
+	 * @return bool
+	 */
+	private function suppressWebNavItem(): bool {
+		if (!$this->appManager->isInstalled('web')) {
+			return false;
+		}
+		return !$this->appManager->isEnabledForUser('web');
 	}
 
 	private function isAdmin() {


### PR DESCRIPTION
## Description
This PR hides the nav item when the oc10 web app is installed but disabled and skips the public & private link rewrite for the same reason. It also introduces a config option to enable public & private link rewrites, so that those are not rewritten by default but only if the admin decides to go for it.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/38602

## Motivation and Context
Fix the app behaviour. Also, the feature set of ownCloud Web is not rich enough, yet, to enforce it being used on public links (misses e.g. office suites).

## How Has This Been Tested?
- tested manually. Happy to receive pointers on how to test this in CI. Would probably need to intercept a private and public link rewrite in an integration test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item
