### PR TITLE
Bump version to 10.8.0 prealpha

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 7, 1, 0];
+$OC_Version = [10, 8, 0, 0];
 
 // The human readable string
-$OC_VersionString = '10.7.1 prealpha';
+$OC_VersionString = '10.8.0 prealpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
There are changes to oC10 apps that need to depend on core code later than 10.7.0. We need to start being able to set core min-version to 10.8, because that will be the next core release version. So bump the core version now to 10.8.0 prealpha

For example, PR https://github.com/owncloud/configreport/pull/146 
https://drone.owncloud.com/owncloud/configreport/1368/4/3
```
  App "Admin Config Report" cannot be installed because the following dependencies are not fulfilled: ownCloud 10.8 or higher is required.
```

Note: changelog not needed. This is a technical "alpha" version bump for development purposes.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
