### PR TITLE
[tests-only] Fix tests that accidentally depended on welcome.txt

### DIFF
--- a/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
@@ -143,7 +143,7 @@ Feature: move (rename) file
     When user "Alice" moves file "/textfile0.txt" asynchronously to "/a\\a" using the WebDAV API
     Then the HTTP status code should be "400"
     And user "Alice" should see the following elements
-      | /welcome.txt |
+      | /textfile0.txt |
 
   Scenario: Renaming a file to a path with extension .part should not be possible
     When user "Alice" moves file "/textfile0.txt" asynchronously to "/textfile0.part" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
@@ -15,7 +15,7 @@ Feature: users cannot move (rename) a file to or into an excluded directory
     And user "Alice" moves file "/textfile0.txt" asynchronously to "/.github" using the WebDAV API
     Then the HTTP status code should be "403"
     And user "Alice" should see the following elements
-      | /welcome.txt |
+      | /textfile0.txt |
 
   Scenario: rename a file to an excluded directory name inside a parent directory
     Given user "Alice" has created folder "FOLDER"
@@ -31,7 +31,7 @@ Feature: users cannot move (rename) a file to or into an excluded directory
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
     And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
-    When user "Alice" moves file "/welcome.txt" asynchronously to these filenames using the webDAV API then the results should be as listed
+    When user "Alice" moves file "/textfile0.txt" asynchronously to these filenames using the webDAV API then the results should be as listed
       | filename                                   | http-code | exists |
       | endswith.bad                               | 403       | no     |
       | thisendswith.bad                           | 403       | no     |

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
@@ -37,7 +37,7 @@ Feature: users cannot move (rename) a file to or into an excluded directory
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
     And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json"
-    When user "Alice" moves file "/welcome.txt" to these filenames using the webDAV API then the results should be as listed
+    When user "Alice" moves file "/textfile0.txt" to these filenames using the webDAV API then the results should be as listed
       | filename                                   | http-code | exists |
       | endswith.bad                               | 403       | no     |
       | thisendswith.bad                           | 403       | no     |


