### PR TITLE
[tests-only] Replace deprecated phpunit methods in tests

### DIFF
--- a/apps/files_external/tests/Command/ListCommandTest.php
+++ b/apps/files_external/tests/Command/ListCommandTest.php
@@ -90,7 +90,7 @@ class ListCommandTest extends CommandTest {
 		$instance->listMounts('', [$mount1, $mount2], $input, $output);
 		$output = $output->fetch();
 
-		$this->assertRegexp('/Number of invalid storages found/', $output);
+		$this->assertMatchesRegularExpression('/Number of invalid storages found/', $output);
 	}
 
 	public function providesShortView() {

--- a/tests/Core/Controller/AvatarControllerTest.php
+++ b/tests/Core/Controller/AvatarControllerTest.php
@@ -293,7 +293,7 @@ class AvatarControllerTest extends TestCase {
 		$this->assertEquals('notsquare', $response->getData()['data']);
 
 		//File should be deleted
-		$this->assertFileNotExists($fileName);
+		$this->assertFileDoesNotExist($fileName);
 	}
 
 	/**
@@ -330,7 +330,7 @@ class AvatarControllerTest extends TestCase {
 		$this->assertEquals('Unknown filetype', $response->getData()['data']['message']);
 
 		//File should be deleted
-		$this->assertFileNotExists($fileName);
+		$this->assertFileDoesNotExist($fileName);
 	}
 
 	/**

--- a/tests/Settings/Panels/Admin/PersistentLockingTest.php
+++ b/tests/Settings/Panels/Admin/PersistentLockingTest.php
@@ -54,7 +54,7 @@ class PersistentLockingTest extends \Test\TestCase {
 
 		$templateHtml = $this->panel->getPanel()->fetchPage();
 		// applied modifiers "m" for multiline and "s" to include newlines in the dot char
-		$this->assertRegExp('/input[[:space:]].*name="lock_timeout_default"[[:space:]].*value="44"/ms', $templateHtml);
-		$this->assertRegExp('/input[[:space:]].*name="lock_timeout_max"[[:space:]].*value="9999"/ms', $templateHtml);
+		$this->assertMatchesRegularExpression('/input[[:space:]].*name="lock_timeout_default"[[:space:]].*value="44"/ms', $templateHtml);
+		$this->assertMatchesRegularExpression('/input[[:space:]].*name="lock_timeout_max"[[:space:]].*value="9999"/ms', $templateHtml);
 	}
 }

--- a/tests/lib/Files/Stream/StaticStreamTest.php
+++ b/tests/lib/Files/Stream/StaticStreamTest.php
@@ -48,9 +48,9 @@ class StaticStreamTest extends \Test\TestCase {
 	}
 
 	public function testIsDir() {
-		$this->assertDirectoryNotExists('static://foo');
+		$this->assertDirectoryDoesNotExist('static://foo');
 		\file_put_contents('static://foo', $this->sourceText);
-		$this->assertDirectoryNotExists('static://foo');
+		$this->assertDirectoryDoesNotExist('static://foo');
 	}
 
 	public function testFileType() {
@@ -59,11 +59,11 @@ class StaticStreamTest extends \Test\TestCase {
 	}
 
 	public function testUnlink() {
-		$this->assertFileNotExists('static://foo');
+		$this->assertFileDoesNotExist('static://foo');
 		\file_put_contents('static://foo', $this->sourceText);
 		$this->assertFileExists('static://foo');
 		\unlink('static://foo');
 		\clearstatcache();
-		$this->assertFileNotExists('static://foo');
+		$this->assertFileDoesNotExist('static://foo');
 	}
 }

--- a/tests/lib/LegacyHelperTest.php
+++ b/tests/lib/LegacyHelperTest.php
@@ -273,11 +273,11 @@ class LegacyHelperTest extends \Test\TestCase {
 		\file_put_contents($baseDir . 'a1/b/test two.txt', 'Hello file two!');
 		\OC_Helper::rmdirr($baseDir . 'a');
 
-		$this->assertFileNotExists($baseDir . 'a');
+		$this->assertFileDoesNotExist($baseDir . 'a');
 		$this->assertFileExists($baseDir . 'a1');
 
 		\OC_Helper::rmdirr($baseDir);
-		$this->assertFileNotExists($baseDir);
+		$this->assertFileDoesNotExist($baseDir);
 	}
 
 	/**

--- a/tests/lib/Log/OwncloudTest.php
+++ b/tests/lib/Log/OwncloudTest.php
@@ -34,7 +34,7 @@ class OwncloudTest extends TestCase {
 		$config = \OC::$server->getConfig();
 		$this->restore_logfile = $config->getSystemValue("logfile");
 		$this->restore_logdateformat = $config->getSystemValue('logdateformat');
-		
+
 		$config->setSystemValue("logfile", $config->getSystemValue('datadirectory') . "/logtest");
 		Owncloud::init();
 	}
@@ -53,7 +53,7 @@ class OwncloudTest extends TestCase {
 		Owncloud::init();
 		parent::tearDown();
 	}
-	
+
 	public function testMicrosecondsLogTimestamp() {
 		$config = \OC::$server->getConfig();
 		# delete old logfile
@@ -62,15 +62,15 @@ class OwncloudTest extends TestCase {
 		# set format & write log line
 		$config->setSystemValue('logdateformat', 'u');
 		Owncloud::write('test', 'message', \OCP\Util::ERROR);
-		
+
 		# read log line
 		$handle = @\fopen($config->getSystemValue('logfile'), 'r');
 		$line = \fread($handle, 1000);
 		\fclose($handle);
-		
+
 		# check timestamp has microseconds part
 		$values = (array) \json_decode($line);
 		$microseconds = $values['time'];
-		$this->assertRegExp('/^\d{6}$/', $microseconds);
+		$this->assertMatchesRegularExpression('/^\d{6}$/', $microseconds);
 	}
 }

--- a/tests/lib/StreamWrappersTest.php
+++ b/tests/lib/StreamWrappersTest.php
@@ -63,7 +63,7 @@ class StreamWrappersTest extends \Test\TestCase {
 		$this->assertFileEquals($sourceFile, $file);
 		\unlink($file);
 		\clearstatcache();
-		$this->assertFileNotExists($file);
+		$this->assertFileDoesNotExist($file);
 
 		//test callback
 		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile('.txt');

--- a/tests/lib/TempManagerTest.php
+++ b/tests/lib/TempManagerTest.php
@@ -92,8 +92,8 @@ class TempManagerTest extends \Test\TestCase {
 
 		$manager->clean();
 
-		$this->assertFileNotExists($file1);
-		$this->assertFileNotExists($file2);
+		$this->assertFileDoesNotExist($file1);
+		$this->assertFileDoesNotExist($file2);
 	}
 
 	public function testCleanFolder() {
@@ -109,10 +109,10 @@ class TempManagerTest extends \Test\TestCase {
 
 		$manager->clean();
 
-		$this->assertFileNotExists($folder1);
-		$this->assertFileNotExists($folder2);
-		$this->assertFileNotExists($folder1 . 'foo.txt');
-		$this->assertFileNotExists($folder1 . 'bar.txt');
+		$this->assertFileDoesNotExist($folder1);
+		$this->assertFileDoesNotExist($folder2);
+		$this->assertFileDoesNotExist($folder1 . 'foo.txt');
+		$this->assertFileDoesNotExist($folder1 . 'bar.txt');
 	}
 
 	public function testCleanOld() {
@@ -130,8 +130,8 @@ class TempManagerTest extends \Test\TestCase {
 
 		$manager2 = $this->getManager();
 		$manager2->cleanOld();
-		$this->assertFileNotExists($oldFile);
-		$this->assertFileNotExists($folder);
+		$this->assertFileDoesNotExist($oldFile);
+		$this->assertFileDoesNotExist($folder);
 		$this->assertFileExists($nonOcFile);
 		$this->assertFileExists($newFile);
 	}


### PR DESCRIPTION
## Description
I noticed that these are being deprecated in phpunit9 and the replacements are already available in phpunit8, so we may as well use them.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
