### PR TITLE
introduce patch for CVE-2019-11358

### DIFF
--- a/changelog/unreleased/38841
+++ b/changelog/unreleased/38841
@@ -1,0 +1,8 @@
+Enhancement: Introduce the patch for CVE-2019-11358
+
+Patched jQuery's `$.extend` method. The code in core doesn't contain any vulnerable invocations of `$.extend` this is just a preventive patch. 
+
+https://nvd.nist.gov/vuln/detail/CVE-2019-11358
+https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/
+https://github.com/DanielRuf/snyk-js-jquery-174006?files=1
+https://github.com/owncloud/core/pull/38841

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -2393,3 +2393,67 @@ jQuery.fn.tipsy = function (argument) {
 	return this;
 }
 
+jQuery.extend = jQuery.fn.extend = function() {
+	var options, name, src, copy, copyIsArray, clone,
+		target = arguments[0] || {},
+		i = 1,
+		length = arguments.length,
+		deep = false;
+
+	// Handle a deep copy situation
+	if ( typeof target === "boolean" ) {
+		deep = target;
+
+		// Skip the boolean and the target
+		target = arguments[ i ] || {};
+		i++;
+	}
+
+	// Handle case when target is a string or something (possible in deep copy)
+	if ( typeof target !== "object" && !jQuery.isFunction(target) ) {
+		target = {};
+	}
+
+	// Extend jQuery itself if only one argument is passed
+	if ( i === length ) {
+		target = this;
+		i--;
+	}
+
+	for ( ; i < length; i++ ) {
+		// Only deal with non-null/undefined values
+		if ( (options = arguments[ i ]) != null ) {
+			// Extend the base object
+			for ( name in options ) {
+				src = target[ name ];
+				copy = options[ name ];
+
+				// Prevent never-ending loop
+				if ( name === "__proto__" || target === copy ) {
+					continue;
+				}
+
+				// Recurse if we're merging plain objects or arrays
+				if ( deep && copy && ( jQuery.isPlainObject(copy) || (copyIsArray = jQuery.isArray(copy)) ) ) {
+					if ( copyIsArray ) {
+						copyIsArray = false;
+						clone = src && jQuery.isArray(src) ? src : [];
+
+					} else {
+						clone = src && jQuery.isPlainObject(src) ? src : {};
+					}
+
+					// Never move original objects, clone them
+					target[ name ] = jQuery.extend( deep, clone, copy );
+
+					// Don't bring in undefined values
+				} else if ( copy !== undefined ) {
+					target[ name ] = copy;
+				}
+			}
+		}
+	}
+
+	// Return the modified object
+	return target;
+};


### PR DESCRIPTION
Patched jQuery's `$.extend` method. The code in core doesn't contain any vulnerable invocations of `$.extend` this is just a preventive patch. 

https://nvd.nist.gov/vuln/detail/CVE-2019-11358
https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/
https://github.com/DanielRuf/snyk-js-jquery-174006?files=1