### PR TITLE
[tests-only] skip on old oC10 tests that were fixed in PR 38794

### DIFF
--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
@@ -74,7 +74,7 @@ Feature: sharing
     And as "Alice" file "/folderToShare/renamedFile" should exist
     But as "Alice" file "/folderToShare/fileInside" should not exist
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: receiver tries to rename a received share with share, read permissions
     Given user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -121,7 +121,7 @@ Feature: rename folders
     When the user renames folder "a-folder" to "a.part" using the webUI
     Then near folder "a-folder" a tooltip with the text '"a.part" has a forbidden file type/extension.' should be displayed on the webUI
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: Rename a folder which is received as a share (without change permission)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "RandomFolder"


### PR DESCRIPTION
## Description
PR #38794 fixed the ability to rename a received read-only share. The related tests will not pass on older oC10 releases, so skip in that case.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
