### PR TITLE
Fix PDF preview provider

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1006,7 +1006,15 @@ $CONFIG = [
  *
  * `sudo apt-get install -y libmagickcore-6.q16-3-extra`
  *
- * Install the `ffmpeg` when using `OC\Preview\Movie` provider.
+ * Change the following imagick security policy when using PDF.
+ *
+ * `sudo vi /etc/ImageMagick-6/policy.xml`
+ *
+ * `<policy domain="coder" rights="none" pattern="PDF" />`
+ *
+ * `rights="none"` -> `rights="read|write"`
+ *
+ * Install `ffmpeg` when using the `OC\Preview\Movie` provider.
  *
  * `sudo apt install -y ffmpeg`
  *

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1007,6 +1007,7 @@ $CONFIG = [
  * `sudo apt-get install -y libmagickcore-6.q16-3-extra`
  *
  * Change the following imagick security policy when using PDF.
+ * Use the editor of your choice, the example uses `vi`.
  *
  * `sudo vi /etc/ImageMagick-6/policy.xml`
  *


### PR DESCRIPTION
## Description
Fixes the need to set the proper security policy for imagick when the preview provider should make  thumbnails for pdf files.

This is a textfix only, no code changes.
Will be transported to docs with a `config-to-docs` run, see referenced docs PR.

## Related Issue

## Motivation and Context
Previewprovider for PDF will not work without changing this setting in imagick.

## How Has This Been Tested?
- local productive instance

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
