### PR TITLE
[tests-only] Specify path of server under test

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1356,7 +1356,9 @@ def acceptance(ctx):
 		'numberOfParts': 1,
 		'skip': False,
 		'debugSuites': [],
-		'skipExceptParts': []
+		'skipExceptParts': [],
+		'testAgainstCoreTarball': False,
+		'coreTarball': 'daily-master-qa',
 	}
 
 	if 'defaults' in config:
@@ -1400,9 +1402,10 @@ def acceptance(ctx):
 
 			needObjectStore = (params['cephS3'] != False) or (params['scalityS3'] != False)
 
-			extraAppsDict = {
-				'testing': 'composer install'
-			}
+			extraAppsDict = {}
+
+			if not params['testAgainstCoreTarball']:
+				extraAppsDict['testing'] = 'composer install'
 
 			if (needObjectStore):
 				# If we need S3 object storage, then install the 'files_primary_s3' app
@@ -1495,6 +1498,11 @@ def acceptance(ctx):
 									# Those commands need to be executed as www-data (which owns the files)
 									suExecCommand = 'su-exec www-data '
 
+								if params['testAgainstCoreTarball']:
+									pathOfServerUnderTest = '/drone/core'
+								else:
+									pathOfServerUnderTest = '/drone/src'
+
 								if (needObjectStore):
 									environment['OC_TEST_ON_OBJECTSTORE'] = '1'
 									if (params['cephS3'] != False):
@@ -1517,18 +1525,22 @@ def acceptance(ctx):
 										composerInstall(phpVersion) +
 										vendorbinBehat() +
 										yarnInstall(phpVersion) +
-										installServer(phpVersion, db, params['logLevel'], params['useHttps'], params['federatedServerNeeded'], params['proxyNeeded']) +
+										((
+											installCoreFromTarball(params['coreTarball'], db, params['logLevel'], params['useHttps'], params['federatedServerNeeded'], params['proxyNeeded'], pathOfServerUnderTest)
+										) if params['testAgainstCoreTarball'] else (
+											installServer(phpVersion, db, params['logLevel'], params['useHttps'], params['federatedServerNeeded'], params['proxyNeeded'])
+										)) +
 										(
 											installAndConfigureFederated(ctx, federatedServerVersion, params['federatedPhpVersion'], params['logLevel'], protocol, federatedDb, federationDbSuffix) +
 											owncloudLog('federated', 'federated') if params['federatedServerNeeded'] else []
 										) +
-										installExtraApps(phpVersion, extraAppsDict) +
+										installExtraApps(phpVersion, extraAppsDict, pathOfServerUnderTest) +
 										setupCeph(phpVersion, params['cephS3']) +
 										setupScality(phpVersion, params['scalityS3']) +
 										params['extraSetup'] +
-										fixPermissions(phpVersion, params['federatedServerNeeded']) +
+										fixPermissions(phpVersion, params['federatedServerNeeded'], pathOfServerUnderTest) +
 										waitForServer(phpVersion, params['federatedServerNeeded']) +
-										owncloudLog('server', 'src') +
+										owncloudLog('server', pathOfServerUnderTest) +
 									[
 										({
 											'name': 'acceptance-tests',
@@ -1551,7 +1563,7 @@ def acceptance(ctx):
 										cephService(params['cephS3']) +
 										scalityService(params['scalityS3']) +
 										params['extraServices'] +
-										owncloudService(phpVersion, 'server', '/drone/src', params['useHttps']) +
+										owncloudService(phpVersion, 'server', pathOfServerUnderTest, params['useHttps']) +
 										((
 											owncloudService(params['federatedPhpVersion'], 'federated', '/drone/federated', params['useHttps']) +
 											databaseServiceForFederation(federatedDb, federationDbSuffix)
@@ -1925,10 +1937,10 @@ def cephService(cephS3):
 		}
 	}]
 
-def owncloudService(phpVersion, name = 'server', path = '/drone/src', ssl = True):
+def owncloudService(phpVersion, name = 'server', pathOfServerUnderTest = '/drone/src', ssl = True):
 	if ssl:
 		environment = {
-			'APACHE_WEBROOT': path,
+			'APACHE_WEBROOT': pathOfServerUnderTest,
 			'APACHE_CONFIG_TEMPLATE': 'ssl',
 			'APACHE_SSL_CERT_CN': name,
 			'APACHE_SSL_CERT': '/drone/%s.crt' % name,
@@ -1936,7 +1948,7 @@ def owncloudService(phpVersion, name = 'server', path = '/drone/src', ssl = True
 		}
 	else:
 		environment = {
-			'APACHE_WEBROOT': path
+			'APACHE_WEBROOT': pathOfServerUnderTest
 		}
 
 	return [{
@@ -2221,14 +2233,14 @@ def createShare(phpVersion):
 		]
 	}]
 
-def installExtraApps(phpVersion, extraApps):
+def installExtraApps(phpVersion, extraApps, pathOfServerUnderTest = '/drone/src'):
 	commandArray = []
 	for app, command in extraApps.items():
-		commandArray.append('git clone https://github.com/owncloud/%s.git /drone/src/apps/%s' % (app, app))
+		commandArray.append('ls %s/apps/%s || git clone https://github.com/owncloud/%s.git %s/apps/%s' % (pathOfServerUnderTest, app, app, pathOfServerUnderTest, app))
 		if (command != ''):
-			commandArray.append('cd /drone/src/apps/%s' % app)
+			commandArray.append('cd %s/apps/%s' % (pathOfServerUnderTest, app))
 			commandArray.append(command)
-		commandArray.append('cd /drone/src')
+		commandArray.append('cd %s' % pathOfServerUnderTest)
 		commandArray.append('php occ a:l')
 		commandArray.append('php occ a:e %s' % app)
 		commandArray.append('php occ a:l')
@@ -2411,13 +2423,13 @@ def setupScality(phpVersion, scalityS3):
 		] if createExtraBuckets else [])
 	}]
 
