### PR TITLE
[Tests-Only]Add `notToImplementOnOcis` tags for old public link webdav tests

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -10,259 +10,261 @@ Feature: changing a public link share
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
 
 
-  Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the old public WebDAV API
+  Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    When the public deletes file "parent.txt" from the last public share using the old public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | permissions               | http-status-code | should-or-not |
-      | read,update,create        | 403              | should        |
-      | read,update,create,delete | 204              | should not    |
+      | permissions               | http-status-code | should-or-not | webdav_api_version |
+      | read,update,create        | 403              | should        | old                |
+      | read,update,create,delete | 204              | should not    | old                |
 
-  @issue-ocis-reva-292
-  Scenario Outline: Public can or can-not delete file through publicly shared link depending on having delete permissions using the new public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT       |
-      | permissions | <permissions> |
-    When the public deletes file "parent.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "<http-status-code>"
-    And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
+    @issue-ocis-reva-292
     Examples:
-      | permissions               | http-status-code | should-or-not |
-      | read,update,create        | 403              | should        |
-      | read,update,create,delete | 204              | should not    |
+      | permissions               | http-status-code | should-or-not | webdav_api_version |
+      | read,update,create        | 403              | should        | new                |
+      | read,update,create,delete | 204              | should not    | new                |
 
 
-  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create with the old public WebDAV API
+  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-  @issue-ocis-reva-292
-  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create with the new public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT            |
-      | permissions | read,update,create |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Alice" file "/PARENT/parent.txt" should exist
-    And as "Alice" file "/PARENT/newparent.txt" should not exist
+    @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+    @issue-ocis-reva-292
+    Examples:
+      | webdav_api_version |
+      | new                |
 
   @skipOnRansomwareProtection @issue-ransomware-208
-  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the old public WebDAV API
+  Scenario Outline: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
 
-  @skipOnRansomwareProtection @issue-ransomware-208
-  Scenario: Public link share permissions work correctly for renaming and share permissions read,update,create,delete using the new public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "201"
-    And as "Alice" file "/PARENT/parent.txt" should not exist
-    And as "Alice" file "/PARENT/newparent.txt" should exist
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
 
-  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the old public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT            |
-      | permissions | read,update,create |
-    When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Alice" file "/PARENT/lorem.txt" should not exist
+    Examples:
+      | webdav_api_version |
+      | new                |
 
-  @issue-ocis-reva-292
-  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create with the new public WebDAV API
+
+  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    When the public uploads file "lorem.txt" with content "test" using the new public WebDAV API
+    When the public uploads file "lorem.txt" with content "test" using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
-  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the old public WebDAV API
+    @issue-ocis-reva-292
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    When the public uploads file "lorem.txt" with content "test" using the old public WebDAV API
+    When the public uploads file "lorem.txt" with content "test" using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
 
-  Scenario: Public link share permissions work correctly for upload with share permissions read,update,create,delete with the new public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-    When the public uploads file "lorem.txt" with content "test" using the new public WebDAV API
-    Then the HTTP status code should be "201"
-    And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
 
-  Scenario: Public cannot delete file through publicly shared link with password using an invalid password with the old public WebDAV API
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Public cannot delete file through publicly shared link with password using an invalid password with public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "parent.txt" from the last public share using the password "invalid" and old public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the password "invalid" and <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "PARENT/parent.txt" should exist
 
-  Scenario: Public cannot delete file through publicly shared link with password using an invalid password with the new public WebDAV API
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Public can delete file through publicly shared link with password using the valid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "parent.txt" from the last public share using the password "invalid" and new public WebDAV API
-    Then the HTTP status code should be "401"
-    And as "Alice" file "PARENT/parent.txt" should exist
-
-
-  Scenario: Public can delete file through publicly shared link with password using the valid password with the old public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public deletes file "parent.txt" from the last public share using the password "newpasswd" and old public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the password "newpasswd" and <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
 
-  Scenario: Public can delete file through publicly shared link with password using the valid password with the new public WebDAV API
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+  @issue-ocis-reva-292
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Public tries to rename a file in a password protected share using an invalid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "parent.txt" from the last public share using the password "newpasswd" and new public WebDAV API
-    Then the HTTP status code should be "204"
-    And as "Alice" file "PARENT/parent.txt" should not exist
-
-
-  Scenario: Public tries to rename a file in a password protected share using an invalid password with the old public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "invalid" and old public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "invalid" and <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/newparent.txt" should not exist
     And as "Alice" file "/PARENT/parent.txt" should exist
 
-  Scenario: Public tries to rename a file in a password protected share using an invalid password with the new public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "invalid" and new public WebDAV API
-    Then the HTTP status code should be "401"
-    And as "Alice" file "/PARENT/newparent.txt" should not exist
-    And as "Alice" file "/PARENT/parent.txt" should exist
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+
+    Examples:
+      | webdav_api_version |
+      | new                |
 
   @skipOnRansomwareProtection @issue-ransomware-208
-  Scenario: Public tries to rename a file in a password protected share using the valid password with the old public WebDAV API
+  Scenario Outline: Public tries to rename a file in a password protected share using the valid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "newpasswd" and old public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "newpasswd" and <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/newparent.txt" should exist
     And as "Alice" file "/PARENT/parent.txt" should not exist
 
