### PR TITLE
[tests-only] Tidy up user cleanup when running on OCIS or reva

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -78,6 +78,7 @@ class OcisHelper {
 		if ($storageDriver === false) {
 			return "OWNCLOUD";
 		}
+		$storageDriver = \strtoupper($storageDriver);
 		if ($storageDriver !== "OCIS" && $storageDriver !== "EOS" && $storageDriver !== "OWNCLOUD" && $storageDriver !== "S3NG") {
 			throw new \Exception(
 				"Invalid storage driver. " .
@@ -95,6 +96,9 @@ class OcisHelper {
 	public static function deleteRevaUserData($user = "") {
 		$deleteCmd = self::getDeleteUserDataCommand();
 		if ($deleteCmd === false) {
+			if (self::getStorageDriver() === "OWNCLOUD") {
+				self::recurseRmdir(self::getOcisRevaDataRoot() . $user);
+			}
 			return;
 		}
 		if (self::getStorageDriver() === "EOS") {

--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -95,7 +95,6 @@ class OcisHelper {
 	public static function deleteRevaUserData($user = "") {
 		$deleteCmd = self::getDeleteUserDataCommand();
 		if ($deleteCmd === false) {
-			self::recurseRmdir(self::getOcisRevaDataRoot() . $user);
 			return;
 		}
 		if (self::getStorageDriver() === "EOS") {


### PR DESCRIPTION
## Description
PR https://github.com/owncloud/ocis/pull/1962 has been merged in OCIS. That has fixed the user delete so that all files of a user are deleted when the user is deleted. But it doesn't seem to have fixed it for `owncloud` storage.

We can remove the special code that does a default attempt to delete the user's files, unless the storage driver is `owncloud`

Note:  there is also cleanup code that does:
```
	$this->deleteAllSharesForUser($user["actualUsername"]);

```
That may not be needed any more. I will make a separate PR to remove that and test if it is really needed or not.

## How Has This Been Tested?
CI
https://github.com/owncloud/ocis/pull/1982 demonstrates that this works OK when testing with OCIS. You set the env var `STORAGE_DRIVER` in the drone pipeline step that runs the test scenarios, so that it knows which storage driver is being used on the system-under-test. Then the test code can make an informed decision about what extra "manual" cleanup of users it needs to do.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
