### PR TITLE
[tests-only] Add webUI test coverage for adding public share to oC

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1035,10 +1035,19 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		if (!$this->publicLinkFilesPage->isOpen()) {
 			throw new Exception('Not on public link page!');
 		}
-		$server = $this->featureContext->substituteInLineCodes($server);
-		$this->publicLinkFilesPage->addToServer($server);
-		// addToServer takes us from the public link page to the login page
-		// of the remote server, waiting for us to login.
+		if ($server === '%remote_server%') {
+			$server = $this->featureContext->substituteInLineCodes($server);
+			$this->publicLinkFilesPage->addToServer($server);
+		} elseif ($server === '%local_server%') {
+			$this->publicLinkFilesPage->saveToSameSever();
+		} else {
+			throw new Exception(
+				"Invalid server provided '" . $server . "'. " .
+				"Either should be '%remote_server%' or '%local_server%'"
+			);
+		}
+		// addToServer and saveToSameSever takes us from the public link page to the login page
+		// of the remote and local server respectively, waiting for us to login.
 		$actualUsername = $this->featureContext->getActualUsername($username);
 		$password = $this->featureContext->getUserPassword($actualUsername);
 		$this->webUIGeneralContext->loginAs($username, $password);

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1039,14 +1039,14 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			$server = $this->featureContext->substituteInLineCodes($server);
 			$this->publicLinkFilesPage->addToServer($server);
 		} elseif ($server === '%local_server%') {
-			$this->publicLinkFilesPage->saveToSameSever();
+			$this->publicLinkFilesPage->saveToSameServer();
 		} else {
 			throw new Exception(
 				"Invalid server provided '" . $server . "'. " .
 				"Either should be '%remote_server%' or '%local_server%'"
 			);
 		}
-		// addToServer and saveToSameSever takes us from the public link page to the login page
+		// addToServer and saveToSameServer takes us from the public link page to the login page
 		// of the remote and local server respectively, waiting for us to login.
 		$actualUsername = $this->featureContext->getActualUsername($username);
 		$password = $this->featureContext->getUserPassword($actualUsername);

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -55,6 +55,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	protected $deleteAllSelectedBtnXpath = "//a[@class='delete-selected']";
 	protected $uploadedElementsCss = '.public-upload-view--completed';
 	protected $uploadedElementsXpath = "//div[@class='public-upload-view--completed']//li";
+	protected $saveToOcButtonId = "save-to-oc-button";
 
 	/**
 	 *
@@ -552,5 +553,23 @@ class PublicLinkFilesPage extends FilesPageBasic {
 			\array_push($uploadedElements, $element->getText());
 		}
 		return $uploadedElements;
+	}
+
+	/**
+	 * adding public link share to same server instance
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function saveToSameSever() {
+		$saveToElement = $this->findById($this->saveToOcButtonId);
+
+		$this->assertElementNotNull(
+			$saveToElement,
+			__METHOD__ .
+			" id $this->saveToOcButtonId could not find 'Add To' button"
+		);
+
+		$saveToElement->click();
 	}
 }

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -561,7 +561,7 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * @return void
 	 * @throws ElementNotFoundException
 	 */
