### PR TITLE
Add security check when updating the permissions of a federated share

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -386,12 +386,12 @@ class RequestHandlerController extends OCSController {
 
 			// we need to prohibit the permission update if it's not a re-share
 			if (!$this->fedShareManager->isFederatedReShare($share)) {
-				throw new \Exception();
+				throw new \Exception("Updating the permissions is only possible on a federated re-share");
 			}
 
 			$validPermission = \ctype_digit((string)$permissions);
 			if (!$validPermission) {
-				throw new \Exception();
+				throw new \Exception("Not allowed to update the permissions");
 			}
 			$permissions = $this->ocmMiddleware->normalizePermissions(
 				(int) $permissions

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -383,6 +383,12 @@ class RequestHandlerController extends OCSController {
 			$permissions = $this->request->getParam('permissions', null);
 			$token = $this->request->getParam('token', null);
 			$share = $this->ocmMiddleware->getValidShare($id, $token);
+
+			// we need to prohibit the permission update if it's not a re-share
+			if (!$this->fedShareManager->isFederatedReShare($share)) {
+				throw new \Exception();
+			}
+
 			$validPermission = \ctype_digit((string)$permissions);
 			if (!$validPermission) {
 				throw new \Exception();

--- a/apps/federatedfilesharing/lib/FedShareManager.php
+++ b/apps/federatedfilesharing/lib/FedShareManager.php
@@ -329,6 +329,28 @@ class FedShareManager {
 	}
 
 	/**
+	 * Check if a federated share was re-shared with another federated server.
+	 *
+	 * @param IShare $share
+	 * @return bool
+	 * @throws NotFoundException
+	 */
+	public function isFederatedReShare(IShare $share) {
+		// get all federated shares on this file
+		$shares = $this->federatedShareProvider->getSharesByPath($share->getNode());
+
+		foreach ($shares as $matchingShare) {
+			// if the share initiator (sharedBy) received a share for this file
+			// in the past, this is a re-share
+			if ($share->getSharedBy() === $matchingShare->getSharedWith()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * @param IShare $share
 	 * @param callable $callback
 	 *

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerTest.php
@@ -447,6 +447,9 @@ class RequestHandlerTest extends TestCase {
 		$this->ocmMiddleware->expects($this->once())
 			->method('getValidShare')
 			->willReturn($share);
+		$this->fedShareManager->expects($this->once())
+			->method('isFederatedReShare')
+			->willReturn(true);
 		$this->requestHandlerController->updatePermissions(5);
 	}
 

--- a/apps/federatedfilesharing/tests/FedShareManagerTest.php
+++ b/apps/federatedfilesharing/tests/FedShareManagerTest.php
@@ -272,4 +272,35 @@ class FedShareManagerTest extends TestCase {
 			->with($share);
 		$this->fedShareManager->undoReshare($share);
 	}
+
+	public function testIsFederatedReShare() {
+		$shareInitiator = 'user';
+		$share = $this->getMockBuilder(IShare::class)
+			->disableOriginalConstructor()->getMock();
+		$share->expects($this->any())
+			->method('getSharedBy')
+			->willReturn($shareInitiator);
+
+		$nodeMock = $this->getMockBuilder('OCP\Files\Node')
+			->disableOriginalConstructor()->getMock();
+		$share->expects($this->once())
+			->method('getNode')
+			->willReturn($nodeMock);
+
+		$otherShare = $this->getMockBuilder(IShare::class)
+			->disableOriginalConstructor()->getMock();
+		$otherShare->expects($this->any())
+			->method('getSharedWith')
+			->willReturn($shareInitiator);
+
+		$this->federatedShareProvider->expects($this->once())
+			->method('getSharesByPath')
+			->willReturn([$share, $otherShare]);
+
+		$isFederatedShared = $this->fedShareManager->isFederatedReShare($share);
+		$this->assertEquals(
+			true,
+			$isFederatedShared
+		);
+	}
 }

--- a/changelog/unreleased/38698
+++ b/changelog/unreleased/38698
@@ -1,0 +1,8 @@
+Bugfix: Add check when updating the permissions of a federated share
+
+This fixes a security issue where a federated share recipient could
+increase permissions on his share. We now limit the permission updates
+to federated re-shares only.
+
+https://github.com/owncloud/core/pull/38698
+https://github.com/owncloud/enterprise/issues/4537


### PR DESCRIPTION
## Description
This fixes a security issue where a federated share recipient could increase permissions on his share. We now limit the permission updates to federated re-shares only.

More detailed explanation of the problem: https://github.com/owncloud/enterprise/issues/4537#issuecomment-832577146
Steps to reproduce: https://github.com/owncloud/enterprise/issues/4537#issue-874550227


## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4537

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
