### PR TITLE
[tests-only] Skip bug demo for issue-38835 on S3 storage

### DIFF
--- a/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
+++ b/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
@@ -6,7 +6,7 @@ Feature: checksums
 
   # this is a bug demo scenario for https://github.com/owncloud/core/issues/38835
   # Once this scenario is fixed Delete this file and remove @skipOnOcV10 tag from tests/acceptance/features/apiMain/checksums.feature:132
-  @files_sharing-app-required
+  @files_sharing-app-required @skipOnStorage:ceph @skipOnStorage:scality
   Scenario: Sharing and modifying a file should return correct checksum in the propfind using new DAV path
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled


### PR DESCRIPTION
## Description
PR #38827 added a bug-demo scenario for issue #38835 - but that bug-demo fails in `files_primary_s3` CI - the issue seems to not be a problem in S3 storage. Skip the scenario in that case.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
