### PR TITLE
Add Workflow / Tagging config key

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -403,7 +403,6 @@ $CONFIG = [
  * Define the group name for users allowed to use Collabora
  * Please note, only one group can be defined. Default = empty = no restriction.
  */
-
 'collabora_group' => '',
 
 /**
@@ -507,5 +506,21 @@ $CONFIG = [
  * be ignored. This flag depends on the `wnd.activity.registerExtension` and has the same restrictions.
  */
 'wnd.activity.sendToSharees' => false,
+
+/**
+ * App: Workflow / Tagging
+ *
+ * Note: This app is for Enterprise Customers only.
+ *
+ * Possible keys: `workflow.retention_engine` STRING
+ */
+
+/**
+ * Provide advanced management of file tagging
+ * Enables admins to specify rules and conditions (file size, file mimetype, group membership and more)
+ * to automatically assign tags to uploaded files. Values: `tagbased` (default) or `userbased`.
+ */
+
+'workflow.retention_engine' => 'tagbased',
 
 ];


### PR DESCRIPTION
## Description
Add missing Workflow / Tagging config key to config.apps.sample.php
No code change, text change only.
`config-to-docs` run already made, see referenced docs PR https://github.com/owncloud/docs/pull/3640

## Related Issue
- Fixes https://github.com/owncloud/docs/issues/3519

## Motivation and Context
Completeness of docs

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