-def fixPermissions(phpVersion, federatedServerNeeded):
+def fixPermissions(phpVersion, federatedServerNeeded, pathOfServerUnderTest = '/drone/src'):
 	return [{
 		'name': 'fix-permissions',
 		'image': 'owncloudci/php:%s' % phpVersion,
 		'pull': 'always',
 		'commands': [
-			'chown -R www-data /drone/src'
+			'chown -R www-data %s' % pathOfServerUnderTest
 		] + ([
 			'chown -R www-data /drone/federated'
 		] if federatedServerNeeded else [])
@@ -2442,7 +2454,7 @@ def owncloudLog(server, folder):
 		'pull': 'always',
 		'detach': True,
 		'commands': [
-			'tail -f /drone/%s/data/owncloud.log' % folder
+			'tail -f %s/data/owncloud.log' % folder
 		]
 	}]
 
@@ -2451,7 +2463,7 @@ def dependsOn(earlierStages, nextStages):
 		for nextStage in nextStages:
 			nextStage['depends_on'].append(earlierStage['name'])
 
-def installCoreFromTarball(version, db, logLevel = '2', ssl = False, federatedServerNeeded = False, proxyNeeded = False):
+def installCoreFromTarball(version, db, logLevel = '2', ssl = False, federatedServerNeeded = False, proxyNeeded = False, pathOfServerUnderTest = '/drone/core'):
 	host = getDbName(db)
 	dbType = host
 
@@ -2459,27 +2471,36 @@ def installCoreFromTarball(version, db, logLevel = '2', ssl = False, federatedSe
 	password = getDbPassword(db)
 	database = getDbDatabase(db)
 
+	if host == 'mariadb':
+		dbType = 'mysql'
+
+	if host == 'postgres':
+		dbType = 'pgsql'
+
+	if host == 'oracle':
+		dbType = 'oci'
+
 	return [{
-		'name': 'install-core',
+		'name': 'install-tarball',
 		'image': 'owncloudci/core',
 		'pull': 'always',
-		'environment': {
-			'DB_TYPE': dbType,
-			'DB_USERNAME': username,
-			'DB_PASSWORD': password,
-			'DB_NAME': database
-		},
 		'settings': {
 			'version': version,
-			'core_path': '/drone/src',
+			'core_path': pathOfServerUnderTest,
 			'db_type': dbType,
 			'db_name': database,
 			'db_host': host,
 			'db_username': username,
 			'db_password': password
 		},
+	},{
+		'name': 'configure-tarball',
+		'image': 'owncloudci/php:7.4',
+		'pull': 'always',
 		'commands': [
-			'bash tests/drone/install-server.sh',
+			'cd %s' % pathOfServerUnderTest,
+			'php occ a:l',
+			'php occ a:e testing',
 			'php occ a:l',
 			'php occ config:system:set trusted_domains 1 --value=server',
 		] + ([


### PR DESCRIPTION
## Description
This PR provides an easy way to run the acceptance tests in drone CI against an ownCloud10 tarball (rather than against the current code in GitHub).

In a test PR, in the `config['acceptance']` section(s) put:
```
testAgainstCoreTarball': True,
'coreTarball': 'daily-master-qa',
```

For `coreTarball` you can put things like `10.7.0` `10.8.0-RC1` etc. The code looks for the relevant tarball in the online downloads folder(s).

## Related Issue
https://github.com/owncloud/QA/issues/437

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