### PR DESCRIPTION
## Description
Some end-to-end test scenarios are failing in oC10 app nightly CI. The scenarios accidentally depend on the user having `welcome.txt` (even though the step specifies "without skeleton files"). Somehow these are passing in core already (I have raised issue #38607 about that)

For example:
https://drone.owncloud.com/owncloud/files_classifier/1937/55/15
```
runsh: Total unexpected failed scenarios throughout the test run:
apiWebdavMove1/moveFileAsync.feature:142
apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature:13
apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature:29

  Scenario: rename a file into an invalid filename                                               # /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature:142
    When user "Alice" moves file "/textfile0.txt" asynchronously to "/a\\a" using the WebDAV API # FeatureContext::userMovesFileUsingTheAPI()
    Then the HTTP status code should be "400"                                                    # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And user "Alice" should see the following elements                                           # FeatureContext::userShouldSeeTheElements()
      | /welcome.txt |
      /remote.php/dav/files/Alice/welcome.txt is not in propfind answer but should be
      
  Scenario: rename a file to an excluded directory name                                                                                    # /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature:13
    When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command # OccContext::theAdministratorAddsSystemConfigKeyWithValueUsingTheOccCommand()
    And user "Alice" moves file "/textfile0.txt" asynchronously to "/.github" using the WebDAV API                                         # FeatureContext::userMovesFileUsingTheAPI()
    Then the HTTP status code should be "403"                                                                                              # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And user "Alice" should see the following elements                                                                                     # FeatureContext::userShouldSeeTheElements()
      | /welcome.txt |
      /remote.php/dav/files/Alice/welcome.txt is not in propfind answer but should be

  Scenario: rename a file to a filename that matches (or not) excluded_directories_regex                                                                                 # /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature:29
    Given user "Alice" has created folder "FOLDER"                                                                                                                       # FeatureContext::userHasCreatedFolder()
    And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json" # OccContext::theAdministratorHasAddedSystemConfigKeyWithValueUsingTheOccCommand()
    When user "Alice" moves file "/welcome.txt" asynchronously to these filenames using the webDAV API then the results should be as listed                              # FeatureContext::userMovesEntriesUsingTheAPI()
      | filename                                   | http-code | exists |
      | endswith.bad                               | 403       | no     |
      | thisendswith.bad                           | 403       | no     |
      | .git                                       | 403       | no     |
      | .github                                    | 403       | no     |
      | containsvirusinthename                     | 403       | no     |
      | this-containsvirusinthename.txt            | 403       | no     |
      | /FOLDER/endswith.bad                       | 403       | no     |
      | /FOLDER/thisendswith.bad                   | 403       | no     |
      | /FOLDER/.git                               | 403       | no     |
      | /FOLDER/.github                            | 403       | no     |
      | /FOLDER/containsvirusinthename             | 403       | no     |
      | /FOLDER/this-containsvirusinthename.txt    | 403       | no     |
      | endswith.badandotherstuff                  | 202       | yes    |
      | thisendswith.badandotherstuff              | 202       | yes    |
      | name.git                                   | 202       | yes    |
      | name.github                                | 202       | yes    |
      | not-contains-virus-in-the-name.txt         | 202       | yes    |
      | /FOLDER/endswith.badandotherstuff          | 202       | yes    |
      | /FOLDER/thisendswith.badandotherstuff      | 202       | yes    |
      | /FOLDER/name.git                           | 202       | yes    |
      | /FOLDER/name.github                        | 202       | yes    |
      | /FOLDER/not-contains-virus-in-the-name.txt | 202       | yes    |
      file 'endswith.badandotherstuff' expected to exist for user Alice but not found
      Failed asserting that false is true.
```

https://drone.owncloud.com/owncloud/files_classifier/1937/56/15
```
runsh: Total unexpected failed scenarios throughout the test run:
apiWebdavMove2/moveFileToExcludedDirectory.feature:66
apiWebdavMove2/moveFileToExcludedDirectory.feature:67

  Scenario Outline: rename a file to a filename that matches (or not) excluded_directories_regex                                                                         # /var/www/owncloud/testrunner/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature:34
    Given using <dav_version> DAV path                                                                                                                                   # FeatureContext::usingOldOrNewDavPath()
    And user "Alice" has created folder "FOLDER"                                                                                                                         # FeatureContext::userHasCreatedFolder()
    And the administrator has updated system config key "excluded_directories_regex" with value '["endswith\\.bad$","^\\.git","containsvirusinthename"]' and type "json" # OccContext::theAdministratorHasAddedSystemConfigKeyWithValueUsingTheOccCommand()
    When user "Alice" moves file "/welcome.txt" to these filenames using the webDAV API then the results should be as listed                                             # FeatureContext::userMovesEntriesUsingTheAPI()
      | filename                                   | http-code | exists |
      | endswith.bad                               | 403       | no     |
      | thisendswith.bad                           | 403       | no     |
      | .git                                       | 403       | no     |
      | .github                                    | 403       | no     |
      | containsvirusinthename                     | 403       | no     |
      | this-containsvirusinthename.txt            | 403       | no     |
      | /FOLDER/endswith.bad                       | 403       | no     |
      | /FOLDER/thisendswith.bad                   | 403       | no     |
      | /FOLDER/.git                               | 403       | no     |
      | /FOLDER/.github                            | 403       | no     |
      | /FOLDER/containsvirusinthename             | 403       | no     |
      | /FOLDER/this-containsvirusinthename.txt    | 403       | no     |
      | endswith.badandotherstuff                  | 201       | yes    |
      | thisendswith.badandotherstuff              | 201       | yes    |
      | name.git                                   | 201       | yes    |
      | name.github                                | 201       | yes    |
      | not-contains-virus-in-the-name.txt         | 201       | yes    |
      | /FOLDER/endswith.badandotherstuff          | 201       | yes    |
      | /FOLDER/thisendswith.badandotherstuff      | 201       | yes    |
      | /FOLDER/name.git                           | 201       | yes    |
      | /FOLDER/name.github                        | 201       | yes    |
      | /FOLDER/not-contains-virus-in-the-name.txt | 201       | yes    |

    Examples:
      | dav_version |
      | old         |
        HTTP status code is not the expected value while trying to move endswith.badandotherstuff
        Failed asserting that 404 matches expected '201'.
      | new         |
        HTTP status code is not the expected value while trying to move endswith.badandotherstuff
        Failed asserting that 404 matches expected '201'.
```

The scenarios are adjusted so trhat they do not mention `welcome.txt`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
