### PR TITLE
[tests-only] skip some tags tests on old oC10

### DIFF
--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -20,6 +20,7 @@ Feature: Assign tags to file/folder
       | name                | type   |
       | JustARegularTagName | normal |
 
+
   Scenario: Assigning a normal tag to a file belonging to someone else as regular user should fail
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -31,6 +32,7 @@ Feature: Assign tags to file/folder
       | name       | type   |
       | MyFirstTag | normal |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user should fail
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "not user-assignable" tag with name "MySecondTag"
@@ -43,6 +45,7 @@ Feature: Assign tags to file/folder
       | name       | type   |
       | MyFirstTag | normal |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user belongs to tag's groups should work
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -54,6 +57,7 @@ Feature: Assign tags to file/folder
     And file "/myFileToTag.txt" shared by user "Alice" should have the following tags
       | name                | type                |
       | JustARegularTagName | not user-assignable |
+
 
   Scenario: Assigning a static tag to a file shared by someone else as regular user belongs to tag's groups should work
     Given group "grp1" has been created
@@ -67,6 +71,7 @@ Feature: Assign tags to file/folder
       | name          | type   |
       | StaticTagName | static |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Assigning a not user-visible tag to a file shared by someone else as regular user should fail
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "not user-visible" tag with name "MySecondTag"
@@ -79,6 +84,7 @@ Feature: Assign tags to file/folder
       | name       | type   |
       | MyFirstTag | normal |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Assigning a static tag to a file shared by someone else as regular user does not belong to tag's group should fail
     Given group "hash#group" has been created
     And user "Alice" has been added to group "hash#group"
@@ -93,6 +99,7 @@ Feature: Assign tags to file/folder
       | name      | type   |
       | NormalTag | normal |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Assigning a not user-visible tag to a file shared by someone else as admin user should work
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "not user-visible" tag with name "MySecondTag"
@@ -109,6 +116,7 @@ Feature: Assign tags to file/folder
       | name       | type   |
       | MyFirstTag | normal |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as admin user should work
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "not user-assignable" tag with name "MySecondTag"

--- a/tests/acceptance/features/apiTags/assignTagsGroup.feature
+++ b/tests/acceptance/features/apiTags/assignTagsGroup.feature
@@ -5,12 +5,14 @@ Feature: Title of your feature
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: User can assign tags when in the tag's groups
     Given group "grp1" has been created
     And user "Alice" has been added to group "grp1"
     When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "grp1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should be able to assign the "not user-assignable" tag with name "TagWithGroups"
+
 
   Scenario: User can assign static tags when in the tag's groups
     Given group "grp1" has been created
@@ -19,6 +21,7 @@ Feature: Title of your feature
     Then the HTTP status code should be "201"
     And user "Alice" should be able to assign the "static" tag with name "TagWithGroups"
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: User cannot assign tags when not in the tag's groups
     When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "grp2|group2" using the WebDAV API
     Then the HTTP status code should be "201"

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -26,6 +26,7 @@ Feature: Creation of tags
       | 😀                  |
       | सिमप्ले             |
 
+
   Scenario: Creating a normal tag as a regular user should work (sending the string "1" to turn on the tag attributes)
     When user "Alice" creates a "normal" tag with name "RegularTag" sending numbers in the request using the WebDAV API
     Then the HTTP status code should be "201"
@@ -36,21 +37,25 @@ Feature: Creation of tags
       | name       | type   |
       | RegularTag | normal |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Creating a not user-assignable tag as regular user should fail
     When user "Alice" creates a "not user-assignable" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for the administrator
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Creating a static tag as regular user should fail
     When user "Alice" creates a "static" tag with name "StaticTagName" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "StaticTagName" should not exist for the administrator
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Creating a not user-visible tag as regular user should fail
     When user "Alice" creates a "not user-visible" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for the administrator
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: Creating a tag as administrator should work
     When the administrator creates a "<tag_type>" tag with name "JustARegularTagName" sending <sending_style> in the request using the WebDAV API
     Then the HTTP status code should be "201"
@@ -68,41 +73,48 @@ Feature: Creation of tags
       | static              | true-false-strings |
       | static              | numbers            |
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Creating a not user-assignable tag with groups as admin should work
     When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "201"
     And the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group2"
+
 
   Scenario: Creating a normal tag with groups as regular user should fail
     When user "Alice" creates a "normal" tag with name "JustARegularTagName" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for user "Alice"
 
+
   Scenario: Creating a normal tag that is already created by other user should fail
     Given user "Brian" has created a "normal" tag with name "JustARegularTagName"
     When user "Alice" creates a "normal" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "409"
+
 
   Scenario: Overwriting existing normal tags should fail
     Given user "Alice" has created a "normal" tag with name "MyFirstTag"
     When user "Alice" creates a "normal" tag with name "MyFirstTag" using the WebDAV API
     Then the HTTP status code should be "409"
 
