### PR TITLE
Save notification url as relative instead of absolute

### DIFF
--- a/apps/federatedfilesharing/lib/FedShareManager.php
+++ b/apps/federatedfilesharing/lib/FedShareManager.php
@@ -400,10 +400,7 @@ class FedShareManager {
 	 */
 	protected function getActionLink($shareId) {
 		$urlGenerator = \OC::$server->getURLGenerator();
-		$link = $urlGenerator->getAbsoluteURL(
-			$urlGenerator->linkTo('', self::ACTION_URL . $shareId)
-		);
-		return $link;
+		return $urlGenerator->linkTo('', self::ACTION_URL . $shareId);
 	}
 
 	/**

--- a/apps/files_sharing/lib/Service/NotificationPublisher.php
+++ b/apps/files_sharing/lib/Service/NotificationPublisher.php
@@ -81,10 +81,8 @@ class NotificationPublisher {
 			return;
 		}
 
-		$fileLink = $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileId' => $share->getNode()->getId()]);
-		$endpointUrl = $this->urlGenerator->getAbsoluteURL(
-			$this->urlGenerator->linkTo('', 'ocs/v1.php/apps/files_sharing/api/v1/shares/pending/' . $share->getId())
-		);
+		$fileLink = $this->urlGenerator->linkToRoute('files.viewcontroller.showFile', ['fileId' => $share->getNode()->getId()]);
+		$endpointUrl = $this->urlGenerator->linkTo('', 'ocs/v1.php/apps/files_sharing/api/v1/shares/pending/' . $share->getId());
 
 		foreach ($this->getAffectedUsers($share) as $userId) {
 			$notification = $this->notificationManager->createNotification();

--- a/apps/files_sharing/tests/Service/NotificationPublisherTest.php
+++ b/apps/files_sharing/tests/Service/NotificationPublisherTest.php
@@ -65,7 +65,7 @@ class NotificationPublisherTest extends TestCase {
 		);
 
 		$this->urlGenerator->expects($this->any())
-			->method('linkToRouteAbsolute')
+			->method('linkToRoute')
 			->with('files.viewcontroller.showFile', ['fileId' => 4000])
 			->willReturn('/owncloud/f/4000');
 

--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -94,7 +94,7 @@ class BackgroundJob extends TimedJob {
 
 		$status = $updater->check();
 		if (isset($status['version'])) {
-			$url = $this->urlGenerator->linkToRouteAbsolute('settings.SettingsPage.getAdmin') . '#updater';
+			$url = $this->urlGenerator->linkToRoute('settings.SettingsPage.getAdmin') . '#updater';
 			$this->createNotifications('core', $status['version'], $url);
 		}
 	}

--- a/apps/updatenotification/tests/Notification/BackgroundJobTest.php
+++ b/apps/updatenotification/tests/Notification/BackgroundJobTest.php
@@ -152,13 +152,13 @@ class BackgroundJobTest extends TestCase {
 
 		if ($notification === null) {
 			$this->urlGenerator->expects($this->never())
-				->method('linkToRouteAbsolute');
+				->method('linkToRoute');
 
 			$job->expects($this->never())
 				->method('createNotifications');
 		} else {
 			$this->urlGenerator->expects($this->once())
-				->method('linkToRouteAbsolute')
+				->method('linkToRoute')
 				->with('settings.SettingsPage.getAdmin')
 				->willReturn('admin-url');
 

--- a/changelog/unreleased/38639
+++ b/changelog/unreleased/38639
@@ -1,0 +1,7 @@
+Enhancement: Use relative notification URLs
+
+Previous to this fix, absolute URLs were passed to the notification app.
+This could cause some CORS issues, hence we now use relative ones.
+
+https://github.com/owncloud/core/pull/38639
+https://github.com/owncloud/enterprise/issues/4250

--- a/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
@@ -32,7 +32,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
 
   Scenario: share to group sends notification to every member
@@ -46,7 +46,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 2 notifications
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -54,7 +54,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
 
 	# This scenario documents behavior discussed in core issue 31870
@@ -83,7 +83,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 1 notification
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -91,7 +91,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "David" should have 0 notifications
 
@@ -111,7 +111,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 1 notification
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -119,7 +119,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "David" should have 0 notifications
 

--- a/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
@@ -33,7 +33,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
 
   Scenario: share to group sends notification to every member
@@ -47,7 +47,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 2 notifications
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -55,7 +55,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
 
 	# This scenario documents behavior discussed in core issue 31870
@@ -72,7 +72,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 1 notification
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -80,7 +80,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "David" should have 0 notifications
 
@@ -100,7 +100,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 1 notification
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -108,7 +108,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^%base_url%(\/index\.php)?\/f\/(\d+)$/          |
+      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
       | object_type | /^local_share$/                                  |
     And user "David" should have 0 notifications
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Previous to this fix, absolute URLs were passed to the notification app.
This could cause some CORS issues, hence we now use relative ones.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4250
- Related PR in the notification app is required to ensure that links are correct in emails: https://github.com/owncloud/notifications/pull/333

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
