### PR TITLE
Fix image preview for file versions

### DIFF
--- a/changelog/unreleased/38778
+++ b/changelog/unreleased/38778
@@ -1,0 +1,7 @@
+Bugfix: Image preview for file versions
+
+Changed the way how preview thumbnails are being rendered so they will
+be rendered properly for file versions.
+
+https://github.com/owncloud/core/pull/38778
+https://github.com/owncloud/core/issues/38766

--- a/lib/private/Preview/Image.php
+++ b/lib/private/Preview/Image.php
@@ -45,9 +45,8 @@ abstract class Image implements IProvider2 {
 
 		$image = new \OC_Image();
 
-		$internalPath = $file->getInternalPath();
-		$localPath = $file->getStorage()->getLocalFile($internalPath);
-		$image->loadFromFile($localPath);
+		$fileContent = $file->getContent();
+		$image->load($fileContent);
 		$image->fixOrientation();
 
 		if ($image->valid()) {


### PR DESCRIPTION
## Description
Changed the way how preview thumbnails are being rendered so they will be rendered properly for file versions.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/38766

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/50302941/119640581-0c9ce200-be19-11eb-8762-ae9fa01c2755.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
