### PR TITLE
fix search highlights for REPORT request

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesSearchReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesSearchReportPlugin.php
@@ -34,6 +34,8 @@ class FilesSearchReportPlugin extends ServerPlugin {
 	// namespace
 	public const NS_OWNCLOUD = 'http://owncloud.org/ns';
 	public const REPORT_NAME = '{http://owncloud.org/ns}search-files';
+	public const REPORT_HIGHLIGHTS = '{http://owncloud.org/ns}search-highlights';
+	public const REPORT_SCORE = '{http://owncloud.org/ns}search-score';
 
 	/**
 	 * Reference to main server object
@@ -148,7 +150,7 @@ class FilesSearchReportPlugin extends ServerPlugin {
 	/**
 	 * @param string $filesUri the base uri for this user's files directory,
 	 * usually /files/username
-	 * @param File[] $searchResults the results coming from the search service,
+	 * @param FileResult[] $searchResults the results coming from the search service,
 	 * within the files app
 	 * @param array $requestedProps the list of requested webDAV properties
 	 * @param int $maxResults the maximum number of results the generator should generate based on the $searchResults
@@ -156,11 +158,11 @@ class FilesSearchReportPlugin extends ServerPlugin {
 	 * search result, suitable for server's multistatus response
 	 */
 	private function getSearchResultIterator($filesUri, $searchResults, $requestedProps, $maxResults) {
-		$paths = \array_map(function ($searchResult) use ($filesUri) {
-			return $filesUri . $searchResult->path;
-		}, $searchResults);
-
-		$nodes = $this->server->tree->getMultipleNodes($paths);
+		$paths = [];
+		foreach ($searchResults as $searchResult) {
+			$paths[$filesUri . $searchResult->path] = $searchResult;
+		}
+		$nodes = $this->server->tree->getMultipleNodes(\array_keys($paths));
 
 		$propFindType = $requestedProps ? PropFind::NORMAL : PropFind::ALLPROPS;
 
@@ -179,7 +181,13 @@ class FilesSearchReportPlugin extends ServerPlugin {
 				$propFindType
 			);
 			$this->server->getPropertiesByNode($propFind, $node);
-
+			// assuming we only have one entry in the highlights array
+			if (isset($paths[$path]->highlights[0])) {
+				$propFind->set(self::REPORT_HIGHLIGHTS, \str_replace(["\r\n", "\r", "\n"], '<br/>', $paths[$path]->highlights[0]));
+			}
+			if (isset($paths[$path]->score)) {
+				$propFind->set(self::REPORT_SCORE, $paths[$path]->score);
+			}
 			$result = $propFind->getResultForMultiStatus();
 			$result['href'] = $propFind->getPath();
 			yield $result;

--- a/apps/dav/lib/Connector/Sabre/FilesSearchReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesSearchReportPlugin.php
@@ -182,10 +182,10 @@ class FilesSearchReportPlugin extends ServerPlugin {
 			);
 			$this->server->getPropertiesByNode($propFind, $node);
 			// assuming we only have one entry in the highlights array
-			if (isset($paths[$path]->highlights[0])) {
+			if (isset($paths[$path]->highlights[0]) && \in_array(self::REPORT_HIGHLIGHTS, $requestedProps)) {
 				$propFind->set(self::REPORT_HIGHLIGHTS, \str_replace(["\r\n", "\r", "\n"], '<br/>', $paths[$path]->highlights[0]));
 			}
-			if (isset($paths[$path]->score)) {
+			if (isset($paths[$path]->score) && \in_array(self::REPORT_SCORE, $requestedProps)) {
 				$propFind->set(self::REPORT_SCORE, $paths[$path]->score);
 			}
 			$result = $propFind->getResultForMultiStatus();

--- a/changelog/unreleased/38787
+++ b/changelog/unreleased/38787
@@ -1,0 +1,5 @@
+Enhancement: Add more properties to the REPORT result
+
+File Search should be done in the future via WebDAV REPORT requests. ownCloud web is using it. In some cases with other search backends we have more properties to return. `<oc:search-highlights />` => returns am html formatted excerpt of the file content which is highlighting the matching words. `<oc:search-score />` returns a float number score value.
+
+https://github.com/owncloud/core/pull/38787


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description

File Search should be done in the future via WebDAV `REPORT` requests. 

ownCloud web is using it.

In combination with the Full Text Search app, we have more properties to return.

`<oc:search-highlights />` => returns am html formatted excerpt of the file content which is highlighting the matching words.

`<oc:search-score />` => returns a float number score value
## Usage

### Request
```
curl --location --request REPORT 'http://cloud.local/remote.php/dav/files/admin/' \
--header 'Authorization: Basic YWRtaW46YWRtaW4=' \
--header 'Content-Type: text/plain' \
--data-raw '<?xml version="1.0" encoding="UTF-8"?>
<oc:search-files
    xmlns:a="DAV:"
    xmlns:oc="http://owncloud.org/ns">
    <a:prop>
        <a:getcontentlength />
        <a:getcontenttype />
        <a:getetag />
        <a:getlastmodified />
        <a:lockdiscovery />
        <a:resourcetype />
        <oc:comments-unread />
        <oc:favorites />
        <oc:fileid />
        <oc:owner-display-name />
        <oc:permissions />
        <oc:share-types />
        <oc:size />
        <oc:tags />
        <oc:search-highlights />
        <oc:search-score />
    </a:prop>
    <oc:search>
        <oc:pattern>wel</oc:pattern>
    </oc:search>
</oc:search-files>'
```
### Response Body
```
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
    <d:response>
        <d:href>/remote.php/dav/files/admin/welcome.txt</d:href>
        <d:propstat>
            <d:prop>
                <d:getcontentlength>167</d:getcontentlength>
                <d:getcontenttype>text/plain</d:getcontenttype>
                <d:getetag>&quot;7e33c954889e86d9a710130a04608559&quot;</d:getetag>
                <d:getlastmodified>Tue, 18 May 2021 18:48:27 GMT</d:getlastmodified>
                <d:lockdiscovery/>
                <d:resourcetype/>
                <oc:comments-unread>0</oc:comments-unread>
                <oc:fileid>4</oc:fileid>
                <oc:owner-display-name>admin</oc:owner-display-name>
                <oc:permissions>RDNVW</oc:permissions>
                <oc:share-types/>
                <oc:size>167</oc:size>
                <oc:tags/>
                <oc:search-highlights>&lt;em&gt;Welcome&lt;/em&gt; to your ownCloud account!&lt;br/&gt;&lt;br/&gt;This is just an example file for developers and git users. &lt;br/&gt;The packaged</oc:search-highlights>
                <oc:search-score>3.4743</oc:search-score>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
        <d:propstat>
            <d:prop>
                <oc:favorites/>
            </d:prop>
            <d:status>HTTP/1.1 404 Not Found</d:status>
        </d:propstat>
    </d:response>
    <d:response>
        <d:href>/remote.php/dav/files/admin/New%20folder/New%20text%20file.txt</d:href>
        <d:propstat>
            <d:prop>
                <d:getcontentlength>13</d:getcontentlength>
                <d:getcontenttype>text/plain</d:getcontenttype>
                <d:getetag>&quot;7d0e539bb33ab2892a806940b2d4172d&quot;</d:getetag>
                <d:getlastmodified>Thu, 27 May 2021 11:14:11 GMT</d:getlastmodified>
                <d:lockdiscovery/>
                <d:resourcetype/>
                <oc:comments-unread>0</oc:comments-unread>
                <oc:fileid>116</oc:fileid>
                <oc:owner-display-name>admin</oc:owner-display-name>
                <oc:permissions>RDNVW</oc:permissions>
                <oc:share-types/>
                <oc:size>13</oc:size>
                <oc:tags/>
                <oc:search-highlights>&lt;em&gt;Welcome&lt;/em&gt;&lt;br/&gt;&lt;br/&gt;&lt;em&gt;well&lt;/em&gt;</oc:search-highlights>
                <oc:search-score>3.0715303</oc:search-score>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
        <d:propstat>
            <d:prop>
                <oc:favorites/>
            </d:prop>
            <d:status>HTTP/1.1 404 Not Found</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>
```
## Motivation and Context

Make Full Text Search Features available for ownCloud Web

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
