### PR TITLE
implement fallback response type for ocm discover

### DIFF
--- a/apps/federatedfilesharing/lib/DiscoveryManager.php
+++ b/apps/federatedfilesharing/lib/DiscoveryManager.php
@@ -141,22 +141,26 @@ class DiscoveryManager {
 		$decodedService = $this->makeRequest($remote . '/ocm-provider/');
 		if (!empty($decodedService) && $decodedService['enabled'] === true) {
 			$discoveredServices['ocm'] = $decodedService['endPoint'];
-			$shareTypes = $decodedService['shareTypes'];
-			foreach ($shareTypes as $type) {
+			$types = [];
+			if (isset($decodedService['shareTypes'])) {
+				$types = $decodedService['shareTypes'];
+			} elseif (isset($decodedService['resourceTypes'])) {
+				$types = $decodedService['resourceTypes'];
+			}
+			foreach ($types as $type) {
 				if ($type['name'] == 'file') {
 					$discoveredServices['webdav'] = $type['protocols']['webdav'];
 				}
 			}
-		} else {
-			return [
-				'webdav' => false,
-				'ocm' => false,
-			];
-		}
 
-		// Write into cache
-		$this->cache->set('OCM' . $remote, \json_encode($discoveredServices));
-		return $discoveredServices;
+			// Write into cache
+			$this->cache->set('OCM' . $remote, \json_encode($discoveredServices));
+			return $discoveredServices;
+		}
+		return [
+			'webdav' => false,
+			'ocm' => false,
+		];
 	}
 
 	/**

--- a/changelog/unreleased/38751
+++ b/changelog/unreleased/38751
@@ -1,0 +1,6 @@
+Bugfix: Correctly parse different ocm-provider api responses
+
+Some WebDAV service providers returns different responses for ocm-provider API
+and we were not able to parse these responses. This problem has been fixed.
+
+https://github.com/owncloud/core/pull/38751


### PR DESCRIPTION
## Description
Some ocm-provider implementations are slightly different than us. This pr implements fallback for different ocm-provider API responses.

## Related Issue
https://github.com/owncloud/enterprise/issues/4522#issuecomment-841884476

## Motivation and Context
Prevent unnecesary error logs.

## How Has This Been Tested?
Tested federated sharing functionality manually with different ocm providers.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
