### PR TITLE
Allow easier rename of shared mount

### DIFF
--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -185,9 +185,18 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 * @return bool true if allowed, false otherwise
 	 */
 	public function isTargetAllowed($target) {
+		$currentMount = $this->getMountPoint();
+		// note: $currentMount has a trailing slash. It doesn't matter for the check below
+		$isRename = \dirname($currentMount) === \dirname($target);
+
 		list($targetStorage, $targetInternalPath) = \OC\Files\Filesystem::resolvePath($target);
 		// note: cannot use the view because the target is already locked
 		$fileId = (int)$targetStorage->getCache()->getId($targetInternalPath);
+		if ($isRename) {
+			// if it's a rename, it's allowed if the target doesn't exists
+			return $fileId === -1;
+		}
+
 		if ($fileId === -1) {
 			// target might not exist, need to check parent instead
 			$fileId = (int)$targetStorage->getCache()->getId(\dirname($targetInternalPath));

--- a/changelog/unreleased/38656
+++ b/changelog/unreleased/38656
@@ -1,0 +1,9 @@
+Change: Optimize share rename
+
+Renaming a received share could cause a file scan to be triggered. This could
+potentially be a performance problem if the file scan took a while.
+
+Now, renaming a received share won't trigger that file scan, so the
+performance will be faster.
+
+https://github.com/owncloud/core/pull/38656


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Superseeds https://github.com/owncloud/core/pull/38654

If we're renaming the shared mount, allow it as long as the target doesn't exists. No need to check for shares in this case.
For moving the shared mount around, we still use the previous check (which could cause a file scan)

## Related Issue
https://github.com/owncloud/enterprise/issues/4266

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually checked.
1. user1 shares folder with user2
2. user2 renames shared file

There is no scan triggered by the rename.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
