### PR TITLE
[Tests-Only]Adjust webdav previews test according to its behaviour in ocis

### DIFF
--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -91,12 +91,15 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
-  @issue-ocis-2067
+
   Scenario: download previews of shared files
-    Given user "Brian" has been created with default attributes and without skeleton files
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And user "Alice" has shared file "/parent.txt" with user "Brian"
-    When user "Brian" downloads the preview of "/parent.txt" with width "32" and height "32" using the WebDAV API
+    And user "Brian" has accepted share "/parent.txt" offered by user "Alice"
+    When user "Brian" downloads the preview of "/Shares/parent.txt" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
@@ -116,6 +119,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "400"
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "Unsupported file type"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\BadRequest"
+
 
   Scenario: download previews of not-existing files
     When user "Alice" downloads the preview of "/parent.txt" with width "32" and height "32" using the WebDAV API


### PR DESCRIPTION
## Description
This PR adjusts a webdav previews test which was failing in ocis and hence was included in the expected failures file. However, the test involved downloading a received share for preview. For that reason, in ocis, the share should be accepted first. Hence, the adjustment of the test is made accordingly in this pr.

## Related Issue
https://github.com/owncloud/ocis/issues/2078

## How Has This Been Tested?
- CI
- https://github.com/owncloud/ocis/pull/2165

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
