### PR TITLE
[tests-only] created resources rather than using skeleton dirs with users in webUI suites

### DIFF
--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -5,16 +5,19 @@ Feature: deleting files and folders
   So that I can keep my filing system clean and tidy
 
   Background:
-    Given these users have been created with default attributes and large skeleton files:
+    Given these users have been created with default attributes and without skeleton files:
       | username |
       | Alice    |
-    And user "Alice" has logged in using the webUI
-    And the user has browsed to the files page
 
   @smokeTest @skipOnLDAP
   Scenario: Delete files & folders one by one and check its existence after page reload
-    Given user "Alice" has uploaded file with content "file with comma" to "s,a,m,p,l,e.txt"
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "strängé नेपाली folder"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "strängé filename (duplicate #2 &).txt"
+    And user "Alice" has uploaded file with content "file with comma" to "s,a,m,p,l,e.txt"
     And user "Alice" has created folder "folder,with,comma"
+    And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user deletes the following elements using the webUI
       | name                                  |
@@ -35,6 +38,9 @@ Feature: deleting files and folders
 
   @skipOnFIREFOX
   Scenario: Delete a file with problematic characters
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user renames the following file using the webUI
       | from-name-parts | to-name-parts   |
       | lorem.txt       | 'single'        |
@@ -71,6 +77,11 @@ Feature: deleting files and folders
   @smokeTest @skipOnLDAP
   @skipOnEncryption @encryption-issue-74
   Scenario: Delete multiple files at once
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user batch deletes these files using the webUI
       | name          |
       | data.zip      |
@@ -84,6 +95,11 @@ Feature: deleting files and folders
 
   @skipOnEncryption @encryption-issue-74
   Scenario: Delete all files at once
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user marks all files for batch action using the webUI
     And the user batch deletes the marked files using the webUI
     # Check just some example files/folders that should not exist any more
@@ -95,6 +111,11 @@ Feature: deleting files and folders
 
   @skipOnEncryption @encryption-issue-74
   Scenario: Delete all except for a few files at once
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user marks all files for batch action using the webUI
     And the user unmarks these files for batch action using the webUI
       | name          |
@@ -110,6 +131,8 @@ Feature: deleting files and folders
     And file "data.zip" should not be listed on the webUI
 
   Scenario: Delete an empty folder
+    Given user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user creates a folder with the name "my-empty-folder" using the webUI
     And the user creates a folder with the name "my-other-empty-folder" using the webUI
     And the user deletes folder "my-empty-folder" using the webUI
@@ -119,15 +142,21 @@ Feature: deleting files and folders
     And folder "my-empty-folder" should not be listed on the webUI
 
   Scenario: Delete the last file in a folder
+    Given user "Alice" has uploaded file "filesForUpload/zzzz-must-be-last-file-in-folder.txt" to "zzzz-must-be-last-file-in-folder.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user deletes file "zzzz-must-be-last-file-in-folder.txt" using the webUI
     Then as "Alice" file "zzzz-must-be-last-file-in-folder.txt" should not exist
     And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
 
   @files_sharing-app-required
   Scenario: delete files from shared with others page
-    Given user "Brian" has been created with default attributes and without skeleton files
-    And the user has shared file "lorem.txt" with user "Brian"
-    And the user has shared folder "simple-folder" with user "Brian"
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has shared file "lorem.txt" with user "Brian"
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Alice" has logged in using the webUI
     And the user has browsed to the shared-with-others page
     When the user deletes file "lorem.txt" using the webUI
     And the user deletes folder "simple-folder" using the webUI
@@ -141,7 +170,9 @@ Feature: deleting files and folders
 
   @public_link_share-feature-required @files_sharing-app-required
   Scenario: delete files from shared by link page
-    Given the user has created a public link share of file "lorem.txt"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has created a public link share of file "lorem.txt"
     And the user has browsed to the shared-by-link page
     Then file "lorem.txt" should be listed on the webUI
     When the user deletes file "lorem.txt" using the webUI
