### PR TITLE
Do not show change permission as duplicate for can edit in case of files

### DIFF
--- a/core/js/sharedialogshareelistview.js
+++ b/core/js/sharedialogshareelistview.js
@@ -82,9 +82,9 @@
 		'			</span>' +
 		'			{{/if}}' +
 		'			{{#if updatePermissionPossible}}' +
-		'			<span class="shareOption">' +
-		'				<input id="canUpdate-{{cid}}-{{shareWith}}-{{shareType}}" type="checkbox" name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
-		'				<label for="canUpdate-{{cid}}-{{shareWith}}-{{shareType}}">{{updatePermissionLabel}}</label>' +
+		'			<span class="shareOption" >' +
+		'				<input id="canUpdate-{{cid}}-{{shareWith}}-{{shareType}}" {{#if isFolder}}type="checkbox"{{else}}type="hidden"{{/if}} name="update" class="permissions checkbox" {{#if hasUpdatePermission}}checked="checked"{{/if}} data-permissions="{{updatePermission}}"/>' +
+		'				{{#if isFolder}}<label for="canUpdate-{{cid}}-{{shareWith}}-{{shareType}}">{{updatePermissionLabel}}</label>{{/if}}' +
 		'			</span>' +
 		'			{{/if}}' +
 		'			{{#if deletePermissionPossible}}' +
@@ -256,6 +256,7 @@
 				crudsLabel: t('core', 'access control'),
 				triangleSImage: OC.imagePath('core', 'actions/triangle-s'),
 				isResharingAllowed: this.configModel.get('isResharingAllowed'),
+				isFolder: this.model.isFolder(),
 				sharePermissionPossible: this.model.sharePermissionPossible(),
 				editPermissionPossible: this.model.editPermissionPossible(),
 				createPermissionPossible: this.model.createPermissionPossible(),


### PR DESCRIPTION
fixes https://github.com/owncloud/enterprise/issues/4587

Background:

The can edit checkbox is in fact role. For files it is filesEditor, for folder it is folderEditor. The delete, create, change are like permissions belonging to corresponding roles.

For filesEditor allowed values are change.
For folderEditor allowed are delete, create, change.

- [ ] instead of checking file/folder do it more generic and check if current permission checkbox is the only one available out of all coming from "can edit" role.