### PR TITLE
Use file_exists instead of getting the file info

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -322,7 +322,7 @@ class TransferOwnership extends Command {
 							}
 						} catch (NotFoundException | NoUserException $e) {
 							$skipped++;
-							$output->writeln('<error>Share with id ' . $share->getId() . ' and type ' . $share->getShareType() . ' points at deleted file or share that is no longer accessible, skipping</error>');
+							$output->writeln("<error>Share with id {$share->getId()} and type {$share->getShareType()} points at deleted file or share that is no longer accessible, skipping</error>");
 							$progress->advance(1);
 						}
 					}
@@ -347,7 +347,7 @@ class TransferOwnership extends Command {
 						try {
 							$share->getNode()->getId();  // force loading the fileinfo
 						} catch (NotFoundException | NoUserException $e) {
-							$output->writeln('<error>Share with id ' . $share->getId() . ' and type ' . $share->getShareType() . ' points at deleted file or share that is no longer accessible, skipping</error>');
+							$output->writeln("<error>Share with id {$share->getId()} and type {$share->getShareType()} points at deleted file or share that is no longer accessible, skipping</error>");
 							return false;
 						}
 						return true;
@@ -430,7 +430,7 @@ class TransferOwnership extends Command {
 				}
 				$this->shareManager->transferShare($share, $this->sourceUser, $this->destinationUser, $this->finalTarget);
 			} catch (NotFoundException | NoUserException $e) {
-				$output->writeln('<error>Share with id ' . $share->getId() . ' and type ' . $share->getShareType() . ' points at deleted file or share that is no longer accessible, skipping</error>');
+				$output->writeln("error>Share with id {$share->getId()} and type {$share->getShareType()} points at deleted file or share that is no longer accessible, skipping</error>");
 			} catch (\Exception $e) {
 				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getTraceAsString() . '</error>');
 				$status = 1;

