### PR TITLE
Mount encrypt password

### DIFF
--- a/apps/files_external/appinfo/Migrations/Version20210511082903.php
+++ b/apps/files_external/appinfo/Migrations/Version20210511082903.php
@@ -36,7 +36,7 @@ class Version20210511082903 implements ISimpleMigration {
 					try {
 						$realValue = $this->crypto->decrypt($value);
 					} catch (\Exception $ex) {
-						$out->warning("Failed to migrate storage configuration with id = {$configId}: Cannot decrypt value {$value}");
+						$out->warning("Storage configuration with id = {$configId}: Cannot decrypt value for key {$key}, assuming unencrypted value");
 					}
 				}
 

--- a/apps/files_external/appinfo/Migrations/Version20210511082903.php
+++ b/apps/files_external/appinfo/Migrations/Version20210511082903.php
@@ -7,6 +7,7 @@ use OCP\Migration\IOutput;
 use OCP\Files\External\Service\IGlobalStoragesService;
 use OCP\Files\External\DefinitionParameter;
 use OCP\Security\ICrypto;
+use OCP\IConfig;
 
 /**
  * Auto-generated migration step: Please modify to your needs!
@@ -16,13 +17,25 @@ class Version20210511082903 implements ISimpleMigration {
 	private $storageService;
 	/** @var ICrypto */
 	private $crypto;
+	/** @var IConfig */
+	private $config;
 
