### PR TITLE
[tests-only] Skip some local storage tests on user-keys encryption

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareFromLocalStorageToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareFromLocalStorageToRootFolder.feature
@@ -1,4 +1,4 @@
-@api @local_storage @notToImplementOnOCIS
+@api @local_storage @files_sharing-app-required @notToImplementOnOCIS
 Feature: local-storage
 
   Background:
@@ -8,7 +8,7 @@ Feature: local-storage
       | Brian    |
 
 
-  @public_link_share-feature-required @files_sharing-app-required
+  @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: Share a file inside a local external storage
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/filetoshare.txt"
@@ -57,7 +57,7 @@ Feature: local-storage
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: Share a file inside a local external storage to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @local_storage @notToImplementOnOCIS
+@api @local_storage @notToImplementOnOCIS @files_sharing-app-required
 Feature: local-storage
 
   Background:
@@ -10,7 +10,7 @@ Feature: local-storage
       | Brian    |
 
 
-  @public_link_share-feature-required @files_sharing-app-required
+  @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: Share a file inside a local external storage
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/filetoshare.txt"
@@ -62,7 +62,7 @@ Feature: local-storage
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: Share a file inside a local external storage to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareFromLocalStorage.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareFromLocalStorage.feature
@@ -7,7 +7,7 @@ Feature: local-storage
       | Alice    |
       | Brian    |
 
-
+  @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: receiver renames a received file share from local storage
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/filetoshare.txt"
@@ -39,7 +39,7 @@ Feature: local-storage
       | 1               |
       | 2               |
 
-
+  @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: sub-folders,file inside a renamed received folder shared from local storage are accessible
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/local_storage/foo"

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
@@ -9,7 +9,7 @@ Feature: local-storage
       | Alice    |
       | Brian    |
 
-
+  @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: receiver renames a received file share from local storage
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/local_storage/filetoshare.txt"
@@ -43,7 +43,7 @@ Feature: local-storage
       | 1               |
       | 2               |
 
-
+  @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: sub-folders,file inside a renamed received folder shared from local storage are accessible
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/local_storage/foo"
@@ -68,7 +68,7 @@ Feature: local-storage
       | 1               |
       | 2               |
 
-
+  @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: receiver renames a received file share from local storage in group sharing
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created


### PR DESCRIPTION
## Description
See details on issue https://github.com/owncloud/encryption/issues/270 and https://github.com/owncloud/encryption/issues/181

Skip these scenarios when running with user-keys encryption.

## Related Issue
- Fixes https://github.com/owncloud/encryption/issues/270

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
