### PR TITLE
[tests-only] Remove tech_preview steps from feature files

### DIFF
--- a/tests/acceptance/features/apiFavorites/favoritesOc10Issue38027.feature
+++ b/tests/acceptance/features/apiFavorites/favoritesOc10Issue38027.feature
@@ -3,7 +3,6 @@ Feature: current oC10 behavior for issue-38027
 
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
     Given using <dav_version> DAV path
-    And the administrator has enabled DAV tech_preview
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature
+++ b/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature
@@ -2,8 +2,7 @@
 Feature: favorite
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And the administrator has set the default folder for received shares to "Shares"
+    Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"

--- a/tests/acceptance/features/apiShareOperationsToRoot/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot/changingFilesShare.feature
@@ -57,8 +57,7 @@ Feature: sharing
       | new              |
 
   Scenario: Move files between shares by same user
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "share1"
+    Given user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
     And user "Alice" has moved file "textfile0.txt" to "share1/shared_file.txt"
     And user "Alice" has shared folder "/share1" with user "Brian"
@@ -70,8 +69,7 @@ Feature: sharing
     But as "Alice" file "share2/shared_file.txt" should exist
 
   Scenario: Move files between shares by same user added by sharee
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "share1"
+    Given user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
     And user "Alice" has shared folder "/share1" with user "Brian"
     And user "Alice" has shared folder "/share2" with user "Brian"
@@ -83,8 +81,7 @@ Feature: sharing
     And as "Alice" file "share2/shared_file.txt" should exist
 
   Scenario: Move files between shares by different users
-    Given the administrator has enabled DAV tech_preview
-    And user "Carol" has been created with default attributes and without skeleton files
+    Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
     And user "Brian" has created folder "/PARENT"
     And user "Carol" has created folder "/PARENT"

--- a/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature
@@ -64,8 +64,7 @@ Feature: sharing
 
 
   Scenario: Move files between shares by same user
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "share1"
+    Given user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has moved file "textfile0.txt" to "share1/textfile0.txt"
@@ -81,8 +80,7 @@ Feature: sharing
 
 
   Scenario: Move files between shares by same user added by sharee
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "share1"
+    Given user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
     And user "Brian" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has shared folder "/share1" with user "Brian"
@@ -98,8 +96,7 @@ Feature: sharing
 
 
   Scenario: Move files between shares by different users
-    Given the administrator has enabled DAV tech_preview
-    And user "Carol" has been created with default attributes and without skeleton files
+    Given user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has created folder "/PARENT"
     And user "Brian" has created folder "/PARENT"

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -11,8 +11,7 @@ Feature: changing a public link share
 
 
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
     When the public deletes file "parent.txt" from the last public share using the old public WebDAV API
@@ -25,8 +24,7 @@ Feature: changing a public link share
 
   @issue-ocis-reva-292
   Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
     When the public deletes file "parent.txt" from the last public share using the new public WebDAV API
@@ -39,8 +37,7 @@ Feature: changing a public link share
 
 
   Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
     When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
@@ -50,8 +47,7 @@ Feature: changing a public link share
 
   @issue-ocis-reva-292
   Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
     When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
@@ -61,8 +57,7 @@ Feature: changing a public link share
 
   @skipOnRansomwareProtection @issue-ransomware-208
   Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
@@ -72,8 +67,7 @@ Feature: changing a public link share
 
   @skipOnRansomwareProtection @issue-ransomware-208
   Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
@@ -83,8 +77,7 @@ Feature: changing a public link share
 
 
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
     When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
@@ -93,8 +86,7 @@ Feature: changing a public link share
 
   @issue-ocis-reva-292
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
     When the public uploads file "lorem.txt" with content "test" using the new public WebDAV API
@@ -103,8 +95,7 @@ Feature: changing a public link share
 
 
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
@@ -112,8 +103,7 @@ Feature: changing a public link share
     And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
 
   Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     When the public uploads file "lorem.txt" with content "test" using the new public WebDAV API