@@ -152,8 +183,10 @@ Feature: deleting files and folders
 
   @systemtags-app-required
   Scenario: delete files from tags page
-    Given user "Alice" has created a "normal" tag with name "lorem"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has created a "normal" tag with name "lorem"
     And user "Alice" has added tag "lorem" to file "/lorem.txt"
+    And user "Alice" has logged in using the webUI
     When the user browses to the tags page
     And the user searches for tag "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -165,6 +198,11 @@ Feature: deleting files and folders
 
   @files_sharing-app-required
   Scenario: delete a file on a public share
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/strängé filename (duplicate #2 &).txt" to "simple-folder/strängé filename (duplicate #2 &).txt"
+    And user "Alice" has logged in using the webUI
     Given user "Alice" has created a public link share with settings
       | path        | /simple-folder            |
       | permissions | read,update,create,delete |
@@ -182,7 +220,9 @@ Feature: deleting files and folders
 
   @skipOnFIREFOX @files_sharing-app-required
   Scenario: delete a file on a public share with problematic characters
-    Given user "Alice" has created a public link share with settings
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has created a public link share with settings
       | path        | /simple-folder |
       | permissions | read,change    |
     And the public accesses the last created public link using the webUI
@@ -214,7 +254,11 @@ Feature: deleting files and folders
 
   @skipOnEncryption @encryption-issue-74 @files_sharing-app-required
   Scenario: Delete multiple files at once on a public share
-    Given user "Alice" has created a public link share with settings
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/data.zip" to "simple-folder/data.zip"
+    And user "Alice" has created a public link share with settings
       | path        | /simple-folder            |
       | permissions | read,update,create,delete |
     And the public accesses the last created public link using the webUI
@@ -238,7 +282,7 @@ Feature: deleting files and folders
     And user "Alice" has created folder "<top_folder2>"
     And user "Alice" has created folder "<top_folder2>/<other_folder2>"
     And user "Brian" has shared folder "/ShareThis" with user "Alice"
-    And the user reloads the current page of the webUI
+    And user "Alice" has logged in using the webUI
     When the user deletes folder "<other_folder1>" using the webUI
     Then as "Alice" folder "<other_folder1>" should not exist
     When the user opens folder "<top_folder2>" using the webUI

--- a/tests/acceptance/features/webUIFavorites/favoritesFile.feature
+++ b/tests/acceptance/features/webUIFavorites/favoritesFile.feature
@@ -5,10 +5,12 @@ Feature: Mark file as favorite
   I would like to mark any file/folder as favorite
   So that I can find my favorite file/folder easily
 
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
   @smokeTest @skipOnLDAP
   Scenario: mark a file as favorite and list it in favorites page
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file "filesForUpload/data.zip" to "/data.zip"
+    Given user "Alice" has uploaded file "filesForUpload/data.zip" to "/data.zip"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "Alice" has uploaded file with content "file with comma" to "s,a,m,p,l,e.txt"
     And user "Alice" has logged in using the webUI
@@ -24,9 +26,10 @@ Feature: Mark file as favorite
     And file "lorem.txt" should not be listed in the favorites page on the webUI
 
   Scenario: mark a folder as favorite and list it in favorites page
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/simple-folder"
-    And user "Alice" has created folder "/simple-folder/simple-empty-folder"
+    Given user "Alice" has created the following folders
+      | path                              |
+      | simple-folder                     |
+      | simple-folder/simple-empty-folder |
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user marks folder "simple-folder" as favorite using the webUI
@@ -37,7 +40,15 @@ Feature: Mark file as favorite
     And folder "simple-empty-folder" should not be listed in the favorites page on the webUI
 
   Scenario: mark files with same name and different path as favorites and list them in favourites page
-    Given user "Alice" has been created with default attributes and large skeleton files
+    Given user "Alice" has created the following folders
+      | path                              |
+      | simple-folder                     |
+      | simple-empty-folder               |
+      | strängé नेपाली folder               |
+      | simple-folder/simple-empty-folder |
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "strängé नेपाली folder/lorem.txt"
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
     When the user marks file "lorem.txt" as favorite using the webUI

--- a/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
+++ b/tests/acceptance/features/webUIFiles/browseDirectlyToDetailsTab.feature
@@ -5,7 +5,14 @@ Feature: browse directly to details tab
   So that I can see the details immediately without needing to click in the UI
 
   Background:
-    Given user "Alice" has been created with default attributes and large skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/block-aligned.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/zzzz-must-be-last-file-in-folder.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "block-aligned.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "zzzz-must-be-last-file-in-folder.txt"
     And user "Alice" has logged in using the webUI
 
   @smokeTest

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -5,7 +5,7 @@ Feature: scroll menu of actions that can be done on a file into view
   So that I can manage and work with my files
 
   Background:
-    Given user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and large skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
+++ b/tests/acceptance/features/webUIFiles/scrollMenuIntoView.feature
@@ -5,7 +5,7 @@ Feature: scroll menu of actions that can be done on a file into view
   So that I can manage and work with my files
 
   Background:
-    Given user "Alice" has been created with default attributes and large skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 

--- a/tests/acceptance/features/webUIFiles/search.feature
+++ b/tests/acceptance/features/webUIFiles/search.feature
@@ -6,12 +6,24 @@ Feature: Search
   So that I can find needed files quickly
 
   Background:
-    Given user "Alice" has been created with default attributes and large skeleton files
-    And user "Alice" has logged in using the webUI
-    And the user has browsed to the files page
+    Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
   Scenario: Simple search
+    Given user "Alice" has created the following folders
+      | path                  |
+      | 0                     |
+      | simple-folder         |
+      | strängé नेपाली folder   |
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "lorem-big.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "simple-folder/lorem-big.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "0/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "strängé नेपाली folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "strängé नेपाली folder/lorem-big.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user searches for "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And file "lorem-big.txt" should be listed on the webUI
@@ -22,6 +34,20 @@ Feature: Search
     And file "lorem-big.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
 
   Scenario: search for folders
+    Given user "Alice" has created the following folders
+      | path                               |
+      | simple-folder                      |
+      | 'single'quotes                     |
+      | 'single'quotes/simple-empty-folder |
+      | strängé नेपाली folder                |
+    And user "Alice" has uploaded file "filesForUpload/zzzz-must-be-last-file-in-folder.txt" to "zzzz-must-be-last-file-in-folder.txt"
+    And user "Alice" has uploaded file "filesForUpload/zzzz-must-be-last-file-in-folder.txt" to "simple-folder/zzzz-must-be-last-file-in-folder.txt"
+    And user "Alice" has uploaded file "filesForUpload/zzzz-must-be-last-file-in-folder.txt" to "strängé नेपाली folder/zzzz-must-be-last-file-in-folder.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "strängé नेपाली folder/lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user searches for "folder" using the webUI
     Then folder "simple-folder" should be listed on the webUI
     And folder "strängé नेपाली folder" should be listed on the webUI
@@ -33,6 +59,20 @@ Feature: Search
     And file "lorem.txt" should not be listed in the search results in the other folders section on the webUI
 
   Scenario: search in sub folder
+    Given user "Alice" has created the following folders
+      | path                  |
+      | 0                     |
+      | simple-folder         |
+      | strängé नेपाली folder   |
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "lorem-big.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "0/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "simple-folder/lorem-big.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "strängé नेपाली folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "strängé नेपाली folder/lorem-big.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user opens folder "simple-folder" using the webUI
     And the user searches for "lorem" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -46,6 +86,9 @@ Feature: Search
 
   @systemtags-app-required
   Scenario: search for a file using a tag
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     Given user "Alice" has created a "normal" tag with name "ipsum"
     And user "Alice" has added tag "ipsum" to file "/lorem.txt"
     When the user browses to the tags page
@@ -54,7 +97,11 @@ Feature: Search
 
   @systemtags-app-required
   Scenario: search for a file with multiple tags
-    Given user "Alice" has created a "normal" tag with name "lorem"
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "testimage.jpg"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+    And user "Alice" has created a "normal" tag with name "lorem"
     And user "Alice" has created a "normal" tag with name "ipsum"
     And user "Alice" has added tag "lorem" to file "/lorem.txt"
     And user "Alice" has added tag "lorem" to file "/testimage.jpg"
@@ -67,7 +114,12 @@ Feature: Search
 
   @systemtags-app-required
   Scenario: search for a file with tags
-    Given user "Alice" has created a "normal" tag with name "lorem"
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+    And user "Alice" has created a "normal" tag with name "lorem"
     And user "Alice" has added tag "lorem" to file "/lorem.txt"
     And user "Alice" has added tag "lorem" to file "/simple-folder/lorem.txt"
     When the user browses to the tags page
@@ -78,16 +130,21 @@ Feature: Search
 
   @files_sharing-app-required
   Scenario: Search for a shared file
-    Given user "Carol" has been created with default attributes and without skeleton files
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
-    When user "Carol" shares file "/lorem.txt" with user "Alice" using the sharing API
-    And the user reloads the current page of the webUI
-    And the user searches for "lorem" using the webUI
+    And user "Carol" has shared file "lorem.txt" with user "Alice"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+    When the user searches for "lorem" using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
 
   @files_sharing-app-required
   Scenario: Search for a re-shared file
-    Given these users have been created without skeleton files:
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+    And these users have been created without skeleton files:
       | username |
       | Brian    |
       | Carol    |
@@ -100,37 +157,55 @@ Feature: Search
 
   @files_sharing-app-required
   Scenario: Search for a shared folder
-    Given user "Carol" has been created with default attributes and without skeleton files
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created folder "simple-folder"
-    When user "Carol" shares folder "simple-folder" with user "Alice" using the sharing API
-    And the user reloads the current page of the webUI
-    And the user searches for "simple" using the webUI
+    And user "Carol" has shared folder "simple-folder" with user "Alice"
+    And the user has reloaded the current page of the webUI
+    When the user searches for "simple" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
   @skipOnFIREFOX
   Scenario: Search for a file after name is changed
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user renames file "lorem.txt" to "torem.txt" using the webUI
     And the user searches for "torem" using the webUI
     Then file "lorem.txt" should not be listed on the webUI
     And file "torem.txt" should be listed on the webUI
 
+  @issue-38641
   Scenario: Search for a newly uploaded file
-    Given user "Alice" has uploaded file with content "does-not-matter" to "torem.txt"
+    Given user "Alice" has created folder "simple-folder"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+    And user "Alice" has uploaded file with content "does-not-matter" to "torem.txt"
     And user "Alice" has uploaded file with content "does-not-matter" to "simple-folder/another-torem.txt"
     When the user searches for "torem" using the webUI
     Then file "torem.txt" with path "/" should be listed in the search results in the other folders section on the webUI
+#    Then file "torem.txt" with path "/" should not be listed in the search results in the other folders section on the webUI
     And file "another-torem.txt" with path "/simple-folder" should be listed in the search results in the other folders section on the webUI
+#    And file "another-torem.txt" with path "/simple-folder" should not be listed in the search results in the other folders section on the webUI
 
   Scenario: Search for files with difficult names
-    Given user "Alice" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
+    Given user "Alice" has created folder "strängé नेपाली folder"
+    And user "Alice" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
     And user "Alice" has uploaded file with content "does-not-matter" to "/strängé नेपाली folder/strängéनेपालीloremfile.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user searches for "lorem" using the webUI
-    Then file "strängéनेपालीloremfile.txt" with path "/" should be listed in the search results in the other folders section on the webUI
+    Then file "strängéनेपालीloremfile.txt" should be listed on the webUI
     And file "strängéनेपालीloremfile.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI
 
   Scenario: Search for files with difficult names and difficult search phrase
-    Given user "Alice" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
+    Given user "Alice" has created folder "strängé नेपाली folder"
+    And user "Alice" has uploaded file with content "does-not-matter" to "/strängéनेपालीloremfile.txt"
     And user "Alice" has uploaded file with content "does-not-matter" to "/strängé नेपाली folder/strängéनेपालीloremfile.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user searches for "strängéनेपाली" using the webUI
-    Then file "strängéनेपालीloremfile.txt" with path "/" should be listed in the search results in the other folders section on the webUI
+    Then file "strängéनेपालीloremfile.txt" should be listed on the webUI
     And file "strängéनेपालीloremfile.txt" with path "/strängé नेपाली folder" should be listed in the search results in the other folders section on the webUI

--- a/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
+++ b/tests/acceptance/features/webUIMoveFilesFolders/moveFiles.feature
@@ -5,16 +5,24 @@ Feature: move files
   So that I can organise my data structure
 
   Background:
-    Given user "Alice" has been created with default attributes and large skeleton files
-    And user "Alice" has logged in using the webUI
-    And the user has browsed to the files page
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/data.zip" to "data.zip"
 
   Scenario: An attempt to move a file into a sub-folder using rename is not allowed
+    Given user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user renames file "data.zip" to "simple-folder/data.zip" using the webUI
     Then near file "data.zip" a tooltip with the text 'File name cannot contain "/".' should be displayed on the webUI
 
   @smokeTest @skipOnLDAP
   Scenario: move a file into a folder
+    Given user "Alice" has created folder "simple-empty-folder"
+    And user "Alice" has created folder "strängé नेपाली folder empty"
+    And user "Alice" has uploaded file "filesForUpload/data.tar.gz" to "data.tar.gz"
+    And user "Alice" has uploaded file "filesForUpload/strängé filename (duplicate #2 &).txt" to "strängé filename (duplicate #2 &).txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user moves file "data.zip" into folder "simple-empty-folder" using the webUI
     Then file "data.zip" should not be listed on the webUI
     But file "data.zip" should be listed in folder "simple-empty-folder" on the webUI
@@ -28,6 +36,11 @@ Feature: move files
     But file "strängé filename (duplicate #2 &).txt" should be listed in folder "strängé नेपाली folder empty" on the webUI
 
   Scenario: move a file into a folder where a file with the same name already exists
+    Given user "Alice" has created folder "strängé नेपाली folder"
+    And user "Alice" has uploaded file "filesForUpload/data.zip" to "simple-folder/data.zip"
+    And user "Alice" has uploaded file "filesForUpload/data.zip" to "strängé नेपाली folder/data.zip"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user moves file "data.zip" into folder "simple-folder" using the webUI
     And the user moves file "data.zip" into folder "strängé नेपाली folder" using the webUI
     Then notifications should be displayed on the webUI with the text
@@ -37,6 +50,11 @@ Feature: move files
 
   @skipOnFIREFOX
   Scenario: move a file into a folder where a file with the same name already exists and the filename contains special characters
+    Given user "Alice" has created folder "strängé नेपाली folder"
+    And user "Alice" has uploaded file "filesForUpload/strängé filename (duplicate #2 &).txt" to "strängé filename (duplicate #2 &).txt"
+    And user "Alice" has uploaded file "filesForUpload/strängé filename (duplicate #2 &).txt" to "strängé नेपाली folder/strängé filename (duplicate #2 &).txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user moves file "strängé filename (duplicate #2 &).txt" into folder "strängé नेपाली folder" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Could not move "strängé filename (duplicate #2 &).txt", target exists |
@@ -44,17 +62,23 @@ Feature: move files
 
   @smokeTest @skipOnLDAP
   Scenario: Move multiple files at once
-    When the user batch moves these files into folder "simple-empty-folder" using the webUI
-      | name        |
-      | data.zip    |
-      | lorem.txt   |
-      | testapp.zip |
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+    When the user batch moves these files into folder "simple-folder" using the webUI
+      | name      |
+      | data.zip  |
+      | lorem.txt |
+      | data.zip  |
     Then the moved elements should not be listed on the webUI
     And the moved elements should not be listed on the webUI after a page reload
-    But the moved elements should be listed in folder "simple-empty-folder" on the webUI
+    But the moved elements should be listed in folder "simple-folder" on the webUI
 
   @skipOnFIREFOX
   Scenario: move a file into a folder (problematic characters)
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     When the user renames the following file using the webUI
       | from-name-parts | to-name-parts   |
       | lorem.txt       | 'single'        |
@@ -62,11 +86,11 @@ Feature: move files
       |                 | question?       |
       |                 | &and#hash       |
     And the user renames the following folder using the webUI
-      | from-name-parts     | to-name-parts       |
-      | simple-empty-folder | folder-with'single' |
-      |                     | "double" quotes     |
-      |                     | question?           |
-      |                     | &and#hash           |
+      | from-name-parts | to-name-parts       |
+      | simple-folder   | folder-with'single' |
+      |                 | "double" quotes     |
+      |                 | question?           |
+      |                 | &and#hash           |
     And the user moves the following file using the webUI
       | item-to-move-name-parts | destination-name-parts |
       | 'single'                | folder-with'single'    |
@@ -82,6 +106,10 @@ Feature: move files
 
   @files_sharing-app-required
   Scenario: move files on a public share
+    Given user "Alice" has created folder "simple-folder/simple-empty-folder"
+    And user "Alice" has uploaded file "filesForUpload/data.zip" to "simple-folder/data.zip"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
     And user "Alice" has created a public link share with settings
       | path        | /simple-folder     |
       | permissions | read,create,change |

--- a/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/webUITrashbin/trashbinDelete.feature
@@ -5,7 +5,13 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
   Background:
-    Given user "Alice" has been created with default attributes and large skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "lorem-big.txt"
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "simple-folder/lorem.txt"
+    And user "Alice" has uploaded file "filesForUpload/lorem-big.txt" to "simple-folder/lorem-big.txt"
     And user "Alice" has logged in using the webUI
     And the following files have been deleted
       | name          |

--- a/tests/acceptance/features/webUIWebdavLocks/locks.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locks.feature
@@ -6,13 +6,17 @@ Feature: Locks
 
   Background:
     #do not set email, see bugs in https://github.com/owncloud/core/pull/32250#issuecomment-434615887
-    Given these users have been created with large skeleton files:
+    Given these users have been created without skeleton files:
       | username       |
       | brand-new-user |
     And user "brand-new-user" has logged in using the webUI
 
   Scenario: setting a lock shows the lock symbols at the correct files/folders
-    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
+    Given user "brand-new-user" has created folder "simple-folder"
+    And user "brand-new-user" has created folder "simple-empty-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.tar.gz" to "data.tar.gz"
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
     And user "brand-new-user" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
@@ -25,7 +29,9 @@ Feature: Locks
     But file "data.tar.gz" should not be marked as locked on the webUI
 
   Scenario: setting a lock shows the display name of a user in the locking details
-    Given the administrator has changed the display name of user "brand-new-user" to "My fancy name"
+    Given user "brand-new-user" has created folder "simple-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And the administrator has changed the display name of user "brand-new-user" to "My fancy name"
     And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
     And user "brand-new-user" has locked file "data.zip" setting the following properties
@@ -79,10 +85,15 @@ Feature: Locks
     And file "data.zip" should be marked as locked by user "user-with-email (mail@oc.org)" in the locks tab of the details panel on the webUI
 
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the favorites page
-    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
+    Given user "brand-new-user" has created folder "simple-folder"
+    And user "brand-new-user" has created folder "simple-empty-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.tar.gz" to "data.tar.gz"
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
     And user "brand-new-user" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
+    And the user has browsed to the files page
     When the user marks folder "simple-folder" as favorite using the webUI
     And the user marks folder "simple-empty-folder" as favorite using the webUI
     And the user marks file "data.zip" as favorite using the webUI
@@ -98,6 +109,10 @@ Feature: Locks
   @skipOnOcV10 @issue-33867 @files_sharing-app-required
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-with-others page
     Given user "receiver" has been created with default attributes and without skeleton files
+    And user "brand-new-user" has created folder "simple-folder"
+    And user "brand-new-user" has created folder "simple-empty-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.tar.gz" to "data.tar.gz"
     And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
     And user "brand-new-user" has locked file "data.zip" setting the following properties
@@ -116,7 +131,11 @@ Feature: Locks
 
   @skipOnOcV10 @issue-33867 @files_sharing-app-required
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-by-link page
-    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
+    Given user "brand-new-user" has created folder "simple-folder"
+    And user "brand-new-user" has created folder "simple-empty-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.tar.gz" to "data.tar.gz"
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
     And user "brand-new-user" has locked file "data.zip" setting the following properties
       | lockscope | exclusive |
@@ -139,6 +158,10 @@ Feature: Locks
   @skipOnOcV10 @issue-33867 @files_sharing-app-required
   Scenario: setting a lock shows the lock symbols at the correct files/folders on the shared-with-you page
     Given user "sharer" has been created with default attributes and without skeleton files
+    And user "sharer" has created folder "simple-folder"
+    And user "sharer" has created folder "simple-empty-folder"
+    And user "sharer" has uploaded file "filesForUpload/data.zip" to "data.zip"
+    And user "sharer" has uploaded file "filesForUpload/data.tar.gz" to "data.tar.gz"
     And user "sharer" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
     And user "sharer" has locked file "data.zip" setting the following properties
@@ -148,15 +171,17 @@ Feature: Locks
     And user "sharer" has shared folder "simple-folder" with user "brand-new-user"
     And user "sharer" has shared folder "simple-empty-folder" with user "brand-new-user"
     When the user browses to the shared-with-you page
-    Then folder "simple-folder (2)" should be marked as locked on the webUI
-    And folder "simple-folder (2)" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
-    But folder "simple-empty-folder (2)" should not be marked as locked on the webUI
-    And file "data (2).zip" should be marked as locked on the webUI
-    And file "data (2).zip" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
-    But file "data.tar (2).gz" should not be marked as locked on the webUI
+    Then folder "simple-folder" should be marked as locked on the webUI
+    And folder "simple-folder" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
+    But folder "simple-empty-folder" should not be marked as locked on the webUI
+    And file "data.zip" should be marked as locked on the webUI
+    And file "data.zip" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
+    But file "data.tar.gz" should not be marked as locked on the webUI
 
   @files_sharing-app-required
   Scenario: clicking other tabs does not change the lock symbol
+    Given user "brand-new-user" has created folder "simple-folder"
+    And the user has browsed to the files page
     When the user opens the share dialog for folder "simple-folder"
     Then folder "simple-folder" should not be marked as locked on the webUI
 
@@ -179,16 +204,15 @@ Feature: Locks
       | lockscope | shared |
     And user "receiver" has locked file "data.zip" setting the following properties
       | lockscope | shared |
-    And user "brand-new-user" has locked file "data (2).zip" setting the following properties
+    And user "brand-new-user" has locked file "data.zip" setting the following properties
       | lockscope | shared |
     And user "receiver2" has locked file "data.tar (2).gz" setting the following properties
       | lockscope | shared |
     When the user browses to the files page
-    Then file "data (2).zip" should be marked as locked on the webUI
-    And file "data (2).zip" should be marked as locked by user "sharer" in the locks tab of the details panel on the webUI
-    And file "data (2).zip" should be marked as locked by user "receiver" in the locks tab of the details panel on the webUI
-    And file "data (2).zip" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
-    But file "data.zip" should not be marked as locked on the webUI
+    Then file "data.zip" should be marked as locked on the webUI
+    And file "data.zip" should be marked as locked by user "sharer" in the locks tab of the details panel on the webUI
+    And file "data.zip" should be marked as locked by user "receiver" in the locks tab of the details panel on the webUI
+    And file "data.zip" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
     When the user re-logs in as "sharer" using the webUI
     Then file "data.zip" should be marked as locked on the webUI
     And file "data.zip" should be marked as locked by user "sharer" in the locks tab of the details panel on the webUI
@@ -201,8 +225,12 @@ Feature: Locks
     And file "data.tar (2).gz" should be marked as locked by user "receiver2" in the locks tab of the details panel on the webUI
 
   Scenario: setting a lock on a folder shows the symbols at the sub-elements
-    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
+    Given user "brand-new-user" has created folder "simple-folder"
+    And user "brand-new-user" has created folder "simple-folder/simple-empty-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.zip" to "simple-folder/data.zip"
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | lockscope | shared |
+    And the user has browsed to the files page
     When the user opens folder "simple-folder" using the webUI
     Then folder "simple-empty-folder" should be marked as locked on the webUI
     And folder "simple-empty-folder" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
@@ -210,7 +238,10 @@ Feature: Locks
     And file "data.zip" should be marked as locked by user "brand-new-user" in the locks tab of the details panel on the webUI
 
   Scenario: setting a depth:0 lock on a folder does not shows the symbols at the sub-elements
-    Given user "brand-new-user" has locked folder "simple-folder" setting the following properties
+    Given user "brand-new-user" has created folder "simple-folder"
+    And user "brand-new-user" has created folder "simple-folder/simple-empty-folder"
+    And user "brand-new-user" has uploaded file "filesForUpload/data.zip" to "simple-folder/data.zip"
+    And user "brand-new-user" has locked folder "simple-folder" setting the following properties
       | depth | 0 |
     When the user browses to the files page
     Then folder "simple-folder" should be marked as locked on the webUI
@@ -314,15 +345,15 @@ Feature: Locks
     And user "sharer" has shared file "lorem.txt" with user "brand-new-user"
     And user "sharer" has shared folder "simple-folder" with user "brand-new-user"
     And the user has browsed to the files page
-    When the user unshares file "lorem (2).txt" using the webUI
-    And the user unshares folder "simple-folder (2)" using the webUI
+    When the user unshares file "lorem.txt" using the webUI
+    And the user unshares folder "simple-folder" using the webUI
     Then notifications should be displayed on the webUI with the text
-      | The file "lorem (2).txt" is locked and cannot be deleted.     |
-      | The file "simple-folder (2)" is locked and cannot be deleted. |
-    And as "brand-new-user" file "lorem (2).txt" should exist
-    And as "brand-new-user" folder "simple-folder (2)" should exist
-    And file "lorem (2).txt" should be listed on the webUI
-    And folder "simple-folder (2)" should be listed on the webUI
+      | The file "lorem.txt" is locked and cannot be deleted.     |
+      | The file "simple-folder" is locked and cannot be deleted. |
+    And as "brand-new-user" file "lorem.txt" should exist
+    And as "brand-new-user" folder "simple-folder" should exist
+    And file "lorem.txt" should be listed on the webUI
+    And folder "simple-folder" should be listed on the webUI
     And 1 locks should be reported for file "lorem.txt" of user "sharer" by the WebDAV API
     And 1 locks should be reported for file "simple-folder/lorem.txt" of user "sharer" by the WebDAV API
     Examples:


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
created resources rather than using skeleton dirs with users in webUI suites

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/658

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
