### PR TITLE
add http client request_fulluri option only if a proxy configured

### DIFF
--- a/changelog/unreleased/38738
+++ b/changelog/unreleased/38738
@@ -1,0 +1,7 @@
+Bugfix: Fix federated share download bug happens on some providers
+
+Some WebDAV service providers are not able to respond properly when
+the HTTP client request_fulluri option set without proxy.
+Now, the HTTP client request_fulluri option set only if a proxy configured.
+
+https://github.com/owncloud/core/pull/38738

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -357,14 +357,7 @@ class DAV extends Common {
 							->newClient()
 							->get($this->createBaseUri() . $this->encodePath($path), [
 									'auth' => [$this->user, $this->password],
-									'stream' => true,
-									'config' => [
-										'stream_context' => [
-											'http' => [
-												'request_fulluri' => true
-											]
-										],
-									],
+									'stream' => true
 							]);
 				} catch (RequestException $e) {
 					if ($e->getResponse() instanceof ResponseInterface

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -141,6 +141,7 @@ class Client implements IClient {
 					'proxy',
 					'tcp://' . $proxyHost
 				);
+				$options['config']['stream_context']['http']['request_fulluri'] = true;
 			}
 
 			$proxyUserPwd = $this->config->getSystemValue('proxyuserpwd', null);

--- a/tests/lib/Files/Storage/DavTest.php
+++ b/tests/lib/Files/Storage/DavTest.php
@@ -533,14 +533,7 @@ class DavTest extends TestCase {
 			->with(
 				'https://davhost/davroot/some%25dir/file%25.txt', [
 					'auth' => ['davuser', 'davpassword'],
-					'stream' => true,
-					'config' => [
-						'stream_context' => [
-							'http' => [
-								'request_fulluri' => true
-							]
-						],
-					],
+					'stream' => true
 				]
 			)
 			->willReturn($response);
@@ -558,14 +551,7 @@ class DavTest extends TestCase {
 			->with(
 				'https://davhost/davroot/some%25dir/file%25.txt', [
 					'auth' => ['davuser', 'davpassword'],
-					'stream' => true,
-					'config' => [
-						'stream_context' => [
-							'http' => [
-								'request_fulluri' => true
-							]
-						],
-					],
+					'stream' => true
 				]
 			)
 			->willThrowException($this->createGuzzleClientException(Http::STATUS_NOT_FOUND));
@@ -583,14 +569,7 @@ class DavTest extends TestCase {
 			->with(
 				'https://davhost/davroot/some%25dir/file%25.txt', [
 					'auth' => ['davuser', 'davpassword'],
-					'stream' => true,
-					'config' => [
-						'stream_context' => [
-							'http' => [
-								'request_fulluri' => true
-							]
-						],
-					],
+					'stream' => true
 				]
 			)
 			->willThrowException($this->createGuzzleClientException(Http::STATUS_FORBIDDEN));
@@ -612,14 +591,7 @@ class DavTest extends TestCase {
 			->with(
 				'https://davhost/davroot/some%25dir/file%25.txt', [
 					'auth' => ['davuser', 'davpassword'],
-					'stream' => true,
-					'config' => [
-						'stream_context' => [
-							'http' => [
-								'request_fulluri' => true
-							]
-						],
-					],
+					'stream' => true
 				]
 			)
 			->willReturn($response);
@@ -905,7 +877,7 @@ class DavTest extends TestCase {
 
 		$this->assertFalse($this->instance->touch('/some%dir', 1508496363));
 	}
-	
+
 	public function testTouchNoServerSupport() {
 		// file_exists
 		$this->davClient->expects($this->at(0))


### PR DESCRIPTION
## Description
We have added the HTTP client `request_fulluri` option to all DAV requests with owncloud/core#34101 when fixing federated shares behind proxy servers.

According to https://www.php.net/manual/en/context.http.php, http `request_fulluri` option only needed when a proxy configured and some webdav service providers are not able to respond properly when this option set without proxy. This pr adds HTTP client `request_fulluri` option only if a proxy configured.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4522

## Motivation and Context
Solving bugs.

## How Has This Been Tested?
Manually tested by sharing a federated share from nextcloud to owncloud. ownCloud user is able to download the share after this change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
