### PR TITLE
[tests-only] skip new trashbinSkip tests on old oC10

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @notToImplementOnOCIS
+@api @files_trashbin-app-required @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7
 Feature: files and folders can be deleted completely skipping the trashbin
   As an admin
   I want to configure some files to be deleted without the trashbin


### PR DESCRIPTION
## Description
The `trashbinSkip` cover a new feature for 10.8. They were added in PR #38747 
Skip them on older oC10 releases.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
