### PR TITLE
[tests-only] Support full-ci in PR title for CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1416,6 +1416,9 @@ def acceptance(ctx):
 			if params['skip']:
 				continue
 
+			if ("full-ci" in ctx.build.title.lower()):
+				params["earlyFail"] = False
+
 			if isAPI or isCLI:
 				params['browsers'] = ['']
 


### PR DESCRIPTION
## Description
We want to be able to control if the CI acceptance tests fail-early or not, without actually editing `.drone.star`.

Add the CI feature, the same as in web and ocis, that if the PR title contains `full-ci` (in any mixed case) then let the CI  run to completion (do not terminate early).

This is useful when a developer knows that there are likely to be test failures in multiple test suites. They can see all the failures in a single CI  run.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