-  @skipOnRansomwareProtection @issue-ransomware-208
-  Scenario: Public tries to rename a file in a password protected share using the valid password with the new public WebDAV API
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Public tries to upload to a password protected public share using an invalid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "newpasswd" and new public WebDAV API
-    Then the HTTP status code should be "201"
-    And as "Alice" file "/PARENT/newparent.txt" should exist
-    And as "Alice" file "/PARENT/parent.txt" should not exist
-
-
-  Scenario: Public tries to upload to a password protected public share using an invalid password with the old public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public uploads file "lorem.txt" with password "invalid" and content "test" using the old public WebDAV API
+    When the public uploads file "lorem.txt" with password "invalid" and content "test" using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-  Scenario: Public tries to upload to a password protected public share using an invalid password with the new public WebDAV API
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Public tries to upload to a password protected public share using the valid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public uploads file "lorem.txt" with password "invalid" and content "test" using the new public WebDAV API
-    Then the HTTP status code should be "401"
-    And as "Alice" file "/PARENT/lorem.txt" should not exist
-
-
-  Scenario: Public tries to upload to a password protected public share using the valid password with the old public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public uploads file "lorem.txt" with password "newpasswd" and content "test" using the old public WebDAV API
+    When the public uploads file "lorem.txt" with password "newpasswd" and content "test" using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/lorem.txt" should exist
 
-  Scenario: Public tries to upload to a password protected public share using the valid password with the new public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT   |
-      | permissions | change    |
-      | password    | newpasswd |
-    When the public uploads file "lorem.txt" with password "newpasswd" and content "test" using the new public WebDAV API
-    Then the HTTP status code should be "201"
-    And as "Alice" file "/PARENT/lorem.txt" should exist
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
 
-  Scenario: Public cannot rename a file in uploadwriteonly public link share with the old public WebDAV API
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Public cannot rename a file in uploadwriteonly public link share with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the old public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
   @issue-ocis-reva-292
-  Scenario: Public cannot rename a file in uploadwriteonly public link share with the new public WebDAV API
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Public cannot delete a file in uploadwriteonly public link share with the public WebDAV API
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Alice" file "/PARENT/parent.txt" should exist
-    And as "Alice" file "/PARENT/newparent.txt" should not exist
-
-
-  Scenario: Public cannot delete a file in uploadwriteonly public link share with the old public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT         |
-      | permissions | uploadwriteonly |
-    When the public deletes file "parent.txt" from the last public share using the old public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/parent.txt" should exist
 
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
   @issue-ocis-reva-292
-  Scenario: Public cannot delete a file in uploadwriteonly public link share with the new public WebDAV API
-    Given user "Alice" has created a public link share with settings
-      | path        | /PARENT         |
-      | permissions | uploadwriteonly |
-    When the public deletes file "parent.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Alice" file "PARENT/parent.txt" should exist
+    Examples:
+      | webdav_api_version |
+      | new                |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -653,46 +653,45 @@ Feature: create a public link share
       | 2               | 200             | 200              | new       |
 
   @issue-ocis-reva-199
-  Scenario: Delete a folder that has been publicly shared and try to access using the new public WebDAV API
+  Scenario Outline: Delete a folder that has been publicly shared and try to access using the public WebDAV API
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
     And user "Alice" has created a public link share with settings
       | path        | PARENT |
       | permissions | read   |
     When user "Alice" deletes folder "PARENT" using the WebDAV API
-    And the public download of file "/parent.txt" from inside the last public shared folder using the new public WebDAV API should fail with HTTP status code "404"
+    And the public download of file "/parent.txt" from inside the last public shared folder using the <webdav_api_version> public WebDAV API should fail with HTTP status code "404"
 
-  @issue-ocis-reva-199 @notToImplementOnOCIS @issue-ocis-2079
-  Scenario: Delete a folder that has been publicly shared and try to access using the old public WebDAV API
-    Given user "Alice" has created folder "PARENT"
-    And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | PARENT |
-      | permissions | read   |
-    When user "Alice" deletes folder "PARENT" using the WebDAV API
-    Then the public download of file "/parent.txt" from inside the last public shared folder using the old public WebDAV API should fail with HTTP status code "404"
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+
+    Examples:
+      | webdav_api_version |
+      | new                |
 
   @issue-ocis-reva-292
-  Scenario: try to download from a public share that has upload only permissions using the new public webdav api
+  Scenario Outline: try to download from a public share that has upload only permissions using the public webdav api
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
     And user "Alice" has created a public link share with settings
       | path        | PARENT          |
       | permissions | uploadwriteonly |
-    When the public downloads file "parent.txt" from inside the last public shared folder using the new public WebDAV API
-    Then the value of the item "//s:message" in the response should be "File not found: parent.txt"
+    When the public downloads file "parent.txt" from inside the last public shared folder using the <webdav_api_version> public WebDAV API
+    Then the value of the item "//s:message" in the response should be "<response>"
     And the HTTP status code should be "404"
 
