### PR TITLE
[tests-only] Add ability to skip pipelines in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -998,7 +998,8 @@ def javascript(ctx):
 	default = {
 		'coverage': True,
 		'logLevel': '2',
-		'phpVersion': '7.2'
+		'phpVersion': '7.2',
+		'skip': False
 	}
 
 	if 'defaults' in config:
@@ -1018,6 +1019,9 @@ def javascript(ctx):
 	params = {}
 	for item in default:
 		params[item] = matrix[item] if item in matrix else default[item]
+
+	if params['skip']:
+		return pipelines
 
 	result = {
 		'kind': 'pipeline',
@@ -1114,6 +1118,7 @@ def phpTests(ctx, testType):
 		'extraEnvironment': {},
 		'extraCommandsBeforeTestRun': [],
 		'extraApps': {},
+		'skip': False
 	}
 
 	if 'defaults' in config:
@@ -1138,6 +1143,9 @@ def phpTests(ctx, testType):
 		params = {}
 		for item in default:
 			params[item] = matrix[item] if item in matrix else default[item]
+		
+		if params['skip']:
+			continue
 
 		for phpVersion in params['phpVersions']:
 
@@ -1346,6 +1354,7 @@ def acceptance(ctx):
 		'includeKeyInMatrixName': False,
 		'runAllSuites': False,
 		'numberOfParts': 1,
+		'skip': False
 	}
 
 	if 'defaults' in config:
@@ -1372,6 +1381,9 @@ def acceptance(ctx):
 			params = {}
 			for item in default:
 				params[item] = matrix[item] if item in matrix else default[item]
+
+			if params['skip']:
+				continue
 
 			if isAPI or isCLI:
 				params['browsers'] = ['']


### PR DESCRIPTION
## Description
This PR adds the ability to skip certain CI pipelines (`PhpUnitTests`, `JavascriptTest` and `acceptanceTest`)

## Related Issue
- part of  https://github.com/owncloud/QA/issues/670

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
