### PR TITLE
ci: replace unmaintained alpine step image

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -543,7 +543,7 @@ def changelog(ctx):
 				},
 				{
 					'name': 'diff',
-					'image': 'owncloud/alpine:latest',
+					'image': 'owncloudci/alpine:latest',
 					'pull': 'always',
 					'commands': [
 						'git diff',


### PR DESCRIPTION
CI only

Would be good to back port to 10.7 and 10.6 as well.