### PR TITLE
Add preflight check if video is supported by browser

### DIFF
--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -86,8 +86,9 @@ OCA.Sharing.PublicApp = {
 		var mimetypeIcon = $('#mimetypeIcon').val();
 		mimetypeIcon = mimetypeIcon.substring(0, mimetypeIcon.length - 3);
 		mimetypeIcon = mimetypeIcon + 'svg';
-
+		var previewEnabled = ($("#previewEnabled").val());
 		var previewSupported = $('#previewSupported').val();
+
 
 		if (typeof FileActions !== 'undefined') {
 			// Show file preview if previewer is available, images are already handled by the template
@@ -120,6 +121,16 @@ OCA.Sharing.PublicApp = {
 			'max-width': previewWidth,
 			'max-height': previewHeight
 		});
+
+		// Check if video type is supported by browser
+		if (mimetype.substr(0, mimetype.indexOf('/')) === 'video' && previewEnabled === 'true') {
+			var obj = document.createElement('video');
+			if (obj.canPlayType(mimetype) === "") {
+				OC.Notification.show(t('files_sharing',
+					'The video cannot be played because your browser does not support the file type. Please try another browser.')
+				);
+			}
+		}
 
 		var fileSize = parseInt($('#filesize').val(), 10);
 		var maxGifSize = parseInt($('#maxSizeAnimateGif').val(), 10);

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -47,6 +47,7 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 <input type="hidden" name="filename" value="<?php p($_['filename']) ?>" id="filename">
 <input type="hidden" name="mimetype" value="<?php p($_['mimetype']) ?>" id="mimetype">
 <input type="hidden" name="previewSupported" value="<?php p($_['previewSupported'] ? 'true' : 'false'); ?>" id="previewSupported">
+<input type="hidden" name="previewEnabled" value="<?php p($_['previewEnabled'] ? 'true' : 'false'); ?>" id="previewEnabled">
 <input type="hidden" name="mimetypeIcon" value="<?php p(\OC::$server->getMimeTypeDetector()->mimeTypeIcon($_['mimetype'])); ?>" id="mimetypeIcon">
 <input type="hidden" name="filesize" value="<?php p($_['nonHumanFileSize']); ?>" id="filesize">
 <input type="hidden" name="maxSizeAnimateGif" value="<?php p($_['maxSizeAnimateGif']); ?>" id="maxSizeAnimateGif">

--- a/changelog/unreleased/38858
+++ b/changelog/unreleased/38858
@@ -1,0 +1,10 @@
+Enhancement: Show notification if video playback is not possible on public share
+
+Before this PR no error notification was shown if a video can't be played due
+to browser incompatibility, for example, mov files on chrome.
+(https://stackoverflow.com/questions/28746645)
+
+Now we will show a dedicated notification.
+
+https://github.com/owncloud/enterprise/issues/4632
+https://github.com/owncloud/core/pull/38858


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Enhancement: Show notification if video playback is not possible on public share

Before this PR no error notification was shown if a video can't be played due
to browser incompatibility, for example, mov files on chrome.
(https://stackoverflow.com/questions/28746645)

Now we will show a dedicated notification.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4632

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/26169327/122216998-478cb580-cead-11eb-95a7-402f6cce670b.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
