### PR TITLE
[tests-only] Only do composer install if composer.json exists in the notifications app

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -137,7 +137,7 @@ config = {
 				'apiSharingNotificationsToShares',
 			],
 			'extraApps': {
-				'notifications': '[ -f "composer.json" ] && composer install'
+				'notifications': 'if [ -f "composer.json" ]; then composer install; fi'
 			},
 		},
 		'apiFederation': {

--- a/.drone.star
+++ b/.drone.star
@@ -137,7 +137,7 @@ config = {
 				'apiSharingNotificationsToShares',
 			],
 			'extraApps': {
-				'notifications': 'composer install'
+				'notifications': '[ -f "composer.json" ] && composer install'
 			},
 		},
 		'apiFederation': {


### PR DESCRIPTION
## Description
Sometimes we test against a tarball that already has a proper "release" of the notifications app already installed. In that case the dependencies have already been fetched, and `composer.json` is not even included in the run-time distribution.

Add code so that `composer install` only happens if `composer.json` exists.

## How Has This Been Tested?
See PR #38735 - that demonstrates that this works when testing against a pre-built tarball.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
