### PR TITLE
Throw generic exception to overcome, senstitive exception data exposure

### DIFF
--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -400,6 +400,7 @@ class ShareController extends Controller {
 	 * @param string $path
 	 * @param string $downloadStartSecret
 	 * @return NotFoundResponse|RedirectResponse|void
+	 * @throws \Exception
 	 */
 	public function downloadShare($token, $files = null, $path = '', $downloadStartSecret = '') {
 		\OC_User::setIncognitoMode(true);
@@ -530,16 +531,21 @@ class ShareController extends Controller {
 		}
 
 		// download selected files
-		if ($files !== null && $files !== '') {
-			// FIXME: The exit is required here because otherwise the AppFramework is trying to add headers as well
-			// after dispatching the request which results in a "Cannot modify header information" notice.
-			OC_Files::get($originalSharePath, $files_list, $server_params);
-			exit();
-		} else {
-			// FIXME: The exit is required here because otherwise the AppFramework is trying to add headers as well
-			// after dispatching the request which results in a "Cannot modify header information" notice.
-			OC_Files::get(\dirname($originalSharePath), \basename($originalSharePath), $server_params);
-			exit();
+
+		try {
+			if ($files !== null && $files !== '') {
+				// FIXME: The exit is required here because otherwise the AppFramework is trying to add headers as well
+				// after dispatching the request which results in a "Cannot modify header information" notice.
+				OC_Files::get($originalSharePath, $files_list, $server_params);
+				exit();
+			} else {
+				// FIXME: The exit is required here because otherwise the AppFramework is trying to add headers as well
+				// after dispatching the request which results in a "Cannot modify header information" notice.
+				OC_Files::get(\dirname($originalSharePath), \basename($originalSharePath), $server_params);
+				exit();
+			}
+		} catch (\Exception $e) {
+			throw new \Exception();
 		}
 	}
 }

--- a/changelog/unreleased/38689
+++ b/changelog/unreleased/38689
@@ -1,0 +1,9 @@
+Bugfix: Hide sensible information on share download
+
+Sensible information could be exposed when downloading a share via public link.
+We now throw a generic exception that overwrites the original exception message.
+Also fixed an error which caused such behavior when appending a null byte
+to the download URL.
+
+https://github.com/owncloud/core/pull/38689
+https://github.com/owncloud/enterprise/issues/4536

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -384,7 +384,7 @@ class Local extends Common {
 		}
 		$pathToResolve = $fullPath;
 		$realPath = \realpath($pathToResolve);
-		while ($realPath === false) { // for non existing files check the parent directory
+		while (!\is_string($realPath)) { // for non existing files check the parent directory
 			$pathToResolve = \dirname($pathToResolve);
 			$realPath = \realpath($pathToResolve);
 		}


### PR DESCRIPTION
## Description
Sensible information could be exposed when downloading a share via public link. We now throw a generic exception that overwrites the original exception message. Also fixed an error which caused such behavior when appending a null byte to the download URL.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4536

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
