### PR TITLE
Adjust the return type of the querybuilder's execute method

### DIFF
--- a/changelog/unreleased/38714
+++ b/changelog/unreleased/38714
@@ -1,0 +1,5 @@
+Enhancement: Adjust the return type of the querybuilder's execute method
+
+The return type changed with the recent update of doctrine/dbal to version 2.13.
+
+https://github.com/owncloud/core/pull/38714

--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -23,6 +23,8 @@
 namespace OCP\DB\QueryBuilder;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ForwardCompatibility\DriverStatement;
+use Doctrine\DBAL\ForwardCompatibility\DriverResultStatement;
 
 /**
  * This class provides a wrapper around Doctrine's QueryBuilder
@@ -122,7 +124,7 @@ interface IQueryBuilder {
 	 * Uses {@see Connection::executeQuery} for select statements and {@see Connection::executeUpdate}
 	 * for insert, update and delete statements.
 	 *
-	 * @return \Doctrine\DBAL\Driver\Statement|int
+	 * @return DriverStatement|DriverResultStatement|int
 	 * @since 8.2.0
 	 */
 	public function execute();


### PR DESCRIPTION
## Description
The return type changed with the recent update of `doctrine/dbal` to version `2.13`. We need this so `phan`, `stan` etc. don't complain when calling new methods (instead of deprecated ones) on the returned instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
