### PR TITLE
Switch order to prevent double-replacement in the query

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -609,15 +609,15 @@ class Cache implements ICache {
 				if (\intval($versionArray[0]) < 12) {
 					$sql = 'UPDATE `*PREFIX*filecache`
 						SET `storage` = :targetStorageId,
-							`path` = REPLACE(`path`, :sourcePath, :targetPath),
-							`path_hash` = LOWER(dbms_obfuscation_toolkit.md5(input => UTL_RAW.cast_to_raw(REPLACE(`path`, :sourcePath, :targetPath))))
+							`path_hash` = LOWER(dbms_obfuscation_toolkit.md5(input => UTL_RAW.cast_to_raw(REPLACE(`path`, :sourcePath, :targetPath)))),
+							`path` = REPLACE(`path`, :sourcePath, :targetPath)
 						WHERE `storage` = :sourceStorageId
 						AND `path` LIKE :sourcePathLike';
 				} else {
 					$sql = 'UPDATE `*PREFIX*filecache`
 						SET `storage` = :targetStorageId,
-							`path` = REPLACE(`path`, :sourcePath, :targetPath),
-							`path_hash` = LOWER(standard_hash(REPLACE(`path`, :sourcePath, :targetPath), \'MD5\'))
+							`path_hash` = LOWER(standard_hash(REPLACE(`path`, :sourcePath, :targetPath), \'MD5\')),
+							`path` = REPLACE(`path`, :sourcePath, :targetPath)
 						WHERE `storage` = :sourceStorageId
 						AND `path` LIKE :sourcePathLike';
 				}
@@ -626,8 +626,8 @@ class Cache implements ICache {
 			case 'postgresql':
 				$sql = 'UPDATE `*PREFIX*filecache`
 					SET `storage` = :targetStorageId,
-						`path` = REPLACE(`path`, :sourcePath, :targetPath),
-						`path_hash` = MD5(REPLACE(`path`, :sourcePath, :targetPath))
+						`path_hash` = MD5(REPLACE(`path`, :sourcePath, :targetPath)),
+						`path` = REPLACE(`path`, :sourcePath, :targetPath)
 					WHERE `storage` = :sourceStorageId
 					AND `path` LIKE :sourcePathLike';
 				break;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The path used in the replacement for the path_hash column was the "new" one already replaced in the previous "set" clause. This was causing problems since the replacement could also happen in that new path, and could generate a wrong md5.
Switching the order makes sure the path used in the replace for both the path and path_hash columns will be the same

## Related Issue
https://github.com/owncloud/encryption/issues/276

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested using `occ files:transfer-ownership`
1. user1 uploads a file
2. user1 shares the file with user3
3. run `occ files:transfer-ownershp user1 user2`

Previously, due to the wrong hash, a duplicate of the transfer file was generated in the DB, which was visible in the user2 account. This duplicate was causing side effects
This PR fixes that. The behaviour is the expected one.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