-	public function __construct(IGlobalStoragesService $storageService, ICrypto $crypto) {
+	public function __construct(
+		IGlobalStoragesService $storageService,
+		ICrypto $crypto,
+		IConfig $config
+	) {
 		$this->storageService = $storageService;
 		$this->crypto = $crypto;
+		$this->config = $config;
 	}
 
 	public function run(IOutput $out) {
+		if (!$this->config->getSystemValue('installed', false)) {
+			// Skip the migration for new installations -> nothing to migrate
+			return;
+		}
+
 		$this->loadFSApps();
 		\OC_Util::setupFS();  // this should load additional backends and auth mechanisms
 		$storageConfigs = $this->storageService->getStorageForAllUsers();

--- a/apps/files_external/appinfo/Migrations/Version20210511082903.php
+++ b/apps/files_external/appinfo/Migrations/Version20210511082903.php
@@ -1,0 +1,76 @@
+<?php
+namespace OCA\files_external\Migrations;
+
+use OCP\Migration\ISimpleMigration;
+use OCP\Migration\IOutput;
+use OCP\Files\External\Service\IGlobalStoragesService;
+use OCP\Files\External\DefinitionParameter;
+use OCP\Security\ICrypto;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20210511082903 implements ISimpleMigration {
+	/** @var IGlobalStoragesService */
+	private $storageService;
+	/** @var ICrypto */
+	private $crypto;
+
+	public function __construct(IGlobalStoragesService $storageService, ICrypto $crypto) {
+		$this->storageService = $storageService;
+		$this->crypto = $crypto;
+	}
+
+	public function run(IOutput $out) {
+		$storageConfigs = $this->storageService->getStorageForAllUsers();
+		foreach ($storageConfigs as $storageConfig) {
+			$backendOptions = $storageConfig->getBackendOptions();
+			$configId = $storageConfig->getId();
+			$changedOptions = [];
+			foreach ($backendOptions as $key => $value) {
+				$realValue = $value;
+				if ($key === 'password') {
+					try {
+						$realValue = $this->crypto->decrypt($value);
+					} catch (\Exception $ex) {
+						$out->warning("Failed to migrate storage configuration with id = {$configId}: Cannot decrypt value {$value}");
+					}
+				}
+
+				if ($this->shouldBeEncrypted($storageConfig, $key)) {
+					$changedOptions[$key] = $realValue;
+				}
+			}
+			if ($changedOptions) {
+				// need to force a fake password change to update the password later
+				foreach ($changedOptions as $key => $value) {
+					$storageConfig->setBackendOption($key, "{$value}0");
+				}
+				$this->storageService->updateStorage($storageConfig);
+				// re-insert the old password so it will be encrypted now
+				foreach ($changedOptions as $key => $value) {
+					$storageConfig->setBackendOption($key, $value);
+				}
+				$this->storageService->updateStorage($storageConfig);
+				$out->info("Storage configuration with id = {$configId} updated correctly");
+			}
+		}
+	}
+
+	private function shouldBeEncrypted($storageConfig, $key) {
+		$backend = $storageConfig->getBackend();
+		$backendParameters = $backend->getParameters();
+
+		$auth = $storageConfig->getAuthMechanism();
+		$authParameters = $auth->getParameters();
+
+		if (isset($backendParameters[$key]) && $backendParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD) {
+			return true;
+		}
+
+		if (isset($authParameters[$key]) && $authParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -13,7 +13,7 @@
 		<admin>admin-external-storage</admin>
 	</documentation>
 	<rememberlogin>false</rememberlogin>
-	<version>0.7.1</version>
+	<version>0.8.0</version>
 	<types>
 		<filesystem/>
 	</types>

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -29,6 +29,7 @@ use OCP\Files\External\Backend\InvalidBackend;
 use OCP\Files\External\IStorageConfig;
 use OCP\Files\External\Service\IGlobalStoragesService;
 use OCP\Files\External\Service\IUserStoragesService;
+use OCP\Files\External\DefinitionParameter;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use Symfony\Component\Console\Helper\Table;
@@ -171,11 +172,11 @@ class ListCommand extends Base {
 			}
 
 			if (!$input->getOption('show-password')) {
-				$hideKeys = ['password', 'refresh_token', 'token', 'client_secret', 'public_key', 'private_key'];
+				$hideKeys = ['refresh_token', 'token', 'public_key', 'private_key'];
 				foreach ($mounts as $mount) {
 					$config = $mount->getBackendOptions();
 					foreach ($config as $key => $value) {
-						if (\in_array($key, $hideKeys)) {
+						if (\in_array($key, $hideKeys, true) || $this->shouldHideKey($mount, $key)) {
 							$mount->setBackendOption($key, '***');
 						}
 					}
@@ -326,6 +327,20 @@ class ListCommand extends Base {
 				"Please make sure that all related apps that provide these storages are enabled or delete these.</error>"
 			);
 		}
+	}
+
+	private function shouldHideKey(IStorageConfig $mount, $key) {
+		$backend = $mount->getBackend();
+		$backendParameters = $backend->getParameters();
+
+		$auth = $mount->getAuthMechanism();
+		$authParameters = $auth->getParameters();
+		if (isset($backendParameters[$key]) && $backendParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD) {
+			return true;
+		} elseif (isset($authParameters[$key]) && $authParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD) {
+			return true;
+		}
+		return false;
 	}
 
 	protected function getStorageService($userId) {

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -335,9 +335,15 @@ class ListCommand extends Base {
 
 		$auth = $mount->getAuthMechanism();
 		$authParameters = $auth->getParameters();
-		if (isset($backendParameters[$key]) && $backendParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD) {
-			return true;
-		} elseif (isset($authParameters[$key]) && $authParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD) {
+		if (
+			(
+				isset($backendParameters[$key]) &&
+				$backendParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD
+			) || (
+				isset($authParameters[$key]) &&
+				$authParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD
+			)
+		) {
 			return true;
 		}
 		return false;

--- a/changelog/unreleased/38728
+++ b/changelog/unreleased/38728
@@ -1,0 +1,11 @@
+Change: All mount configuration items marked as passwords will be encrypted
+
+Previously, only some known configuration items were encrypted. This was a
+problem for new items that required protection because this required
+changes in the core product.
+
+Now, all the items marked as passwords will be encrypted. This will be done
+automatically without 3rd party apps needing to do anything. A migration
+is also provided to update the items if needed.
+
+https://github.com/owncloud/core/pull/38728

--- a/lib/private/Files/External/Service/DBConfigService.php
+++ b/lib/private/Files/External/Service/DBConfigService.php
@@ -270,9 +270,6 @@ class DBConfigService {
 	 * @param string $value
 	 */
 	public function setConfig($mountId, $key, $value) {
-		if ($key === 'password') {
-			$value = $this->encryptValue($value);
-		}
 		$count = $this->connection->insertIfNotExist('*PREFIX*external_config', [
 			'mount_id' => $mountId,
 			'key' => $key,
@@ -434,31 +431,13 @@ class DBConfigService {
 	 * @return array ['key1' => $value1, ...]
 	 */
 	private function createKeyValueMap(array $keyValuePairs) {
-		$decryptedPairts = \array_map(function ($pair) {
-			if ($pair['key'] === 'password') {
-				$pair['value'] = $this->decryptValue($pair['value']);
-			}
-			return $pair;
-		}, $keyValuePairs);
 		$keys = \array_map(function ($pair) {
 			return $pair['key'];
-		}, $decryptedPairts);
+		}, $keyValuePairs);
 		$values = \array_map(function ($pair) {
 			return $pair['value'];
-		}, $decryptedPairts);
+		}, $keyValuePairs);
 
 		return \array_combine($keys, $values);
-	}
-
-	private function encryptValue($value) {
-		return $this->crypto->encrypt($value);
-	}
-
-	private function decryptValue($value) {
-		try {
-			return $this->crypto->decrypt($value);
-		} catch (\Exception $e) {
-			return $value;
-		}
 	}
 }

--- a/lib/private/Files/External/Service/StoragesService.php
+++ b/lib/private/Files/External/Service/StoragesService.php
@@ -28,7 +28,7 @@ namespace OC\Files\External\Service;
 
 use OC\Files\Filesystem;
 use OC\Files\External\StorageConfig;
-
+use OCP\Files\External\DefinitionParameter;
 use OCP\Files\External\IStorageConfig;
 use OCP\Files\External\Backend\Backend;
 use OCP\Files\External\Auth\AuthMechanism;
@@ -573,9 +573,15 @@ abstract class StoragesService implements IStoragesService {
 	private function encryptIfPassword(Backend $backend, AuthMechanism $auth, $key, $value) {
 		$backendParameters = $backend->getParameters();
 		$authParameters = $auth->getParameters();
-		if (isset($backendParameters[$key]) && $backendParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD) {
-			$value = $this->crypto->encrypt($value);
-		} elseif (isset($authParameters[$key]) && $authParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD) {
+		if (
+			(
+				isset($backendParameters[$key]) &&
+				$backendParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD
+			) || (
+				isset($authParameters[$key]) &&
+				$authParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD
+			)
+		) {
 			$value = $this->crypto->encrypt($value);
 		}
 		return $value;
@@ -584,13 +590,15 @@ abstract class StoragesService implements IStoragesService {
 	private function decryptIfPassword(Backend $backend, AuthMechanism $auth, $key, $value) {
 		$backendParameters = $backend->getParameters();
 		$authParameters = $auth->getParameters();
-		if (isset($backendParameters[$key]) && $backendParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD) {
-			try {
-				$value = $this->crypto->decrypt($value);
-			} catch (\Exception $e) {
-				// assume the value isn't encrypted
-			}
-		} elseif (isset($authParameters[$key]) && $authParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD) {
+		if (
+			(
+				isset($backendParameters[$key]) &&
+				$backendParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD
+			) || (
+				isset($authParameters[$key]) &&
+				$authParameters[$key]->getType() === DefinitionParameter::VALUE_PASSWORD
+			)
+		) {
 			try {
 				$value = $this->crypto->decrypt($value);
 			} catch (\Exception $e) {

--- a/lib/private/Files/External/Service/StoragesService.php
+++ b/lib/private/Files/External/Service/StoragesService.php
@@ -574,9 +574,9 @@ abstract class StoragesService implements IStoragesService {
 		$backendParameters = $backend->getParameters();
 		$authParameters = $auth->getParameters();
 		if (isset($backendParameters[$key]) && $backendParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD) {
-			$value = \base64_encode($this->crypto->encrypt($value));
+			$value = $this->crypto->encrypt($value);
 		} elseif (isset($authParameters[$key]) && $authParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD) {
-			$value = \base64_encode($this->crypto->encrypt($value));
+			$value = $this->crypto->encrypt($value);
 		}
 		return $value;
 	}
@@ -586,13 +586,13 @@ abstract class StoragesService implements IStoragesService {
 		$authParameters = $auth->getParameters();
 		if (isset($backendParameters[$key]) && $backendParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD) {
 			try {
-				$value = $this->crypto->decrypt(\base64_decode($value));
+				$value = $this->crypto->decrypt($value);
 			} catch (\Exception $e) {
 				// assume the value isn't encrypted
 			}
 		} elseif (isset($authParameters[$key]) && $authParameters[$key]->getType() === \OCP\Files\External\DefinitionParameter::VALUE_PASSWORD) {
 			try {
-				$value = $this->crypto->decrypt(\base64_decode($value));
+				$value = $this->crypto->decrypt($value);
 			} catch (\Exception $e) {
 				// assume the value isn't encrypted
 			}

--- a/lib/private/Files/External/Service/UserGlobalStoragesService.php
+++ b/lib/private/Files/External/Service/UserGlobalStoragesService.php
@@ -29,6 +29,7 @@ use OCP\IGroupManager;
 use OCP\Files\External\IStorageConfig;
 use OCP\Files\External\IStoragesBackendService;
 use OCP\Files\External\Service\IUserGlobalStoragesService;
+use OCP\Security\ICrypto;
 
 /**
  * Service class to read global storages applicable to the user
@@ -52,9 +53,10 @@ class UserGlobalStoragesService extends GlobalStoragesService implements IUserGl
 		DBConfigService $dbConfig,
 		IUserSession $userSession,
 		IGroupManager $groupManager,
-		IUserMountCache $userMountCache
+		IUserMountCache $userMountCache,
+		ICrypto $crypto
 	) {
-		parent::__construct($backendService, $dbConfig, $userMountCache);
+		parent::__construct($backendService, $dbConfig, $userMountCache, $crypto);
 		$this->userSession = $userSession;
 		$this->groupManager = $groupManager;
 	}

--- a/lib/private/Files/External/Service/UserStoragesService.php
+++ b/lib/private/Files/External/Service/UserStoragesService.php
@@ -34,6 +34,7 @@ use OCP\Files\External\IStorageConfig;
 use OCP\Files\External\NotFoundException;
 use OCP\Files\External\IStoragesBackendService;
 use OCP\Files\External\Service\IUserStoragesService;
+use OCP\Security\ICrypto;
 
 /**
  * Service class to manage user external storages
@@ -54,11 +55,12 @@ class UserStoragesService extends StoragesService implements IUserStoragesServic
 		IStoragesBackendService $backendService,
 		DBConfigService $dbConfig,
 		IUserSession $userSession,
-		IUserMountCache $userMountCache
+		IUserMountCache $userMountCache,
+		ICrypto $crypto
 	) {
 		$this->userSession = $userSession;
 		$this->userMountCache = $userMountCache;
-		parent::__construct($backendService, $dbConfig, $userMountCache);
+		parent::__construct($backendService, $dbConfig, $userMountCache, $crypto);
 	}
 
 	protected function readDBConfig() {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -848,7 +848,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			return new GlobalStoragesService(
 				$c->query('StoragesBackendService'),
 				$c->query('StoragesDBConfigService'),
-				$c->query('UserMountCache')
+				$c->query('UserMountCache'),
+				$c->query('Crypto')
 			);
 		});
 		$this->registerAlias('OCP\Files\External\Service\IGlobalStoragesService', 'GlobalStoragesService');
@@ -858,7 +859,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$c->query('StoragesDBConfigService'),
 				$c->query('UserSession'),
 				$c->query('GroupManager'),
-				$c->query('UserMountCache')
+				$c->query('UserMountCache'),
+				$c->query('Crypto')
 			);
 		});
 		$this->registerAlias('OCP\Files\External\Service\IUserGlobalStoragesService', 'UserGlobalStoragesService');
@@ -867,7 +869,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$c->query('StoragesBackendService'),
 				$c->query('StoragesDBConfigService'),
 				$c->query('UserSession'),
-				$c->query('UserMountCache')
+				$c->query('UserMountCache'),
+				$c->query('Crypto')
 			);
 		});
 		$this->registerAlias('OCP\Files\External\Service\IUserStoragesService', 'UserStoragesService');

--- a/tests/acceptance/features/cliLocalStorage/manageBackendConfig.feature
+++ b/tests/acceptance/features/cliLocalStorage/manageBackendConfig.feature
@@ -18,14 +18,14 @@ Feature: manage backend configuration for a mount using occ command
     And the administrator configures the key "client_secret" with value "nextUserSecret" for the local storage mount "local_storage3"
     And the administrator lists the local storage using the occ command
     Then the following should be included in the configuration of local storage "/local_storage2":
-      | configuration             |
-      | client_id: "owncloudUser" |
-      | client_secret: "***"      |
-      | token: "***"              |
+      | configuration                  |
+      | client_id: "owncloudUser"      |
+      | client_secret: "userSecretKey" |
+      | token: "***"                   |
     And the following should be included in the configuration of local storage "/local_storage3":
-      | configuration           |
-      | client_id: "nextOCUser" |
-      | client_secret: "***"    |
+      | configuration                   |
+      | client_id: "nextOCUser"         |
+      | client_secret: "nextUserSecret" |
 
   Scenario: manage backend configuration for a local storage mount and list the local storages with --show-password
     When the administrator configures the key "client_id" with value "owncloudUser" for the local storage mount "local_storage2"

--- a/tests/lib/Files/External/Service/GlobalStoragesServiceDeleteUserTest.php
+++ b/tests/lib/Files/External/Service/GlobalStoragesServiceDeleteUserTest.php
@@ -129,7 +129,7 @@ class GlobalStoragesServiceDeleteUserTest extends TestCase {
 		$dbConfigService = new DBConfigService(\OC::$server->getDatabaseConnection(), \OC::$server->getCrypto());
 		$userManager = \OC::$server->getUserManager();
 		$userMountCache = new UserMountCache(\OC::$server->getDatabaseConnection(), $userManager, \OC::$server->getLogger());
-		$service = new GlobalStoragesService($backendService, $dbConfigService, $userMountCache);
+		$service = new GlobalStoragesService($backendService, $dbConfigService, $userMountCache, \OC::$server->getCrypto());
 
 		$storageIds = [];
 		foreach ($storageParams as $storageParam) {

--- a/tests/lib/Files/External/Service/GlobalStoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/GlobalStoragesServiceTest.php
@@ -33,7 +33,7 @@ use OCP\Files\External\IStorageConfig;
 class GlobalStoragesServiceTest extends StoragesServiceTest {
 	public function setUp(): void {
 		parent::setUp();
-		$this->service = new GlobalStoragesService($this->backendService, $this->dbConfig, $this->mountCache);
+		$this->service = new GlobalStoragesService($this->backendService, $this->dbConfig, $this->mountCache, $this->crypto);
 	}
 
 	public function tearDown(): void {

--- a/tests/lib/Files/External/Service/StoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/StoragesServiceTest.php
@@ -33,6 +33,7 @@ use Test\TestCase;
 use OCP\Files\External\Backend\InvalidBackend;
 use OCP\Files\External\Auth\InvalidAuth;
 use OCP\Files\External\Backend\Backend;
+use OCP\Security\ICrypto;
 
 /**
  * @group DB
@@ -73,6 +74,9 @@ abstract class StoragesServiceTest extends TestCase {
 	 * @var Backend[]
 	 */
 	protected $backends;
+
+	/** @var ICrypto */
+	protected $crypto;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -148,6 +152,21 @@ abstract class StoragesServiceTest extends TestCase {
 			->will($this->returnCallback(function ($name) {
 				if ($name === 'OCP\Files\External\IStoragesBackendService') {
 					return $this->backendService;
+				}
+			}));
+
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->crypto->method('encrypt')
+			->will($this->returnCallback(function ($value) {
+				return "-$value-";
+			}));
+		$this->crypto->method('decrypt')
+			->will($this->returnCallback(function ($value) {
+				$expectedDecrypt = \trim($value, '-');
+				if ($value === "-$expectedDecrypt-") {
+					return $expectedDecrypt;
+				} else {
+					throw new \Exception('Cannot decrypt');
 				}
 			}));
 	}

--- a/tests/lib/Files/External/Service/UserGlobalStoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/UserGlobalStoragesServiceTest.php
@@ -95,7 +95,8 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 			$this->dbConfig,
 			$userSession,
 			$this->groupManager,
-			$this->mountCache
+			$this->mountCache,
+			$this->crypto
 		);
 	}
 

--- a/tests/lib/Files/External/Service/UserStoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/UserStoragesServiceTest.php
@@ -53,7 +53,7 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->globalStoragesService = new GlobalStoragesService($this->backendService, $this->dbConfig, $this->mountCache);
+		$this->globalStoragesService = new GlobalStoragesService($this->backendService, $this->dbConfig, $this->mountCache, $this->crypto);
 
 		$this->userId = $this->getUniqueID('user_');
 		$this->user = $this->createUser($this->userId, $this->userId);
@@ -65,7 +65,7 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 			->method('getUser')
 			->will($this->returnValue($this->user));
 
-		$this->service = new UserStoragesService($this->backendService, $this->dbConfig, $userSession, $this->mountCache);
+		$this->service = new UserStoragesService($this->backendService, $this->dbConfig, $userSession, $this->mountCache, $this->crypto);
 	}
 
 	private function makeTestStorageData() {
@@ -258,7 +258,7 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 
 		$backendService = \OC::$server->getStoragesBackendService();
 		$userSession = \OC::$server->getUserSession();
-		$this->service = new UserStoragesService($backendService, $this->dbConfig, $userSession, $userMountCache);
+		$this->service = new UserStoragesService($backendService, $this->dbConfig, $userSession, $userMountCache, $this->crypto);
 
 		$dbConfigService = new DBConfigService(\OC::$server->getDatabaseConnection(), \OC::$server->getCrypto());
 		$id = $dbConfigService->addMount('/directtest', 'foo', 'bar', 100, DBConfigService::MOUNT_TYPE_PERSONAl);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Ensure configuration parameters marked as passwords in the mount point configuration are encrypted in the DB.
The encryption only happens on rest. The values are decrypted after getting the information from normal means so they can be sent to the storage without problems. The storage implementations won't need to decrypt anything.
A migration is also provided so the mount points are properly updated.

Note that this applies to any password parameter that is saved through the storage. Parameters that don't go through the storage, such as login credentials, and which are saved differently still have its own way of handling. There is no change in this regard.

## Related Issue
https://github.com/owncloud/enterprise/issues/4461

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested.
Test 1
1. Configure a mount point having any parameter marked as password (textbox in the web UI will hide the content)
2. Check the DB. Target parameter has the value encrypted

Test 2
1. Configure a mount point having a parameter marked as password in OC 10.7.0 or less
2. Check that you can access normally to the mount point
3. Update the code (planned 10.8.0)
4. Check that you can still access to the mount point without problems (migrations didn't break anything)
5. Check that the DB has the parameter encrypted.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
