### PR TITLE
[tests-only] removed welcome.txt occurrences from acceptance tests with no skeleton files

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
@@ -3,12 +3,13 @@ Feature: share resources with a disabled user
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
 
   Scenario Outline: Creating a new share with a disabled user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
-    When user "Alice" shares file "welcome.txt" with user "Brian" using the sharing API
+    When user "Alice" shares file "fileToShare.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "401"
     Examples:
@@ -20,6 +21,6 @@ Feature: share resources with a disabled user
     Given using OCS API version "2"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
-    When user "Alice" shares file "welcome.txt" with user "Brian" using the sharing API
+    When user "Alice" shares file "fileToShare.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
@@ -3,13 +3,14 @@ Feature: share resources with a disabled user - current oC10 behavior for issue-
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
 
   @issue-32068
   Scenario: Creating a new share with a disabled user
     Given using OCS API version "2"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has been disabled
-    When user "Alice" shares file "welcome.txt" with user "Brian" using the sharing API
+    When user "Alice" shares file "fileToShare.txt" with user "Brian" using the sharing API
     Then the OCS status code should be "997"
     #Then the OCS status code should be "401"
     And the HTTP status code should be "401"

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/excludeGroupFromReceivingShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/excludeGroupFromReceivingShares.feature
@@ -127,7 +127,7 @@ Feature: Exclude groups from receiving shares
     When user "Alice" shares folder "PARENT" with group "grp3" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And as "Brian" file "/welcome.txt" should exist
+    And as "Brian" file "/fileToShare.txt" should exist
     And as "Brian" folder "/PARENT" should exist
     Examples:
       | ocs_api_version | ocs_status_code |

--- a/tests/acceptance/features/apiShareManagementToRoot/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/disableSharing.feature
@@ -13,8 +13,9 @@ Feature: sharing
   @smokeTest
   Scenario Outline: user tries to share a file with another user when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
-    Then user "Alice" should not be able to share file "welcome.txt" with user "Brian" using the sharing API
+    Then user "Alice" should not be able to share file "fileToShare.txt" with user "Brian" using the sharing API
     And the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -36,10 +37,11 @@ Feature: sharing
 
   Scenario Outline: user tries to share a file with group when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
-    Then user "Alice" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
+    Then user "Alice" should not be able to share file "fileToShare.txt" with group "grp1" using the sharing API
     And the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -63,8 +65,9 @@ Feature: sharing
 
   Scenario Outline: user tries to create public link share of a file when the sharing api has been disabled
     Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When parameter "shareapi_enabled" of app "core" has been set to "no"
-    Then user "Alice" should not be able to create a public link share of file "welcome.txt" using the sharing API
+    Then user "Alice" should not be able to create a public link share of file "fileToShare.txt" using the sharing API
     And the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -90,8 +93,9 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-    Then user "Brian" should not be able to share file "welcome.txt" with user "Alice" using the sharing API
+    Then user "Brian" should not be able to share file "fileToShare.txt" with user "Alice" using the sharing API
     And the OCS status code should be "403"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -105,8 +109,9 @@ Feature: sharing
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-    Then user "Carol" should be able to share file "welcome.txt" with user "Brian" using the sharing API
+    Then user "Carol" should be able to share file "fileToShare.txt" with user "Brian" using the sharing API
     And the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     Examples:
@@ -121,8 +126,9 @@ Feature: sharing
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp2"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
-    Then user "Carol" should be able to share file "welcome.txt" with group "grp1" using the sharing API
+    Then user "Carol" should be able to share file "fileToShare.txt" with group "grp1" using the sharing API
     And the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     Examples:
@@ -135,8 +141,9 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-    Then user "Alice" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
+    Then user "Alice" should not be able to share file "fileToShare.txt" with group "grp1" using the sharing API
     And the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     Examples:
@@ -150,8 +157,9 @@ Feature: sharing
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has been added to group "grp1"
     And user "Carol" has been added to group "grp1"
+    And user "Carol" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     When parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
-    Then user "Carol" should not be able to share file "welcome.txt" with group "grp1" using the sharing API
+    Then user "Carol" should not be able to share file "fileToShare.txt" with group "grp1" using the sharing API
     And the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     Examples:

--- a/tests/acceptance/features/apiShareOperationsToRoot/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/changingFilesShare.feature
@@ -60,14 +60,14 @@ Feature: sharing
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
-    And user "Alice" has moved file "textfile0.txt" to "share1/welcome.txt"
+    And user "Alice" has moved file "textfile0.txt" to "share1/shared_file.txt"
     And user "Alice" has shared folder "/share1" with user "Brian"
     And user "Alice" has shared folder "/share2" with user "Brian"
