### PR TITLE
Optional skip expiration validation for update share

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -420,12 +420,13 @@ class Manager implements IManager {
 	 * Validate if the expiration date fits the system settings
 	 *
 	 * @param \OCP\Share\IShare $share The share to validate the expiration date of
+	 * @param Boolean $skip if true, lets expiration to be a past date
 	 * @return \OCP\Share\IShare The modified share object
 	 * @throws GenericShareException
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
 	 */
-	protected function validateExpirationDate(\OCP\Share\IShare $share) {
+	protected function validateExpirationDate(\OCP\Share\IShare $share, $skip = false) {
 		$expirationDate = $share->getExpirationDate();
 
 		if ($expirationDate !== null) {
@@ -436,7 +437,7 @@ class Manager implements IManager {
 			$date = new \DateTime('now', new DateTimeZone($expirationDate->getTimezone()->getName()));
 			$date->setTime(0, 0, 0, 0);
 
-			if ($date > $expirationDate) {
+			if ($date > $expirationDate && !$skip) {
 				$message = $this->l->t('Expiration date is in the past');
 				throw new GenericShareException($message, $message, 404);
 			}
@@ -954,11 +955,12 @@ class Manager implements IManager {
 	 * Update a share
 	 *
 	 * @param \OCP\Share\IShare $share
+	 * @param Boolean $skipExpirationValidation defaults to false
 	 * @return \OCP\Share\IShare The share object
 	 * @throws \InvalidArgumentException
 	 * @throws GenericShareException
 	 */
-	public function updateShare(\OCP\Share\IShare $share) {
+	public function updateShare(\OCP\Share\IShare $share, $skipExpirationValidation = false) {
 		$expirationDateUpdated = false;
 
 		$this->canShare($share);
@@ -990,7 +992,7 @@ class Manager implements IManager {
 
 		if ($share->getExpirationDate() != $originalShare->getExpirationDate()) {
 			//Verify the expiration date
-			$this->validateExpirationDate($share);
+			$this->validateExpirationDate($share, $skipExpirationValidation);
 			$expirationDateUpdated = true;
 		}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -420,13 +420,13 @@ class Manager implements IManager {
 	 * Validate if the expiration date fits the system settings
 	 *
 	 * @param \OCP\Share\IShare $share The share to validate the expiration date of
-	 * @param Boolean $skip if true, lets expiration to be a past date
+	 * @param Boolean $skipPastDateValidation if true, lets expiration to be a past date
 	 * @return \OCP\Share\IShare The modified share object
 	 * @throws GenericShareException
 	 * @throws \InvalidArgumentException
 	 * @throws \Exception
 	 */
-	protected function validateExpirationDate(\OCP\Share\IShare $share, $skip = false) {
+	protected function validateExpirationDate(\OCP\Share\IShare $share, $skipPastDateValidation = false) {
 		$expirationDate = $share->getExpirationDate();
 
 		if ($expirationDate !== null) {
@@ -437,7 +437,7 @@ class Manager implements IManager {
 			$date = new \DateTime('now', new DateTimeZone($expirationDate->getTimezone()->getName()));
 			$date->setTime(0, 0, 0, 0);
 
-			if ($date > $expirationDate && !$skip) {
+			if ($date > $expirationDate && !$skipPastDateValidation) {
 				$message = $this->l->t('Expiration date is in the past');
 				throw new GenericShareException($message, $message, 404);
 			}

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -53,12 +53,13 @@ interface IManager {
 	 * The share can't be removed this way (permission 0): use deleteShare
 	 *
 	 * @param IShare $share
+	 * @param Boolean $skipExpirationCheck
 	 * @return IShare The share object
 	 * @throws \InvalidArgumentException If $share is a link share or the $recipient does not match
 	 * @throws GenericShareException If $share requirements do not match
 	 * @since 9.0.0
 	 */
-	public function updateShare(IShare $share);
+	public function updateShare(IShare $share, $skipExpirationCheck = false);
 
 	/**
 	 * Delete a share
@@ -105,7 +106,7 @@ interface IManager {
 	 * @since 10.0.0
 	 */
 	public function getAllSharesBy($userId, $shareTypes, $nodeIDs, $reshares = false);
-	
+
 	/**
 	 * Get shares shared by (initiated) by the provided user.
 	 *
@@ -154,7 +155,7 @@ interface IManager {
 	 * @since 10.0.0
 	 */
 	public function getAllSharedWith($userId, $shareTypes, $node = null);
-	
+
 	/**
 	 * Get shares shared with $user.
 	 * Filter by $node if provided

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -53,13 +53,13 @@ interface IManager {
 	 * The share can't be removed this way (permission 0): use deleteShare
 	 *
 	 * @param IShare $share
-	 * @param Boolean $skipExpirationCheck
+	 * @param Boolean $skipExpirationValidation
 	 * @return IShare The share object
 	 * @throws \InvalidArgumentException If $share is a link share or the $recipient does not match
 	 * @throws GenericShareException If $share requirements do not match
 	 * @since 9.0.0
 	 */
-	public function updateShare(IShare $share, $skipExpirationCheck = false);
+	public function updateShare(IShare $share, $skipExpirationValidation = false);
 
 	/**
 	 * Delete a share

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1010,11 +1010,11 @@ trait Sharing {
 		if ($data === null) {
 			$data = $this->getResponseXml(null, __METHOD__)->data[0];
 		}
-
 		Assert::assertIsObject($data, __METHOD__ . " data not found in response XML");
 
+		$dateFieldsArrayToConvert = ['expiration', 'original_date', 'new_date'];
 		//do not try to convert empty date
-		if ((string) $field === 'expiration' && !empty($contentExpected)) {
+		if ((string) \in_array($field, \array_merge($dateFieldsArrayToConvert)) && !empty($contentExpected)) {
 			$timestamp = \strtotime($contentExpected, $this->getServerShareTimeFromLastResponse());
 			// strtotime returns false if it failed to parse, just leave it as it is in that condition
 			if ($timestamp !== false) {


### PR DESCRIPTION
## Description:
- to expire a share explicitly, `expiration` field of a share should not be validated to be a future date
- optional skip feature to bypass expiration field validation

## Motivation
- https://github.com/owncloud/core/issues/36550