### PR TITLE
Improved config key description for auto-provision for OIDC

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -245,12 +245,13 @@ $CONFIG = [
  * login without requiring the user to click a button. The default is `false`.
  *
  * auto-provision::
- * If auto-provision is setup, an owncloud user will be created after successful login
- * using openid connect. The config parameters 'mode' and 'search-attribute' will be used
- * to create a unique user so that the lookup mechanism can find the user again.
- * If auto-provision is not setup, it is expected that the user exists.
- * This is where an LDAP setup is usually required. `auto-provision` holds several sub keys,
- * see the example setup with the explanations below.
+ * If auto-provision is setup, an ownCloud user will be created if not exists, after successful
+ * login using openid connect. The config parameters `mode` and `search-attribute` will be used
+ * to create a unique user so that the lookup mechanism can find the user again. This is where
+ * an LDAP setup is usually required.
+ * If auto-provision is not setup or required, it is expected that the user exists and you
+ * MUST declare this with `['enabled' => false]` like shown in the Easy Setup example.
+ * `auto-provision` holds several sub keys, see the example setup with the explanations below.
  *
  * insecure::
  * Boolean value (`true`/`false`), no SSL verification will take place when talking to the
@@ -316,6 +317,8 @@ $CONFIG = [
  * Easy setup
  */
 'openid-connect' => [
+	  // it is expected that the user already exists in ownCloud
+	'auto-provision' => ['enabled' => false],
 	'provider-url' => 'https://idp.example.net',
 	'client-id' => 'fc9b5c78-ec73-47bf-befc-59d4fe780f6f',
 	'client-secret' => 'e3e5b04a-3c3c-4f4d-b16c-2a6e9fdd3cd1',
@@ -326,8 +329,9 @@ $CONFIG = [
  * Setup auto provisioning mode
  */
 'openid-connect' => [
-	  'auto-provision' => [
-		  // explicit enable the auto provisioning mode
+	  // explicit enable the auto provisioning mode,
+	  // if not exists, the user will be created in ownCloud
+	'auto-provision' => [
 		'enabled' => true,
 		  // documentation about standard claims:
 		  // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
@@ -339,19 +343,26 @@ $CONFIG = [
 		'picture-claim' => 'picture',
 		  // defines a list of groups to which the newly created user will be added automatically
 		'groups' => ['admin', 'guests', 'employees']
-	  ],
+	],
+	  // `mode` and `search-attribute` will be used to create a unique use in ownCloud
+	'mode' => 'email',
+	'search-attribute' => 'email',
 ],
 
 /**
  * Manual setup
  */
 'openid-connect' => [
+	  // it is expected that the user already exists in ownCloud
+	'auto-provision' => ['enabled' => false],
 	'autoRedirectOnLoginPage' => false,
 	'client-id' => 'fc9b5c78-ec73-47bf-befc-59d4fe780f6f',
 	'client-secret' => 'e3e5b04a-3c3c-4f4d-b16c-2a6e9fdd3cd1',
 	'loginButtonName' => 'OpenId Connect',
 	'mode' => 'userid',
-	  // Only required if the OpenID Connect Provider does not support service discovery
+	'search-attribute' => 'sub',
+	  // only required if the OpenID Connect Provider does not support service discovery
+	  // replace the dots with your values
 	'provider-params' => [
 		'authorization_endpoint' => '...',
 		'end_session_endpoint' => '...',
@@ -362,7 +373,6 @@ $CONFIG = [
 		'userinfo_endpoint' => '...'
 	],
 	'provider-url' => '...',
-	'search-attribute' => 'sub',
 	'use-token-introspection-endpoint' => true
 ],
 
@@ -370,15 +380,17 @@ $CONFIG = [
  * Test setup
  */
 'openid-connect' => [
-	  'provider-url' => 'http://localhost:3000',
-	  'client-id' => 'ownCloud',
-	  'client-secret' => 'ownCloud',
-	  'loginButtonName' => 'node-oidc-provider',
-	  'mode' => 'userid',
-	  'search-attribute' => 'sub',
-	  'use-token-introspection-endpoint' => true,
-		// do not verify tls host or peer
-	  'insecure' => true
+	  // it is expected that the user already exists in ownCloud
+	'auto-provision' => ['enabled' => false],
+	'provider-url' => 'http://localhost:3000',
+	'client-id' => 'ownCloud',
+	'client-secret' => 'ownCloud',
+	'loginButtonName' => 'node-oidc-provider',
+	'mode' => 'userid',
+	'search-attribute' => 'sub',
+	'use-token-introspection-endpoint' => true,
+	  // do not verify tls host or peer
+	'insecure' => true
 ],
   
 /**

--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -344,7 +344,7 @@ $CONFIG = [
 		  // defines a list of groups to which the newly created user will be added automatically
 		'groups' => ['admin', 'guests', 'employees']
 	],
-	  // `mode` and `search-attribute` will be used to create a unique use in ownCloud
+	  // `mode` and `search-attribute` will be used to create a unique user in ownCloud
 	'mode' => 'email',
 	'search-attribute' => 'email',
 ],


### PR DESCRIPTION
## Description
This PR improves the config key description for `auto-provision` which is necessary for OIDC
A `config-to-docs` run has already been made, see PR: https://github.com/owncloud/docs/pull/3631

Text change only (no code changes)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of the fix for https://github.com/owncloud/docs/issues/3537

## Motivation and Context
Make OICD working using the key

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
