### PR TITLE
[tests-only] add commas in .drone.star and skip some tests on old oC10 versions

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,11 +1,11 @@
 config = {
 	'rocketchat': {
 		'channel': 'server',
-		'from_secret': 'public_rocketchat'
+		'from_secret': 'public_rocketchat',
 	},
 
 	'branches': [
-		'master'
+		'master',
 	],
 
 	'dependencies': True,
@@ -70,9 +70,9 @@ config = {
 				'webdav',
 				'sftp',
 				'scality',
-				'owncloud'
+				'owncloud',
 			],
-			'coverage': True
+			'coverage': True,
 		}
 	},
 
@@ -137,7 +137,7 @@ config = {
 				'apiSharingNotificationsToShares',
 			],
 			'extraApps': {
-				'notifications': 'if [ -f "composer.json" ]; then composer install; fi'
+				'notifications': 'if [ -f "composer.json" ]; then composer install; fi',
 			},
 		},
 		'apiFederation': {
@@ -148,7 +148,7 @@ config = {
 				'apiFederationToShares2',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['git', 'latest', '10.5.0']
+			'federatedServerVersions': ['git', 'latest', '10.5.0'],
 		},
 		'cli': {
 			'suites': [
@@ -164,14 +164,14 @@ config = {
 			'suites': [
 				'cliAppManagement',
 			],
-			'testingRemoteSystem': False
+			'testingRemoteSystem': False,
 		},
 		'cliExternalStorage': {
 			'suites': [
 				'cliExternalStorage',
 			],
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['git', 'latest', '10.5.0']
+			'federatedServerVersions': ['git', 'latest', '10.5.0'],
 		},
 		'webUI': {
 			'suites': {
@@ -215,7 +215,7 @@ config = {
 			'emailNeeded': True,
 			'useHttps': False,
 			'extraApps': {
-				'notifications': 'composer install'
+				'notifications': 'composer install',
 			},
 		},
 		'webUIFileActionsMenu': {
@@ -234,14 +234,14 @@ config = {
 				'webUISharingExternal2': 'webUISharingExt2',
 			},
 			'federatedServerNeeded': True,
-			'federatedServerVersions': ['git', 'latest', '10.5.0']
+			'federatedServerVersions': ['git', 'latest', '10.5.0'],
 		},
 		'webUIFirefox': {
 			'suites': {
 				'webUIFirefoxSmoketest': 'webUIFfSmoke',
 			},
 			'browsers': [
-				'firefox'
+				'firefox',
 			],
 			'emailNeeded': True,
 			'useHttps': False,
@@ -254,7 +254,7 @@ config = {
 				'webUIProxySmoketest': 'webUIProxySmoke',
 			},
 			'browsers': [
-				'chrome'
+				'chrome',
 			],
 			'emailNeeded': True,
 			'proxyNeeded': True,

--- a/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
@@ -11,7 +11,7 @@ Feature: Share by public link
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
+  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392 @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: mount public link of a folder
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -33,7 +33,7 @@ Feature: Share by public link
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/file-in-my-own-storage.txt"
     But user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "/simple-folder/new-file-in-read-only-public-link.txt"
 
-  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
+  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392 @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: mount public link of a file
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -51,7 +51,7 @@ Feature: Share by public link
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/file-in-my-own-storage.txt"
     But user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "/file-shared-by-public-link.txt"
 
-  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
+  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392 @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: mount public link and overwrite file
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files


### PR DESCRIPTION
## Description
1) The last entry in `list` and `dict` structures can have a comma at the end. I annoyed myself yesterday when adding settings in some config sections, forgetting to add the comma on the last entry before adding a new entry. Put the commas in so that future editors do not have this small hassle.

2) PR #38712 changed the webUI for adding a public link share to your ownCloud. The changed UI acceptance tests do not work when run with an older oC10 version. So skip in that case.

For example, nighlty CI https://drone.owncloud.com/owncloud/encryption/1886/212/17
```
runsh: Total unexpected failed scenarios throughout the test run:
webUISharingPublic2/shareByPublicLink.feature:15
webUISharingPublic2/shareByPublicLink.feature:37
webUISharingPublic2/shareByPublicLink.feature:55
```

```
    And the public adds the public link to "%remote_server%" as user "Brian" using the webUI                           # WebUISharingContext::thePublicAddsThePublicLinkToUsingTheWebUI()
      Page\PublicLinkFilesPage::addToServer id save-to-oc-button-expand could not find 'expand save to owncloud' button (SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException)
```


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
