### PR TITLE
[tests-only] Add more test cases for issue 30325

### DIFF
--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareOc10Issue30325.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareOc10Issue30325.feature
@@ -10,10 +10,10 @@ Feature: sharing - current oC10 behavior for issue-30325
       | Carol    |
 
   @issue-30325
-  Scenario: receiver tries to rename a received share with share, read permissions
+  Scenario Outline: receiver tries to rename a received share with limited permissions
     Given user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
-    And user "Alice" has shared folder "folderToShare" with user "Brian" with permissions "share,read"
+    And user "Alice" has shared folder "folderToShare" with user "Brian" with permissions "<permissions>"
     When user "Brian" moves folder "folderToShare" to "myFolder" using the WebDAV API
     Then the HTTP status code should be "403"
 #    Then the HTTP status code should be "201"
@@ -27,3 +27,9 @@ Feature: sharing - current oC10 behavior for issue-30325
 #    And as "Brian" file "/myFolder/renamedFile" should not exist
     But as "Brian" file "/folderToShare/fileInside" should exist
 #    But as "Brian" file "/myFolder/fileInside" should exist
+    Examples:
+      | permissions        |
+      | share,read         |
+      | read               |
+      | read,create,delete |
+    # Note: if change permission is given, only then can the share receiver rename the received folder


### PR DESCRIPTION
## Description
Issue #30325 has just one example of the problem when a sharee tries to rename a folder that they have received.
Actually the problem happens for combinations of permissions that do not include "change" permission.
Add a couple more scenarios so that the extent of the problem is demonstrated better.

## How Has This Been Tested?
Local run of the test scenarios

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
