### PR TITLE
use filter_var instead of (bool)

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -177,15 +177,15 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 		$userEditable = false;
 
 		if (isset($data['userVisible'])) {
-			$userVisible = filter_var($data['userVisible'], FILTER_VALIDATE_BOOLEAN);
+			$userVisible = \filter_var($data['userVisible'], FILTER_VALIDATE_BOOLEAN);
 		}
 
 		if (isset($data['userAssignable'])) {
-			$userAssignable = filter_var($data['userAssignable'], FILTER_VALIDATE_BOOLEAN);
+			$userAssignable = \filter_var($data['userAssignable'], FILTER_VALIDATE_BOOLEAN);
 		}
 
 		if (isset($data['userEditable'])) {
-			$userEditable = filter_var($data['userEditable'], FILTER_VALIDATE_BOOLEAN);
+			$userEditable = \filter_var($data['userEditable'], FILTER_VALIDATE_BOOLEAN);
 		}
 
 		$groups = [];

--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -177,15 +177,15 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 		$userEditable = false;
 
 		if (isset($data['userVisible'])) {
-			$userVisible = (bool)$data['userVisible'];
+			$userVisible = filter_var($data['userVisible'], FILTER_VALIDATE_BOOLEAN);
 		}
 
 		if (isset($data['userAssignable'])) {
-			$userAssignable = (bool)$data['userAssignable'];
+			$userAssignable = filter_var($data['userAssignable'], FILTER_VALIDATE_BOOLEAN);
 		}
 
 		if (isset($data['userEditable'])) {
-			$userEditable = (bool)$data['userEditable'];
+			$userEditable = filter_var($data['userEditable'], FILTER_VALIDATE_BOOLEAN);
 		}
 
 		$groups = [];

--- a/changelog/unreleased/38719
+++ b/changelog/unreleased/38719
@@ -1,0 +1,7 @@
+Bugfix: String to bool conversion in systemtags API
+
+String values like "true" and "false" were always converted to true
+when creating a tag via API. We now use filter_var() to fix this
+behavior.
+
+https://github.com/owncloud/core/pull/38719


### PR DESCRIPTION
## Description
String values like "true" and "false" were always converted to true
when creating a tag via API. We now use filter_var() to fix this
behavior.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related https://github.com/owncloud/files_backup/issues/37

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
