### PR TITLE
[tests-only] Be more strict when checking Given user has deleted file

### DIFF
--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -242,7 +242,6 @@ Feature: checksums
   @local_storage @notToImplementOnOCIS @skipOnEncryptionType:user-keys @encryption-issue-42
   Scenario Outline: Uploaded file to external storage should have the same checksum when downloaded
     Given using <dav_version> DAV path
-    And file "/local_storage/chksumtst.txt" has been deleted for user "Alice"
     And user "Alice" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"
     When user "Alice" downloads file "/local_storage/chksumtst.txt" using the WebDAV API
     Then the following headers should be set

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -2402,7 +2402,7 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @When the administrator deletes last background job :job using the occ command
+	 * @When the administrator deletes the last background job :job using the occ command
 	 *
 	 * @param string $job
 	 *

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2767,8 +2767,11 @@ trait WebDav {
 		$user = $this->getActualUsername($user);
 		$this->userDeletesFile($user, $entry);
 		// If the file or folder was there and got deleted then we get a 204
-		// If the file or folder was already not there then then get a 404
-		// Either way, the outcome of the "given" step is OK
+		// That is good and the expected status
+		// If the file or folder was already not there then then we get a 404
+		// That is not expected. Scenarios that use "Given user has deleted..."
+		// should only be using such steps when it is a file that exists and needs
+		// to be deleted.
 		if ($deletedOrUnshared === "deleted") {
 			$deleteText = "delete";
 		} else {
@@ -2776,8 +2779,8 @@ trait WebDav {
 		}
 
 		$this->theHTTPStatusCodeShouldBe(
-			["204", "404"],
-			"HTTP status code was not 204 or 404 while trying to $deleteText $fileOrFolder '$entry' for user '$user'"
+			["204"],
+			"HTTP status code was not 204 while trying to $deleteText $fileOrFolder '$entry' for user '$user'"
 		);
 	}
 

--- a/tests/acceptance/features/cliBackground/backgroundQueue.feature
+++ b/tests/acceptance/features/cliBackground/backgroundQueue.feature
@@ -25,6 +25,6 @@ Feature: get status, delete and execute jobs in background queue
   Scenario: delete one of the job in background queue
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
-    When the administrator deletes last background job "OC\Command\CommandJob" using the occ command
+    When the administrator deletes the last background job "OC\Command\CommandJob" using the occ command
     Then the command should have been successful
     And the last deleted background job "OC\Command\CommandJob" should not be listed in the background jobs queue


### PR DESCRIPTION
## Description
If we use the `Given user "xyz" has deleted file "abc"` step then we really expect that there is an existing file to delete. This PR adjusts the code for the step so that only success (204) is allowed. A 404 "not found" will now cause the scenario to fail, so we will know if someone writes a step like this that has the wrong file name or is unnecessary.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
