### PR TITLE
Translation in the activity stream for shares which expired automatically

### DIFF
--- a/apps/files_sharing/lib/Activity.php
+++ b/apps/files_sharing/lib/Activity.php
@@ -248,7 +248,7 @@ class Activity implements IExtension {
 			case self::SUBJECT_SHARED_WITH_BY:
 				return (string) $l->t('%2$s shared %1$s with you', $params);
 			case self::SUBJECT_UNSHARED_BY:
-				if ($this->actorIsShareExpiry($params[1])) {
+				if ($this->actorIsAutomation($params[1]) && $this->shareIsExpired($params[2])) {
 					return (string) $l->t('The share for %1$s expired', $params);
 				}
 				return (string) $l->t('%2$s removed the share for %1$s', $params);
@@ -491,12 +491,22 @@ class Activity implements IExtension {
 	}
 
 	/**
-	 * Check if the actor is "share expiry" which means the share expired automatically.
+	 * Check if the actor is an automation.
 	 *
 	 * @param string $user Parameter e.g. `<user display-name="admin">admin</user>`
 	 * @return bool
 	 */
-	protected function actorIsShareExpiry($user) {
-		return \strip_tags($user) === IEvent::SHARE_EXPIRY_AUTHOR;
+	protected function actorIsAutomation($user) {
+		return \strip_tags($user) === IEvent::AUTOMATION_AUTHOR;
+	}
+
+	/**
+	 * Check if the share is expired.
+	 *
+	 * @param string $param Parameter e.g. `<user display-name="admin">admin</user>`
+	 * @return bool
+	 */
+	protected function shareIsExpired($param) {
+		return \strip_tags($param) === 'shareExpired';
 	}
 }

--- a/apps/files_sharing/lib/Activity.php
+++ b/apps/files_sharing/lib/Activity.php
@@ -24,6 +24,7 @@
 
 namespace OCA\Files_Sharing;
 
+use OCP\Activity\IEvent;
 use OCP\Activity\IExtension;
 use OCP\Activity\IManager;
 use OCP\IL10N;
@@ -247,6 +248,9 @@ class Activity implements IExtension {
 			case self::SUBJECT_SHARED_WITH_BY:
 				return (string) $l->t('%2$s shared %1$s with you', $params);
 			case self::SUBJECT_UNSHARED_BY:
+				if ($this->actorIsShareExpiry($params[1])) {
+					return (string) $l->t('The share for %1$s expired', $params);
+				}
 				return (string) $l->t('%2$s removed the share for %1$s', $params);
 			case self::SUBJECT_SHARED_EMAIL:
 				return (string) $l->t('You shared %1$s with %2$s', $params);
@@ -484,5 +488,15 @@ class Activity implements IExtension {
 			];
 		}
 		return false;
+	}
+
+	/**
+	 * Check if the actor is "share expiry" which means the share expired automatically.
+	 *
+	 * @param string $user Parameter e.g. `<user display-name="admin">admin</user>`
+	 * @return bool
+	 */
+	protected function actorIsShareExpiry($user) {
+		return \strip_tags($user) === IEvent::SHARE_EXPIRY_AUTHOR;
 	}
 }