-    When user "Brian" moves file "share1/welcome.txt" to "share2/welcome.txt" using the WebDAV API
-    Then as "Brian" file "share1/welcome.txt" should not exist
-    But as "Brian" file "share2/welcome.txt" should exist
-    And as "Alice" file "share1/welcome.txt" should not exist
-    But as "Alice" file "share2/welcome.txt" should exist
+    When user "Brian" moves file "share1/shared_file.txt" to "share2/shared_file.txt" using the WebDAV API
+    Then as "Brian" file "share1/shared_file.txt" should not exist
+    But as "Brian" file "share2/shared_file.txt" should exist
+    And as "Alice" file "share1/shared_file.txt" should not exist
+    But as "Alice" file "share2/shared_file.txt" should exist
 
   Scenario: Move files between shares by same user added by sharee
     Given the administrator has enabled DAV tech_preview
@@ -75,12 +75,12 @@ Feature: sharing
     And user "Alice" has created folder "share2"
     And user "Alice" has shared folder "/share1" with user "Brian"
     And user "Alice" has shared folder "/share2" with user "Brian"
-    When user "Brian" moves file "textfile0.txt" to "share1/welcome.txt" using the WebDAV API
-    Then as "Brian" file "share1/welcome.txt" should exist
-    And as "Alice" file "share1/welcome.txt" should exist
-    When user "Brian" moves file "share1/welcome.txt" to "share2/welcome.txt" using the WebDAV API
-    Then as "Brian" file "share2/welcome.txt" should exist
-    And as "Alice" file "share2/welcome.txt" should exist
+    When user "Brian" moves file "textfile0.txt" to "share1/shared_file.txt" using the WebDAV API
+    Then as "Brian" file "share1/shared_file.txt" should exist
+    And as "Alice" file "share1/shared_file.txt" should exist
+    When user "Brian" moves file "share1/shared_file.txt" to "share2/shared_file.txt" using the WebDAV API
+    Then as "Brian" file "share2/shared_file.txt" should exist
+    And as "Alice" file "share2/shared_file.txt" should exist
 
   Scenario: Move files between shares by different users
     Given the administrator has enabled DAV tech_preview
@@ -88,10 +88,10 @@ Feature: sharing
     And user "Alice" has created folder "/PARENT"
     And user "Brian" has created folder "/PARENT"
     And user "Carol" has created folder "/PARENT"
-    And user "Alice" has moved file "textfile0.txt" to "PARENT/welcome.txt"
+    And user "Alice" has moved file "textfile0.txt" to "PARENT/shared_file.txt"
     And user "Alice" has shared folder "/PARENT" with user "Carol"
     And user "Brian" has shared folder "/PARENT" with user "Carol"
-    When user "Carol" moves file "PARENT (2)/welcome.txt" to "PARENT (3)/welcome.txt" using the WebDAV API
-    Then as "Carol" file "PARENT (3)/welcome.txt" should exist
-    And as "Brian" file "PARENT/welcome.txt" should exist
-    But as "Alice" file "PARENT/welcome.txt" should not exist
+    When user "Carol" moves file "PARENT (2)/shared_file.txt" to "PARENT (3)/shared_file.txt" using the WebDAV API
+    Then as "Carol" file "PARENT (3)/shared_file.txt" should exist
+    And as "Brian" file "PARENT/shared_file.txt" should exist
+    But as "Alice" file "PARENT/shared_file.txt" should not exist

--- a/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
@@ -89,12 +89,12 @@ Feature: sharing
     And user "Alice" has shared folder "/share2" with user "Brian"
     And user "Brian" has accepted share "/share1" offered by user "Alice"
     And user "Brian" has accepted share "/share2" offered by user "Alice"
-    When user "Brian" moves file "textfile0.txt" to "/Shares/share1/welcome.txt" using the WebDAV API
-    Then as "Brian" file "/Shares/share1/welcome.txt" should exist
-    And as "Alice" file "share1/welcome.txt" should exist
-    When user "Brian" moves file "/Shares/share1/welcome.txt" to "/Shares/share2/welcome.txt" using the WebDAV API
-    Then as "Brian" file "/Shares/share2/welcome.txt" should exist
-    And as "Alice" file "share2/welcome.txt" should exist
+    When user "Brian" moves file "textfile0.txt" to "/Shares/share1/shared_file.txt" using the WebDAV API
+    Then as "Brian" file "/Shares/share1/shared_file.txt" should exist
+    And as "Alice" file "share1/shared_file.txt" should exist
+    When user "Brian" moves file "/Shares/share1/shared_file.txt" to "/Shares/share2/shared_file.txt" using the WebDAV API
+    Then as "Brian" file "/Shares/share2/shared_file.txt" should exist
+    And as "Alice" file "share2/shared_file.txt" should exist
 
 
   Scenario: Move files between shares by different users
@@ -103,12 +103,12 @@ Feature: sharing
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has created folder "/PARENT"
     And user "Brian" has created folder "/PARENT"
-    And user "Alice" has moved file "textfile0.txt" to "PARENT/welcome.txt"
+    And user "Alice" has moved file "textfile0.txt" to "PARENT/shared_file.txt"
     And user "Alice" has shared folder "/PARENT" with user "Carol"
     And user "Brian" has shared folder "/PARENT" with user "Carol"
     And user "Carol" has accepted share "/PARENT" offered by user "Alice"
     And user "Carol" has accepted share "/PARENT" offered by user "Brian"