--- a/changelog/unreleased/38767
+++ b/changelog/unreleased/38767
@@ -1,0 +1,13 @@
+Bugfix: Delay getting the file info until it's going to be used
+
+Some operations require getting the file info to perform the action.
+Previously, this file info was fetched and stored before any operation. In
+some cases fetching the file info triggered a file scan that could delay
+the whole request considerably.
+
+Now, we fetch the file info only in those operations that require it. There
+are some node operations such as getting the file path that don't require
+fetching the file info, so those operation won't fetch it, and so a potential
+file scan is prevented (for those operations)
+
+https://github.com/owncloud/core/pull/38767

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -130,11 +130,12 @@ class Node implements \OCP\Files\Node {
 			$this->sendHooks(['preTouch']);
 			$this->view->touch($this->path, $mtime);
 			$this->sendHooks(['postTouch']);
-			if ($this->fileInfo) {
+			$fileInfo = $this->getFileInfo();
+			if ($fileInfo) {
 				if ($mtime === null) {
 					$mtime = \time();
 				}
-				$this->fileInfo['mtime'] = $mtime;
+				$fileInfo['mtime'] = $mtime;
 			}
 		} else {
 			throw new NotPermittedException();

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -130,12 +130,11 @@ class Node implements \OCP\Files\Node {
 			$this->sendHooks(['preTouch']);
 			$this->view->touch($this->path, $mtime);
 			$this->sendHooks(['postTouch']);
-			$fileInfo = $this->getFileInfo();
-			if ($fileInfo) {
+			if ($this->fileInfo) {
 				if ($mtime === null) {
 					$mtime = \time();
 				}
-				$fileInfo['mtime'] = $mtime;
+				$this->fileInfo['mtime'] = $mtime;
 			}
 		} else {
 			throw new NotPermittedException();

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -191,6 +191,11 @@ class Root extends Folder implements IRootFolder {
 			if ($fileExists) {
 				return $this->createNode($fullPath);
 			} else {
+				// try getting the fileinfo in case we have data in the filecache
+				$fileInfo = $this->view->getFileInfo($fullPath);
+				if ($fileInfo) {
+					return $this->createNode($fullPath, $fileInfo);
+				}
 				throw new NotFoundException($path);
 			}
 		} else {

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -187,9 +187,9 @@ class Root extends Folder implements IRootFolder {
 			if ($virtualNode !== null) {
 				return $virtualNode;
 			}
-			$fileInfo = $this->view->getFileInfo($fullPath);
-			if ($fileInfo) {
-				return $this->createNode($fullPath, $fileInfo);
+			$fileExists = $this->view->file_exists($fullPath);
+			if ($fileExists) {
+				return $this->createNode($fullPath);
 			} else {
 				throw new NotFoundException($path);
 			}

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -193,10 +193,10 @@ class Root extends Folder implements IRootFolder {
 			} else {
 				// try getting the fileinfo in case we have data in the filecache
 				$fileInfo = $this->view->getFileInfo($fullPath);
-				if ($fileInfo) {
-					return $this->createNode($fullPath, $fileInfo);
+				if (!$fileInfo) {
+					throw new NotFoundException($path);
 				}
-				throw new NotFoundException($path);
+				return $this->createNode($fullPath, $fileInfo);
 			}
 		} else {
 			throw new NotPermittedException();

--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -62,7 +62,7 @@ php occ app:list
 
 phpunit_cmd="php ../lib/composer/bin/phpunit"
 if [[ "${COVERAGE}" == "true" ]]; then
-    phpunit_cmd="phpdbg -d memory_limit=4096M -rr ../lib/composer/bin/phpunit"
+    phpunit_cmd="phpdbg -d memory_limit=6G -rr ../lib/composer/bin/phpunit"
 fi
 
 if [[ -n "${FILES_EXTERNAL_TYPE}" ]]; then

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -575,10 +575,8 @@ class FolderTest extends NodeTest {
 		$mount = new MountPoint($storage, '/bar');
 		$cache = $this->createMock(Cache::class);
 
-		// called twice because of Folder::nodeExists and Folder::get
-		$view->expects(self::exactly(2))
-			->method('getFileInfo')
-			->willReturn(new FileInfo('/bar/foo/qwerty', null, 'qwerty', ['mimetype' => 'text/plain'], null));
+		$view->method('file_exists')
+			->willReturn(true);
 
 		$storage->expects(self::once())
 			->method('getCache')
@@ -664,9 +662,8 @@ class FolderTest extends NodeTest {
 		$mount2 = new MountPoint($storage, '/bar/foo/asd');
 		$cache = $this->createMock(Cache::class);
 
-		$view->expects($this->any())
-			->method('getFileInfo')
-			->will($this->returnValue(new FileInfo('/bar/foo/qwerty', null, 'qwerty', ['mimetype' => 'plain'], null)));
+		$view->method('file_exists')
+			->willReturn(true);
 
 		$storage->expects($this->any())
 			->method('getCache')

--- a/tests/lib/Files/Node/RootTest.php
+++ b/tests/lib/Files/Node/RootTest.php
@@ -44,6 +44,10 @@ class RootTest extends TestCase {
 		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
 
 		$view->expects($this->once())
+			->method('file_exists')
+			->with('/bar/foo')
+			->willReturn(true);
+		$view->expects($this->once())
 			->method('getFileInfo')
 			->with('/bar/foo')
 			->will($this->returnValue($this->getFileInfo(['fileid' => 10, 'path' => 'bar/foo', 'name', 'mimetype' => 'text/plain'])));
@@ -71,7 +75,7 @@ class RootTest extends TestCase {
 		$root = new \OC\Files\Node\Root($manager, $view, $this->user);
 
 		$view->expects($this->once())
-			->method('getFileInfo')
+			->method('file_exists')
 			->with('/bar/foo')
 			->will($this->returnValue(false));
 


### PR DESCRIPTION
This will delay getting the file info until it's going to be used. It
will benefit some operations that don't rely on the file info, which
could trigger a file scan in some scenarios

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Nodes coming from the root's `get` method won't have the file info injected directly. Getting the file info will be delayed until it's needed. This will help on some scenarios where getting the file info triggers a big scan although we don't really use that file info.

## Related Issue
https://github.com/owncloud/enterprise/issues/4266

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. admin creates "folder1/path/to/file.txt" and "folder2/pot/too/fool.txt"
2. admins shares "folder1" and "folder2" with user1.
3. user1 moves "folder2" (shared) into "folder1/path/to"
4. Move is prevented and no file scan happens.

Note that the move doesn't happen, which is expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
