### PR TITLE
[tests-only] Break CI

### DIFF
--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -19,7 +19,7 @@ Feature: Add, delete and edit comments in files and folders
     And the user comments with content "<comment>" using the webUI
     Then the comment "<comment>" should be listed in the comments tab in details dialog
     When the user deletes the comment "<comment>" using the webUI
-    Then the comment "<comment>" should not be listed in the comments tab in details dialog
+    Then the comment "<comment>" should be listed in the comments tab in details dialog
     Examples:
       | comment     |
       | lorem ipsum |

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -18,7 +18,7 @@ Feature: login users
     Given the administrator has added system config key "strict_login_enforced" with value "true" and type "boolean"
     When the user browses to the login page
     Then the username field on the login page should have placeholder text "Login"
-    And the password field on the login page should have placeholder text "Password"
+    And the password field on the login page should have placeholder text "Broken"
 
   Scenario: simple user login
     Given these users have been created with default attributes and without skeleton files:


### PR DESCRIPTION
This purposely breaks a test in webUILogin suite to see if the earlyFail behavior is working correctly. - that worked, there is a single comment posted below.

The 2nd commit also breaks a scenario in webUIComments - we got just a post about webUIComments. webUILogin was cancelled before it got to post a fail - that is what should happen.

So this seems to work as it should. I don't know what happen in PR #38821 when it got spammed with test failure comments.