-  @issue-ocis-reva-292 @notToImplementOnOCIS @issue-ocis-2079
-  Scenario: try to download from a public share that has upload only permissions using the old public webdav api
-    Given user "Alice" has created folder "PARENT"
-    And user "Alice" has uploaded file with content "Random data" to "/PARENT/parent.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | PARENT          |
-      | permissions | uploadwriteonly |
-    When the public downloads file "parent.txt" from inside the last public shared folder using the old public WebDAV API
-    Then the value of the item "//s:message" in the response should be ""
-    And the HTTP status code should be "404"
+    @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version | response |
+      | old                |          |
+
+
+    Examples:
+      | webdav_api_version | response                   |
+      | new                | File not found: parent.txt |
 
   @skipOnOcV10.3
   Scenario: Get the size of a file shared by public link

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
@@ -11,6 +11,7 @@ Feature: reshare as public link
       | Alice     |
       | Brian     |
 
+
   Scenario Outline: creating a public link from a share with read permission only is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -25,6 +26,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 404              |
 
+
   Scenario Outline: creating a public link from a share with share+read only permissions is allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -35,16 +37,22 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the <webdav_api_version> public WebDAV API
     And the downloaded content should be "some content"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API
-    And the downloaded content should be "some content"
-    But uploading a file should not work using the old public WebDAV API
-    And uploading a file should not work using the new public WebDAV API
+    But uploading a file should not work using the <webdav_api_version> public WebDAV API
+
+    @notToImplementOnOCIS
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | old                |
+      | 2               | 200             | old                |
+
+
+    Examples:
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | new                |
+      | 2               | 200             | new                |
+
 
   Scenario Outline: creating an upload public link from a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
@@ -61,6 +69,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 404              |
 
+
   Scenario Outline: creating a public link from a share with read+write permissions only is not allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -75,6 +84,7 @@ Feature: reshare as public link
       | 1               | 200              |
       | 2               | 404              |
 
+
   Scenario Outline: creating a public link from a share with share+read+write permissions is allowed
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/test"
@@ -85,16 +95,22 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the <webdav_api_version> public WebDAV API
     And the downloaded content should be "some content"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API
-    And the downloaded content should be "some content"
-    But uploading a file should not work using the old public WebDAV API
-    And uploading a file should not work using the new public WebDAV API
+    But uploading a file should not work using the <webdav_api_version> public WebDAV API
+
+    @notToImplementOnOCIS
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | old                |
+      | 2               | 200             | old                |
+
+
+    Examples:
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | new                |
+      | 2               | 200             | new                |
+
 
   Scenario Outline: creating an upload public link from a share with share+read+write permissions is allowed
     Given using OCS API version "<ocs_api_version>"
@@ -107,16 +123,23 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public shared folder using the <webdav_api_version> public WebDAV API
     And the downloaded content should be "some content"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API
-    And the downloaded content should be "some content"
-    And uploading a file should work using the old public WebDAV API
-    And uploading a file should work using the new public WebDAV API
+    And uploading a file should work using the <webdav_api_version> public WebDAV API
+
+    @notToImplementOnOCIS
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | old                |
+      | 2               | 200             | old                |
+
+
+    Examples:
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | new                |
+      | 2               | 200             | new                |
+
+
 
   Scenario Outline: creating an upload public link from a sub-folder of a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
@@ -147,12 +170,19 @@ Feature: reshare as public link
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the old public WebDAV API
-    And uploading a file should not work using the new public WebDAV API
+    And uploading a file should not work using the <webdav_api_version> public WebDAV API
+
+    @notToImplementOnOCIS
     Examples:
-      | ocs_api_version | http_status_code |
-      | 1               | 200              |
-      | 2               | 404              |
+      | ocs_api_version | http_status_code | webdav_api_version |
+      | 1               | 200              | old                |
+      | 2               | 404              | old                |
+
+
+    Examples:
+      | ocs_api_version | http_status_code | webdav_api_version |
+      | 1               | 200              | new                |
+      | 2               | 404              | new                |
 
   Scenario Outline: increasing permissions of a public link from a sub-folder of a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
@@ -163,15 +193,21 @@ Feature: reshare as public link
       | path         | /test/sub |
       | permissions  | read      |
       | publicUpload | false     |
-    And uploading a file should not work using the old public WebDAV API
-    And uploading a file should not work using the new public WebDAV API
+    And uploading a file should not work using the <webdav_api_version> public WebDAV API
     When user "Brian" updates the last share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the old public WebDAV API
-    And uploading a file should not work using the new public WebDAV API
+    And uploading a file should not work using the <webdav_api_version> public WebDAV API
+
+    @notToImplementOnOCIS
     Examples:
