### PR TITLE
Check a local attribute for the SMB log switch instead

### DIFF
--- a/changelog/unreleased/38819
+++ b/changelog/unreleased/38819
@@ -1,0 +1,10 @@
+Enhancement: Improve performance of the SMB log when it is inactive
+
+The SMB connector includes very verbose logs to trace what could have
+gone wrong. These logs are disabled by default, but although they're disabled
+we still need to check the state to decide whether we want to log or not.
+
+Now, the state check is faster and it takes less time to decide, so the
+overall performance of the connector is improved.
+
+https://github.com/owncloud/core/pull/38819


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Use a local attribute to decide whether to log something in the SMB connector or not
It also improves the log handling in the subclasses because the inherited methods will use the same flag

## Related Issue
Related to https://github.com/owncloud/enterprise/issues/4594

## Motivation and Context
Just deciding to log nothing in the connector takes some time. It might be a few microseconds, but the sheer amount of calls that big installations can make might rise this number a lot.
For a particular setup with a folder with 1000 files and another folder inside, there are 73240 calls to the log method. Although each call could take around 10-15 microseconds per call on average, the total amount takes close to 1 second in order to log nothing.

This PR make the logging calls to take nanoseconds if the logging is disabled. For the same amount of data, the waste should be around 10 miliseconds instead of 1 second.

Side note: the request takes around 35 seconds, so it isn't a big gain.

## How Has This Been Tested?
Manually tested. Checked with a propfind against the folder with 1000 files using curl, as well as navigating to the folder using the browser. In both cases, a file scan was forced to be triggered with the propfind.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
