### PR TITLE
[Tests-Only] preview tests modified for ocis server

### DIFF
--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -1,11 +1,11 @@
-@api @issue-ocis-187 @preview-extension-required
+@api @preview-extension-required
 Feature: previews of files downloaded through the webdav API
 
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-200
-  Scenario Outline: download previews of different sizes
+  @skipOnOcis @issue-ocis-2069
+  Scenario Outline: download different sizes of previews of file
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "Alice" downloads the preview of "/parent.txt" with width <width> and height <height> using the WebDAV API
     Then the HTTP status code should be "200"
@@ -52,7 +52,7 @@ Feature: previews of files downloaded through the webdav API
       | A      |
       | %2F    |
 
-  @issue-ocis-200
+
   Scenario: download previews of files inside sub-folders
     Given user "Alice" has created folder "subfolder"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/subfolder/parent.txt"
@@ -60,7 +60,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
-  @issue-ocis-189
+
   Scenario Outline: download previews of file types that don't support preview
     Given user "Alice" has uploaded file "filesForUpload/<filename>" to "/<newfilename>"
     When user "Alice" downloads the preview of "/<newfilename>" with width "32" and height "32" using the WebDAV API
@@ -72,7 +72,7 @@ Feature: previews of files downloaded through the webdav API
       | simple.odt   | test.odt    |
       | new-data.zip | test.zip    |
 
-  @issue-ocis-187
+
   Scenario Outline: download previews of different image file types
     Given user "Alice" has uploaded file "filesForUpload/<imageName>" to "/<newImageName>"
     When user "Alice" downloads the preview of "/<newImageName>" with width "32" and height "32" using the WebDAV API
@@ -83,7 +83,7 @@ Feature: previews of files downloaded through the webdav API
       | testavatar.jpg | testimage.jpg |
       | testavatar.png | testimage.png |
 
-  @issue-ocis-187
+
   Scenario: download previews of image after renaming it
     Given user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"
     When user "Alice" moves file "/testimage.jpg" to "/testimage.txt" using the WebDAV API
@@ -91,7 +91,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
-  @issue-ocis-68
+  @issue-ocis-2067
   Scenario: download previews of shared files
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -100,7 +100,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
-  @issue-ocis-thumbnails-191
+  @issue-ocis-2071 @skipOnOcis
   Scenario: download previews of other users files
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -109,7 +109,7 @@ Feature: previews of files downloaded through the webdav API
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "File not found: parent.txt in '%username%'"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-190
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-2064
   Scenario: download previews of folders
     Given user "Alice" has created folder "subfolder"
     When user "Alice" downloads the preview of "/subfolder/" with width "32" and height "32" using the WebDAV API
@@ -123,7 +123,7 @@ Feature: previews of files downloaded through the webdav API
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "File with name parent.txt could not be located"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @issue-ocis-192
+  @issue-ocis-192 @issue-ocis-2070 @skipOnOcis
   Scenario: Download file previews when it is disabled by the administrator
     Given the administrator has updated system config key "enable_previews" with value "false" and type "boolean"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -131,7 +131,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @issue-ocis-193
+  @issue-ocis-2070 @skipOnOcis
   Scenario: unset maximum size of previews
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And the administrator has updated system config key "preview_max_x" with value "null"
@@ -140,7 +140,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-193
+  @issue-ocis-2070 @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcis
   Scenario: set maximum size of previews
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When the administrator updates system config key "preview_max_x" with value "null" using the occ command
@@ -150,7 +150,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "400"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\BadRequest"
 
-  @issue-ocis-200
+  @issue-ocis-2070 @skipOnOcis
   Scenario Outline: download previews of different size smaller than the maximum size set
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And the administrator has updated system config key "preview_max_x" with value "32"
@@ -165,7 +165,7 @@ Feature: previews of files downloaded through the webdav API
       | 32    | 12     | 200       |
       | 12    | 32     | 200       |
 
-  @issue-ocis-200
+  @issue-ocis-2070 @skipOnOcis
   Scenario Outline: download previews of different size larger than the maximum size set
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And the administrator has updated system config key "preview_max_x" with value "32"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
- In oC10 when a request for a thumbnail is made with the dimensions `x=1,y=32` then server responds with an image `1px` wide and `32px` high. In `ocis`, the larger value from the two dimensions is taken to recalculate the smaller dimension to match the original aspect ratio. For that reason requesting `x=0` is a valid option in the oCIS service. https://github.com/owncloud/ocis/issues/188#issuecomment-816570583
- different resolution for thumbnails is set using the following query parameters in the endpoint `{{base-url}}/remote.php/dav/files/{{username}}/{{file_path}}`
  - `oc10` query params 
  ```js
  {
      c: e00d1bc836c635bb6d741c343c0b71e1,
      x: 32,
      y: 32,
      forceIcon: 0,
      preview: 1
  }
  ```
  - `ocis` query params
  ```js
  {
     a: 1,
     c: 39029fa1ad3b0ab20194b45f130fab2a,
     preview: 1,
     scalingup: 0,
     x: 1280,
     y: 1280
  }
  ```
     > PROXY_ENABLE_BASIC_AUTH=true
- different test scenarios added for the different behavior of the different backend

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/1472

## Motivation and Context
- https://github.com/owncloud/ocis/issues/2071
- https://github.com/owncloud/ocis/issues/2070
- https://github.com/owncloud/ocis/issues/2069
- https://github.com/owncloud/ocis/issues/2067
- https://github.com/owncloud/ocis/issues/2064

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot:
- ci


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