-	public function saveToSameSever() {
+	public function saveToSameServer() {
 		$saveToElement = $this->findById($this->saveToOcButtonId);
 
 		$this->assertElementNotNull(

--- a/tests/acceptance/features/webUISharingPublic2/savePublicLinkShare.feature
+++ b/tests/acceptance/features/webUISharingPublic2/savePublicLinkShare.feature
@@ -1,0 +1,214 @@
+@webUI @insulated @disablePreviews @files_sharing-app-required
+Feature: Save public shares created by oC users
+  As a user
+  I want to mount public link shares to my owncloud account
+  So that I can easily access them from my account
+
+  Background:
+    Given using server "LOCAL"
+    And user "Alice" has been created with default attributes and without skeleton files
+
+
+  Scenario: mount public link share of a folder to local server
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%local_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    When the user opens folder "PARENT" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And the content of file "PARENT/lorem.txt" for user "Brian" should be "original content"
+    And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
+    But user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt"
+    And user "Brian" should not be able to delete file "PARENT/lorem.txt"
+
+
+  Scenario: mount public link share of a file to local server
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "original content" to "lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /lorem.txt |
+      | permissions | read       |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%local_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And the content of file "lorem.txt" for user "Brian" should be "original content"
+    And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
+    But user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "lorem.txt"
+
+
+  Scenario: mount public link share of a folder (all permissions set) to local server
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%local_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    When the user opens folder "PARENT" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And the content of file "PARENT/lorem.txt" for user "Brian" should be "original content"
+    # upload a new file
+    When the user uploads file "new-lorem.txt" using the webUI
+    Then file "new-lorem.txt" should be listed on the webUI
+    # overwrite an existing file
+    When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
+    Then file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the local "lorem.txt"
+    # delete a file
+    When the user deletes file "lorem.txt" using the webUI
+    Then file "lorem.txt" should not be listed on the webUI
+
+
+  Scenario: mount public link share of a file (all permissions set) to local server
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "original content" to "lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /lorem.txt                |
+      | permissions | read,update,create,delete |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%local_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And the content of file "lorem.txt" for user "Brian" should be "original content"
+    # overwrite an existing file
+    When the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
+    Then file "lorem.txt" should be listed on the webUI
+    And the content of "lorem.txt" should be the same as the local "lorem.txt"
+
+
+  Scenario: mount public link share of a folder that exist in local server
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/PARENT"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%local_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT (2)" should be listed on the webUI
+    When the user opens folder "PARENT (2)" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And the content of file "PARENT (2)/lorem.txt" for user "Brian" should be "original content"
+
+
+  Scenario: mount public link share of a file that already exists in local server
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has uploaded file with content "file in local server" to "lorem.txt"
+    And user "Alice" has uploaded file with content "original content" to "lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /lorem.txt |
+      | permissions | read       |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%local_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "lorem (2).txt" should be listed on the webUI
+    And the content of file "lorem (2).txt" for user "Brian" should be "original content"
+
+
+  Scenario: unshare mounted public link share in local server
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%local_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    When the user opens folder "PARENT" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When the user browses to the files page
+    And the user unshares folder "PARENT" using the webUI
+    Then folder "PARENT" should not be listed on the webUI
+    But as "Alice" folder "PARENT" should exist
+    And as "Alice" file "PARENT/lorem.txt" should exist
+
+  @skipOnOcV10 @issue-38763
+  Scenario: mount public link share of a folder in local server and the sharer deletes the folder
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%local_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    When the user opens folder "PARENT" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When user "Alice" deletes folder "/PARENT" using the WebDAV API
+    And the user browses to the files page
+    Then folder "PARENT" should not be listed on the webUI
+
+
+  Scenario: mount public link share of a folder that already exists in remote server
+    Given using server "REMOTE"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/PARENT"
+    And using server "LOCAL"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%remote_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT (2)" should be listed on the webUI
+    When the user opens folder "PARENT (2)" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And the content of file "PARENT (2)/lorem.txt" for user "Brian" on server "REMOTE" should be "original content"
+
+
+  Scenario: unshare mounted public link share in remote server
+    Given using server "REMOTE"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And using server "LOCAL"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%remote_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    When the user unshares folder "PARENT" using the webUI
+    Then folder "PARENT" should not be listed on the webUI
+    But as "Alice" folder "PARENT" should exist
+    And as "Alice" file "PARENT/lorem.txt" should exist
+
+  @skipOnOcV10 @issue-38763
+  Scenario: mount public link share of a folder in remote server and the sharer deletes the folder
+    Given using server "REMOTE"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And using server "LOCAL"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%remote_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    When the user opens folder "PARENT" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When user "Alice" deletes folder "/PARENT" using the WebDAV API
+    And the user selects the breadcrumb for folder "/"
+    And the user reloads the current page of the webUI
+    Then folder "PARENT" should not be listed on the webUI

--- a/tests/acceptance/features/webUISharingPublic2/savePublicLinkShareOc10Issue38763.feature
+++ b/tests/acceptance/features/webUISharingPublic2/savePublicLinkShareOc10Issue38763.feature
@@ -1,0 +1,60 @@
+# When the issue is resolved, delete this file
+# and adjust the tests scenarios in savePublicLinkShare.feature
+# tagged with this issue
+
+@webUI @insulated @disablePreviews @files_sharing-app-required
+Feature: Save public shares created by oC users
+  As a user
+  I want to mount public link shares to my owncloud account
+  So that I can easily access them from my account
+
+  Background:
+    Given using server "LOCAL"
+    And user "Alice" has been created with default attributes and without skeleton files
+
+  @issue-38763 @notToImplementOnOCIS
+  Scenario: mount public link share of a folder and the sharer deletes the folder
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%local_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    When the user opens folder "PARENT" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When user "Alice" deletes folder "/PARENT" using the WebDAV API
+    And the user browses to the files page
+    Then folder "PARENT" should be listed on the webUI
+    When the user opens folder "PARENT" using the webUI
+    Then file "lorem.txt" should not be listed on the webUI
+    When the user browses to the files page
+    Then folder "PARENT" should not be listed on the webUI
+
+  @issue-38763 @notToImplementOnOCIS
+  Scenario: mount public link share of a folder in remote server and the sharer deletes the folder
+    Given using server "REMOTE"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And using server "LOCAL"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file with content "original content" to "/PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And the public has accessed the last created public link using the webUI
+    When the public adds the public link to "%remote_server%" as user "Brian" using the webUI
+    And the user accepts the offered remote shares using the webUI
+    Then folder "PARENT" should be listed on the webUI
+    When the user opens folder "PARENT" using the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    When user "Alice" deletes folder "/PARENT" using the WebDAV API
+    And the user selects the breadcrumb for folder "/"
+    And the user reloads the current page of the webUI
+    Then folder "PARENT" should be listed on the webUI
+    When the user opens folder "PARENT" using the webUI
+    Then file "lorem.txt" should not be listed on the webUI
+    When the user selects the breadcrumb for folder "/"
+    Then folder "PARENT" should not be listed on the webUI


### PR DESCRIPTION
## Description
Adds more webUI test coverage for adding public share to oC server
Scenarios:
- save public share of file/folder to local server (with read-only and all permissions)
- save public share of file/folder that already exists (local and remote)
- unshare/delete saved public share (local and remote)
- sharer deletes public shared folder (local and remote)

Here, `local` means sharer and the user who saves public share are in the save oC server
and `remote` means public share is created by user in one server instance and public share is added to account by a user in another server instance (federated share)

Some tests for federated share of public link share already exists in `shareByPublicLink.feature`

## Related Issue
Part of https://github.com/owncloud/core/issues/38752

## How Has This Been Tested?
- test environment:

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
