### PR TITLE
New cache state

### DIFF
--- a/changelog/unreleased/38804
+++ b/changelog/unreleased/38804
@@ -1,0 +1,15 @@
+Enhancement: Introduce new state to prevent scanning of shallow scanned folders
+
+Folders can be partially scanned, this means that a folder could have its closest
+contents scanned (the first level), but not deeper contents. Folder "/A" could be
+scanned but not "/A/B/C".
+
+Previously, we couldn't detect that a folder had been partially scanned, so we
+triggered another scan on that folder even though we already had data in the DB.
+
+Now, we can detect that the folder has been partially scanned to avoid another
+scan if it isn't needed. This leads to notable performance improvements in cases
+where a FS hasn't been scanned fully. Note that an initial scan is still required,
+and the performance will remain the same in this case.
+
+https://github.com/owncloud/core/pull/38804

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -858,9 +858,11 @@ class Cache implements ICache {
 			if ($row = $result->fetch()) {
 				$result->closeCursor();
 				list($sum, $min) = \array_values($row);
-				if ($min === null) {
+				if ($min === null && $entry['size'] < 0) {
 					// could happen if the folder hasn't been scanned.
 					// we don't have any data, so return the SIZE_NEEDS_SCAN
+					// if the size of the entry is positive it means that the entry has been scanned,
+					// so the folder is empty (no need to be scanned)
 					return IScanner::SIZE_NEEDS_SCAN;
 				}
 				$sum = 0 + $sum;

--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -87,6 +87,7 @@ class Propagator implements IPropagator {
 
 		if ($sizeDifference !== 0) {
 			// if we need to update size, only update the records with calculated size (>-1)
+			// special cases (IScanner::SIZE_*) have negative values, so they won't interfere
 			$builder->set('size', $builder->createFunction(
 				'CASE' .
 					' WHEN ' . $builder->expr()->gt('size', $builder->expr()->literal(-1, IQueryBuilder::PARAM_INT)) .
@@ -168,6 +169,7 @@ class Propagator implements IPropagator {
 			->set('size', $sizeQuery->createFunction('`size` + ' . $sizeQuery->createParameter('size')))
 			->where($query->expr()->eq('storage', $query->expr()->literal($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('path_hash', $query->createParameter('hash')))
+			// special cases (IScanner::SIZE_*) have negative values, so they won't interfere
 			->andWhere($sizeQuery->expr()->gt('size', $sizeQuery->expr()->literal(-1, IQueryBuilder::PARAM_INT)));
 
 		foreach ($this->batch as $item) {

--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -506,14 +506,10 @@ class Scanner extends BasicEmitter implements IScanner {
 				$this->scan('', self::SCAN_RECURSIVE, self::REUSE_ETAG);
 			}, '');
 		} else {
-			$lastPath = null;
-			while (($path = $this->cache->getIncomplete()) !== false && $path !== $lastPath) {
+			while (($path = $this->cache->getIncomplete()) !== false) {
 				$this->runBackgroundScanJob(function () use ($path) {
 					$this->scan($path, self::SCAN_RECURSIVE_INCOMPLETE, self::REUSE_ETAG | self::REUSE_SIZE);
 				}, $path);
-				// FIXME: this won't proceed with the next item, needs revamping of getIncomplete()
-				// to make this possible
-				$lastPath = $path;
 			}
 		}
 	}

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -187,7 +187,7 @@ class CacheJail extends CacheWrapper {
 	/**
 	 * @param string $file
 	 *
-	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
+	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW, Cache::COMPLETE or Cache::NOT_SCANNED
 	 */
 	public function getStatus($file) {
 		return $this->cache->getStatus($this->getSourcePath($file));

--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -198,7 +198,7 @@ class CacheWrapper extends Cache {
 	/**
 	 * @param string $file
 	 *
-	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
+	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW, Cache::COMPLETE or Cache::NOT_SCANNED
 	 */
 	public function getStatus($file) {
 		return $this->cache->getStatus($file);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -53,6 +53,7 @@ use OC\User\RemoteUser;
 use OCP\Constants;
 use OCP\Events\EventEmitterTrait;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Cache\IScanner;
 use OCP\Files\FileNameTooLongException;
 use OCP\Files\InvalidCharacterInPathException;
 use OCP\Files\InvalidPathException;
@@ -1399,7 +1400,7 @@ class View {
 
 		try {
 			// if the file is not in the cache or needs to be updated, trigger the scanner and reload the data
-			if (!$data || (isset($data['size']) && ($data['size'] === -1))) {
+			if (!$data || (isset($data['size']) && ($data['size'] === IScanner::SIZE_NEEDS_SCAN))) {
 				$this->lockFile($relativePath, ILockingProvider::LOCK_SHARED);
 				if (!$storage->file_exists($internalPath)) {
 					$this->unlockFile($relativePath, ILockingProvider::LOCK_SHARED);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1416,6 +1416,8 @@ class View {
 				$storage->getPropagator()->propagateChange($internalPath, \time());
 				$data = $cache->get($internalPath);
 				$this->unlockFile($relativePath, ILockingProvider::LOCK_SHARED);
+			} elseif ($data['size'] === IScanner::SIZE_SHALLOW_SCANNED) {
+				$cache->correctFolderSize($internalPath, $data);
 			}
 		} catch (LockedException $e) {
 			// if the file is locked we just use the old cache info

--- a/lib/public/Files/Cache/ICache.php
+++ b/lib/public/Files/Cache/ICache.php
@@ -38,6 +38,14 @@ interface ICache {
 	public const PARTIAL = 1; //only partial data available, file not cached in the database
 	public const SHALLOW = 2; //folder in cache, but not all child files are completely scanned
 	public const COMPLETE = 3;
+	/**
+	 * folder in cache, but contents not scanned yet. This is different than SHALLOW
+	 * because SHALLOW implies a partial scan.
+	 * If there are "/A/D1" (folder) and "/A/F1" (file), "/A" should be with SHALLOW status
+	 * (we have data for D1 and F1), but "/A/D1" should be with NOT_SCANNED status because
+	 * we don't know what is inside.
+	 */
+	public const NOT_SCANNED = 4;
 
 	/**
 	 * Get the numeric storage id for this cache's storage

--- a/lib/public/Files/Cache/IScanner.php
+++ b/lib/public/Files/Cache/IScanner.php
@@ -36,8 +36,8 @@ interface IScanner {
 	public const REUSE_SIZE = 2;
 	public const REUSE_ONLY_FOR_FILES = 4;  // apply the etag reuse only to files, not folders
 
-	const SIZE_NEEDS_SCAN = -1;
-	const SIZE_SHALLOW_SCANNED = -2;  // current folder might be scanned but deeper folders not
+	public const SIZE_NEEDS_SCAN = -1;
+	public const SIZE_SHALLOW_SCANNED = -2;  // current folder might be scanned but deeper folders not
 
 	/**
 	 * scan a single file and store it in the cache

--- a/lib/public/Files/Cache/IScanner.php
+++ b/lib/public/Files/Cache/IScanner.php
@@ -36,6 +36,9 @@ interface IScanner {
 	public const REUSE_SIZE = 2;
 	public const REUSE_ONLY_FOR_FILES = 4;  // apply the etag reuse only to files, not folders
 
+	const SIZE_NEEDS_SCAN = -1;
+	const SIZE_SHALLOW_SCANNED = -2;  // current folder might be scanned but deeper folders not
+
 	/**
 	 * scan a single file and store it in the cache
 	 *

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -264,6 +264,8 @@ class CacheTest extends TestCase {
 		$this->cache->put('foo', ['size' => -1]);
 		$this->assertEquals(Cache::PARTIAL, $this->cache->getStatus('foo'));
 		$this->cache->put('foo', ['size' => -1, 'mtime' => 20, 'mimetype' => 'foo/file']);
+		$this->assertEquals(Cache::NOT_SCANNED, $this->cache->getStatus('foo'));
+		$this->cache->put('foo', ['size' => -2, 'mtime' => 20, 'mimetype' => 'foo/file']);
 		$this->assertEquals(Cache::SHALLOW, $this->cache->getStatus('foo'));
 		$this->cache->put('foo', ['size' => 10]);
 		$this->assertEquals(Cache::COMPLETE, $this->cache->getStatus('foo'));

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -135,7 +135,8 @@ class CacheTest extends TestCase {
 		$fileData['unkownSize'] = ['size' => -1, 'mtime' => 25, 'mimetype' => 'foo/file'];
 		$this->cache->put($file4, $fileData['unkownSize']);
 
-		$this->assertEquals(-1, $this->cache->calculateFolderSize($folder));
+		// -2 = IScanner::SIZE_SHALLOW_SCANNED
+		$this->assertEquals(-2, $this->cache->calculateFolderSize($folder));
 
 		$fileData['unkownSize'] = ['size' => 5, 'mtime' => 25, 'mimetype' => 'foo/file'];
 		$this->cache->put($file4, $fileData['unkownSize']);
@@ -208,7 +209,8 @@ class CacheTest extends TestCase {
 		$fileData['unkownSize'] = ['size' => -1, 'mtime' => 25, 'mimetype' => 'foo/file'];
 		$this->cache->put($file4, $fileData['unkownSize']);
 
-		$this->assertEquals(-1, $this->cache->calculateFolderSize($file1));
+		// -2 = IScanner::SIZE_SHALLOW_SCANNED
+		$this->assertEquals(-2, $this->cache->calculateFolderSize($file1));
 
 		$fileData['unkownSize'] = ['size' => 5, 'mtime' => 25, 'mimetype' => 'foo/file'];
 		$this->cache->put($file4, $fileData['unkownSize']);
@@ -244,7 +246,8 @@ class CacheTest extends TestCase {
 		$this->assertTrue($this->cache->inCache($dir2));
 
 		// check that root size ignored the unknown sizes
-		$this->assertEquals(-1, $this->cache->calculateFolderSize(''));
+		// -2 = IScanner::SIZE_SHALLOW_SCANNED
+		$this->assertEquals(-2, $this->cache->calculateFolderSize(''));
 
 		// clean up
 		$this->cache->remove('');

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -118,7 +118,9 @@ class ScannerTest extends \Test\TestCase {
 		$cachedDataFolder = $this->cache->get('');
 		$cachedDataFolder2 = $this->cache->get('folder');
 
-		$this->assertEquals(-1, $cachedDataFolder['size']);
+		// -2 = IScanner::SIZE_SHALLOW_SCANNED
+		// -1 = IScanner::SIZE_NEEDS_SCAN
+		$this->assertEquals(-2, $cachedDataFolder['size']);
 		$this->assertEquals(-1, $cachedDataFolder2['size']);
 
 		$this->scanner->scan('folder', \OC\Files\Cache\Scanner::SCAN_SHALLOW);
@@ -142,7 +144,8 @@ class ScannerTest extends \Test\TestCase {
 		$this->assertFalse($this->cache->inCache('folder/bar.txt'));
 		$this->assertFalse($this->cache->inCache('folder/2bar.txt'));
 		$cachedData = $this->cache->get('');
-		$this->assertEquals(-1, $cachedData['size']);
+		// -2 = IScanner::SIZE_SHALLOW_SCANNED
+		$this->assertEquals(-2, $cachedData['size']);
 
 		$this->scanner->backgroundScan();
 
@@ -150,7 +153,10 @@ class ScannerTest extends \Test\TestCase {
 		$this->assertTrue($this->cache->inCache('folder/bar.txt'));
 
 		$cachedData = $this->cache->get('');
-		$this->assertnotEquals(-1, $cachedData['size']);
+		// -2 = IScanner::SIZE_SHALLOW_SCANNED
+		// -1 = IScanner::SIZE_NEEDS_SCAN
+		$this->assertNotEquals(-1, $cachedData['size']);
+		$this->assertNotEquals(-2, $cachedData['size']);
 
 		$this->assertFalse($this->cache->getIncomplete());
 	}
@@ -167,7 +173,8 @@ class ScannerTest extends \Test\TestCase {
 		$this->cache->put('folder2', ['size' => 1]); // mark as complete
 
 		$cachedData = $this->cache->get('');
-		$this->assertEquals(-1, $cachedData['size']);
+		// -2 = IScanner::SIZE_SHALLOW_SCANNED
+		$this->assertEquals(-2, $cachedData['size']);
 
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE_INCOMPLETE, \OC\Files\Cache\Scanner::REUSE_ETAG | \OC\Files\Cache\Scanner::REUSE_SIZE);
 
@@ -177,6 +184,7 @@ class ScannerTest extends \Test\TestCase {
 
 		$cachedData = $this->cache->get('');
 		$this->assertNotEquals(-1, $cachedData['size']);
+		$this->assertNotEquals(-2, $cachedData['size']);
 
 		$this->assertFalse($this->cache->getIncomplete());
 	}
@@ -199,11 +207,12 @@ class ScannerTest extends \Test\TestCase {
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_SHALLOW, \OC\Files\Cache\Scanner::REUSE_ETAG);
 		$newData = $this->cache->get('');
 		$this->assertSame($oldData['etag'], $newData['etag']);
-		$this->assertEquals(-1, $newData['size']);
+		$this->assertEquals(-2, $newData['size']);
 
 		$this->scanner->scan('', \OC\Files\Cache\Scanner::SCAN_RECURSIVE);
 		$oldData = $this->cache->get('');
 		$this->assertNotEquals(-1, $oldData['size']);
+		$this->assertNotEquals(-2, $oldData['size']);
 		$this->scanner->scanFile('', \OC\Files\Cache\Scanner::REUSE_ETAG + \OC\Files\Cache\Scanner::REUSE_SIZE);
 		$newData = $this->cache->get('');
 		$this->assertSame($oldData['etag'], $newData['etag']);

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -347,7 +347,8 @@ class ViewTest extends TestCase {
 
 		$cachedData = $rootView->getFileInfo('/');
 		$this->assertEquals('httpd/unix-directory', $cachedData['mimetype']);
-		$this->assertEquals(-1, $cachedData['size']);
+		// -2 = IScanner::SIZE_SHALLOW_SCANNED
+		$this->assertEquals(-2, $cachedData['size']);
 
 		$folderData = $rootView->getDirectoryContent('/substorage/folder');
 		$this->assertEquals('text/plain', $folderData[0]['mimetype']);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Add a new state in the cache to know the folders that have been shallow scanned to avoid re-scanning them

## Related Issue
https://github.com/owncloud/enterprise/issues/4594

## Motivation and Context
A partial scan implies that a folder might have been scanned on its first level but not deeper. Except for the size, the rest of the information can be reused and there is no need to scan the folder again (if there is no change detected).
This PR improves this scenario and prevents hitting the backend storage if there is no change

## How Has This Been Tested?
Checked with an slow external storage
1. Create folders "/ext/A/B/C/D" in the backend
2. Ensure "/ext/A" contains plenty of files and folders
3. Enter in "/ext/A". A scan of the backend should happen
4. Reload the page

Page will load faster because we won't hit the external storage.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
