### PR TITLE
Prevent user to see directory content if share is a file drop

### DIFF
--- a/apps/files_sharing/ajax/shareinfo.php
+++ b/apps/files_sharing/ajax/shareinfo.php
@@ -82,8 +82,13 @@ $sharePermissions= (int)$share->getPermissions();
  * @return array
  */
 function getChildInfo($dir, $view, $sharePermissions) {
+	// Prevent user to see directory content if share is a file drop
+	if ($sharePermissions === \OCP\Constants::PERMISSION_CREATE) {
+		return [];
+	}
 	$children = $view->getDirectoryContent($dir->getPath());
 	$result = [];
+
 	foreach ($children as $child) {
 		$formatted = \OCA\Files\Helper::formatFileInfo($child);
 		if ($child->getType() === 'dir') {

--- a/changelog/unreleased/38691
+++ b/changelog/unreleased/38691
@@ -1,0 +1,8 @@
+Bugfix: Hide file drop content
+
+Requesting file drop share with the deprecated shareinfo API, exposed
+information about the content of the file drop share.
+We will now deliver empty content on the children entry.
+
+https://github.com/owncloud/core/pull/38691
+https://github.com/owncloud/enterprise/issues/4540


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Requesting file drop share with the deprecated shareinfo API, exposed
information about the content of the file drop share.
We will now deliver empty content on the children entry.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4540

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