-      | ocs_api_version | http_status_code |
-      | 1               | 200              |
-      | 2               | 404              |
+      | ocs_api_version | http_status_code | webdav_api_version |
+      | 1               | 200              | old                |
+      | 2               | 404              | old                |
+
+
+    Examples:
+      | ocs_api_version | http_status_code | webdav_api_version |
+      | 1               | 200              | new                |
+      | 2               | 404              | new                |

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required
+@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS @issue-ocis-2079
 Feature: reshare as public link
   As a user
   I want to create public link shares from files/folders shared with me

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -117,7 +117,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  Scenario Outline: Creating a new public link share with password and adding an expiration date using the old public API
+  Scenario Outline: Creating a new public link share with password and adding an expiration date using public API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -127,27 +127,19 @@ Feature: update a public link share
       | expireDate | +3 days |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "Random data"
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+    And the public should be able to download the last publicly shared file using the <webdav_api_version> public WebDAV API with password "%public%" and the content should be "Random data"
 
-  Scenario Outline: Creating a new public link share with password and adding an expiration date using the new public API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path     | randomfile.txt |
-      | password | %public%       |
-    And user "Alice" updates the last share using the sharing API with
-      | expireDate | +3 days |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | old                |
+      | 2               | 200             | old                |
+
+
+    Examples:
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | new                |
+      | 2               | 200             | new                |
 
   @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info (ocis Bug demonstration)
@@ -311,159 +303,127 @@ Feature: update a public link share
       | 2               | 200             |
 
 
-  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the old public API
-    Given using OCS API version "<ocs_api_version>"
+  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the public API
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has shared folder "/test" with user "Brian" with permissions "share,read"
+    And user "Brian" has accepted share "/test" offered by user "Alice"
     And user "Brian" has created a public link share with settings
-      | path         | /test |
+      | path         | /Shares/test |
       | publicUpload | false |
     When user "Brian" updates the last share using the sharing API with
       | publicUpload | true |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the <webdav_api_version> public WebDAV API
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | ocs_api_version | http_status_code |
-      | 1               | 200              |
-      | 2               | 404              |
+      | ocs_api_version | http_status_code | webdav_api_version |
+      | 1               | 200              | old                |
+      | 2               | 404              | old                |
 
-  @issue-ocis-reva-11
-  Scenario Outline: Adding public upload to a read only shared folder as recipient is not allowed using the new public API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/test"
-    And user "Alice" has shared folder "/test" with user "Brian" with permissions "share,read"
-    And user "Brian" has created a public link share with settings
-      | path         | /test |
-      | publicUpload | false |
-    When user "Brian" updates the last share using the sharing API with
-      | publicUpload | true |
-    Then the OCS status code should be "404"
-    And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the new public WebDAV API
+    @issue-ocis-reva-11
     Examples:
-      | ocs_api_version | http_status_code |
-      | 1               | 200              |
-      | 2               | 404              |
+      | ocs_api_version | http_status_code | webdav_api_version |
+      | 1               | 200              | new                |
+      | 2               | 404              | new                |
 
 
-  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the old public API
-    Given using OCS API version "<ocs_api_version>"
+  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the public API
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
+    And user "Brian" has accepted share "/test" offered by user "Alice"
     And user "Brian" has created a public link share with settings
-      | path         | /test |
+      | path         | /Shares/test |
       | publicUpload | false |
     When user "Brian" updates the last share using the sharing API with
       | publicUpload | true |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the <webdav_api_version> public WebDAV API
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | old                |
+      | 2               | 200             | old                |
 
-  @issue-ocis-reva-11
-  Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the new public API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/test"
-    And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
-    And user "Brian" has created a public link share with settings
-      | path         | /test |
-      | publicUpload | false |
-    When user "Brian" updates the last share using the sharing API with
-      | publicUpload | true |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And uploading a file should work using the new public WebDAV API
+    @issue-ocis-reva-11
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | new                |
+      | 2               | 200             | new                |
 
 
-  Scenario Outline: Adding public link with all permissions to a read only shared folder as recipient is not allowed using the old public API
-    Given using OCS API version "<ocs_api_version>"
+  Scenario Outline: Adding public link with all permissions to a read only shared folder as recipient is not allowed using the public API
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has shared folder "/test" with user "Brian" with permissions "share,read"
+    And user "Brian" has accepted share "/test" offered by user "Alice"
     And user "Brian" has created a public link share with settings
-      | path        | /test |
+      | path        | /Shares/test |
       | permissions | read  |
     When user "Brian" updates the last share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the <webdav_api_version> public WebDAV API
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | ocs_api_version | http_status_code |
-      | 1               | 200              |
-      | 2               | 404              |
+      | ocs_api_version | http_status_code | webdav_api_version |
+      | 1               | 200              | old                |
+      | 2               | 404              | old                |
 
-  @issue-ocis-reva-11
-  Scenario Outline: Adding public link with all permissions to a read only shared folder as recipient is not allowed using the new public API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/test"
-    And user "Alice" has shared folder "/test" with user "Brian" with permissions "share,read"
-    And user "Brian" has created a public link share with settings
-      | path        | /test |
-      | permissions | read  |
-    When user "Brian" updates the last share using the sharing API with
-      | permissions | read,update,create,delete |
-    Then the OCS status code should be "404"
-    And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the new public WebDAV API
+    @issue-ocis-reva-11
     Examples:
