### PR TITLE
[tests-only] test if a user can delete a share after loosing resharing permissions

### DIFF
--- a/tests/acceptance/features/apiShareReshareToRoot3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot3/reShareUpdate.feature
@@ -116,3 +116,19 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+
+  Scenario Outline: After losing share permissions user can still delete a previously reshared share
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/TMP"
+    And user "Alice" has shared folder "/TMP" with user "Brian" with permissions "share,create,update,read"
+    And user "Brian" has shared folder "/TMP" with user "Carol" with permissions "share,create,update,read"
+    And user "Alice" has updated the last share of "Alice" with
+      | permissions | create,update,read |
+    When user "Brian" deletes the last share using the sharing API
+    And the OCS status code should be "<ocs_status_code>"
+    And user "Carol" should not have any received shares
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
@@ -132,3 +132,21 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+
+  Scenario Outline: After losing share permissions user can still delete a previously reshared share
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has created folder "/TMP"
+    And user "Alice" has shared folder "/TMP" with user "Brian" with permissions "share,create,update,read"
+    And user "Brian" has accepted share "/TMP" offered by user "Alice"
+    And user "Brian" has shared folder "Shares/TMP" with user "Carol" with permissions "share,create,update,read"
+    And user "Carol" has accepted share "/TMP" offered by user "Brian"
+    And user "Alice" has updated the last share of "Alice" with
+      | permissions | create,update,read |
+    When user "Brian" deletes the last share using the sharing API
+    And the OCS status code should be "<ocs_status_code>"
+    And user "Carol" should not have any received shares
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1650,8 +1650,13 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function userGetsInfoOfLastShareUsingTheSharingApi($user, $language=null) {
+		if (isset($this->lastShareData->data[0]->id)) {
+			$share_id = $this->lastShareData->data[0]->id;
+		} else {
+			$share_id = $this->getLastShareIdOf($user);
+		}
 		$language = TranslationHelper::getLanguage($language);
-		$this->getShareData($user, $this->lastShareData->data[0]->id, $language);
+		$this->getShareData($user, $share_id, $language);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1649,9 +1649,6 @@ trait Sharing {
 	 */
 	public function getLastShareIdOf($user) {
 		$user = $this->getActualUsername($user);
-		if (isset($this->lastShareData->data[0]->id)) {
-			return $this->lastShareData->data[0]->id;
-		}
 
 		$this->getListOfShares($user);
 		$id = $this->extractLastSharedIdFromLastResponse();

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1650,7 +1650,6 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function userGetsInfoOfLastShareUsingTheSharingApi($user, $language=null) {
-		$share_id = $this->getLastShareIdOf($user);
 		$language = TranslationHelper::getLanguage($language);
 		$this->getShareData($user, $this->lastShareData->data[0]->id, $language);
 	}
@@ -1944,7 +1943,7 @@ trait Sharing {
 	) {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeRows($body, [], $this->shareResponseFields);
-		$this->userGetsInfoOfLastShareUsingTheSharingApi($user);
+		$this->getShareData($user, $this->lastShareData->data[0]->id);
 		$this->theHTTPStatusCodeShouldBe(
 			200,
 			"Error getting info of last share for user $user"

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -814,13 +814,18 @@ trait Sharing {
 	/**
 	 * @param string $user
 	 * @param TableNode|null $body
+	 * @param string|null $shareOwner
 	 *
 	 * @return void
 	 */
-	public function updateLastShareWithSettings($user, $body) {
+	public function updateLastShareWithSettings($user, $body, $shareOwner = null) {
 		$user = $this->getActualUsername($user);
 
-		$share_id = $this->lastShareData->data[0]->id;
+		if ($shareOwner === null) {
+			$share_id = $this->lastShareData->data[0]->id;
+		} else {
+			$share_id = $this->getLastShareIdOf($shareOwner);
+		}
 
 		$this->verifyTableNodeRows(
 			$body,
@@ -877,6 +882,20 @@ trait Sharing {
 	 */
 	public function userHasUpdatedTheLastShareWith($user, $body) {
 		$this->updateLastShareWithSettings($user, $body);
+		$this->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has updated the last share of "([^"]*)" with$/
+	 *
+	 * @param string $user
+	 * @param string $shareOwner
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 */
+	public function userHasUpdatedTheLastShareOfWith($user, $shareOwner, $body) {
+		$this->updateLastShareWithSettings($user, $body, $shareOwner);
 		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1643,7 +1643,7 @@ trait Sharing {
 	 * @When /^user "([^"]*)" gets the info of the last share in language "([^"]*)" using the sharing API$/
 	 * @When /^user "([^"]*)" gets the info of the last share using the sharing API$/
 	 *
-	 * @param string $user
+	 * @param string $user username that requests the information (might not be the user that has initiated the share)
 	 * @param string $language
 	 *
 	 * @return void
@@ -1652,7 +1652,7 @@ trait Sharing {
 	public function userGetsInfoOfLastShareUsingTheSharingApi($user, $language=null) {
 		$share_id = $this->getLastShareIdOf($user);
 		$language = TranslationHelper::getLanguage($language);
-		$this->getShareData($user, $share_id, $language);
+		$this->getShareData($user, $this->lastShareData->data[0]->id, $language);
 	}
 
 	/**


### PR DESCRIPTION
## Description
- use API requests to get the last share ID of a specific user
- test if a user can delete a share after loosing resharing permissions

## Related Issue
- proves behaiviour of https://github.com/owncloud/client/issues/7423 on API level 

## How Has This Been Tested?
- :robot:


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