@@ -122,8 +112,7 @@ Feature: changing a public link share
 
 
   Scenario: Public cannot delete file through publicly shared link with password using an invalid password with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -132,8 +121,7 @@ Feature: changing a public link share
     And as "Alice" file "PARENT/parent.txt" should exist
 
   Scenario: Public cannot delete file through publicly shared link with password using an invalid password with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -143,8 +131,7 @@ Feature: changing a public link share
 
 
   Scenario: Public can delete file through publicly shared link with password using the valid password with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -153,8 +140,7 @@ Feature: changing a public link share
     And as "Alice" file "PARENT/parent.txt" should not exist
 
   Scenario: Public can delete file through publicly shared link with password using the valid password with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -164,8 +150,7 @@ Feature: changing a public link share
 
 
   Scenario: Public tries to rename a file in a password protected share using an invalid password with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -175,8 +160,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
 
   Scenario: Public tries to rename a file in a password protected share using an invalid password with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -187,8 +171,7 @@ Feature: changing a public link share
 
   @skipOnRansomwareProtection @issue-ransomware-208
   Scenario: Public tries to rename a file in a password protected share using the valid password with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -199,8 +182,7 @@ Feature: changing a public link share
 
   @skipOnRansomwareProtection @issue-ransomware-208
   Scenario: Public tries to rename a file in a password protected share using the valid password with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -211,8 +193,7 @@ Feature: changing a public link share
 
 
   Scenario: Public tries to upload to a password protected public share using an invalid password with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -221,8 +202,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
   Scenario: Public tries to upload to a password protected public share using an invalid password with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -232,8 +212,7 @@ Feature: changing a public link share
 
 
   Scenario: Public tries to upload to a password protected public share using the valid password with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -242,8 +221,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/lorem.txt" should exist
 
   Scenario: Public tries to upload to a password protected public share using the valid password with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
@@ -253,8 +231,7 @@ Feature: changing a public link share
 
 
   Scenario: Public cannot rename a file in uploadwriteonly public link share with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
     When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
@@ -264,8 +241,7 @@ Feature: changing a public link share
 
   @issue-ocis-reva-292
   Scenario: Public cannot rename a file in uploadwriteonly public link share with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
     When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
@@ -275,8 +251,7 @@ Feature: changing a public link share
 
 
   Scenario: Public cannot delete a file in uploadwriteonly public link share with the old public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
     When the public deletes file "parent.txt" from the last public share using the old public WebDAV API
@@ -285,8 +260,7 @@ Feature: changing a public link share
 
   @issue-ocis-reva-292
   Scenario: Public cannot delete a file in uploadwriteonly public link share with the new public WebDAV API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
     When the public deletes file "parent.txt" from the last public share using the new public WebDAV API

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -8,7 +8,6 @@ Feature: create a public link share
   @smokeTest
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1) using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
-    And the administrator has enabled DAV tech_preview
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | randomfile.txt |
@@ -37,7 +36,6 @@ Feature: create a public link share
   @issue-ocis-reva-12
   Scenario Outline: Creating a new public link share of a file, the default permissions are read (1) using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
-    And the administrator has enabled DAV tech_preview
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | randomfile.txt |
@@ -186,7 +184,6 @@ Feature: create a public link share
 
   Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
-    And the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -218,7 +215,6 @@ Feature: create a public link share
   @issue-ocis-reva-12
   Scenario Outline: Creating a new public link share of a folder, the default permissions are read (1) and can be accessed with no password or any password using the new public WebDAV API
     Given using OCS API version "<ocs_api_version>"
-    And the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -748,8 +744,7 @@ Feature: create a public link share
 
   @issue-ocis-reva-292
   Scenario: try to download from a public share that has upload only permissions
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "PARENT"
+    Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
     And user "Alice" has created a public link share with settings
       | path        | PARENT          |
@@ -763,8 +758,7 @@ Feature: create a public link share
 
   @skipOnOcV10.3
   Scenario: Get the size of a file shared by public link
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
+    Given user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
     And user "Alice" has created a public link share with settings
       | path        | test-file.txt |
       | permissions | read          |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