-      | ocs_api_version | http_status_code |
-      | 1               | 200              |
-      | 2               | 404              |
+      | ocs_api_version | http_status_code | webdav_api_version |
+      | 1               | 200              | new                |
+      | 2               | 404              | new                |
 
 
-  Scenario Outline: Adding public link with all permissions to a read only shared folder as recipient is allowed with permissions using the old public API
-    Given using OCS API version "<ocs_api_version>"
+  Scenario Outline: Adding public link with all permissions to a read only shared folder as recipient is allowed with permissions using the public API
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
     And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
+    And user "Brian" has accepted share "/test" offered by user "Alice"
     And user "Brian" has created a public link share with settings
-      | path        | /test |
+      | path        | /Shares/test |
       | permissions | read  |
     When user "Brian" updates the last share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the <webdav_api_version> public WebDAV API
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | old                |
+      | 2               | 200             | old                |
 
-  @issue-ocis-reva-11
-  Scenario Outline:  Adding public link with all permissions to a read only folder as recipient is allowed with permissions using the new public API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has created folder "/test"
-    And user "Alice" has shared folder "/test" with user "Brian" with permissions "all"
-    And user "Brian" has created a public link share with settings
-      | path        | /test |
-      | permissions | read  |
-    When user "Brian" updates the last share using the sharing API with
-      | permissions | read,update,create,delete |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And uploading a file should work using the new public WebDAV API
+    @issue-ocis-reva-11
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | new                |
+      | 2               | 200             | new                |
 
 
-  Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the old public API
+  Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the public API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
@@ -478,40 +438,24 @@ Feature: update a public link share
     When user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Alice" should include
       | permissions | read |
-    When the public deletes file "CHILD/child.txt" from the last public share using the old public WebDAV API
+    When the public deletes file "CHILD/child.txt" from the last public share using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/CHILD/child.txt" should exist
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | old                |
+      | 2               | 200             | old                |
 
-  @issue-ocis-reva-292
-  Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the new public API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has created folder "PARENT"
-    And user "Alice" has created folder "PARENT/CHILD"
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-    When user "Alice" updates the last share using the sharing API with
-      | permissions | read |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    When user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | permissions | read |
-    When the public deletes file "CHILD/child.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Alice" file "PARENT/CHILD/child.txt" should exist
+    @issue-ocis-reva-292
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | new                |
+      | 2               | 200             | new                |
 
 
-  Scenario Outline: Updating share permissions from read to change allows public to delete files using the old public API
+  Scenario Outline: Updating share permissions from read to change allows public to delete files using the public API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
@@ -527,40 +471,21 @@ Feature: update a public link share
     When user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response to user "Alice" should include
       | permissions | read,update,create,delete |
-    When the public deletes file "CHILD/child.txt" from the last public share using the old public WebDAV API
+    When the public deletes file "CHILD/child.txt" from the last public share using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/CHILD/child.txt" should not exist
-    When the public deletes file "parent.txt" from the last public share using the old public WebDAV API
+    When the public deletes file "parent.txt" from the last public share using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
 
-  Scenario Outline: Updating share permissions from read to change allows public to delete files using the new public API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has created folder "PARENT"
-    And user "Alice" has created folder "PARENT/CHILD"
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/CHILD/child.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT |
-      | permissions | read    |
-    When user "Alice" updates the last share using the sharing API with
-      | permissions | read,update,create,delete |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    When user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
-      | permissions | read,update,create,delete |
-    When the public deletes file "CHILD/child.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "204"
-    And as "Alice" file "PARENT/CHILD/child.txt" should not exist
-    When the public deletes file "parent.txt" from the last public share using the new public WebDAV API
-    Then the HTTP status code should be "204"
-    And as "Alice" file "PARENT/parent.txt" should not exist
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | old                |
+      | 2               | 200             | old                |
+
+
+    Examples:
+      | ocs_api_version | ocs_status_code | webdav_api_version |
+      | 1               | 100             | new                |
+      | 2               | 200             | new                |

--- a/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature
@@ -6,7 +6,7 @@ Feature: upload to a public link share
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "FOLDER"
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS @issue-ocis-2079
   Scenario: Uploading same file to a public upload-only share multiple times via old API
     # The old API needs to have the header OC-Autorename: 1 set to do the autorename
     Given user "Alice" has created a public link share with settings
@@ -35,213 +35,219 @@ Feature: upload to a public link share
     And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
 
 
-  Scenario Outline: Uploading file to a public upload-only share using old public API that was deleted does not work
+  Scenario Outline: Uploading file to a public upload-only share using public API that was deleted does not work
     Given using <dav-path> DAV path
     And user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     When user "Alice" deletes file "/FOLDER" using the WebDAV API
