### PR TITLE
Include incoming and parent shares permissions for subfolder reshares in SharePanel

### DIFF
--- a/changelog/unreleased/38788
+++ b/changelog/unreleased/38788
@@ -1,0 +1,8 @@
+Bugfix: Include incoming and parent permissions in Share UI subfolder reshares
+
+Before this fix SharePanel in Share UI did not include permissions of both incoming and parent shares 
+for subfolder reshares. It caused lack of possibility of resharing such files/folder even 
+though server-side permissions allowed it.
+
+https://github.com/owncloud/core/pull/38788
+https://github.com/owncloud/enterprise/issues/4497

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -778,9 +778,17 @@
 				return {};
 			}
 
+			// check if this file has received shares to current user (direct incoming shared_with_me shares)
 			var permissions = this.get('possiblePermissions');
 			if(!_.isUndefined(data.reshare) && !_.isUndefined(data.reshare.permissions) && data.reshare.uid_owner !== OC.currentUser) {
-				permissions = permissions & data.reshare.permissions;
+				if (this.fileInfoModel.get('mountType') === 'shared' && this.fileInfoModel.isDirectory()) {
+					// if this file is already contained in a share (subfolder of shared folder) combine incoming shares permissions
+					// with parent folder share permissions. This handles a case of resharing a file/folder reshared from same 
+					// share mountpoint multiple times in subfolders
+					permissions = permissions & (this.fileInfoModel.get('sharePermissions') | data.reshare.permissions);
+				} else {
+					permissions = permissions & data.reshare.permissions;
+				}
 			}
 
 			/** @type {OC.Share.Types.ShareInfo[]} **/

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -482,3 +482,34 @@ Feature: Sharing files and folders with internal groups
       | uid_owner   | Brian           |
       | share_with  | grp3            |
       | permissions | 19              |
+
+  @skipOnOcV10.6 @skipOnOcV10.7
+  Scenario: Reshares with groups of subfolder with lower permissions
+    Given these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
+      | grp3      |
+    And user "Alice" has been added to group "grp1"
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has been added to group "grp2"
+    And user "Brian" has been added to group "grp2"
+    And user "Alice" has been added to group "grp3"
+    And user "Brian" has been added to group "grp3"
+    And user "Carol" has uploaded file with content "some data" to "/simple-folder/simple-inner-folder/simple-inner-inner-folder/textfile-2.txt"
+    And user "Carol" has shared folder "/simple-folder" with user "Alice" with permissions "all"
+    And user "Alice" has shared file "/simple-folder" with group "grp2" with permissions "all"
+    And user "Alice" has shared file "/simple-folder/simple-inner-folder" with group "grp1" with permissions "read"
+    And user "Alice" has logged in using the webUI
+    And the user opens folder "/simple-folder" using the webUI
+    When the user shares folder "simple-inner-folder" with group "grp3" using the webUI
+    Then the following permissions are seen for "simple-inner-folder" in the sharing dialog for group "grp3"
+      | edit   | yes |
+      | change | yes |
+      | share  | yes |
+    And the information for user "Brian" about the received share of folder "simple-inner-folder" shared with a group should include
+      | share_type  | group                |
+      | file_target | /simple-inner-folder |
+      | uid_owner   | Alice                |
+      | share_with  | grp3                 |
+      | permissions | 31                   |


### PR DESCRIPTION
This PR fixes issue with sharing subfolder when file is shared with high permissions (e.g. 31) to a group (grp1) , and then its subfolder is shared again to a group (grp2) however with lower permission (e.g. 1). The lack of building most permissive permissions for that subfolder prevents resharing of folder when it should be allowed.

issue: https://github.com/owncloud/enterprise/issues/4497#issuecomment-842488281 