### PR TITLE
[Tests-Only]earlyFail

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1377,6 +1377,7 @@ def acceptance(ctx):
 		'skipExceptParts': [],
 		'testAgainstCoreTarball': False,
 		'coreTarball': 'daily-master-qa',
+		'earlyFail': True,
 	}
 
 	if 'defaults' in config:
@@ -1571,7 +1572,7 @@ def acceptance(ctx):
 												'%smake %s' % (suExecCommand, makeParameter)
 											]
 										}),
-									],
+									] + buildGithubCommentForBuildStopped(name, params['earlyFail']) + githubComment(params['earlyFail']) + stopBuild(params['earlyFail']) ,
 									'services':
 										databaseService(db) +
 										browserService(browser) +
@@ -1759,6 +1760,129 @@ def notify():
 		result['trigger']['ref'].append('refs/heads/%s' % branch)
 
 	return result
+
+def stopBuild(earlyFail):
+    if (earlyFail):
+        return [{
+            "name": "stop-build",
+            "image": "drone/cli:alpine",
+            "pull": "always",
+            "environment": {
+                "DRONE_SERVER": "https://drone.owncloud.com",
+                "DRONE_TOKEN": {
+                    "from_secret": "drone_token",
+                },
+            },
+            "commands": [
+                "drone build stop owncloud/core ${DRONE_BUILD_NUMBER}",
+            ],
+            "when": {
+                "status": [
+                    "failure",
+                ],
+                "event": [
+                    "pull_request",
+                ],
+            },
+        }]
+
+    else:
+        return [{
+            "name": "stop-build",
+            "image": "drone/cli:alpine",
+            "pull": "always",
+           "commands": [
+                'echo "The build is not cancelled because earlyFail is set to False"',
+            ],
+            "when": {
+                "status": [
+                    "failure",
+                ],
+                "event": [
+                    "pull_request",
+                ],
+            },
+        }]
+
+def buildGithubCommentForBuildStopped(alternateSuiteName, earlyFail):
+    if (earlyFail):
+        return [{
+            "name": "build-github-comment-buildStop",
+            "image": "owncloud/ubuntu:16.04",
+            "pull": "always",
+            "commands": [
+                'echo "<details><summary>:boom: Acceptance tests <strong>%s</strong> failed. The build is cancelled...</summary>\\n\\n" >> /drone/src/comments.file' % alternateSuiteName,
+            ],
+            "when": {
+                 "status": [
+                     "failure",
+                 ],
+                "event": [
+                    "pull_request",
+                ],
+            },
+        }]
+
+    else:
+        return [{
+            "name": "build-github-comment-buildStop",
+            "image": "owncloud/ubuntu:16.04",
+            "pull": "always",
+            "commands": [
+                'echo "No comment is generated because the earlyFail is set to False"',
+            ],
+            "when": {
+                 "status": [
+                     "failure",
+                 ],
+                "event": [
+                    "pull_request",
+                ],
+            },
+        }]
+
+
+def githubComment(earlyFail):
+    if (earlyFail):
+        return [{
+            "name": "github-comment",
+            "image": "jmccann/drone-github-comment:1",
+            "pull": "if-not-exists",
+            "settings": {
+                "message_file": "/drone/src/comments.file",
+            },
+            "environment": {
+                "GITHUB_TOKEN": {
+                    "from_secret": "github_token",
+                },
+            },
+            "when": {
+                "status": [
+                    "failure",
+                ],
+                "event": [
+                    "pull_request",
+                ],
+            },
+        }]
+
+    else:
+        return [{
+            "name": "github-comment",
+            "image": "jmccann/drone-github-comment:1",
+            "pull": "if-not-exists",
+            "commands": [
+                'echo "No comment is generated because the earlyFail is set to False"',
+            ],
+            "when": {
+                "status": [
+                    "failure",
+                ],
+                "event": [
+                    "pull_request",
+                ],
+            },
+        }]
 
 def databaseService(db):
 	dbName = getDbName(db)

--- a/.drone.star
+++ b/.drone.star
@@ -1787,22 +1787,7 @@ def stopBuild(earlyFail):
         }]
 
     else:
-        return [{
-            "name": "stop-build",
-            "image": "drone/cli:alpine",
-            "pull": "always",
-           "commands": [
-                'echo "The build is not cancelled because earlyFail is set to False"',
-            ],
-            "when": {
-                "status": [
-                    "failure",
-                ],
-                "event": [
-                    "pull_request",
-                ],
-            },
-        }]
+        return []
 
 def buildGithubCommentForBuildStopped(alternateSuiteName, earlyFail):
     if (earlyFail):
@@ -1824,22 +1809,7 @@ def buildGithubCommentForBuildStopped(alternateSuiteName, earlyFail):
         }]
 
     else:
-        return [{
-            "name": "build-github-comment-buildStop",
-            "image": "owncloud/ubuntu:16.04",
-            "pull": "always",
-            "commands": [
-                'echo "No comment is generated because the earlyFail is set to False"',
-            ],
-            "when": {
-                 "status": [
-                     "failure",
-                 ],
-                "event": [
-                    "pull_request",
-                ],
-            },
-        }]
+        return []
 
 
 def githubComment(earlyFail):
@@ -1867,22 +1837,7 @@ def githubComment(earlyFail):
         }]
 
     else:
-        return [{
-            "name": "github-comment",
-            "image": "jmccann/drone-github-comment:1",
-            "pull": "if-not-exists",
-            "commands": [
-                'echo "No comment is generated because the earlyFail is set to False"',
-            ],
-            "when": {
-                "status": [
-                    "failure",
-                ],
-                "event": [
-                    "pull_request",
-                ],
-            },
-        }]
+        return []
 
 def databaseService(db):
 	dbName = getDbName(db)


### PR DESCRIPTION
## Description
This PR enables `fail-early` system for tests running in CI.
When ever a test suite fails, it stops the particular build so that the resources are not wasted.
The `drone.star` is adjusted such that when `earlyFail` feature is set to `True`, any test failure in the suite stops the build. If we do not want the failing tests to stop the build, we can adjust `"earlyFail": False`.

Whenever a test suite fails, a github comment is generated which helps us identify which test failure actually stopped the build.

## Related Issue
- https://github.com/owncloud/QA/issues/672

## Motivation and Context
The drone build seems to be run for all the suites even when a particular suite fails early. To reduce the amount of CI resources used we needed a fail-early system, so that when one pipeline fails the rest of the build is canceled.

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
