### PR TITLE
[tests-only] Skip quota test added in 38591, on old oC10 versions

### DIFF
--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -130,7 +130,7 @@ Feature: quota
     And the DAV exception should be "Sabre\DAV\Exception\InsufficientStorage"
     And as "Brian" file "/shareFolder/newTextFile.txt" should not exist
 
-
+  @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
   Scenario: share receiver with 0 quota should not be able to move file from shared folder to home folder
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled


### PR DESCRIPTION
## Description
PR #38591 add various test scenarios for a user with zero quota. It fixed a bug. So one of the scenarios fails against older versions of oC10 - skip it in that case.

For example: https://drone.owncloud.com/owncloud/files_primary_s3/2162/112/17
```
runsh: Total unexpected failed scenarios throughout the test run:
apiMain/quota.feature:134
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
