### PR TITLE
[Tests-Only]Cleans up shares after the deletion of the user

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -4967,7 +4967,6 @@ trait Provisioning {
 
 		if (OcisHelper::isTestingOnOcisOrReva() && $this->someUsersHaveBeenCreated()) {
 			foreach ($this->getCreatedUsers() as $user) {
-				$this->deleteAllSharesForUser($user["actualUsername"]);
 				OcisHelper::deleteRevaUserData($user["actualUsername"]);
 			}
 		} elseif (OcisHelper::isTestingOnOc10()) {

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2875,41 +2875,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @param $user
-	 *
-	 * @throws Exception
-	 *
-	 * @return void
-	 */
-	public function deleteAllSharesForUser($user) {
-		$user = $this->getActualUsername($user);
-		$url = $this->getSharesEndpointPath("?format=json");
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
-			$user, "GET", $url, null
-		);
-		if ($this->response->getStatusCode() !== 200) {
-			return;
-		}
-		$result = $this->response->getBody()->getContents();
-		$usersShares = \json_decode($result, true);
-		if (!\is_array($usersShares)) {
-			throw new Exception(
-				__METHOD__ . " API result about shares is not valid JSON"
-			);
-		}
-		if (!isset($usersShares['ocs']['data'])) {
-			return;
-		}
-		foreach ($usersShares['ocs']['data'] as $share) {
-			$share_id = $share['id'];
-			$url = $this->getSharesEndpointPath("/$share_id");
-			$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
-				$user, "DELETE", $url, null
-			);
-		}
-	}
-
-	/**
 	 * replace values from table
 	 *
 	 * @param string $field


### PR DESCRIPTION
## Description
This PR minimizes the cleanup of user shares after the deletion of user

## Related Issue
- https://github.com/owncloud/ocis/issues/1985

## How Has This Been Tested?
- CI 
- https://github.com/owncloud/ocis/pull/1994 The failing test is not related to this changes. Expected failures needs to be adjusted in ocis
- https://github.com/cs3org/reva/pull/1676 - passes in reva

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
