### PR TITLE
Fix config.sample and preview provider

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -952,9 +952,9 @@ $CONFIG = [
 
 /**
  * Define preview providers
- * Only register providers that have been explicitly enabled
+ * Show thumbnails for register providers that have been explicitly enabled.
  *
- * The following providers are enabled by default:
+ * The following providers are enabled by default if no other providers are selected:
  *
  *  - OC\Preview\PNG
  *  - OC\Preview\JPEG
@@ -965,33 +965,65 @@ $CONFIG = [
  *  - OC\Preview\MP3
  *  - OC\Preview\TXT
  *
- * The following providers are disabled by default due to performance or privacy
- * concerns:
+ * The following providers are available, but disabled by default due to performance or privacy concerns:
  *
  *  - OC\Preview\Illustrator
  *  - OC\Preview\Movie
+ *  - OC\Preview\MSOfficeDoc
  *  - OC\Preview\MSOffice2003
  *  - OC\Preview\MSOffice2007
- *  - OC\Preview\MSOfficeDoc
  *  - OC\Preview\OpenDocument
+ *  - OC\Preview\StarOffice
  *  - OC\Preview\PDF
  *  - OC\Preview\Photoshop
  *  - OC\Preview\Postscript
- *  - OC\Preview\StarOffice
  *  - OC\Preview\SVG
  *  - OC\Preview\TIFF
  *  - OC\Preview\Font
  *
- * The following providers are not available in Microsoft Windows:
+ * The following providers are only available if either LibreOffice or OpenOffice is installed on the server:
  *
- *  - OC\Preview\Movie
  *  - OC\Preview\MSOfficeDoc
  *  - OC\Preview\MSOffice2003
  *  - OC\Preview\MSOffice2007
  *  - OC\Preview\OpenDocument
  *  - OC\Preview\StarOffice
+ *
+ * The following providers require the php `imagick` extension:
+ *
+ *  - OC\Preview\SVG
+ *  - OC\Preview\TIFF
+ *  - OC\Preview\PDF
+ *  - OC\Preview\AI
+ *  - OC\Preview\PSD
+ *  - OC\Preview\EPS
+ *  - OC\Preview\TTF
+ *  - OC\Preview\HEIC
+ *  - OC\Preview\SGI
+ *
+ * Install the following additional imagick library when using SVG.
+ * This library adds imagick support for SVG, WMF, OpenEXR, DjVu and Graphviz:
+ *
+ * `sudo apt-get install -y libmagickcore-6.q16-3-extra`
+ *
+ * Install the `ffmpeg` when using `OC\Preview\Movie` provider.
+ *
+ * `sudo apt install -y ffmpeg`
+ *
+ * To get a list of file extensions linked to the image provider, change into the owncloud
+ * directory and run the following example command. Use a different filter for other provider types.
+ *
+ * `cat resources/config/mimetypemapping.dist.json | grep image`
+ *
+ * If you want to add a preview provider to the default ones, you must add all default ones too,
+ * else they will get disabled!
+ *
+ * To disable all preview providers set `'enabledPreviewProviders' => false,`
  */
 'enabledPreviewProviders' => [
+	'OC\Preview\PDF',
+	'OC\Preview\SGI',
+	'OC\Preview\Heic',
 	'OC\Preview\PNG',
 	'OC\Preview\JPEG',
 	'OC\Preview\GIF',

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1010,7 +1010,7 @@ $CONFIG = [
  *
  * `sudo apt install -y ffmpeg`
  *
- * To get a list of file extensions linked to the image provider, change into the owncloud
+ * To get a list of file extensions linked to the image provider, change into the `owncloud`
  * directory and run the following example command. Use a different filter for other provider types.
  *
  * `cat resources/config/mimetypemapping.dist.json | grep image`

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -248,10 +248,10 @@ class PreviewManager implements IPreview {
 	 *  - OC\Preview\MSOffice2003
 	 *  - OC\Preview\MSOffice2007
 	 *  - OC\Preview\OpenDocument
+	 *  - OC\Preview\StarOffice
 	 *  - OC\Preview\PDF
 	 *  - OC\Preview\Photoshop
 	 *  - OC\Preview\Postscript
-	 *  - OC\Preview\StarOffice
 	 *  - OC\Preview\SVG
 	 *  - OC\Preview\TIFF
 	 *
@@ -318,6 +318,9 @@ class PreviewManager implements IPreview {
 		$this->registerCoreProvider('OC\Preview\MP3', '/audio\/mpeg/');
 
 		// SVG, Office and Bitmap require imagick
+		// Install `libmagickcore-6.q16-3-extra` additional to the imagick library when using SVG.
+		// This library adds imagick support for SVG, WMF, OpenEXR, DjVu and Graphviz:
+		
 		if (\extension_loaded('imagick')) {
 			$checkImagick = new \Imagick();
 
@@ -345,7 +348,7 @@ class PreviewManager implements IPreview {
 			}
 
 			if (\count($checkImagick->queryFormats('PDF')) === 1) {
-				// Office previews are currently not supported on Windows
+				// Office previews are only supported if either LibreOffice or OpenOffice is installed on the server
 				if (\OC_Helper::is_function_enabled('shell_exec')) {
 					$officeFound = \is_string($this->config->getSystemValue('preview_libreoffice_path', null));
 
@@ -370,10 +373,8 @@ class PreviewManager implements IPreview {
 			}
 		}
 
-		// Video requires avconv or ffmpeg and is therefor
-		// currently not supported on Windows.
+		// Video requires avconv or ffmpeg to be installed on the server
 		if (\in_array('OC\Preview\Movie', $this->getEnabledDefaultProvider())) {
-			// AtomicParsley would actually work under Windows.
 			$avconvBinary = \OC_Helper::findBinaryPath('avconv');
 			$ffmpegBinary = ($avconvBinary) ? null : \OC_Helper::findBinaryPath('ffmpeg');
 			$atomicParsleyBinary = \OC_Helper::findBinaryPath('AtomicParsley');


### PR DESCRIPTION
## Description
When writing docs for https://github.com/owncloud/docs/issues/2735 (Document the support for SGI Images) I ran into the issue that:
* Update in `config.sample.php` to reflect the necessary changes
(which will then be transported via a `config-to-docs` run
* The PreviewManager did not had all necessary comments respectively had outdated information (there is no more an install possible on windows)

No code changes, text only!

## Related Issue
- Fixes https://github.com/owncloud/docs/issues/2735
- Based on: https://github.com/owncloud/core/pull/37758

## Motivation and Context
Fix missing and wrong information

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With my own productive instance

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