-    When user "Carol" moves file "/Shares/PARENT/welcome.txt" to "/Shares/PARENT (2)/welcome.txt" using the WebDAV API
-    Then as "Carol" file "/Shares/PARENT (2)/welcome.txt" should exist
-    And as "Brian" file "PARENT/welcome.txt" should exist
-    But as "Alice" file "PARENT/welcome.txt" should not exist
+    When user "Carol" moves file "/Shares/PARENT/shared_file.txt" to "/Shares/PARENT (2)/shared_file.txt" using the WebDAV API
+    Then as "Carol" file "/Shares/PARENT (2)/shared_file.txt" should exist
+    And as "Brian" file "PARENT/shared_file.txt" should exist
+    But as "Alice" file "PARENT/shared_file.txt" should not exist

--- a/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
@@ -130,7 +130,7 @@ Feature: move (rename) file
       | /textfile0.txt |
 
   Scenario: move file into a not-existing folder
-    When user "Alice" moves file "/textfile0.txt" asynchronously to "/not-existing/welcome.txt" using the WebDAV API
+    When user "Alice" moves file "/textfile0.txt" asynchronously to "/not-existing/not-existing-file.txt" using the WebDAV API
     Then the HTTP status code should be "202"
     And the oc job status values of last request for user "Alice" should match these regular expressions
       | status       | /^error$/                             |
@@ -164,20 +164,20 @@ Feature: move (rename) file
   Scenario: disabled async operations leads to original behavior
     Given the administrator has disabled async operations
     And user "Alice" has created folder "FOLDER"
-    When user "Alice" moves file "/textfile0.txt" asynchronously to "/FOLDER/welcome.txt" using the WebDAV API
+    When user "Alice" moves file "/textfile0.txt" asynchronously to "/FOLDER/fileToMove.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the following headers should not be set
       | header                |
       | OC-JobStatus-Location |
-    And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "Alice" with range "bytes=0-7" should be "ownCloud"
+    And the downloaded content when downloading file "/FOLDER/fileToMove.txt" for user "Alice" with range "bytes=0-7" should be "ownCloud"
 
   Scenario Outline: enabling async operations does no difference to normal MOVE - Moving a file
     Given the administrator has enabled async operations
     And user "Alice" has created folder "FOLDER"
     And using <dav_version> DAV path
-    When user "Alice" moves file "/textfile0.txt" to "/FOLDER/welcome.txt" using the WebDAV API
+    When user "Alice" moves file "/textfile0.txt" to "/FOLDER/fileToMove.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And the downloaded content when downloading file "/FOLDER/welcome.txt" for user "Alice" with range "bytes=0-7" should be "ownCloud"
+    And the downloaded content when downloading file "/FOLDER/fileToMove.txt" for user "Alice" with range "bytes=0-7" should be "ownCloud"
     Examples:
       | dav_version |
       | old         |
@@ -218,7 +218,7 @@ Feature: move (rename) file
   Scenario Outline: enabling async operations does no difference to normal MOVE - move file into a not-existing folder
     Given the administrator has enabled async operations
     And using <dav_version> DAV path
-    When user "Alice" moves file "/textfile0.txt" to "/not-existing/welcome.txt" using the WebDAV API
+    When user "Alice" moves file "/textfile0.txt" to "/not-existing/fileToMove.txt" using the WebDAV API
     Then the HTTP status code should be "409"
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -216,7 +216,7 @@ Feature: move (rename) file
   Scenario Outline: move file into a not-existing folder
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToMove.txt"
-    When user "Alice" moves file "/fileToMove.txt" to "/not-existing/welcome.txt" using the WebDAV API
+    When user "Alice" moves file "/fileToMove.txt" to "/not-existing/fileToMove.txt" using the WebDAV API
     Then the HTTP status code should be "409"
     Examples:
       | dav_version |

--- a/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
+++ b/tests/acceptance/features/apiWebdavOperations/deleteFolderContents.feature
@@ -14,7 +14,7 @@ Feature: delete folder contents
     And user "Alice" has created folder "/FOLDER/SUBFOLDER"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/textfile0.txt"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/textfile1.txt"
-    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/FOLDER/welcome.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/FOLDER/fileToDelete.txt"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/FOLDER/SUBFOLDER/textfile0.txt"
     When user "Alice" deletes everything from folder "/FOLDER/" using the WebDAV API
     Then user "Alice" should see the following elements
@@ -24,7 +24,7 @@ Feature: delete folder contents
       | /textfile1.txt |
     And user "Alice" should not see the following elements
       | /FOLDER/SUBFOLDER/              |
-      | /FOLDER/welcome.txt             |
+      | /FOLDER/fileToDelete.txt             |
       | /FOLDER/SUBFOLDER/testfile0.txt |
     Examples:
       | dav_version |


### PR DESCRIPTION
## Description
With this PR:
- `welcome.txt` is avoided in acceptance tests with no skeleton files.

## Related Issue
- part of https://github.com/owncloud/core/issues/38607

## How Has This Been Tested?
- :robot:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
