### PR TITLE
[tests-only] [full-ci] Add API test coverage for saving public share to oC

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2449,7 +2449,8 @@ def installServer(phpVersion, db, logLevel = '2', ssl = False, federatedServerNe
 			'php occ a:l',
 			'php occ config:system:set trusted_domains 1 --value=server',
 		] + ([
-			'php occ config:system:set trusted_domains 2 --value=federated'
+			'php occ config:system:set trusted_domains 2 --value=federated',
+			'php occ config:system:set csrf.disabled --value=true'
 		] if federatedServerNeeded else []) + [
 		] + ([
 			'php occ config:system:set trusted_domains 3 --value=proxy'

--- a/tests/acceptance/features/apiFederationToRoot1/savePublicShare.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/savePublicShare.feature
@@ -1,0 +1,127 @@
+@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+Feature: Save public shares created by oC users
+
+  Background:
+    Given using server "LOCAL"
+    And user "Alice" has been created with default attributes and without skeleton files
+
+
+  Scenario: Mount public share created from local server
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When user "Brian" adds the public share created from server "LOCAL" using the sharing API
+    Then the HTTP status code should be "200"
+    And as "Brian" folder "/PARENT" should exist
+    And as "Brian" file "/PARENT/lorem.txt" should exist
+
+
+  Scenario: Mount public share and then delete (local server share)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And user "Brian" has added the public share created from server "LOCAL" using the sharing API
+    When user "Brian" deletes folder "/PARENT" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Brian" folder "/PARENT" should not exist
+
+
+  Scenario: Mount public share and sharer unshares the share (local server share)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT    |
+      | permissions | read       |
+      | name        | sharedlink |
+    And user "Brian" has added the public share created from server "LOCAL" using the sharing API
+    When user "Alice" deletes public link share named "sharedlink" in file "/PARENT" using the sharing API
+    Then the HTTP status code should be "200"
+    And as "Brian" folder "/PARENT" should not exist
+
+
+  Scenario Outline: Mount public share and try to reshare (local server share)
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    And user "Brian" has added the public share created from server "LOCAL" using the sharing API
+    When user "Brian" creates a public link share using the sharing API with settings
+      | path | PARENT |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+
+  Scenario: Mount public share created from remote server
+    Given using server "REMOTE"
+    And user "RemoteAlice" has been created with default attributes and without skeleton files
+    And user "RemoteAlice" has created folder "/PARENT"
+    And user "RemoteAlice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/lorem.txt"
+    And user "RemoteAlice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    And using server "LOCAL"
+    When user "Alice" adds the public share created from server "REMOTE" using the sharing API
+    Then the HTTP status code should be "200"
+    And as "Alice" folder "/PARENT" should exist
+    And as "Alice" file "/PARENT/lorem.txt" should exist
+
+
+  Scenario: Mount public share and then delete (remote server share)
+    Given using server "REMOTE"
+    And user "RemoteAlice" has been created with default attributes and without skeleton files
+    And user "RemoteAlice" has created folder "/PARENT"
+    And user "RemoteAlice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And using server "LOCAL"
+    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    When user "Alice" deletes folder "/PARENT" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" folder "/PARENT" should not exist
+
+
+  Scenario: Mount public share and sharer unshares the share (remote server share)
+    Given using server "REMOTE"
+    And user "RemoteAlice" has been created with default attributes and without skeleton files
+    And user "RemoteAlice" has created folder "/PARENT"
+    And user "RemoteAlice" has created a public link share with settings
+      | path        | /PARENT    |
+      | permissions | read       |
+      | name        | sharedlink |
+    And using server "LOCAL"
+    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    And using server "REMOTE"
+    When user "RemoteAlice" deletes public link share named "sharedlink" in file "/PARENT" using the sharing API
+    And using server "LOCAL"
+    Then as "Alice" folder "/PARENT" should not exist
+
+
+  Scenario Outline: Mount public share and try to reshare (remote server share)
+    Given using OCS API version "<ocs_api_version>"
+    And using server "REMOTE"
+    And user "RemoteAlice" has been created with default attributes and without skeleton files
+    And user "RemoteAlice" has created folder "/PARENT"
+    And user "RemoteAlice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    And using server "LOCAL"
+    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | PARENT |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |

--- a/tests/acceptance/features/apiFederationToRoot1/savePublicShare.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/savePublicShare.feature
@@ -85,7 +85,7 @@ Feature: Save public shares created by oC users
       | path        | /PARENT |
       | permissions | read    |
     And using server "LOCAL"
-    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    And user "Alice" has added the public share created from server "REMOTE" using the sharing API
     When user "Alice" deletes folder "/PARENT" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/PARENT" should not exist
@@ -100,7 +100,7 @@ Feature: Save public shares created by oC users
       | permissions | read       |
       | name        | sharedlink |
     And using server "LOCAL"
-    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    And user "Alice" has added the public share created from server "REMOTE" using the sharing API
     And using server "REMOTE"
     When user "RemoteAlice" deletes public link share named "sharedlink" in file "/PARENT" using the sharing API
     And using server "LOCAL"
@@ -116,7 +116,7 @@ Feature: Save public shares created by oC users
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     And using server "LOCAL"
-    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    And user "Alice" has added the public share created from server "REMOTE" using the sharing API
     When user "Alice" creates a public link share using the sharing API with settings
       | path | PARENT |
     Then the OCS status code should be "404"

--- a/tests/acceptance/features/apiFederationToShares1/savePublicShare.feature
+++ b/tests/acceptance/features/apiFederationToShares1/savePublicShare.feature
@@ -1,0 +1,128 @@
+@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+Feature: Save public shares created by oC users
+
+  Background:
+    Given using server "LOCAL"
+    And the administrator has set the default folder for received shares to "Shares"
+    And user "Alice" has been created with default attributes and without skeleton files
+
+
+  Scenario: Mount public share created from local server
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/lorem.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    When user "Brian" adds the public share created from server "LOCAL" using the sharing API
+    Then the HTTP status code should be "200"
+    And as "Brian" folder "/Shares/PARENT" should exist
+    And as "Brian" file "/Shares/PARENT/lorem.txt" should exist
+
+
+  Scenario: Mount public share and then delete (local server share)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And user "Brian" has added the public share created from server "LOCAL" using the sharing API
+    When user "Brian" deletes folder "/Shares/PARENT" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Brian" folder "/Shares/PARENT" should not exist
+
+
+  Scenario: Mount public share and sharer unshares the share (local server share)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT    |
+      | permissions | read       |
+      | name        | sharedlink |
+    And user "Brian" has added the public share created from server "LOCAL" using the sharing API
+    When user "Alice" deletes public link share named "sharedlink" in file "/PARENT" using the sharing API
+    Then the HTTP status code should be "200"
+    And as "Brian" folder "/Shares/PARENT" should not exist
+
+
+  Scenario Outline: Mount public share and try to reshare (local server share)
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    And user "Brian" has added the public share created from server "LOCAL" using the sharing API
+    When user "Brian" creates a public link share using the sharing API with settings
+      | path | /Shares/PARENT |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
+
+
+  Scenario: Mount public share created from remote server
+    Given using server "REMOTE"
+    And user "RemoteAlice" has been created with default attributes and without skeleton files
+    And user "RemoteAlice" has created folder "/PARENT"
+    And user "RemoteAlice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/lorem.txt"
+    And user "RemoteAlice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    And using server "LOCAL"
+    When user "Alice" adds the public share created from server "REMOTE" using the sharing API
+    Then the HTTP status code should be "200"
+    And as "Alice" folder "/Shares/PARENT" should exist
+    And as "Alice" file "/Shares/PARENT/lorem.txt" should exist
+
+
+  Scenario: Mount public share and then delete (remote server share)
+    Given using server "REMOTE"
+    And user "RemoteAlice" has been created with default attributes and without skeleton files
+    And user "RemoteAlice" has created folder "/PARENT"
+    And user "RemoteAlice" has created a public link share with settings
+      | path        | /PARENT |
+      | permissions | read    |
+    And using server "LOCAL"
+    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    When user "Alice" deletes folder "/Shares/PARENT" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" folder "/Shares/PARENT" should not exist
+
+
+  Scenario: Mount public share and sharer unshares the share (remote server share)
+    Given using server "REMOTE"
+    And user "RemoteAlice" has been created with default attributes and without skeleton files
+    And user "RemoteAlice" has created folder "/PARENT"
+    And user "RemoteAlice" has created a public link share with settings
+      | path        | /PARENT    |
+      | permissions | read       |
+      | name        | sharedlink |
+    And using server "LOCAL"
+    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    And using server "REMOTE"
+    When user "RemoteAlice" deletes public link share named "sharedlink" in file "/PARENT" using the sharing API
+    And using server "LOCAL"
+    Then as "Alice" folder "/Shares/PARENT" should not exist
+
+
+  Scenario Outline: Mount public share and try to reshare (remote server share)
+    Given using OCS API version "<ocs_api_version>"
+    And using server "REMOTE"
+    And user "RemoteAlice" has been created with default attributes and without skeleton files
+    And user "RemoteAlice" has created folder "/PARENT"
+    And user "RemoteAlice" has created a public link share with settings
+      | path        | /PARENT                   |
+      | permissions | read,update,create,delete |
+    And using server "LOCAL"
+    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | /Shares/PARENT |
+    Then the OCS status code should be "404"
+    And the HTTP status code should be "<http_status_code>"
+    Examples:
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |

--- a/tests/acceptance/features/apiFederationToShares1/savePublicShare.feature
+++ b/tests/acceptance/features/apiFederationToShares1/savePublicShare.feature
@@ -86,7 +86,7 @@ Feature: Save public shares created by oC users
       | path        | /PARENT |
       | permissions | read    |
     And using server "LOCAL"
-    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    And user "Alice" has added the public share created from server "REMOTE" using the sharing API
     When user "Alice" deletes folder "/Shares/PARENT" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" folder "/Shares/PARENT" should not exist
@@ -101,7 +101,7 @@ Feature: Save public shares created by oC users
       | permissions | read       |
       | name        | sharedlink |
     And using server "LOCAL"
-    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    And user "Alice" has added the public share created from server "REMOTE" using the sharing API
     And using server "REMOTE"
     When user "RemoteAlice" deletes public link share named "sharedlink" in file "/PARENT" using the sharing API
     And using server "LOCAL"
@@ -117,7 +117,7 @@ Feature: Save public shares created by oC users
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
     And using server "LOCAL"
-    And user "Alice" has added the public share created from server "LOCAL" using the sharing API
+    And user "Alice" has added the public share created from server "REMOTE" using the sharing API
     When user "Alice" creates a public link share using the sharing API with settings
       | path | /Shares/PARENT |
     Then the OCS status code should be "404"

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -3255,6 +3255,15 @@ trait Sharing {
 	 */
 	public function userHasAddedPublicShareCreatedByUser($user, $shareServer) {
 		$this->saveLastSharedPublicLinkShare($user, $shareServer);
+
+		$resBody = json_decode($this->response->getBody()->getContents());
+		$status = '';
+		$message = '';
+		if ($resBody) {
+			$status = $resBody->status;
+			$message = $resBody->data->message;
+		}
+
 		Assert::assertEquals(
 			200,
 			$this->response->getStatusCode(),
@@ -3262,6 +3271,12 @@ trait Sharing {
 			. " Expected status code is '200' but got '"
 			. $this->response->getStatusCode()
 			. "'"
+		);
+		Assert::assertNotEquals(
+			'error',
+			$status,
+			__METHOD__
+			. "\nFailed to save public share.\n'$message'"
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -3200,6 +3200,84 @@ trait Sharing {
 	}
 
 	/**
+	 * @param string $user
+	 * @param string $shareServer
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function saveLastSharedPublicLinkShare(
+		$user,
+		$shareServer,
+		$password = ""
+	) {
+		$user = $this->getActualUsername($user);
+		$userPassword = $this->getPasswordForUser($user);
+
+		$shareData = $this->getLastShareData();
+		$owner = (string) $shareData->data->uid_owner;
+		$name = $this->encodePath((string) $shareData->data->file_target);
+		$name = \trim($name, "/");
+		$ownerDisplayName = (string) $shareData->data->displayname_owner;
+		$token = (string) $shareData->data->token;
+
+		if (\strtolower($shareServer) == "remote") {
+			$remote = $this->getRemoteBaseUrl();
+		} else {
+			$remote = $this->getLocalBaseUrl();
+		}
+
+		$body['remote'] = $remote;
+		$body['token'] = $token;
+		$body['owner'] = $owner;
+		$body['ownerDisplayName'] = $ownerDisplayName;
+		$body['name'] = $name;
+		$body['password'] = $password;
+
+		Assert::assertNotNull(
+			$token,
+			__METHOD__ . " could not find any public share"
+		);
+
+		$url = $this->getBaseUrl() . "/index.php/apps/files_sharing/external";
+
+		$response = HttpRequestHelper::post($url, $user, $userPassword, null, $body);
+		$this->setResponse($response);
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has added the public share created from server "([^"]*)" using the sharing API$/
+	 *
+	 * @param string $user
+	 * @param string $shareServer
+	 *
+	 * @return void
+	 */
+	public function userHasAddedPublicShareCreatedByUser($user, $shareServer) {
+		$this->saveLastSharedPublicLinkShare($user, $shareServer);
+		Assert::assertEquals(
+			200,
+			$this->response->getStatusCode(),
+			__METHOD__
+			. " Expected status code is '200' but got '"
+			. $this->response->getStatusCode()
+			. "'"
+		);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" adds the public share created from server "([^"]*)" using the sharing API$/
+	 *
+	 * @param string $user
+	 * @param string $shareServer
+	 *
+	 * @return void
+	 */
+	public function userAddsPublicShareCreatedByUser($user, $shareServer) {
+		$this->saveLastSharedPublicLinkShare($user, $shareServer);
+	}
+
+	/**
 	 * replace values from table
 	 *
 	 * @param string $field


### PR DESCRIPTION
## Description
This PR adds API tests for saving public share to oC accounts (local and remote instances)

## Related Issue
- Part of #38752

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