+
   Scenario: Overwriting existing not user-assignable tags should fail
     Given the administrator has created a "not user-assignable" tag with name "MyFirstTag"
     When the administrator creates a "not user-assignable" tag with name "MyFirstTag" using the WebDAV API
     Then the HTTP status code should be "409"
+
 
   Scenario: Overwriting existing not user-visible tags should fail
     Given the administrator has created a "not user-visible" tag with name "MyFirstTag"
     When the administrator creates a "not user-visible" tag with name "MyFirstTag" using the WebDAV API
     Then the HTTP status code should be "409"
 
+
   Scenario: Overwriting existing static tags should fail
     Given the administrator has created a "static" tag with name "StaticTag"
     When the administrator creates a "static" tag with name "StaticTag" using the WebDAV API
     Then the HTTP status code should be "409"
+
 
   Scenario: Creating tags in lowercase and uppercase should work
     When the administrator creates a "normal" tag with name "UppercaseTag" using the WebDAV API
@@ -113,6 +125,7 @@ Feature: Creation of tags
       | name         | type   |
       | UppercaseTag | normal |
       | lowercasetag | normal |
+
 
   Scenario: Creating tags with the same name in lowercase and uppercase should work
     When the administrator creates a "normal" tag with name "testtag" using the WebDAV API

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -13,6 +13,7 @@ Feature: Deletion of tags
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for the administrator
 
+
   Scenario: Deleting a normal tag that has already been assigned to a file should work
     Given user "Alice" has created a "normal" tag with name "JustARegularTagName"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"
@@ -22,6 +23,7 @@ Feature: Deletion of tags
     And tag "JustARegularTagName" should not exist for the administrator
     And file "/myFileToTag.txt" should have no tags for user "Alice"
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Deleting a not user-assignable tag as regular user should fail
     Given the administrator has created a "not user-assignable" tag with name "JustARegularTagName"
     When user "Alice" deletes the tag with name "JustARegularTagName" using the WebDAV API
@@ -30,6 +32,7 @@ Feature: Deletion of tags
       | name                | type                |
       | JustARegularTagName | not user-assignable |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Deleting a not user-visible tag as regular user should fail
     Given the administrator has created a "not user-visible" tag with name "JustARegularTagName"
     When user "Alice" deletes the tag with name "JustARegularTagName" using the WebDAV API
@@ -38,6 +41,7 @@ Feature: Deletion of tags
       | name                | type             |
       | JustARegularTagName | not user-visible |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Deleting a static tag as regular user should fail
     Given the administrator has created a "static" tag with name "StaticTagName"
     When user "Alice" deletes the tag with name "StaticTagName" using the WebDAV API
@@ -46,17 +50,20 @@ Feature: Deletion of tags
       | name          | type   |
       | StaticTagName | static |
 
+
   Scenario: Deleting a not user-assignable tag as admin should work
     Given the administrator has created a "not user-assignable" tag with name "JustARegularTagName"
     When the administrator deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for the administrator
 
+
   Scenario: Deleting a not user-visible tag as admin should work
     Given the administrator has created a "not user-visible" tag with name "JustARegularTagName"
     When the administrator deletes the tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "204"
     And tag "JustARegularTagName" should not exist for the administrator
+
 
   Scenario: Deleting a static tag as admin should work
     Given the administrator has created a "static" tag with name "StaticTagName"

--- a/tests/acceptance/features/apiTags/editTags.feature
+++ b/tests/acceptance/features/apiTags/editTags.feature
@@ -19,6 +19,7 @@ Feature: Editing the tags
       | 😀                  |
       | सिमप्ले             |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Renaming a not user-assignable tag as regular user should fail
     Given the administrator has created a "not user-assignable" tag with name "JustARegularTagName"
     When user "Alice" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -26,6 +27,7 @@ Feature: Editing the tags
       | name                | type                |
       | JustARegularTagName | not user-assignable |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Renaming a static tag as regular user should fail
     Given the administrator has created a "static" tag with name "StaticTagName"
     When user "Alice" edits the tag with name "StaticTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -33,6 +35,7 @@ Feature: Editing the tags
       | name          | type   |
       | StaticTagName | static |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Renaming a not user-visible tag as regular user should fail
     Given the administrator has created a "not user-visible" tag with name "JustARegularTagName"
     When user "Alice" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -40,6 +43,7 @@ Feature: Editing the tags
       | name                | type             |
       | JustARegularTagName | not user-visible |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Renaming a not user-assignable tag as administrator should work
     Given the administrator has created a "not user-assignable" tag with name "JustARegularTagName"
     When the administrator edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -48,6 +52,7 @@ Feature: Editing the tags
       | AnotherTagName | not user-assignable |
     And tag "JustARegularTagName" should not exist for the administrator
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Renaming a not user-visible tag as administrator should work
     Given the administrator has created a "not user-visible" tag with name "JustARegularTagName"
     When the administrator edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -55,6 +60,7 @@ Feature: Editing the tags
       | name           | type             |
       | AnotherTagName | not user-visible |
     And tag "JustARegularTagName" should not exist for the administrator
