### PR TITLE
[tests-only] Skip cors scenarios changed in PR 38486 on old oC10

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -4,7 +4,7 @@ Feature: CORS headers
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @files_sharing-app-required
+  @files_sharing-app-required @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
@@ -37,12 +37,10 @@ Feature: CORS headers
       | 2               | /cloud/groups                                    | 997      | 401       |
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
-    @skipOnOcV10.5 @skipOnOcV10.6.0
-    Examples:
-      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /config                                          | 100      | 200       |
       | 2               | /config                                          | 200      | 200       |
 
+  @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
     And the administrator has added "https://aphno.badal" to the list of personal CORS domains
@@ -101,6 +99,7 @@ Feature: CORS headers
       | 2               | /cloud/groups                                    | 997      | 401       |
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
+
 
   Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"


### PR DESCRIPTION
## Description
PR #38486 was merged yesterday. It adjusted some CORS acceptance test scenarios. Those scenarios will no longer pass on old oC10 releases. So skip them in that case.

https://drone.owncloud.com/owncloud/user_ldap/3052/108/17
```
runsh: Total unexpected failed scenarios throughout the test run:
apiAuth/cors.feature:24
apiAuth/cors.feature:25
apiAuth/cors.feature:26
apiAuth/cors.feature:27
apiAuth/cors.feature:28
apiAuth/cors.feature:29
apiAuth/cors.feature:30
apiAuth/cors.feature:31
apiAuth/cors.feature:32
apiAuth/cors.feature:33
apiAuth/cors.feature:34
apiAuth/cors.feature:35
apiAuth/cors.feature:36
apiAuth/cors.feature:37
apiAuth/cors.feature:38
apiAuth/cors.feature:39
apiAuth/cors.feature:43
apiAuth/cors.feature:44
apiAuth/cors.feature:62
apiAuth/cors.feature:63
apiAuth/cors.feature:64
apiAuth/cors.feature:65
apiAuth/cors.feature:66
apiAuth/cors.feature:67
```


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
