### PR TITLE
[tests-only] Use tiny skeleton in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1104,7 +1104,13 @@ trait Provisioning {
 		try {
 			$this->createTheseUsers($setDefaultAttributes, $initialize, true, $table);
 		} finally {
-			$this->setSkeletonDir($originalSkeletonPath);
+			// The effective skeleton directory is the one when the user is initialized
+			// If we did not initialize the user on creation, then we need to leave
+			// the skeleton directory in effect so that it applies when some action
+			// happens later in the scenario that causes the user to be initialized.
+			if ($initialize) {
+				$this->setSkeletonDir($originalSkeletonPath);
+			}
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -380,7 +380,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has been created with default attributes and (small|large)\s?skeleton files$/
+	 * @Given /^user "([^"]*)" has been created with default attributes and (tiny|small|large)\s?skeleton files$/
 	 *
 	 * @param string $user
 	 * @param string $skeletonType
@@ -390,9 +390,14 @@ trait Provisioning {
 	 * @throws \Exception
 	 */
 	public function userHasBeenCreatedWithDefaultAttributes(
-		string $user, string $skeletonType, $skeleton = true
+		string $user, string $skeletonType = "", $skeleton = true
 	) {
+		if ($skeletonType === "") {
+			$skeletonType = $this->getSmallestSkeletonDirName();
+		}
+
 		$originalSkeletonPath = $this->setSkeletonDirByType($skeletonType);
+
 		try {
 			$this->createUser(
 				$user, null, null, null, true, null, true, $skeleton
@@ -412,14 +417,7 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles($user) {
-		$baseUrl = $this->getBaseUrl();
-		$path = $this->popSkeletonDirectoryConfig($baseUrl);
-		try {
-			$this->userHasBeenCreatedWithDefaultAttributes($user, "", false);
-		} finally {
-			// restore skeletondirectory even if user creation failed
-			$this->setSkeletonDir($path);
-		}
+		$this->userHasBeenCreatedWithDefaultAttributes($user);
 	}
 
 	/**
@@ -433,13 +431,12 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function theseUsersHaveBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles(TableNode $table) {
-		$baseUrl = $this->getBaseUrl();
-		$path = $this->popSkeletonDirectoryConfig($baseUrl);
+		$originalSkeletonPath = $this->setSkeletonDirByType($this->getSmallestSkeletonDirName());
 		try {
-			$this->createTheseUsers(true, true, false, $table);
+			$this->createTheseUsers(true, true, true, $table);
 		} finally {
 			// restore skeletondirectory even if user creation failed
-			$this->setSkeletonDir($path);
+			$this->setSkeletonDir($originalSkeletonPath);
 		}
 	}
 
@@ -456,14 +453,7 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function theseUsersHaveBeenCreatedWithoutSkeletonFiles(TableNode $table, string $doNotInitialize) {
-		$baseUrl = $this->getBaseUrl();
-		$path = $this->popSkeletonDirectoryConfig($baseUrl);
-		try {
-			$this->theseUsersHaveBeenCreated("", "", $doNotInitialize, $table);
-		} finally {
-			// restore skeletondirectory even if user creation failed
-			$this->setSkeletonDir($path);
-		}
+		$this->theseUsersHaveBeenCreated("", "", $doNotInitialize, $table);
 	}
 
 	/**
@@ -1084,7 +1074,7 @@ trait Provisioning {
 	}
 
 	/**
-	 * @Given /^these users have been created with ?(default attributes and|) (small|large)\s?skeleton files ?(but not initialized|):$/
+	 * @Given /^these users have been created with ?(default attributes and|) (tiny|small|large)\s?skeleton files ?(but not initialized|):$/
 	 *
 	 * expects a table of users with the heading
 	 * "|username|password|displayname|email|"
@@ -1104,8 +1094,11 @@ trait Provisioning {
 		string $doNotInitialize,
 		TableNode $table
 	) {
-		$originalSkeletonPath = $this->setSkeletonDirByType($skeletonType);
+		if ($skeletonType === "") {
+			$skeletonType = $this->getSmallestSkeletonDirName();
+		}
 
+		$originalSkeletonPath = $this->setSkeletonDirByType($skeletonType);
 		$setDefaultAttributes = $defaultAttributesText !== "";
 		$initialize = $doNotInitialize === "";
 		try {
@@ -5180,9 +5173,24 @@ trait Provisioning {
 	}
 
 	/**
+	 * Get the name of the smallest available skeleton, to "simulate" without skeleton.
+	 *
+	 * In ownCloud 10 there is always a skeleton directory. If none is specified
+	 * then whatever is in core/skeleton is used. That contains different files
+	 * and folders depending on the build that is being tested. So for testing
+	 * we have "tiny" skeleton that contains just one file. That provides a
+	 * consistent skeleton for test scenarios that specify "without skeleton files"
+	 *
+	 * @return string name of the smallest skeleton folder
+	 */
+	private function getSmallestSkeletonDirName(): string {
+		return "tiny";
+	}
+
+	/**
 	 * sets the skeletondirectory according to the type
 	 *
-	 * @param string $skeletonType can be "small" OR "large" OR empty.
+	 * @param string $skeletonType can be "tiny", "small", "large" OR empty.
 	 *                             If an empty string is given, the current
 	 *                             setting will not be changed
 	 *


### PR DESCRIPTION
## Description
PR https://github.com/owncloud/testing/pull/171 added `tinySkeleton` to the skeletons available in the testing app. That has just a `.gitignore` file.

Use `tinySkeleton` for users that are created "without skeleton files".

Note: "without skeleton files" is not really a thing in oC10. You always have some folder that is the skeleton directory. So this change makes "without skeleton files" have a tiny known skeleton, rather than getting whatever might happen in the system-under-test. See the discussion in the issue for more details.

Note 2: I discovered an existing latent problem in the case where a user is created but not initialized, and they require a skeleton that is not the existing one that is in effect. In that case, for example, the skeleton is switched from `tiny` to `small`, then the user is created (without initializing), then the skeleton is switched back to tiny, then the scenario proceeds and the user does an action at some point. At that point the user gets initialized, but with the tiny skeleton. The 2nd commit corrects the problem - do not revert the skeleton setting if the user was not initialized. (We rely on AfterScenario and/or the code in `run.sh` to put the skeleton back to the original value when the test(s) are finished)



## Related Issue
- Fixes #38607 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