+
 
   Scenario: Renaming a static tag as administrator should work
     Given the administrator has created a "static" tag with name "StaticTagName"
@@ -64,16 +70,19 @@ Feature: Editing the tags
       | AnotherTagName | static |
     And tag "StaticTagName" should not exist for the administrator
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Editing tag groups as admin should work
     Given the administrator has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
     When the administrator edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
     Then the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group3"
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Editing static tag groups as admin should work
     Given the administrator has created a "static" tag with name "StaticTagWithGroups" and groups "group1|group2"
     When the administrator edits the tag with name "StaticTagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
     Then the "static" tag with name "StaticTagWithGroups" should have the groups "group1|group3"
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Editing tag groups as regular user should fail
     Given the administrator has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
     When user "Alice" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API

--- a/tests/acceptance/features/apiTags/retreiveTags.feature
+++ b/tests/acceptance/features/apiTags/retreiveTags.feature
@@ -7,6 +7,7 @@ Feature: tags
       | Alice    |
       | Brian    |
 
+
   Scenario: Getting tags only works with access to the file
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToTag.txt"

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -23,6 +23,7 @@ Feature: Unassigning tags from file/folder
       | name        | type   |
       | MySecondTag | normal |
 
+
   Scenario: Unassigning a normal tag from a file unshared by someone else as regular user should fail
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -36,6 +37,7 @@ Feature: Unassigning tags from file/folder
       | MyFirstTag  | normal |
       | MySecondTag | normal |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as regular user should fail
     Given the administrator has created a "not user-visible" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -54,6 +56,7 @@ Feature: Unassigning tags from file/folder
       | MyFirstTag  | not user-visible |
       | MySecondTag | normal           |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Unassigning a static tag from a file and not part of static tags group shared by someone else as regular user should fail
     Given the administrator has created a "static" tag with name "StaticTag"
     And user "Alice" has created a "normal" tag with name "MySecondTag"
@@ -73,6 +76,7 @@ Feature: Unassigning tags from file/folder
       | StaticTag   | static |
       | MySecondTag | normal |
 
+
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as admin should work
     Given the administrator has created a "not user-visible" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -89,6 +93,7 @@ Feature: Unassigning tags from file/folder
     And file "/myFileToTag.txt" should have the following tags for the administrator
       | name        | type   |
       | MySecondTag | normal |
+
 
   Scenario: Unassigning a static tag from a file shared by someone else as admin should work
     Given the administrator has created a "static" tag with name "StaticTag"
@@ -107,6 +112,7 @@ Feature: Unassigning tags from file/folder
       | name        | type   |
       | MySecondTag | normal |
 
+
   Scenario: Unassigning a not user-visible tag from a file unshared by someone else should fail
     Given the administrator has created a "not user-visible" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -119,6 +125,7 @@ Feature: Unassigning tags from file/folder
     When the administrator removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "Alice" using the WebDAV API
     Then the HTTP status code should be "404"
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as regular user should fail
     Given the administrator has created a "not user-assignable" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -138,6 +145,7 @@ Feature: Unassigning tags from file/folder
       | MyFirstTag  | not user-assignable |
       | MySecondTag | normal              |
 
+
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as admin should work
     Given the administrator has created a "not user-assignable" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -154,6 +162,7 @@ Feature: Unassigning tags from file/folder
     And file "/myFileToTag.txt" should have the following tags for the administrator
       | name        | type   |
       | MySecondTag | normal |
+
 
   Scenario: Unassigning a not user-assignable tag from a file unshared by someone else should fail
     Given the administrator has created a "not user-assignable" tag with name "MyFirstTag"

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -20,6 +20,7 @@ Feature: Suggestion for matching tag names
     And the administrator has created a "not user-assignable" tag with name "sponsored"
     And user "Alice" has logged in using the webUI
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: User should get suggestion from already existing tags
     Given user "Alice" has created folder "a-folder"
     And user "Alice" has uploaded file with content "some content" to "/a-folder/randomfile.txt"
@@ -31,6 +32,7 @@ Feature: Suggestion for matching tag names
     But tag "notspam" should not be listed in the dropdown list on the webUI
     And tag "Violates T&C" should not be listed in the dropdown list on the webUI
     And tag "sponsored" should not be listed in the dropdown list on the webUI
+
 
   Scenario: User of static tags group should get suggestion for static tags
     Given user "Alice" has created folder "a-folder"


### PR DESCRIPTION
## Description
core was recently changed so that tag attributes can be set in the API with the strings "true" and "false". The acceptance test code was then modified to send "true" and "false" strings rather than "1" and "0". https://github.com/owncloud/core/pull/38721

Because of this, the `apiTags` tests that rely on combinations of tag attributes are now failing against `latest` oC10 (which is 10.7), for example https://drone.owncloud.com/owncloud/encryption/1895/126/16 and https://drone.owncloud.com/owncloud/user_ldap/3193/127/17

Skip the tests in that case.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
