### PR TITLE
Add action to resend the invitation email for a user

### DIFF
--- a/changelog/unreleased/38774
+++ b/changelog/unreleased/38774
@@ -1,0 +1,7 @@
+Enhancement: Resend invitation email
+
+Implemented an action to resend the invitation email for a user that has
+never been logged in yet.
+
+https://github.com/owncloud/core/pull/38774
+https://github.com/owncloud/enterprise/issues/4577

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -747,3 +747,7 @@ li > a.icon-settings {
 div.app-settings .section {
 	margin-bottom: 0;
 }
+
+.action.resendInvitationEmail img {
+	vertical-align: text-bottom;
+}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -120,7 +120,7 @@ var UserList = {
 				src: OC.imagePath('core', 'actions/mail')
 			});
 			var resendLink = $('<a class="action resendInvitationEmail">')
-				.attr({ href: '#', 'original-title': t('settings', 'Resend invitation email')})
+				.attr({ href: '#', 'title': t('settings', 'Resend invitation email')})
 				.append(resendImage);
 			$tr.find('td.resendInvitationEmail').append(resendLink);
 		}
@@ -133,7 +133,7 @@ var UserList = {
 				src: OC.imagePath('core', 'actions/delete')
 			});
 			var deleteLink = $('<a class="action delete">')