-    Then uploading a file should not work using the old public WebDAV API
+    Then uploading a file should not work using the <webdav_api_version> public WebDAV API
     And the HTTP status code should be "404"
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path | webdav_api_version |
+      | old      | old                |
+      | new      | old                |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @issue-ocis-reva-290
-  Scenario Outline: Uploading file to a public upload-only share using new public API that was deleted does not work
-    Given using <dav-path> DAV path
-    And user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | create |
-    When user "Alice" deletes file "/FOLDER" using the WebDAV API
-    Then uploading a file should not work using the new public WebDAV API
-    And the HTTP status code should be "404"
+    @skipOnOcV10.3 @skipOnOcV10.4 @issue-ocis-reva-290
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path | webdav_api_version |
+      | old      | new                |
+      | new      | new                |
 
 
-  Scenario: Uploading file to a public read-only share folder with old public API does not work
+  Scenario Outline: Uploading file to a public read-only share folder with public API does not work
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | read   |
-    Then uploading a file should not work using the old public WebDAV API
+    Then uploading a file should not work using the <webdav_api_version> public WebDAV API
     And the HTTP status code should be "403"
 
-  @issue-ocis-reva-292
-  Scenario: Uploading file to a public read-only share folder with new public API does not work
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path        | FOLDER |
-      | permissions | read   |
-    Then uploading a file should not work using the new public WebDAV API
-    And the HTTP status code should be "403"
+    @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+    @issue-ocis-reva-292
+    Examples:
+      | webdav_api_version |
+      | new                |
 
 
-  Scenario: Uploading to a public upload-only share with old public API
+  Scenario Outline: Uploading to a public upload-only share with public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
-    When the public uploads file "test-old.txt" with content "test-old" using the old public WebDAV API
-    Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
+    When the public uploads file "test.txt" with content "test-file" using the <webdav_api_version> public WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
 
-  Scenario: Uploading to a public upload-only share with new public API
-    Given user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | create |
-    When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
-    Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
-    And the following headers should match these regular expressions
-      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
 
-  Scenario: Uploading to a public upload-only share with password with old public API
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Uploading to a public upload-only share with password with public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
       | permissions | create   |
-    When the public uploads file "test-old.txt" with password "%public%" and content "test-old" using the old public WebDAV API
-    Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
+    When the public uploads file "test.txt" with password "%public%" and content "test-file" using the <webdav_api_version> public WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
 
-  Scenario: Uploading to a public upload-only share with password with new public API
-    Given user "Alice" has created a public link share with settings
-      | path        | FOLDER   |
-      | password    | %public% |
-      | permissions | create   |
-    When the public uploads file "test-new.txt" with password "%public%" and content "test-new" using the new public WebDAV API
-    Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
+    @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
 
-  Scenario: Uploading to a public read/write share with password with old public API
-    Given user "Alice" has created a public link share with settings
-      | path        | FOLDER   |
-      | password    | %public% |
-      | permissions | change   |
-    When the public uploads file "test-old.txt" with password "%public%" and content "test-old" using the old public WebDAV API
-    Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
+    Examples:
+      | webdav_api_version |
+      | new                |
 
-  Scenario: Uploading to a public read/write share with password with new public API
+
+  Scenario Outline: Uploading to a public read/write share with password with public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER   |
       | password    | %public% |
       | permissions | change   |
-    When the public uploads file "test-new.txt" with password "%public%" and content "test-new" using the new public WebDAV API
-    Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
+    When the public uploads file "test.txt" with password "%public%" and content "test-file" using the <webdav_api_version> public WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
+
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
 
-  Scenario: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with old public API
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+
+  Scenario Outline: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with public API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | change |
     And the quota of user "Alice" has been set to "0"
-    Then uploading a file should not work using the old public WebDAV API
+    Then uploading a file should not work using the <webdav_api_version> public WebDAV API
     And the HTTP status code should be "507"
+
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
   @issue-ocis-reva-195
-  Scenario: Uploading file to a public shared folder with read/write permission when the sharer has insufficient quota does not work with new public API
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path        | FOLDER |
-      | permissions | change |
-    And the quota of user "Alice" has been set to "0"
-    And uploading a file should not work using the new public WebDAV API
-    And the HTTP status code should be "507"
+    Examples:
+      | webdav_api_version |
+      | new                |
 
 
-  Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with old public API
+  Scenario Outline: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with public API
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | FOLDER |
       | permissions | create |
     And the quota of user "Alice" has been set to "0"
-    Then uploading a file should not work using the old public WebDAV API
+    Then uploading a file should not work using the <webdav_api_version> public WebDAV API
     And the HTTP status code should be "507"
+
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
   @issue-ocis-reva-195
-  Scenario: Uploading file to a public shared folder with upload-only permission when the sharer has insufficient quota does not work with new public API
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path        | FOLDER |
-      | permissions | create |
-    And the quota of user "Alice" has been set to "0"
-    And uploading a file should not work using the new public WebDAV API
-    And the HTTP status code should be "507"
+    Examples:
+      | webdav_api_version |
+      | new                |
 
 
-  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder with old public API
+  Scenario Outline: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder with public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
-    Then uploading a file should not work using the old public WebDAV API
+    Then uploading a file should not work using the <webdav_api_version> public WebDAV API
     And the HTTP status code should be "403"
 
-  @issue-ocis-reva-41
-  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled after sharing the folder with new public API
-    Given user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | create |
-    When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "no"
-    And uploading a file should not work using the new public WebDAV API
-    And the HTTP status code should be "403"
+    @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+    @issue-ocis-reva-41
+    Examples:
+      | webdav_api_version |
+      | new                |
 
 
-  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder with old public API
+  Scenario Outline: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder with public API
     Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | all    |
     When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes"
