### PR TITLE
[tests-only] skip changed webUIAdminSettings tests on old oC10

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage
+@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @skipOnOcV10.6 @skipOnOcV10.7
 Feature: admin storage settings
   As an admin
   I want to be able to manage external storages on the ownCloud server

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @notToImplementOnOCIS
+@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7
 Feature: admin storage settings
   As an admin
   I want to be able to manage external storages on the ownCloud server


### PR DESCRIPTION
## Description
PR #38795 enhanced the way that the admin storage settings UI works. So the test scenarios will no longer work against an old oC10. (There is a new element on the page is only there from oC10.8 onwards). Skip the test scenarios on old oC10.

For example, https://drone.owncloud.com/owncloud/encryption/1922/186/17 has these tests failing against oC10.7.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