@@ -9,7 +9,6 @@ Feature: create a public link share when share_folder is set to Shares
   @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario Outline: Creating a new public link share of a file gives the correct response
     Given using OCS API version "<ocs_api_version>"
-    And the administrator has enabled DAV tech_preview
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
       | path | randomfile.txt |

--- a/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature
@@ -4,7 +4,6 @@ Feature: copying from public link share
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
-    And the administrator has enabled DAV tech_preview
 
   Scenario: Copy file within a public link folder new public WebDAV API
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"

--- a/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLinkOc10Issue37683.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLinkOc10Issue37683.feature
@@ -4,7 +4,6 @@ Feature: copying from public link share
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
-    And the administrator has enabled DAV tech_preview
 
   @issue-ocis-reva-373 @issue-37683
   Scenario: Copy folder within a public link folder to the same folder name as an already existing file

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -464,8 +464,7 @@ Feature: update a public link share
 
 
   Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the old public API
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
@@ -489,8 +488,7 @@ Feature: update a public link share
 
   @issue-ocis-reva-292
   Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the new public API
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
@@ -514,8 +512,7 @@ Feature: update a public link share
 
 
   Scenario Outline: Updating share permissions from read to change allows public to delete files using the old public API
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
@@ -542,8 +539,7 @@ Feature: update a public link share
       | 2               | 200             |
 
   Scenario Outline: Updating share permissions from read to change allows public to delete files using the new public API
-    Given the administrator has enabled DAV tech_preview
-    And using OCS API version "<ocs_api_version>"
+    Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -23,8 +23,7 @@ Feature: upload to a public link share
   @smokeTest @issue-ocis-reva-286
   Scenario: Uploading same file to a public upload-only share multiple times via new API
     # The new API does the autorename automatically in upload-only folders
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     When the public uploads file "test.txt" with content "test" using the new public WebDAV API
@@ -73,7 +72,6 @@ Feature: upload to a public link share
 
   @issue-ocis-reva-292
   Scenario: Uploading file to a public read-only share folder with new public API does not work
-    Given the administrator has enabled DAV tech_preview
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | read   |
@@ -91,8 +89,7 @@ Feature: upload to a public link share
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
 
   Scenario: Uploading to a public upload-only share with new public API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
@@ -110,8 +107,7 @@ Feature: upload to a public link share
     Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
 
   Scenario: Uploading to a public upload-only share with password with new public API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
       | permissions | create   |
@@ -128,8 +124,7 @@ Feature: upload to a public link share
     Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
 
   Scenario: Uploading to a public read/write share with password with new public API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
       | permissions | change   |
@@ -147,7 +142,6 @@ Feature: upload to a public link share
 
   @issue-ocis-reva-195
   Scenario: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with new public API
-    Given the administrator has enabled DAV tech_preview
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | change |
@@ -166,7 +160,6 @@ Feature: upload to a public link share
 
   @issue-ocis-reva-195
   Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with new public API
-    Given the administrator has enabled DAV tech_preview
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | create |
@@ -185,8 +178,7 @@ Feature: upload to a public link share
 
   @issue-ocis-reva-41
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder with new public API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
@@ -205,8 +197,7 @@ Feature: upload to a public link share
 
   @issue-ocis-reva-41
   Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder with new public API
-    Given the administrator has enabled DAV tech_preview
-    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
+    Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | all    |
@@ -226,8 +217,7 @@ Feature: upload to a public link share
 
   @issue-ocis-reva-41
   Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder with new public API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -245,8 +235,7 @@ Feature: upload to a public link share
 
   @smokeTest
   Scenario: Uploading to a public upload-write and no edit and no overwrite share with new public API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
     When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
@@ -254,8 +243,7 @@ Feature: upload to a public link share
 
   @smokeTest
   Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with old public API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
     When the public uploads file "test.txt" with content "test" using the old public WebDAV API
