### PR TITLE
[tests-only] reduce Apache output log for tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1966,8 +1966,6 @@ def owncloudService(phpVersion, name = 'server', pathOfServerUnderTest = '/drone
 		'environment': environment,
 		'command': [
 			'/usr/local/bin/apachectl',
-			'-e',
-			'debug',
 			'-D',
 			'FOREGROUND'
 		]


### PR DESCRIPTION
## Description
dont't use apache debug mode to serve core

## Motivation and Context
this logs are usually not so important and that should save a couple of thousand line of logs in every pipeline

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
