### PR TITLE
Adjust position of the autocomplete element

### DIFF
--- a/changelog/unreleased/38831
+++ b/changelog/unreleased/38831
@@ -1,0 +1,9 @@
+Bugfix: Adjust position of the share autocomplete element
+
+We now append the share autocomplete element to #shareTabView to prevent the
+autocomplete dialog from being hidden in certain scenarios. This happened
+with Safari for example as soon as the filelist was long enough to have a
+vertical scrollbar.
+
+https://github.com/owncloud/core/pull/38831
+https://github.com/owncloud/enterprise/issues/4603

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -276,6 +276,7 @@
 							$('.shareWithField').removeClass('error')
 								.tooltip('hide')
 								.autocomplete("option", "autoFocus", true);
+
 							response(suggestions, result);
 						} else {
 							var title = t('core', 'No users or groups found for {search}', {search: $('.shareWithField').val()});
@@ -432,7 +433,8 @@
 						event.preventDefault();
 					},
 					source: this.autocompleteHandler,
-					select: this._onSelectRecipient
+					select: this._onSelectRecipient,
+					appendTo: '#shareTabView'
 				}).data('ui-autocomplete')._renderItem = _.bind(this.autocompleteRenderItem, this);
 			}
 

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -276,7 +276,6 @@
 							$('.shareWithField').removeClass('error')
 								.tooltip('hide')
 								.autocomplete("option", "autoFocus", true);
-
 							response(suggestions, result);
 						} else {
 							var title = t('core', 'No users or groups found for {search}', {search: $('.shareWithField').val()});


### PR DESCRIPTION
We now append the element to `#shareTabView` to prevent the autocomplete dialog from being hidden in certain scenarios. This happened with Safari for example as soon as the filelist was long enough to have a vertical scrollbar.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4603

## Screenshots (if appropriate):

before:

![image](https://user-images.githubusercontent.com/50302941/121507985-70143b80-c9e5-11eb-8ef0-0bb8d4a5c863.png)


after:

![image](https://user-images.githubusercontent.com/50302941/121507919-5e329880-c9e5-11eb-97eb-cd3e34e2da85.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
