### PR TITLE
[tests-only] Test creating tags with true/false string settings

### DIFF
--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -178,9 +178,9 @@ class TagsHelper extends \PHPUnit\Framework\Assert {
 	 * @param string $user
 	 * @param string $password
 	 * @param string $name
-	 * @param string $userVisible "true" or "false"
-	 * @param string $userAssignable "true" or "false"
-	 * @param string $userEditable "true" or "false"
+	 * @param string $userVisible "true", "1" or "false", "0"
+	 * @param string $userAssignable "true", "1" or "false", "0"
+	 * @param string $userEditable "true", "1" or "false", "0"
 	 * @param string $groups separated by "|"
 	 * @param int $davPathVersionToUse (1|2)
 	 *
@@ -249,27 +249,42 @@ class TagsHelper extends \PHPUnit\Framework\Assert {
 	}
 
 	/**
+	 * Validate the keyword(s) used for the type of tag
+	 * Tags can be "normal", "not user-assignable", "not user-visible" or "static"
+	 * That determines the tag attributes which are set when creating the tag.
+	 *
+	 * When creating the tag, the attributes can be enabled/disabled by specifying
+	 * either "true"/"false" or "1"/"0" in the request. Choose this "request style"
+	 * by passing the $useTrueFalseStrings parameter.
 	 *
 	 * @param string $type
+	 * @param boolean $useTrueFalseStrings use the strings "true"/"false" else "1"/"0"
 	 *
 	 * @throws \Exception
-	 * @return boolean[]
+	 * @return string[]
 	 */
-	public static function validateTypeOfTag($type) {
-		$userVisible = "true";
-		$userAssignable = "true";
-		$userEditable = "true";
+	public static function validateTypeOfTag($type, $useTrueFalseStrings = true) {
+		if ($useTrueFalseStrings) {
+			$trueValue = "true";
+			$falseValue = "false";
+		} else {
+			$trueValue = "1";
+			$falseValue = "0";
+		}
+		$userVisible = $trueValue;
+		$userAssignable = $trueValue;
+		$userEditable = $trueValue;
 		switch ($type) {
 			case 'normal':
 				break;
 			case 'not user-assignable':
-				$userAssignable = "false";
+				$userAssignable = $falseValue;
 				break;
 			case 'not user-visible':
-				$userVisible = "false";
+				$userVisible = $falseValue;
 				break;
 			case 'static':
-				$userEditable = "false";
+				$userEditable = $falseValue;
 				break;
 			default:
 				throw new \Exception('Unsupported type');

--- a/tests/TestHelpers/TagsHelper.php
+++ b/tests/TestHelpers/TagsHelper.php
@@ -178,9 +178,9 @@ class TagsHelper extends \PHPUnit\Framework\Assert {
 	 * @param string $user
 	 * @param string $password
 	 * @param string $name
-	 * @param bool $userVisible
-	 * @param bool $userAssignable
-	 * @param bool $userEditable
+	 * @param string $userVisible "true" or "false"
+	 * @param string $userAssignable "true" or "false"
+	 * @param string $userEditable "true" or "false"
 	 * @param string $groups separated by "|"
 	 * @param int $davPathVersionToUse (1|2)
 	 *
@@ -192,9 +192,9 @@ class TagsHelper extends \PHPUnit\Framework\Assert {
 		$user,
 		$password,
 		$name,
-		$userVisible = true,
-		$userAssignable = true,
-		$userEditable = false,
+		$userVisible = "true",
+		$userAssignable = "true",
+		$userEditable = "false",
 		$groups = null,
 		$davPathVersionToUse = 2
 	) {
@@ -256,20 +256,20 @@ class TagsHelper extends \PHPUnit\Framework\Assert {
 	 * @return boolean[]
 	 */
 	public static function validateTypeOfTag($type) {
-		$userVisible = "1";
-		$userAssignable = "1";
-		$userEditable = "1";
+		$userVisible = "true";
+		$userAssignable = "true";
+		$userEditable = "true";
 		switch ($type) {
 			case 'normal':
 				break;
 			case 'not user-assignable':
-				$userAssignable = "0";
+				$userAssignable = "false";
 				break;
 			case 'not user-visible':
-				$userVisible = "0";
+				$userVisible = "false";
 				break;
 			case 'static':
-				$userEditable = "0";
+				$userEditable = "false";
 				break;
 			default:
 				throw new \Exception('Unsupported type');

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -26,6 +26,16 @@ Feature: Creation of tags
       | 😀                  |
       | सिमप्ले             |
 
+  Scenario: Creating a normal tag as a regular user should work (sending the string "1" to turn on the tag attributes)
+    When user "Alice" creates a "normal" tag with name "RegularTag" sending numbers in the request using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the following tags should exist for the administrator
+      | name       | type   |
+      | RegularTag | normal |
+    And the following tags should exist for user "Alice"
+      | name       | type   |
+      | RegularTag | normal |
+
   Scenario: Creating a not user-assignable tag as regular user should fail
     When user "Alice" creates a "not user-assignable" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
@@ -41,33 +51,22 @@ Feature: Creation of tags
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for the administrator
 
-  Scenario: Creating a normal tag as administrator should work
-    When the administrator creates a "normal" tag with name "JustARegularTagName" using the WebDAV API
+  Scenario Outline: Creating a tag as administrator should work
+    When the administrator creates a "<tag_type>" tag with name "JustARegularTagName" sending <sending_style> in the request using the WebDAV API
     Then the HTTP status code should be "201"
     And the following tags should exist for the administrator
-      | name                | type   |
-      | JustARegularTagName | normal |
-
-  Scenario: Creating a not user-assignable tag as administrator should work
-    When the administrator creates a "not user-assignable" tag with name "JustARegularTagName" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And the following tags should exist for the administrator
-      | name                | type                |
-      | JustARegularTagName | not user-assignable |
-
-  Scenario: Creating a not user-visible tag as administrator should work
-    When the administrator creates a "not user-visible" tag with name "JustARegularTagName" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And the following tags should exist for the administrator
-      | name                | type             |
-      | JustARegularTagName | not user-visible |
-
-  Scenario: Creating a static tag as administrator should work
-    When the administrator creates a "static" tag with name "StaticTagName" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And the following tags should exist for the administrator
-      | name          | type   |
-      | StaticTagName | static |
+      | name                | type       |
+      | JustARegularTagName | <tag_type> |
+    Examples:
+      | tag_type            | sending_style      |
+      | normal              | true-false-strings |
+      | normal              | numbers            |
+      | not user-assignable | true-false-strings |
+      | not user-assignable | numbers            |
+      | not user-visible    | true-false-strings |
+      | not user-visible    | numbers            |
+      | static              | true-false-strings |
+      | static              | numbers            |
 
   @smokeTest
   Scenario: Creating a not user-assignable tag with groups as admin should work

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -49,9 +49,9 @@ class TagsContext implements Context {
 
 	/**
 	 * @param string $user
-	 * @param string $userVisible "true" or "false"
-	 * @param string $userAssignable "true" or "false"
-	 * @param string $userEditable "true" or "false"
+	 * @param string $userVisible "true", "1" or "false", "0"
+	 * @param string $userAssignable "true", "1" or "false", "0"
+	 * @param string $userEditable "true", "1" or "false", "0"
 	 * @param string $name
 	 * @param string $groups
 	 *
@@ -73,7 +73,8 @@ class TagsContext implements Context {
 			$tagUrl = $responseHeaders['Content-Location'][0];
 			$lastTagId = \substr($tagUrl, \strrpos($tagUrl, '/') + 1);
 			$this->createdTags[$lastTagId]['name'] = $name;
-			$this->createdTags[$lastTagId]['userAssignable'] = ($userAssignable === 'true');
+			$this->createdTags[$lastTagId]['userAssignable']
+				= (($userAssignable === 'true') || ($userAssignable === '1'));
 		}
 	}
 
@@ -140,15 +141,17 @@ class TagsContext implements Context {
 	/**
 	 * @param string $type
 	 * @param string $name
+	 * @param boolean $useTrueFalseStrings use the strings "true"/"false" else "1"/"0"
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function createTagWithNameAsAdmin($type, $name) {
+	public function createTagWithNameAsAdmin($type, $name, $useTrueFalseStrings = true) {
 		$this->createTagWithName(
 			$this->featureContext->getAdminUsername(),
 			$type,
-			$name
+			$name,
+			$useTrueFalseStrings
 		);
 	}
 
@@ -165,6 +168,30 @@ class TagsContext implements Context {
 		$this->createTagWithNameAsAdmin(
 			$type,
 			$name
+		);
+	}
+
+	/**
+	 * @When /^the administrator creates a "([^"]*)" tag with name "([^"]*)" sending (true-false-strings|numbers) in the request using the WebDAV API$/
+	 *
+	 * @param string $type
+	 * @param string $name
+	 * @param string $stringsOrNumbers
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function theAdministratorCreatesATagWithNameSending($type, $name, $stringsOrNumbers) {
+		if ($stringsOrNumbers === "true-false-strings") {
+			$useTrueFalseStrings = true;
+		} else {
+			$useTrueFalseStrings = true;
+		}
+
+		$this->createTagWithNameAsAdmin(
+			$type,
+			$name,
+			$useTrueFalseStrings
 		);
 	}
 
@@ -188,15 +215,17 @@ class TagsContext implements Context {
 	/**
 	 * @param string $type
 	 * @param string $name
+	 * @param boolean $useTrueFalseStrings use the strings "true"/"false" else "1"/"0"
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function createTagWithNameAsCurrentUser($type, $name) {
+	public function createTagWithNameAsCurrentUser($type, $name, $useTrueFalseStrings = true) {
 		$this->createTagWithName(
 			$this->featureContext->getCurrentUser(),
 			$type,
-			$name
+			$name,
+			$useTrueFalseStrings
 		);
 	}
 
@@ -237,20 +266,22 @@ class TagsContext implements Context {
 	 * @param string $user
 	 * @param string $type
 	 * @param string $name
+	 * @param boolean $useTrueFalseStrings use the strings "true"/"false" else "1"/"0"
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function createTagWithName($user, $type, $name) {
+	public function createTagWithName($user, $type, $name, $useTrueFalseStrings = true) {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->createTag(
 			$user,
-			TagsHelper::validateTypeOfTag($type)[0],
-			TagsHelper::validateTypeOfTag($type)[1],
-			TagsHelper::validateTypeOfTag($type)[2],
+			TagsHelper::validateTypeOfTag($type, $useTrueFalseStrings)[0],
+			TagsHelper::validateTypeOfTag($type, $useTrueFalseStrings)[1],
+			TagsHelper::validateTypeOfTag($type, $useTrueFalseStrings)[2],
 			$name
 		);
 	}
+
 	/**
 	 * @When user :user creates a :type tag with name :name using the WebDAV API
 	 *
@@ -266,6 +297,34 @@ class TagsContext implements Context {
 			$user,
 			$type,
 			$name
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" creates a "([^"]*)" tag with name "([^"]*)" sending (true-false-strings|numbers) in the request using the WebDAV API$/
+	 *
+	 * @param string $user
+	 * @param string $type
+	 * @param string $name
+	 * @param string $stringsOrNumbers
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function userCreatesATagWithNameSendingInTheRequest(
+		$user, $type, $name, $stringsOrNumbers
+	) {
+		if ($stringsOrNumbers === "true-false-strings") {
+			$useTrueFalseStrings = true;
+		} else {
+			$useTrueFalseStrings = true;
+		}
+
+		$this->createTagWithName(
+			$user,
+			$type,
+			$name,
+			$useTrueFalseStrings
 		);
 	}
 
@@ -398,16 +457,17 @@ class TagsContext implements Context {
 	 * @param string $type
 	 * @param string $name
 	 * @param string $groups
+	 * @param boolean $useTrueFalseStrings use the strings "true"/"false" else "1"/"0"
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function createTagWithNameAndGroups($user, $type, $name, $groups) {
+	public function createTagWithNameAndGroups($user, $type, $name, $groups, $useTrueFalseStrings = true) {
 		$this->createTag(
 			$user,
-			TagsHelper::validateTypeOfTag($type)[0],
-			TagsHelper::validateTypeOfTag($type)[1],
-			TagsHelper::validateTypeOfTag($type)[2],
+			TagsHelper::validateTypeOfTag($type, $useTrueFalseStrings)[0],
+			TagsHelper::validateTypeOfTag($type, $useTrueFalseStrings)[1],
+			TagsHelper::validateTypeOfTag($type, $useTrueFalseStrings)[2],
 			$name,
 			$groups
 		);

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -49,9 +49,9 @@ class TagsContext implements Context {
 
 	/**
 	 * @param string $user
-	 * @param bool $userVisible
-	 * @param bool $userAssignable
-	 * @param bool $userEditable
+	 * @param string $userVisible "true" or "false"
+	 * @param string $userAssignable "true" or "false"
+	 * @param string $userEditable "true" or "false"
 	 * @param string $name
 	 * @param string $groups
 	 *
@@ -73,9 +73,7 @@ class TagsContext implements Context {
 			$tagUrl = $responseHeaders['Content-Location'][0];
 			$lastTagId = \substr($tagUrl, \strrpos($tagUrl, '/') + 1);
 			$this->createdTags[$lastTagId]['name'] = $name;
-			if ($userAssignable) {
-				$this->createdTags[$lastTagId]['userAssignable'] = true;
-			}
+			$this->createdTags[$lastTagId]['userAssignable'] = ($userAssignable === 'true');
 		}
 	}
 
@@ -110,8 +108,8 @@ class TagsContext implements Context {
 	 */
 	private function assertTypeOfTag($tagData, $type) {
 		$userAttributes = TagsHelper::validateTypeOfTag($type);
-		$userVisible = ($userAttributes[0]) ? 'true' : 'false';
-		$userAssignable = ($userAttributes[1]) ? 'true' : 'false';
+		$userVisible = $userAttributes[0];
+		$userAssignable = $userAttributes[1];
 
 		$tagDisplayName = $tagData->xpath(".//oc:display-name");
 		Assert::assertArrayHasKey(


### PR DESCRIPTION
PR #38719 adjusted the server code so that the attributes of tags (`userVisible` `userAssignable` `userEditable`) will process "boolean" strings like "true" and "false" to the appropriate boolean `true` or `false` value in incoming API requests. 

We have some client(s) that can send strings "true"/"false" instead of "1"/"0".

This PR adjusts the test code so that it sends strings "true"/"false" by default, and optionally "1"/"0" for the attributes of tags when creating tags.

~We could have "duplicated" test scenarios that try creating tags both ways? But that seems a bit overkill?~

The "basic" tag creation tests have scenarios that check the previous "0"/"1" behaviour as well as the newer "true"/"false" behaviour.