### PR TITLE
Fix ExpireSharesJob so that it only expires shares that expired yesterday or earlier

### DIFF
--- a/apps/files_sharing/lib/ExpireSharesJob.php
+++ b/apps/files_sharing/lib/ExpireSharesJob.php
@@ -84,8 +84,8 @@ class ExpireSharesJob extends TimedJob {
 	 */
 	public function run($argument) {
 		//Current time
-		$now = new \DateTime();
-		$now = $now->format('Y-m-d H:i:s');
+		$today = new \DateTime("today");
+		$today = $today->format('Y-m-d H:i:s');
 
 		/*
 		 * Expire file shares only (for now)
@@ -95,7 +95,7 @@ class ExpireSharesJob extends TimedJob {
 			->from('share')
 			->where(
 				$qb->expr()->andX(
-					$qb->expr()->lte('expiration', $qb->expr()->literal($now)),
+					$qb->expr()->lt('expiration', $qb->expr()->literal($today)),
 					$qb->expr()->orX(
 						$qb->expr()->eq('item_type', $qb->expr()->literal('file')),
 						$qb->expr()->eq('item_type', $qb->expr()->literal('folder'))

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -137,6 +137,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 		return [
 			[false,   '', false, false],
 			[false,   '',  true, false],
+			[true, 'P0D',  true, false],
 			[true, 'P1D', false,  true],
 			[true, 'P1D',  true, false],
 			[true, 'P1W', false,  true],
@@ -204,7 +205,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 			}
 			$expire = $expire->format('Y-m-d 00:00:00');
 
-			// Set expiration date to yesterday
+			// Set expiration to the calculated date
 			$qb = $this->connection->getQueryBuilder();
 			$qb->update('share')
 				->set('expiration', $qb->createParameter('expiration'))
@@ -261,7 +262,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 			->with($linkShare->getId())
 			->willThrowException(new ShareNotFound());
 		$this->logout();
-		
+
 		$this->job->run([]);
 	}
 }

--- a/changelog/unreleased/38775
+++ b/changelog/unreleased/38775
@@ -1,0 +1,9 @@
+Bugfix: Expire shares at end of day
+
+The Expire Share background job was immediately expiring shares that had an
+expiration date of today. But those shares should continue to work for the rest
+of the day. The behaviour has been corrected. All shares will now work until
+the end of the day that they expire.
+
+https://github.com/owncloud/enterprise/issues/4324
+https://github.com/owncloud/core/pull/38775


### PR DESCRIPTION
## Description
`ExpireSharesJob` is currently deleting shares that have an expiration date in the past of "now". For example, if the job runs at 2021-05-25:11:30 then a share that has an expiration date set to "2021-05-25" will be "expired" and get removed. But actually the "meaning" of expiring on "2021-05-25" is understood to be that the share works all of that day, right up to and including "2021-05-25:23:59:59"

https://github.com/owncloud/core/blob/master/lib/private/Share20/Manager.php#L185 has the real-time logic of this:
```
	private static function shareHasExpired($share) {
		$expirationDate = $share->getExpirationDate();
		return ($expirationDate !== null) && ($expirationDate < new \DateTime("today"));
	}
```

That compares the expiration date of the share to the "zero" hour of "today", and only considers the share expired if the expiration date is strictly less than the beginning of "today". So a share that has an expiration date "today" will not actually expire until the next day starts.

This PR adjusts `ExpireSharesJob` so that it uses the same logic.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4324

## How Has This Been Tested?
Unit test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
