### PR TITLE
validating rereshare permission when creating share using API make sure to check most permissive mountpoint

### DIFF
--- a/changelog/unreleased/38625
+++ b/changelog/unreleased/38625
@@ -1,0 +1,9 @@
+Bugfix: When validating rereshare permission make sure to check parent mountpoint
+
+When receiving reshare for a group from parent folder and subfolder of that folder with lower permission,
+further reshares were subject to subfolder reshare permissions due to issue with resolving parent mountpoint.
+With this change we now ensure to take parent mountpoint out of received mountpoints
+
+https://github.com/owncloud/enterprise/issues/4497
+https://github.com/owncloud/enterprise/issues/4382
+https://github.com/owncloud/core/pull/38625

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -355,20 +355,36 @@ class Manager implements IManager {
 		 */
 		if ($this->userSession !== null && $this->userSession->getUser() !== null &&
 			$share->getShareOwner() !== $this->userSession->getUser()->getUID()) {
-			// retrieve received share node $shareFileNode being reshared with $share
+			// retrieve received share node mounts $shareFileNodes being reshared with $share
+			// originating from <<exactly>> the same file/folder node, by using getById($node, $first=false)
 			$userFolder = $this->rootFolder->getUserFolder($share->getSharedBy());
-			$shareFileNodes = $userFolder->getById($shareNode->getId(), true);
-			$shareFileNode = $shareFileNodes[0] ?? null;
-			if ($shareFileNode) {
-				$shareFileStorage = $shareFileNode->getStorage();
-				if ($shareFileStorage->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
-					// if $shareFileNode is an incoming federated share, use share node permission directly
+			$shareFileNodes = $userFolder->getById($shareNode->getId(), false);
+
+			// if there are many mount points for exact same file/folder, e.g. due to multiple group reshares
+			// coming from different users or subfolders, take:
+			// - in case of exact match, first (reshare from different users should use first found node)
+			// - longest file node path indicates reshare originates
+			//   from parent folder, and is not reshared subfolder that would contain lower or equal permission by design
+			\usort($shareFileNodes, function (\OCP\Files\Node $first, \OCP\Files\Node $second) {
+				if (\strcmp($first->getPath(), $second->getPath()) < 0) {
+					// first is shorther, take second
+					return -1;
+				}
+				// take first that is exact or longer
+				return 1;
+			});
+
+			$parentShareNode = $shareFileNodes[0] ?? null;
+			if ($parentShareNode) {
+				$parentShareFileStorage = $parentShareNode->getStorage();
+				if ($parentShareFileStorage->instanceOfStorage('OCA\Files_Sharing\External\Storage')) {
+					// if $parentShareNode is an incoming federated share, use share node permission directly
 					$maxPermissions = $shareNode->getPermissions();
-				} elseif ($shareFileStorage->instanceOfStorage('OCA\Files_Sharing\SharedStorage')) {
-					// if $shareFileNode is user/group share, use supershare permissions
-					/** @var \OCA\Files_Sharing\SharedStorage $shareFileStorage */
-					'@phan-var \OCA\Files_Sharing\SharedStorage $shareFileStorage';
-					$parentShare = $shareFileStorage->getShare();
+				} elseif ($parentShareFileStorage->instanceOfStorage('OCA\Files_Sharing\SharedStorage')) {
+					// if $parentShareNode is user/group share, use supershare permissions
+					/** @var \OCA\Files_Sharing\SharedStorage $parentShareFileStorage */
+					'@phan-var \OCA\Files_Sharing\SharedStorage $parentShareFileStorage';
+					$parentShare = $parentShareFileStorage->getShare();
 					$maxPermissions = $parentShare->getPermissions();
 					$requiredAttributes = $parentShare->getAttributes();
 				}

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -12,6 +12,7 @@ Feature: Sharing files and folders with internal groups
       | Carol    |
     And user "Carol" has created folder "simple-folder"
     And user "Carol" has created folder "simple-folder/simple-empty-folder"
+    And user "Carol" has created folder "simple-folder/simple-inner-folder"
 
   Scenario Outline: sharing  files and folder with an internal problematic group name
     Given these groups have been created:
@@ -401,3 +402,30 @@ Feature: Sharing files and folders with internal groups
     And as "Brian" folder "/simple-empty-folder" should exist
     And user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "simple-folder/textfile.txt"
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "simple-empty-folder/textfile.txt"
+
+  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
+  Scenario: Reshare mount received from multiple group reshare by different users and different subfolders 
+    Given these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
+      | grp3      |
+    And user "Alice" has been added to group "grp1"
+    And user "Alice" has been added to group "grp2"
+    And user "Brian" has been added to group "grp1"
+    And user "Brian" has been added to group "grp2"
+    And user "Carol" has shared folder "/simple-folder" with user "Alice" with permissions "all"
+    And user "Alice" has shared folder "/simple-folder" with group "grp1" with permissions "all"
+    And user "Brian" has shared file "/simple-folder/simple-inner-folder" with group "grp2" with permissions "read"
+    And user "Alice" has uploaded file with content "some data" to "/simple-folder/simple-inner-folder/textfile.txt"
+    And user "Alice" has shared file "/simple-folder/simple-inner-folder/textfile.txt" with group "grp3" with permissions "read"
+    And user "Alice" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    And the user opens folder "simple-inner-folder" using the webUI
+    And the user sets the sharing permissions of group "grp3" for "textfile.txt" using the webUI to
+      | edit  | yes |
+      | share | yes |
+    Then the following permissions are seen for "textfile.txt" in the sharing dialog for group "grp3"
+      | edit  | yes |
+      | share | yes |
+


### PR DESCRIPTION
## Description

0. there is a file simple-folder/simple-inner-folder/test.txt (user **test1**)
1. user **test1** shares simple-folder with permission all to **test2**
2. user **test2** reshares simple-folder with permission all to **grp1** (has test1,test2,test3 users)
3. user **test3** reshares simple-folder/simple-inner-folder with permission read to **grp2** (has test1,test2,test3 users)
4. user **test2** tries to reshare simple-folder/simple-inner-folder/test.txt with **test4** and fails, besides it is reshare from folder **with permissions all**!!

What happens:
1. user receives folder simple-folder from reshare of simple-folder and grp1, and can find test.txt in simple-folder/simple-inner-folder/test.txt
2. user receives folder simple-inner-folder from reshare of simple-folder/simple-inner-folder with lower permission, and can additionally now find test.txt in /simple-inner-folder/test.txt (but with lower permission)
3. mount logic works correctly, thus all the permissions are restricted for respective mountpoints (see screenshots below)
4. However there is bug in createShare() function of Manager while validating permissions. This is due to the fact that OCS API /share is not aware of from which "folder/subfolder" is share reshared, and thus "suspected" mountpoint is returned as first to validate permissions
5. we should check permissions of "parent mountpoint" that is original share, and not some subfolder reshares that by design contain lower permissions. User CAN create share for that NODE in his user folder with permissions up to max permission that is allowed

fixes: https://github.com/owncloud/enterprise/issues/4497

## How Has This Been Tested?
Integration Tests, Manually

## Screenshots (if appropriate):

**BACKGROUND:**

![Zrzut ekranu 2021-04-16 o 09 29 59](https://user-images.githubusercontent.com/13368647/114988436-9f4f7600-9e96-11eb-942e-98e4ea4fa482.png)
![Zrzut ekranu 2021-04-16 o 09 30 07](https://user-images.githubusercontent.com/13368647/114988440-a080a300-9e96-11eb-80ce-045f61786956.png)
![Zrzut ekranu 2021-04-16 o 09 30 49](https://user-images.githubusercontent.com/13368647/114988442-a1193980-9e96-11eb-88fb-a2d9e93b8aa8.png)
![Zrzut ekranu 2021-04-16 o 09 33 03](https://user-images.githubusercontent.com/13368647/114988575-c6a64300-9e96-11eb-8b00-8518948ab0b3.png)


**BEFORE:**

![Zrzut ekranu 2021-04-16 o 09 31 22](https://user-images.githubusercontent.com/13368647/114988460-a5455700-9e96-11eb-8802-0aee34b1b61b.png)


**AFTER:** 

![Zrzut ekranu 2021-04-16 o 09 31 42](https://user-images.githubusercontent.com/13368647/114988474-a9717480-9e96-11eb-819a-094dc3b042cb.png)



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Acceptance tests added
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

