### PR TITLE
[Tests-Only]Add tests containing `[` and `]` in path names

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -273,6 +273,15 @@ config = {
 			'runAllSuites': True,
 			'numberOfParts': 8,
 		},
+		'apiOnSqlite': {
+			'suites': {
+				'apiOnSqlite': 'apiOnSqlite',
+			},
+			'databases': ['sqlite'],
+			'useHttps': False,
+			'filterTags': '@sqliteDB',
+			'runAllSuites': True,
+		}
 	}
 }
 

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -197,3 +197,16 @@ Feature: add user
     Then the OCS status code should be "105"
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
+
+  @sqliteDB
+  Scenario: admin tries to create user with brackets in the username
+    When the administrator sends a user creation request for the following users with password using the provisioning API
+      | username  | password |
+      | [user1]   | %alt1%   |
+      | [ user2 ] | %alt1%   |
+    Then the OCS status code of responses on all endpoints should be "101"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And the following users should not exist
+      | username  |
+      | [user1]   |
+      | [ user2 ] |

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -197,3 +197,16 @@ Feature: add user
     Then the OCS status code should be "400"
     And the HTTP status code should be "400"
     And user "brand-new-user" should not exist
+
+  @sqliteDB
+  Scenario: admin tries to create user with brackets in the username
+    When the administrator sends a user creation request for the following users with password using the provisioning API
+      | username  | password |
+      | [user1]   | %alt1%   |
+      | [ user2 ] | %alt1%   |
+    Then the OCS status code of responses on all endpoints should be "400"
+    And the HTTP status code of responses on all endpoints should be "400"
+    And the following users should not exist
+      | username  |
+      | [user1]   |
+      | [ user2 ] |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -22,20 +22,23 @@ Feature: add groups
       | España§àôœ€ |
       | नेपाली        |
 
+  @sqliteDB
   Scenario: admin creates a group with special characters
     When the administrator sends a group creation request for the following groups using the provisioning API
-      | groupname           | comment                                 |
-      | brand-new-group     | dash                                    |
-      | the.group           | dot                                     |
-      | left,right          | comma                                   |
-      | 0                   | The "false" group                       |
-      | Finance (NP)        | Space and brackets                      |
-      | Admin&Finance       | Ampersand                               |
-      | admin:Pokhara@Nepal | Colon and @                             |
-      | maint+eng           | Plus sign                               |
-      | $x<=>[y*z^2]!       | Maths symbols                           |
-      | Mgmt\Middle         | Backslash                               |
-      | 😅 😆               | emoji                                   |
+      | groupname           | comment            |
+      | brand-new-group     | dash               |
+      | the.group           | dot                |
+      | left,right          | comma              |
+      | 0                   | The "false" group  |
+      | Finance (NP)        | Space and brackets |
+      | Admin&Finance       | Ampersand          |
+      | admin:Pokhara@Nepal | Colon and @        |
+      | maint+eng           | Plus sign          |
+      | $x<=>[y*z^2]!       | Maths symbols      |
+      | Mgmt\Middle         | Backslash          |
+      | 😅 😆               | emoji              |
+      | [group1]            | brackets           |
+      | group [ 2 ]         | bracketsAndSpace   |
     Then the OCS status code of responses on all endpoints should be "100"
     And the HTTP status code of responses on all endpoints should be "200"
     And these groups should exist:
@@ -51,6 +54,8 @@ Feature: add groups
       | $x<=>[y*z^2]!       |
       | Mgmt\Middle         |
       | 😅 😆               |
+      | [group1]            |
+      | group [ 2 ]         |
 
   @toImplementOnOCIS @issue-product-284
   Scenario: admin creates a group with % and # in name

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -290,16 +290,23 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+  @sqliteDB
   Scenario: renaming to a file with special characters
     Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 2" to "textfile2.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 3" to "textfile3.txt"
     When user "Alice" moves the following file using the WebDAV API
       | source         | destination   |
       | /textfile0.txt | *a@b#c$e%f&g* |
       | /textfile1.txt | 1 2 3##.##    |
+      | /textfile2.txt | file[2]       |
+      | /textfile3.txt | file [ 3 ]    |
     Then the HTTP status code of responses on all endpoints should be "201"
     And the content of file "*a@b#c$e%f&g*" for user "Alice" should be "ownCloud test text file 0"
     And the content of file "1 2 3##.##" for user "Alice" should be "ownCloud test text file 1"
+    And the content of file "file[2]" for user "Alice" should be "ownCloud test text file 2"
+    And the content of file "file [ 3 ]" for user "Alice" should be "ownCloud test text file 3"
 
   @issue-ocis-reva-265
   #after fixing the issues merge this Scenario into the one above


### PR DESCRIPTION
## Description
This PR adds tests for names containing `[` and `]` in path names and run the tests in sqlite db

## Related Issue
- https://github.com/owncloud/core/issues/31394

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
