### PR TITLE
[tests-only] Tag userSync tests notToImplementOnOCIS

### DIFF
--- a/tests/acceptance/features/apiMain/userSync.feature
+++ b/tests/acceptance/features/apiMain/userSync.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.3 @issue-ocis-reva-401
+@api @notToImplementOnOCIS @issue-ocis-1241
 Feature: Users sync
 
   Background:
@@ -6,6 +6,7 @@ Feature: Users sync
       | username |
       | Alice    |
       | Brian    |
+
 
   Scenario Outline: Trying to sync a user when there is no external user backend
     Given using OCS API version "<ocs-api-version>"
@@ -18,6 +19,7 @@ Feature: Users sync
       | 1               | 100             |
       | 2               | 200             |
 
+
   Scenario Outline: Trying to sync a user which does not exist
     Given using OCS API version "<ocs-api-version>"
     When the administrator tries to sync user "nonexistentuser" using the OCS API
@@ -28,6 +30,7 @@ Feature: Users sync
       | ocs-api-version | http-status-code |
       | 1               | 200              |
       | 2               | 404              |
+
 
   Scenario Outline: Trying to sync a user as another user which does not exist
     Given using OCS API version "<ocs-api-version>"
@@ -51,6 +54,7 @@ Feature: Users sync
       | ocs-api-version | ocs-status-code | http-status-code |
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
+
 
   Scenario Outline: Trying to sync a user by admin using an incorrect password
     Given using OCS API version "<ocs-api-version>"


### PR DESCRIPTION
## Description
userSync is not to be implemented on OCIS (see related issue). Tag it so that OCIS and reva CI will skip the feature.

Note: I also removed an "ancient" `skipOnOcV10.3` tag - they are old, and not useful any more. And I spaced out the scenarios like we do nowadays.

## Related Issue
https://github.com/owncloud/ocis/issues/1241

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
