### PR TITLE
[tests-only] Adjust trashbinFilesFolders test setups

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -160,7 +160,7 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "testtrashbin101" has been created with default attributes and without skeleton files
     And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
+    And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile2.txt"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin101" has deleted file "/textfile0.txt"
     And user "testtrashbin101" has deleted file "/textfile2.txt"
@@ -180,7 +180,7 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "testtrashbin102" has been created with default attributes and without skeleton files
     And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
+    And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile2.txt"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin102" has deleted file "/textfile0.txt"
     And user "testtrashbin102" has deleted file "/textfile2.txt"


### PR DESCRIPTION
## Description
PR #38541 adjusted the use of skeleton files. The files created in the Given steps need to be adjusted in some scenarios that use `textfile2`

## Related Issue
- related to #38657 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
