### PR TITLE
Fix database query filter when getting a tag

### DIFF
--- a/changelog/unreleased/38725
+++ b/changelog/unreleased/38725
@@ -1,0 +1,6 @@
+Bugfix: Database query filter when getting a tag
+
+The filter values for userAssignable and userEditable were swapped, causing
+a wrong result in certain cases.
+
+https://github.com/owncloud/core/pull/38725

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -183,8 +183,8 @@ class SystemTagManager implements ISystemTagManager {
 		$result = $this->selectTagQuery
 			->setParameter('name', $tagName)
 			->setParameter('visibility', $userVisible)
-			->setParameter('editable', $userAssignable)
-			->setParameter('assignable', $userEditable)
+			->setParameter('editable', $userEditable)
+			->setParameter('assignable', $userAssignable)
 			->execute();
 
 		$row = $result->fetch();

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -266,7 +266,7 @@ class SystemTagManagerTest extends TestCase {
 	public function testGetExistingTag($name, $userVisible, $userAssignable, $userEditable) {
 		$tag1 = $this->tagManager->createTag($name, $userVisible, $userAssignable, $userEditable);
 		if ($userEditable === false) {
-			$userEditable = true;
+			$userAssignable = true;
 		}
 		$tag2 = $this->tagManager->getTag($name, $userVisible, $userAssignable, $userEditable);
 


### PR DESCRIPTION
## Description
The filter values for userAssignable and userEditable were swapped, causing a wrong result in certain cases.

## Related Issue
Related to https://github.com/owncloud/files_backup/issues/37

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