-    Then uploading a file should not work using the old public WebDAV API
+    Then uploading a file should not work using the <webdav_api_version> public WebDAV API
     And the HTTP status code should be "403"
+
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
   @issue-ocis-reva-41
-  Scenario: Uploading file to a public shared folder does not work when allow public uploads has been disabled before sharing and again enabled after sharing the folder with new public API
-    Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    And user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | all    |
-    When the administrator sets parameter "shareapi_allow_public_upload" of app "core" to "yes"
-    And uploading a file should not work using the new public WebDAV API
-    And the HTTP status code should be "403"
+    Examples:
+      | webdav_api_version |
+      | new                |
 
 
-  Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder with old public API
+  Scenario Outline: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder with public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
       | permissions | create |
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"
-    When the public uploads file "test-old.txt" with content "test-old" using the old public WebDAV API
-    Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
+    When the public uploads file "test.txt" with content "test-file" using the <webdav_api_version> public WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
+
+  @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
   @issue-ocis-reva-41
-  Scenario: Uploading file to a public shared folder works when allow public uploads has been disabled and again enabled after sharing the folder with new public API
-    Given user "Alice" has created a public link share with settings
-      | path        | FOLDER |
-      | permissions | create |
-    And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    And parameter "shareapi_allow_public_upload" of app "core" has been set to "yes"
-    When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
-    Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
+    Examples:
+      | webdav_api_version |
+      | new                |
 
   @smokeTest
-  Scenario: Uploading to a public upload-write and no edit and no overwrite share with old public API
+  Scenario Outline: Uploading to a public upload-write and no edit and no overwrite share with public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
-    When the public uploads file "test-old.txt" with content "test-old" using the old public WebDAV API
-    Then the content of file "/FOLDER/test-old.txt" for user "Alice" should be "test-old"
+    When the public uploads file "test.txt" with content "test-file" using the <webdav_api_version> public WebDAV API
+    Then the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
 
-  @smokeTest
-  Scenario: Uploading to a public upload-write and no edit and no overwrite share with new public API
-    Given user "Alice" has created a public link share with settings
-      | path        | FOLDER          |
-      | permissions | uploadwriteonly |
-    When the public uploads file "test-new.txt" with content "test-new" using the new public WebDAV API
-    Then the content of file "/FOLDER/test-new.txt" for user "Alice" should be "test-new"
+    @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
 
-  @smokeTest
+
+    Examples:
+      | webdav_api_version |
+      | new                |
+
+  @smokeTest @notToImplementOnOCIS @issue-ocis-2079
   Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -15,15 +15,24 @@ Feature: persistent-locking in case of a public link
     And user "Alice" has created a public link share of folder "FOLDER" with change permission
     When user "Alice" locks folder "FOLDER" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
-    Then uploading a file should not work using the old public WebDAV API
-    And uploading a file should not work using the new public WebDAV API
+    Then uploading a file should not work using the <webdav_api_version> public WebDAV API
     And the HTTP status code should be "423"
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | dav-path | lock-scope |
-      | old      | shared     |
-      | old      | exclusive  |
-      | new      | shared     |
-      | new      | exclusive  |
+      | dav-path | lock-scope | webdav_api_version |
+      | old      | shared     | old                |
+      | old      | exclusive  | old                |
+      | new      | shared     | old                |
+      | new      | exclusive  | old                |
+
+
+    Examples:
+      | dav-path | lock-scope | webdav_api_version |
+      | old      | shared     | new                |
+      | old      | exclusive  | new                |
+      | new      | shared     | new                |
+      | new      | exclusive  | new                |
 
   @skipOnOcV10 @issue-36064
   Scenario Outline: Uploading a file into a locked subfolder of a public folder
@@ -75,9 +84,15 @@ Feature: persistent-locking in case of a public link
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "405"
     And the value of the item "//s:message" in the response should be "Locking not allowed from public endpoint"
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version | lock-scope |
       | old                       | shared     |
       | old                       | exclusive  |
+
+
+    Examples:
+      | public-webdav-api-version | lock-scope |
       | new                       | shared     |
       | new                       | exclusive  |

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -90,15 +90,21 @@ Feature: actions on a locked item are possible if the token is sent with the req
     And user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "Alice" using the old public WebDAV API
-    Then the HTTP status code should be "423"
-    When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "Alice" using the new public WebDAV API
-    Then the HTTP status code should be "412"
+    When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "Alice" using the <webdav_api_version> public WebDAV API
+    Then the HTTP status code should be "<http_status_code>"
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | lock-scope |
-      | shared     |
-      | exclusive  |
+      | lock-scope | webdav_api_version | http_status_code |
+      | shared     | old                | 423              |
+      | exclusive  | old                | 423              |
+
+
+    Examples:
+      | lock-scope | webdav_api_version | http_status_code |
+      | shared     | new                | 412              |
+      | exclusive  | new                | 412              |
 
   @skipOnOcV10 @issue-34360 @files_sharing-app-required
   Scenario Outline: two users having both a shared lock can use the resource

