### PR TITLE
fix doc link

### DIFF
--- a/changelog/unreleased/38860
+++ b/changelog/unreleased/38860
@@ -1,0 +1,6 @@
+Bugfix: Fix docs link to federated sharing docs
+
+The link in the share dialogue on the info icon was broken. Was fixed by pointing to the correct config value.
+
+https://github.com/owncloud/core/issues/38859
+https://github.com/owncloud/core/pull/38860

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -241,7 +241,7 @@ $array = [
 ];
 
 if (\OC::$server->getUserSession() !== null && \OC::$server->getUserSession()->isLoggedIn()) {
-	$array['oc_appconfig']['federatedCloudShareDoc'] = \OC::$server->getURLGenerator()->linkToDocs('user-sharing-federated');
+	$array['oc_appconfig']['core']['federatedCloudShareDoc'] = \OC::$server->getURLGenerator()->linkToDocs('user-sharing-federated');
 	$array['oc_config']['version'] = \implode('.', \OCP\Util::getVersion());
 	$array['oc_config']['versionstring'] = OC_Util::getVersionString();
 	$array['oc_defaults']['docBaseUrl'] = $defaults->getDocBaseUrl();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The link in the share dialogue on the info icon was empty. Should be https://doc.owncloud.com/server/10.7/go.php?to=user-sharing-federated

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #38859 

## Motivation and Context
Was broken since 10.0.0

## How Has This Been Tested?
- manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
