### PR TITLE
[tests-only] clear the dependency cache on merge CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -395,6 +395,7 @@ def dependencies(ctx):
 				},
 				'steps':
 					cacheRestore() +
+					cacheClearOnEventPush(phpVersion) +
 					composerInstall(phpVersion) +
 					vendorbinCodestyle(phpVersion) +
 					vendorbinCodesniffer(phpVersion) +
@@ -2049,6 +2050,26 @@ def cacheRestore():
 			}
 		},
 		'when': {
+			'instance': [
+				'drone.owncloud.services',
+				'drone.owncloud.com'
+			],
+		}
+	}]
+
+def cacheClearOnEventPush(phpVersion):
+	return [{
+		'name': 'cache-clear',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'rm -Rf /drone/src/.cache/composer',
+			'rm -Rf /drone/src/.cache/yarn',
+		],
+		'when': {
+			'event': [
+				'push',
+			],
 			'instance': [
 				'drone.owncloud.services',
 				'drone.owncloud.com'


### PR DESCRIPTION
## Description
There is a cache of the dependencies that are typically used by CI pipelines (PHP composer and JavaScript yarn). The cache has got large in recent weeks. IMO it has old and/or extra stuff in it that is not really needed/used any more. (currently has 730MB total in the cache - see comment https://github.com/owncloud/core/pull/38772#issuecomment-847526057 )

When the merge CI runs after a PR is merged, there are pipeline steps that update the cache in S3 storage. That does all the `composer install` `yarn install` type of commands, which makes sure that the cache has currently-used dependencies. But there is no step to try and clean out old stuff from the cache.

This PR adds a pipeline step `cacheClearOnEventPush` - that deletes all `composer` and `yarn` items from the cache. The various install commands are then done, and the S3 storage is updated. 

That will make the cache only have the very latest dependencies in it. IMO that is OK. Most times there are only small (or no) dependency changes in a PR, so most of the "latest" dependencies are also relevant to PRs that are running slightly out-of-date from master.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
