### PR TITLE
objectids for tags and comment are strings

### DIFF
--- a/changelog/unreleased/38682
+++ b/changelog/unreleased/38682
@@ -1,0 +1,10 @@
+Bugfix: objectids for comments and tags are strings
+
+We were using integers when asking for some information related to comments
+and tag. This was working fine, but PHP 7.4.18 made some changes in the
+postgresql driver making things more strict. As result, some queries were
+failing because that information was stored as string, not integer.
+
+This problem is now fixed, and the queries can run without problems.
+
+https://github.com/owncloud/core/pull/38682

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -390,7 +390,7 @@ class Manager implements ICommentsManager {
 				->where($qbMain->expr()->eq('object_type', $qbMain->createParameter('type')))
 				->andWhere($qbMain->expr()->in('object_id', $qbMain->createParameter('object_ids')))
 				->setParameter('type', $objectType)
-				->setParameter('object_ids', $objectIdChunk, IQueryBuilder::PARAM_INT_ARRAY);
+				->setParameter('object_ids', $objectIdChunk, IQueryBuilder::PARAM_STR_ARRAY);
 
 			// For those found object_id, find all records from oc_comments which are not existing in oc_comments_read_markers or
 			// if matched, its timestamp is lower then the one in oc_comments_read_markers

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -82,7 +82,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 				->from(self::RELATION_TABLE)
 				->where($query->expr()->in('objectid', $query->createParameter('objectids')))
 				->andWhere($query->expr()->eq('objecttype', $query->createParameter('objecttype')))
-				->setParameter('objectids', $objectIdChunk, IQueryBuilder::PARAM_INT_ARRAY)
+				->setParameter('objectids', $objectIdChunk, IQueryBuilder::PARAM_STR_ARRAY)
 				->setParameter('objecttype', $objectType)
 				->addOrderBy('objectid', 'ASC')
 				->addOrderBy('systemtagid', 'ASC');


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The object ids changed in the PR are stored as strings in the DB, but ownCloud tries to store them as int.

## Related Issue
No issue opened
https://central.owncloud.org/t/php-7-4-18-breaking-owncloud-10-6-wih-postgresql-9-6-on-centos-7/31933

## Motivation and Context
Fixed bug in php caused a problem on our side.

## How Has This Been Tested?
Manually checked with postgresql 9.2 and php 7.4.18
**NOT** tested with other DBs yet.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