--- a/tests/acceptance/features/cliMain/transfer-ownership.feature
+++ b/tests/acceptance/features/cliMain/transfer-ownership.feature
@@ -1,8 +1,7 @@
 @cli
 Feature: transfer-ownership
 
-  @smokeTest
-  @skipOnEncryptionType:user-keys
+  @smokeTest @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of a file
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and small skeleton files
@@ -136,11 +135,13 @@ Feature: transfer-ownership
     When the administrator transfers ownership from "Alice" to "Brian" using the occ command
     Then the command should have been successful
 
+
   Scenario: transferring ownership fails with invalid source user
     Given user "Alice" has been created with default attributes and small skeleton files
     When the administrator transfers ownership from "invalid_user" to "Alice" using the occ command
     Then the command output should contain the text "Unknown source user"
     And the command should have failed with exit code 1
+
 
   Scenario: transferring ownership fails with invalid destination user
     Given user "Alice" has been created with default attributes and small skeleton files
@@ -148,8 +149,7 @@ Feature: transfer-ownership
     Then the command output should contain the text "Unknown destination user"
     And the command should have failed with exit code 1
 
-  @smokeTest
-  @skipOnEncryptionType:user-keys
+  @smokeTest @skipOnEncryptionType:user-keys
   Scenario: transferring ownership of only a single folder containing a file
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and small skeleton files
@@ -158,6 +158,7 @@ Feature: transfer-ownership
     When the administrator transfers ownership of path "test" from "Alice" to "Brian" using the occ command
     Then the command should have been successful
     And the downloaded content when downloading file "/test/somefile.txt" for user "Brian" with range "bytes=0-6" from the last received transfer folder should be "This is"
+
 
   Scenario: transferring ownership of only a single folder containing an empty folder
     Given user "Alice" has been created with default attributes and small skeleton files
@@ -168,6 +169,7 @@ Feature: transfer-ownership
     Then the command should have been successful
     And as "Brian" folder "/test" should exist in the last received transfer folder
     And as "Brian" folder "/test/subfolder" should exist in the last received transfer folder
+
 
   Scenario: transferring ownership of an account containing only an empty folder
     Given user "Alice" has been created with default attributes and small skeleton files
@@ -191,7 +193,7 @@ Feature: transfer-ownership
     And the downloaded content when downloading file "/somefile.txt" for user "Carol" with range "bytes=0-6" should be "This is"
 
   @skipOnEncryptionType:user-keys @public_link_share-feature-required @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
-  Scenario: transferring ownership of folder shares which has public link
+  Scenario Outline: transferring ownership of folder shares which has public link
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/test"
@@ -200,8 +202,17 @@ Feature: transfer-ownership
       | path | /test/somefile.txt |
     When the administrator transfers ownership of path "test" from "Alice" to "Brian" using the occ command
     Then the command should have been successful
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the <webdav_api_version> public WebDAV API without a password and the content should be "Random data"
+
+    @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | webdav_api_version |
+      | old                |
+
+
+    Examples:
+      | webdav_api_version |
+      | new                |
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292
   Scenario: transferring ownership of folder shared with third user
@@ -280,12 +291,14 @@ Feature: transfer-ownership
     Then the command should have been successful
     And as "Brian" folder "/local_storage" should not exist in the last received transfer folder
 
+
   Scenario: transferring ownership of a folder fails with invalid source user
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/sub"
     When the administrator transfers ownership of path "sub" from "invalid_user" to "Alice" using the occ command
     Then the command output should contain the text "Unknown source user"
     And the command should have failed with exit code 1
+
 
   Scenario: transferring ownership of a folder fails with invalid destination user
     Given user "Alice" has been created with default attributes and small skeleton files
@@ -294,12 +307,14 @@ Feature: transfer-ownership
     Then the command output should contain the text "Unknown destination user"
     And the command should have failed with exit code 1
 
+
   Scenario: transferring ownership fails with invalid path
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and small skeleton files
     When the administrator transfers ownership of path "test" from "Alice" to "Brian" using the occ command
     Then the command output should contain the text "Unknown path provided"
     And the command should have failed with exit code 1
+
 
   Scenario: transferring ownership fails with empty files
     Given user "Alice" has been created with default attributes and small skeleton files


### PR DESCRIPTION
## Description
This PR adds `notToImplementOnOCIS` tags on the tests using the old public WebDAV API. 
Also, the tests in `apiSharePublicLink2/updatePublicLinkShare.feature` are failing in ocis mainly because the path for the folder was missing `/Shares`. So, this PR adjusts few tests in the feature file according to the behavior in ocis as well, i.e by setting the default shares folder to `Shares` and then setting the `auto-accept` shares to `no.`

## Related Issue
- https://github.com/owncloud/ocis/issues/2078
- Fixes https://github.com/owncloud/ocis/issues/2079

## Motivation and Context
The old public link webdav API will not be implemented in OCIS. However, the tests using the old public WebDAV API were added in the expected failures file. This used some unnecessary time and resources. So, those tests which are not expected to be implemented in ocis are required to be skipped in ocis.

## How Has This Been Tested?
- https://github.com/owncloud/ocis/pull/2159

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