@@ -272,8 +260,7 @@ Feature: upload to a public link share
 
   @smokeTest @issue-ocis-reva-286
   Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with new public API
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
     When the public uploads file "test.txt" with content "test" using the new public WebDAV API

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -5,8 +5,7 @@ Feature: files and folders can be deleted from the trashbin
   So that I can control my trashbin space and which files are kept in that space
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "to delete" to "/textfile0.txt"
     And user "Alice" has uploaded file with content "to delete" to "/textfile1.txt"
     And user "Alice" has created folder "PARENT"

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -5,8 +5,7 @@ Feature: files and folders exist in the trashbin after being deleted
   So that I can recover data easily
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "to delete" to "/textfile0.txt"
 
   @smokeTest

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
@@ -5,8 +5,7 @@ Feature: files and folders exist in the trashbin after being deleted
   So that I can recover data easily
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "to delete" to "/textfile0.txt"
 
   # This scenario deletes many files as close together in time as the test can run.

--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -5,8 +5,7 @@ Feature: Restore deleted files/folders
   So that I can recover accidentally deleted files/folders in ownCloud
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "file to delete" to "/textfile0.txt"
 
   @smokeTest

--- a/tests/acceptance/features/apiTrashbin/trashbinRestoreOc10Issue35900.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestoreOc10Issue35900.feature
@@ -5,8 +5,7 @@ Feature: Restore deleted files/folders
   So that I can recover accidentally deleted files/folders in ownCloud
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "file to delete" to "/textfile0.txt"
 
   @issue-35900 @files_sharing-app-required

--- a/tests/acceptance/features/apiTrashbin/trashbinRestoreOc10Issue35974.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestoreOc10Issue35974.feature
@@ -6,8 +6,7 @@ Feature: Restore deleted files/folders
 
   @issue-35974
   Scenario Outline: restoring a file to an already existing path overrides the file
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "file to delete" to "/textfile0.txt"
     And user "Alice" has uploaded file with content "file to delete" to "/.hiddenfile0.txt"
     And using <dav-path> DAV path

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -2,8 +2,7 @@
 Feature: using trashbin together with sharing
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "to delete" to "/textfile0.txt"
 
   @smokeTest

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -2,8 +2,7 @@
 Feature: using trashbin together with sharing
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And the administrator has set the default folder for received shares to "Shares"
+    Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "file to delete" to "/textfile0.txt"

--- a/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
@@ -5,7 +5,6 @@ Feature: dav-versions
   Background:
     Given using OCS API version "2"
     And using new DAV path
-    And the administrator has enabled DAV tech_preview
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiVersions/fileVersionsSharingToSharesIssue38027.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsSharingToSharesIssue38027.feature
@@ -5,7 +5,6 @@ Feature: dav-versions
   Background:
     Given using OCS API version "2"
     And using new DAV path
-    And the administrator has enabled DAV tech_preview
     And the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -191,8 +191,7 @@ Feature: propagation of etags when deleting a file or folder
 
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario: deleting a file in a publicly shared folder changes its etag for the sharer
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings
       | path        | upload |
       | permissions | change |
@@ -206,8 +205,7 @@ Feature: propagation of etags when deleting a file or folder
 
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario: deleting a folder in a publicly shared folder changes its etag for the sharer
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "/upload/sub"
+    Given user "Alice" has created folder "/upload/sub"
     And user "Alice" has created a public link share with settings
       | path        | upload |
       | permissions | change |

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
@@ -316,8 +316,7 @@ Feature: propagation of etags when moving files or folders
 
 
   Scenario: renaming a file in a publicly shared folder changes its etag for the sharer
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "/upload"
+    Given user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings
       | path        | upload |