-				.attr({ href: '#', 'original-title': t('settings', 'Delete')})
+				.attr({ href: '#', 'title': t('settings', 'Delete')})
 				.append(deleteImage);
 			$tr.find('td.remove').append(deleteLink);
 		} else if (OC.currentUser === user.name) {

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -113,6 +113,19 @@ var UserList = {
 		}
 
 		/**
+		 * resend invitation email action
+		 */
+		if (user.lastLogin === 0) {
+			var resendImage = $('<img class="action">').attr({
+				src: OC.imagePath('core', 'actions/mail')
+			});
+			var resendLink = $('<a class="action resendInvitationEmail">')
+				.attr({ href: '#', 'original-title': t('settings', 'Resend invitation email')})
+				.append(resendImage);
+			$tr.find('td.resendInvitationEmail').append(resendLink);
+		}
+
+		/**
 		 * remove action
 		 */
 		if ($tr.find('td.remove img').length === 0 && OC.currentUser !== user.name) {
@@ -381,6 +394,22 @@ var UserList = {
 					if (confirmation) {
 						UserDeleteHandler.mark(uid);
 						UserDeleteHandler.deleteEntry();
+					}
+				}
+			);
+		});
+	},
+	initResendInvitationEmailHandling: function() {
+		$userListBody.on('click', '.action.resendInvitationEmail', function () {
+			var uid = UserList.getUID(this);
+			$.post(
+				OC.generateUrl('/resend/token/{id}', {id: uid}),
+				{},
+				function (result, status) {
+					if (status === 'success'){
+						OC.Notification.showTemporary(t('settings', 'The invitation email for this user has been resent'));
+					} else {
+						OC.Notification.showTemporary(t('settings', 'The invitation email for this user could not be resent'));
 					}
 				}
 			);
@@ -733,6 +762,7 @@ $(document).ready(function () {
 	$userListBody = $userList.find('tbody');
 
 	UserList.initDeleteHandling();
+	UserList.initResendInvitationEmailHandling();
 
 	// Implements User Search
 	OCA.Search.users= new UserManagementFilter(UserList, GroupList);

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -17,6 +17,7 @@
 			<th class="storageLocation" scope="col"><?php p($l->t('Storage Location')); ?></th>
 			<th class="userBackend" scope="col"><?php p($l->t('User Backend')); ?></th>
 			<th class="lastLogin" scope="col"><?php p($l->t('Last Login')); ?></th>
+			<th id="headerResendInvitationEmail">&nbsp;</th>
 			<th id="headerRemove">&nbsp;</th>
 		</tr>
 	</thead>
@@ -71,6 +72,7 @@
 			<td class="storageLocation"></td>
 			<td class="userBackend"></td>
 			<td class="lastLogin"></td>
+			<td class="resendInvitationEmail"></td>
 			<td class="remove"></td>
 		</tr>
 	</tbody>

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
+use Page\GeneralErrorPage;
 use Page\LoginPage;
 use Page\UsersPage;
 use Page\OwncloudPage;
@@ -53,6 +54,12 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 
 	/**
 	 *
+	 * @var GeneralErrorPage
+	 */
+	private $generalErrorPage;
+
+	/**
+	 *
 	 * @var WebUIGeneralContext
 	 */
 	private $webUIGeneralContext;
@@ -71,11 +78,14 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @param UsersPage $usersPage
 	 * @param LoginPage $loginPage
 	 * @param OwncloudPage $owncloudPage
+	 * @param GeneralErrorPage $generalErrorPage
+
 	 */
-	public function __construct(UsersPage $usersPage, LoginPage $loginPage, OwncloudPage $owncloudPage) {
+	public function __construct(UsersPage $usersPage, LoginPage $loginPage, OwncloudPage $owncloudPage, GeneralErrorPage $generalErrorPage) {
 		$this->usersPage = $usersPage;
 		$this->loginPage = $loginPage;
 		$this->owncloudPage = $owncloudPage;
+		$this->generalErrorPage = $generalErrorPage;
 	}
 
 	/**
@@ -202,6 +212,32 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		$this->theAdminCreatesAUserUsingTheWebUI(
 			$attemptTo, $username, null, $email, $groupsTable
 		);
+	}
+
+	/**
+	 * @When the administrator resends invitation email for user with the name :username using the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function theAdminResendsInvitationEmailUsingTheWebUI(
+		string $username
+	) {
+		$this->usersPage->resendInvitationEmail($username, $this->getSession());
+	}
+
+	/**
+	 * @Then the user should see an error message saying :message
+	 *
+	 * @param string $message
+	 *
+	 * @return void
+	 */
+	public function theUserShouldSeeAnErrorWithMessage(
+		string $message
+	) {
+		Assert::assertEquals($message, $this->generalErrorPage->getErrorMessage());
 	}
 
 	/**

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -81,6 +81,8 @@ class UsersPage extends OwncloudPage {
 	protected $disableUserCheckboxXpath = "//input[@type='checkbox']";
 	protected $deleteUserBtnXpath
 		= ".//td[@class='remove']/a[@class='action delete']";
+	protected $resendInvitationEmailBtnXpath
+		= ".//td[@class='resendInvitationEmail']/a[@class='action resendInvitationEmail']";
 	protected $deleteConfirmBtnXpath
 		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style, 'display: none')])]//button[text()='Yes']";
 	protected $deleteNotConfirmBtnXpath
@@ -897,5 +899,27 @@ class UsersPage extends OwncloudPage {
 			return null;
 		}
 		return (int) $groupUserCount;
+	}
+
+	/**
+	 * @param string $username
+	 * @param Session $session
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function resendInvitationEmail($username, $session) {
+		$userTr = $this->findUserInTable($username);
+		$resendInvitationEmailBtn = $userTr->find('xpath', $this->resendInvitationEmailBtnXpath);
+
+		$this->assertElementNotNull(
+			$resendInvitationEmailBtn,
+			__METHOD__ .
+			" xpath $this->resendInvitationEmailBtnXpath " .
+			"could not find resend invitation email button for user $username"
+		);
+
+		$resendInvitationEmailBtn->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 }

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -91,6 +91,27 @@ Feature: add users
       | guiusr1  | simple user-name      |
       | a@-+_.'b | complicated user-name |
 
+  @smokeTest @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7
+  Scenario Outline: user sets his own password after being created with an Email address only and invitation link resend
+    When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
+    And the administrator resends invitation email for user with the name "<username>" using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" in Email number 2 using the webUI
+    Then the user should see an error message saying "The token provided is invalid."
+    And the user follows the password set link received by "guiusr1@owncloud" in Email number 1 using the webUI
+    And the user sets the password to "%regular%" and confirms with the same password using the webUI
+    Then the user should be redirected to the login page
+    And the email address "guiusr1@owncloud" should have received an email with the body containing
+      """
+      Password changed successfully
+      """
+    When the user logs in with username "<username>" and password "%regular%" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
+    Examples:
+      | username | comment               |
+      | guiusr1  | simple user-name      |
+      | a@-+_.'b | complicated user-name |
+
   @skipOnOcV10.3
   Scenario Outline: user sets his own password but retypes it wrongly after being created with an Email address only
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI


### PR DESCRIPTION
## Description
Resend invitation email
Implemented an action to resend the invitation email for a user that hasnever been logged in yet.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4577

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/50302941/119481754-5c18da80-bd53-11eb-9d48-9cb00e503705.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket raised: <link> @mmattel required ? 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
