### PR TITLE
[tests-only] Remove unused DIR_URL in acceptance tests run.sh

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -727,7 +727,6 @@ then
 	# we know the TEST_SERVER_URL already
 	TESTING_APP_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/"
 	OCC_URL="${TESTING_APP_URL}occ"
-	DIR_URL="${TESTING_APP_URL}dir"
 	# test that server is up and running, and testing app is enabled.
 	assert_server_up ${TEST_SERVER_URL}
 	if [ "${TEST_OCIS}" != "true" ] && [ "${TEST_REVA}" != "true" ]
@@ -792,7 +791,6 @@ else
 	# The endpoint to use to do occ commands via the testing app
 	TESTING_APP_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/"
 	OCC_URL="${TESTING_APP_URL}occ"
-	DIR_URL="${TESTING_APP_URL}dir"
 
 	# Give time for the PHP dev server to become available
 	# because we want to use it to get and change settings with the testing app


### PR DESCRIPTION
## Description
While looking at other things in `run.sh` my IDE was telling me that `DIR_URL` is unused. The IDE was right. I guess it was used somewhere in past history. Delete it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