@@ -332,8 +331,7 @@ Feature: propagation of etags when moving files or folders
 
 
   Scenario: renaming a folder in a publicly shared folder changes its etag for the sharer
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "/upload"
+    Given user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created a public link share with settings
       | path        | upload |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -95,8 +95,7 @@ Feature: propagation of etags when copying files or folders
 
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
-    Given the administrator has enabled DAV tech_preview
-    And using <dav_version> DAV path
+    Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
@@ -93,8 +93,7 @@ Feature: propagation of etags when creating folders
 
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario: creating a folder in a publicly shared folder changes its etag for the sharer
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "/folder"
+    Given user "Alice" has created folder "/folder"
     And user "Alice" has created a public link share with settings
       | path        | folder |
       | permissions | create |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
@@ -2,8 +2,7 @@
 Feature: propagation of etags when restoring a file or folder from trash
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/upload"
 
 

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
@@ -142,8 +142,7 @@ Feature: propagation of etags when uploading data
 
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario: uploading a file into a publicly shared folder changes its etag for the sharer
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created a public link share with settings
+    Given user "Alice" has created a public link share with settings
       | path        | upload |
       | permissions | create |
     And user "Alice" has stored etag of element "/"

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -2,8 +2,7 @@
 Feature: persistent-locking in case of a public link
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue36064.feature
@@ -3,8 +3,7 @@
 Feature: persistent-locking in case of a public link
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has been created with default attributes and without skeleton files
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -85,8 +85,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
 
   @files_sharing-app-required
   Scenario Outline: public cannot overwrite a file in a folder locked by the owner even when sending the locktoken
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has created folder "PARENT"
+    Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
     And user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT" setting the following properties

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesOc10Issue36064.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesOc10Issue36064.feature
@@ -8,7 +8,6 @@ Feature: lock should propagate correctly if a share is reshared
       | Alice    |
       | Brian    |
       | Carol    |
-    And the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "PARENT"
     And user "Brian" has created folder "PARENT"
     And user "Carol" has created folder "PARENT"

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
@@ -56,8 +56,7 @@ Feature: lock should propagate correctly if a share is reshared
 
   @skipOnOcV10 @issue-36064
   Scenario Outline: public uploads to a reshared share that was locked by original owner
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has shared folder "PARENT" with user "Brian"
+    Given user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
     And user "Carol" has created a public link share of folder "PARENT (2)" with change permission
     And user "Alice" has locked folder "PARENT" setting the following properties

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -2,8 +2,7 @@
 Feature: lock should propagate correctly if a share is reshared
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And the administrator has set the default folder for received shares to "Shares"
+    Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And these users have been created with default attributes and without skeleton files:
       | username |
@@ -63,8 +62,7 @@ Feature: lock should propagate correctly if a share is reshared
 
   @skipOnOcV10 @issue-36064
   Scenario Outline: public uploads to a reshared share that was locked by original owner
-    Given the administrator has enabled DAV tech_preview
-    And user "Alice" has shared folder "PARENT" with user "Brian"
+    Given user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has shared folder "Shares/PARENT" with user "Carol"
     And user "Carol" has accepted share "/PARENT" offered by user "Brian"

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -2,8 +2,7 @@
 Feature: set timeouts of LOCKS on shares
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And the administrator has set the default folder for received shares to "Shares"
+    Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -2,8 +2,7 @@
 Feature: UNLOCK locked items (sharing)
 
   Background:
-    Given the administrator has enabled DAV tech_preview
-    And the administrator has set the default folder for received shares to "Shares"
+    Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -59,8 +59,10 @@ class OccContext implements Context {
 	private $lastDeletedJobId;
 
 	/**
-	 * ToDo: remove all the tech_preview test code after official release of
-	 *       10.4 and we no longer need to test against 10.3.* as "latest"
+	 * The code to manage dav.enable.tech_preview was used in 10.4/10.3
+	 * The use of the steps to enable/disable it has been removed from the
+	 * feature files. But the infrastructure has been left here, as a similar
+	 * thing might likely happen in the future.
 	 *
 	 * @var boolean
 	 */


### PR DESCRIPTION
## Description
Remove "DAV tech_preview" steps from feature files. That was something that was done for 10.3/10.4 to be able to enable some new functionality without it being enabled by default. It is no longer relevant.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
