### PR TITLE
Prevent files:checksum:verify from crashing on exception

### DIFF
--- a/apps/files/lib/Command/VerifyChecksums.php
+++ b/apps/files/lib/Command/VerifyChecksums.php
@@ -207,6 +207,7 @@ class VerifyChecksums extends Command {
 				$nodes = $currentFolder->getDirectoryListing();
 			} catch (NotFoundException $e) {
 				$nodes = [];
+				$output->writeln("Skipping $currentFolderPath => Directory could not be found");
 			} catch (StorageNotAvailableException $e) {
 				$nodes = [];
 				$output->writeln("Skipping $currentFolderPath => Storage is not available");

--- a/changelog/unreleased/38785
+++ b/changelog/unreleased/38785
@@ -1,0 +1,7 @@
+Bugfix: Prevent files:checksum:verify from crashing on exception
+
+The command now skips files with exceptions instead of crashing.
+A proper message will be displayed to the user who fires the command.
+
+https://github.com/owncloud/core/pull/38785
+https://github.com/owncloud/core/issues/38782


### PR DESCRIPTION
## Description
The command now skips files with exceptions instead of crashing. A proper message will be displayed to the user who fires the command.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/38782

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
