### PR TITLE
[tests-only] Skip changed login tests on old oC10

### DIFF
--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -8,17 +8,19 @@ Feature: login users
   I want only authorised users to log in
   So that unauthorised access is impossible
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: login page username and password field placeholder text
     When the user browses to the login page
     Then the username field on the login page should have label text "Username or email"
     And the password field on the login page should have label text "Password"
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: login page username and password field placeholder text when strict_login_enforced is set
     Given the administrator has added system config key "strict_login_enforced" with value "true" and type "boolean"
     When the user browses to the login page
     Then the username field on the login page should have label text "Login"
     And the password field on the login page should have label text "Password"
+
 
   Scenario: simple user login
     Given these users have been created with default attributes and without skeleton files:
@@ -47,11 +49,13 @@ Feature: login users
     When the administrator tries to login with an invalid password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
 
+
   Scenario: access the personal general settings page when not logged in
     When the user attempts to browse to the personal general settings page
     Then the user should be redirected to a webUI page with the title "%productname%"
     When the administrator logs in using the webUI after a redirect from the "personal general settings" page
     Then the user should be redirected to a webUI page with the title "Settings - %productname%"
+
 
   Scenario: access the personal general settings page when not logged in using incorrect then correct password
     When the user attempts to browse to the personal general settings page


### PR DESCRIPTION
## Description
PR #38821 changed the labels/placeholders on the webUI login page. The adjusted tests are not relevant to old oC10 core releases, so skip them in that case.

This will fix failing nightly CI like https://drone.owncloud.com/owncloud/files_primary_s3/2309/52/19
"WebUILoginContext::usernameFieldOnLoginPageShouldHaveLabelText The username label text was expected to be 'Login', but got '' instead."

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