--- a/apps/files_sharing/lib/ExpireSharesJob.php
+++ b/apps/files_sharing/lib/ExpireSharesJob.php
@@ -70,7 +70,7 @@ class ExpireSharesJob extends TimedJob {
 		ActivityIManager $activityManager
 	) {
 		// Run once a day
-		$this->setInterval(5);
+		$this->setInterval(24 * 60 * 60);
 		$this->shareManager = $shareManager;
 		$this->connection = $connection;
 		$this->defaultShareProvider = $defaultShareProvider;

--- a/apps/files_sharing/lib/ExpireSharesJob.php
+++ b/apps/files_sharing/lib/ExpireSharesJob.php
@@ -28,6 +28,7 @@ use OCP\Activity\IEvent;
 use OCP\IDBConnection;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
+use OCP\Activity\IManager as ActivityIManager;
 
 /**
  * Delete all shares that are expired
@@ -50,7 +51,7 @@ class ExpireSharesJob extends TimedJob {
 	private $defaultShareProvider;
 
 	/**
-	 * @var \OCP\Activity\IManager $activityManager
+	 * @var ActivityIManager $activityManager
 	 */
 	private $activityManager;
 
@@ -60,16 +61,16 @@ class ExpireSharesJob extends TimedJob {
 	 * @param IManager $shareManager
 	 * @param IDBConnection $connection
 	 * @param DefaultShareProvider $defaultShareProvider
-	 * @param \OCP\Activity\IManager $activityManager
+	 * @param ActivityIManager $activityManager
 	 */
 	public function __construct(
 		IManager $shareManager,
 		IDBConnection $connection,
 		DefaultShareProvider $defaultShareProvider,
-		\OCP\Activity\IManager $activityManager
+		ActivityIManager $activityManager
 	) {
 		// Run once a day
-		$this->setInterval(24 * 60 * 60);
+		$this->setInterval(5);
 		$this->shareManager = $shareManager;
 		$this->connection = $connection;
 		$this->defaultShareProvider = $defaultShareProvider;
@@ -111,7 +112,7 @@ class ExpireSharesJob extends TimedJob {
 				 * $share['id'] has been casted to string to ensure consistency.
 				 */
 				$shareObject = $this->defaultShareProvider->getShareById((string)$share['id']);
-				$this->activityManager->setAgentAuthor(IEvent::SHARE_EXPIRY_AUTHOR);
+				$this->activityManager->setAgentAuthor(IEvent::AUTOMATION_AUTHOR);
 				$this->shareManager->deleteShare($shareObject);
 				$this->activityManager->restoreAgentAuthor();
 			} catch (ShareNotFound $ex) {

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -59,6 +59,11 @@ class ExpireSharesJobTest extends \Test\TestCase {
 	private $defaultShareProvider;
 
 	/**
+	 * @var \OCP\Activity\IManager | MockObject
+	 */
+	private $activityManager;
+
+	/**
 	 * @var string
 	 */
 	private $user1;
@@ -76,11 +81,13 @@ class ExpireSharesJobTest extends \Test\TestCase {
 		// clear occasional leftover shares from other tests
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');
 		$this->defaultShareProvider = $this->createMock(DefaultShareProvider::class);
+		$this->activityManager = $this->createMock(\OCP\Activity\IManager::class);
 
 		$this->job = new ExpireSharesJob(
 			$this->shareManager,
 			$this->connection,
-			$this->defaultShareProvider
+			$this->defaultShareProvider,
+			$this->activityManager
 		);
 
 		$this->user1 = $this->getUniqueID('user1_');

--- a/changelog/unreleased/38631
+++ b/changelog/unreleased/38631
@@ -1,0 +1,7 @@
+Enhancement: Expired shares in activity stream
+
+Add a proper translation in the activity stream for shares which expired automatically.
+Previous to this, the expiry was authored by a user, which is technically not true.
+
+https://github.com/owncloud/core/pull/38631
+https://github.com/owncloud/enterprise/issues/4455

--- a/changelog/unreleased/38631
+++ b/changelog/unreleased/38631
@@ -1,6 +1,6 @@
 Enhancement: Expired shares in activity stream
 
-Add a proper translation in the activity stream for shares which expired automatically.
+Add a proper message in the activity stream for shares which expired automatically.
 Previous to this, the expiry was authored by a user, which is technically not true.
 
 https://github.com/owncloud/core/pull/38631

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -891,6 +891,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$c->getEventDispatcher(),
 				new View('/'),
 				$c->getDatabaseConnection(),
+				$c->getActivityManager(),
 				$c->getUserSession()
 			);
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -31,6 +31,7 @@ use OC\Cache\CappedMemoryCache;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\View;
 use OC\Helper\UserTypeHelper;
+use OCP\Activity\IEvent;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -90,6 +91,8 @@ class Manager implements IManager {
 	private $connection;
 	/** @var IUserSession  */
 	private $userSession;
+	/** @var \OCP\Activity\IManager  */
+	private $activityManager;
 
 	/**
 	 * Manager constructor.
@@ -107,6 +110,7 @@ class Manager implements IManager {
 	 * @param EventDispatcher $eventDispatcher
 	 * @param View $view
 	 * @param IDBConnection $connection
+	 * @param \OCP\Activity\IManager $activityManager
 	 * @param IUserSession $userSession
 	 */
 	public function __construct(
@@ -123,6 +127,7 @@ class Manager implements IManager {
 			EventDispatcher $eventDispatcher,
 			View $view,
 			IDBConnection $connection,
+			\OCP\Activity\IManager $activityManager,
 			IUserSession $userSession = null
 	) {
 		$this->logger = $logger;
@@ -139,6 +144,7 @@ class Manager implements IManager {
 		$this->eventDispatcher = $eventDispatcher;
 		$this->view = $view;
 		$this->connection = $connection;
+		$this->activityManager = $activityManager;
 		$this->userSession = $userSession;
 	}
 
@@ -1234,7 +1240,9 @@ class Manager implements IManager {
 			foreach ($queriedShares as $queriedShare) {
 				if ($this->shareHasExpired($queriedShare)) {
 					try {
+						$this->activityManager->setAgentAuthor(IEvent::SHARE_EXPIRY_AUTHOR);
 						$this->deleteShare($queriedShare);
+						$this->activityManager->restoreAgentAuthor();
 					} catch (NotFoundException $e) {
 						//Ignore since this basically means the share is deleted
 					}
@@ -1273,7 +1281,9 @@ class Manager implements IManager {
 				// Check if the share is expired and if so delete it
 				if ($this->shareHasExpired($share)) {
 					try {
+						$this->activityManager->setAgentAuthor(IEvent::SHARE_EXPIRY_AUTHOR);
 						$this->deleteShare($share);
+						$this->activityManager->restoreAgentAuthor();
 					} catch (NotFoundException $e) {
 						//Ignore since this basically means the share is deleted
 					}
@@ -1332,7 +1342,9 @@ class Manager implements IManager {
 				// Check if the share is expired and if so delete it
 				if ($this->shareHasExpired($share)) {
 					try {
+						$this->activityManager->setAgentAuthor(IEvent::SHARE_EXPIRY_AUTHOR);
 						$this->deleteShare($share);
+						$this->activityManager->restoreAgentAuthor();
 					} catch (NotFoundException $e) {
 						//Ignore since this basically means the share is deleted
 					}
@@ -1389,7 +1401,9 @@ class Manager implements IManager {
 			foreach ($queriedShares as $queriedShare) {
 				if ($this->shareHasExpired($queriedShare)) {
 					try {
+						$this->activityManager->setAgentAuthor(IEvent::SHARE_EXPIRY_AUTHOR);
 						$this->deleteShare($queriedShare);
+						$this->activityManager->restoreAgentAuthor();
 					} catch (NotFoundException $e) {
 						//Ignore since this basically means the share is deleted
 					}
@@ -1417,7 +1431,9 @@ class Manager implements IManager {
 
 		// Validate shares expiration date
 		if ($this->shareHasExpired($share)) {
+			$this->activityManager->setAgentAuthor(IEvent::SHARE_EXPIRY_AUTHOR);
 			$this->deleteShare($share);
+			$this->activityManager->restoreAgentAuthor();
 			throw new ShareNotFound();
 		}
 
@@ -1473,7 +1489,9 @@ class Manager implements IManager {
 		}
 
 		if ($this->shareHasExpired($share)) {
+			$this->activityManager->setAgentAuthor(IEvent::SHARE_EXPIRY_AUTHOR);
 			$this->deleteShare($share);
+			$this->activityManager->restoreAgentAuthor();
 			throw new ShareNotFound();
 		}
 

--- a/lib/public/Activity/IEvent.php
+++ b/lib/public/Activity/IEvent.php
@@ -36,6 +36,7 @@ namespace OCP\Activity;
  */
 interface IEvent {
 	public const AUTOMATION_AUTHOR = 'auto:automation';
+	public const SHARE_EXPIRY_AUTHOR = 'auto:share-expiry';
 
 	/**
 	 * Set the app of the activity

--- a/lib/public/Activity/IEvent.php
+++ b/lib/public/Activity/IEvent.php
@@ -36,7 +36,6 @@ namespace OCP\Activity;
  */
 interface IEvent {
 	public const AUTOMATION_AUTHOR = 'auto:automation';
-	public const SHARE_EXPIRY_AUTHOR = 'auto:share-expiry';
 
 	/**
 	 * Set the app of the activity

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -23,6 +23,7 @@ namespace Test\Share20;
 use OC\Files\View;
 use OC\Share20\Manager;
 use OC\Share20\ShareAttributes;
+use OCP\Activity\IManager;
 use OCP\Files\File;
 use OC\Share20\Share;
 use OCP\DB\QueryBuilder\IExpressionBuilder;
@@ -94,6 +95,8 @@ class ManagerTest extends \Test\TestCase {
 	protected $connection;
 	/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
+	/** @var IManager | \PHPUnit\Framework\MockObject\MockObject */
+	protected $activityManager;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -110,6 +113,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->view = $this->createMock(View::class);
 		$this->connection = $this->createMock(IDBConnection::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+		$this->activityManager = $this->createMock(IManager::class);
 
 		$this->l = $this->createMock('\OCP\IL10N');
 		$this->l->method('t')
@@ -133,6 +137,7 @@ class ManagerTest extends \Test\TestCase {
 			$this->eventDispatcher,
 			$this->view,
 			$this->connection,
+			$this->activityManager,
 			$this->userSession
 		);
 
@@ -167,7 +172,8 @@ class ManagerTest extends \Test\TestCase {
 				$this->rootFolder,
 				$this->eventDispatcher,
 				$this->view,
-				$this->connection
+				$this->connection,
+				$this->activityManager
 			]);
 	}
 
@@ -3050,7 +3056,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->rootFolder,
 			$this->eventDispatcher,
 			$this->view,
-			$this->connection
+			$this->connection,
+			$this->activityManager
 		);
 
 		$share = $this->createMock('\OCP\Share\IShare');
@@ -3085,7 +3092,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->rootFolder,
 			$this->eventDispatcher,
 			$this->view,
-			$this->connection
+			$this->connection,
+			$this->activityManager
 		);
 
 		$share = $this->createMock('\OCP\Share\IShare');
@@ -3190,7 +3198,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->rootFolder,
 			$this->eventDispatcher,
 			$this->view,
-			$this->connection
+			$this->connection,
+			$this->activityManager
 		);
 
 		$provider1 = $this->getMockBuilder('\OC\Share20\DefaultShareProvider')
@@ -3692,7 +3701,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->rootFolder,
 			$this->eventDispatcher,
 			$this->view,
-			$this->connection
+			$this->connection,
+			$this->activityManager
 		);
 
 		$share = $this->createMock(IShare::class);

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -243,6 +243,7 @@ class ManagerTest extends \Test\TestCase {
 			'uidOwner' => 'sharedBy',
 			'fileSource' => 1,
 			'fileTarget' => 'myTarget',
+			'shareExpired' => false,
 		];
 
 		$hookListnerExpectsPost = [
@@ -255,6 +256,7 @@ class ManagerTest extends \Test\TestCase {
 			'uidOwner' => 'sharedBy',
 			'fileSource' => 1,
 			'fileTarget' => 'myTarget',
+			'shareExpired' => false,
 			'deletedShares' => [
 				[
 					'id' => 42,
@@ -266,6 +268,7 @@ class ManagerTest extends \Test\TestCase {
 					'uidOwner' => 'sharedBy',
 					'fileSource' => 1,
 					'fileTarget' => 'myTarget',
+					'shareExpired' => false,
 				],
 			],
 		];
@@ -341,6 +344,7 @@ class ManagerTest extends \Test\TestCase {
 			'uidOwner' => 'sharedBy',
 			'fileSource' => 1,
 			'fileTarget' => 'myTarget',
+			'shareExpired' => false,
 		];
 
 		$hookListnerExpectsPost = [
@@ -353,6 +357,7 @@ class ManagerTest extends \Test\TestCase {
 			'uidOwner' => 'sharedBy',
 			'fileSource' => 1,
 			'fileTarget' => 'myTarget',
+			'shareExpired' => false,
 			'deletedShares' => [
 				[
 					'id' => 42,
@@ -364,6 +369,7 @@ class ManagerTest extends \Test\TestCase {
 					'uidOwner' => 'sharedBy',
 					'fileSource' => 1,
 					'fileTarget' => 'myTarget',
+					'shareExpired' => false,
 				],
 			],
 		];
@@ -462,6 +468,7 @@ class ManagerTest extends \Test\TestCase {
 			'uidOwner' => 'sharedBy1',
 			'fileSource' => 1,
 			'fileTarget' => 'myTarget1',
+			'shareExpired' => false,
 		];
 
 		$hookListnerExpectsPost = [
@@ -474,6 +481,7 @@ class ManagerTest extends \Test\TestCase {
 			'uidOwner' => 'sharedBy1',
 			'fileSource' => 1,
 			'fileTarget' => 'myTarget1',
+			'shareExpired' => false,
 			'deletedShares' => [
 				[
 					'id' => 44,
@@ -485,6 +493,7 @@ class ManagerTest extends \Test\TestCase {
 					'uidOwner' => 'sharedBy3',
 					'fileSource' => 1,
 					'fileTarget' => 'myTarget3',
+					'shareExpired' => false,
 				],
 				[
 					'id' => 43,
@@ -496,6 +505,7 @@ class ManagerTest extends \Test\TestCase {
 					'uidOwner' => 'sharedBy2',
 					'fileSource' => 1,
 					'fileTarget' => 'myTarget2',
+					'shareExpired' => false,
 				],
 				[
 					'id' => 42,
@@ -507,6 +517,7 @@ class ManagerTest extends \Test\TestCase {
 					'uidOwner' => 'sharedBy1',
 					'fileSource' => 1,
 					'fileTarget' => 'myTarget1',
+					'shareExpired' => false,
 				],
 			],
 		];
@@ -2090,7 +2101,8 @@ class ManagerTest extends \Test\TestCase {
 				'itemparent' => null,
 				'uidOwner' => 'user1',
 				'fileSource' => $share->getNodeId(),
-				'fileTarget' => '/test_share'
+				'fileTarget' => '/test_share',
+				'shareExpired' => false,
 			];
 			$hookListnerUnshareExpectsPost = [
 				'id' => '22',
@@ -2102,6 +2114,7 @@ class ManagerTest extends \Test\TestCase {
 				'uidOwner' => 'user1',
 				'fileSource' => $share->getNodeId(),
 				'fileTarget' => '/test_share',
+				'shareExpired' => false,
 				'deletedShares' => [
 					[
 						'id' => 22,
@@ -2113,6 +2126,7 @@ class ManagerTest extends \Test\TestCase {
 						'uidOwner' => 'user1',
 						'fileSource' => $share->getNodeId(),
 						'fileTarget' => '/test_share',
+						'shareExpired' => false,
 					]
 				],
 			];


### PR DESCRIPTION
## Description
Add a proper translation in the activity stream for shares which expired automatically. Previous to this, the expiry was authored by a user, which is technically not true.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4455

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/50302941/114160225-fd280f00-9926-11eb-9e87-e0a27b312d19.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
