### PR TITLE
[docs-only] Update links to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A personal cloud which runs on your own server.**
 * ...
 
 ## Installation instructions
-https://doc.owncloud.org/server/10.5/admin_manual/installation/
+https://doc.owncloud.org/server/latest/admin_manual/installation/
 
 ## Contribution Guidelines
 https://owncloud.org/contribute/
@@ -40,4 +40,4 @@ Please submit translations via Transifex:
 https://www.transifex.com/projects/p/owncloud/
 
 For detailed information about translations:
-https://doc.owncloud.org/server/10.4/developer_manual/core/translation.html
+https://doc.owncloud.org/server/latest/developer_manual/core/translation.html


### PR DESCRIPTION
## Description
Docs links in README were pointing to specific (and old) versions of the docs. Point them to `latest` so that they give the current docs.

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
