### PR TITLE
Reshares with groups where the same file ends up in different mountpoints that are moved should have correct permissions

### DIFF
--- a/changelog/unreleased/38625
+++ b/changelog/unreleased/38625
@@ -8,3 +8,4 @@ https://github.com/owncloud/enterprise/issues/4497
 https://github.com/owncloud/enterprise/issues/4382
 https://github.com/owncloud/core/pull/38625
 https://github.com/owncloud/core/pull/38651
+https://github.com/owncloud/core/pull/38862

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -513,3 +513,37 @@ Feature: Sharing files and folders with internal groups
       | uid_owner   | Alice                |
       | share_with  | grp3                 |
       | permissions | 31                   |
+
+  @skipOnOcV10.6 @skipOnOcV10.7
+  Scenario: Reshares with groups where the same file ends up in different mountpoints that are renamed should have correct permissions
+    Given these groups have been created:
+      | groupname |
+      | grp1      |
+      | grp2      |
+      | grp3      |
+      | grp4      |
+    And user "Alice" has been added to group "grp1"
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has been added to group "grp2"
+    And user "Brian" has been added to group "grp2"
+    And user "Carol" has uploaded file with content "some data" to "/simple-folder/simple-inner-folder/simple-inner-inner-folder/textfile-2.txt"
+    And user "Carol" has shared folder "/simple-folder" with user "Alice" with permissions "all"
+    And user "Alice" has shared folder "/simple-folder" with group "grp2" with permissions "all"
+    And user "Alice" has shared folder "/simple-folder/simple-inner-folder" with group "grp1" with permissions "read"
+    And user "Brian" has created folder "/renamed-simple-folder"
+    And user "Brian" has logged in using the webUI
+    When the user opens the sharing tab from the file action menu of folder "simple-inner-folder" using the webUI
+    Then the user should see an error message on the share dialog saying "Sharing is not allowed"
+    # now move received simple-inner-folder into some folder
+    And the user moves folder "simple-inner-folder" into folder "renamed-simple-folder" using the webUI
+    And the user opens folder "/renamed-simple-folder" using the webUI
+    When the user opens the sharing tab from the file action menu of folder "simple-inner-folder" using the webUI
+    Then the user should see an error message on the share dialog saying "Sharing is not allowed"
+    # after move, sharing folder simple-inner-folder again but with different group should be possible
+    And the user browses to the home page
+    And the user opens folder "/simple-folder" using the webUI
+    When the user shares folder "simple-inner-folder" with group "grp3" using the webUI
+    Then the following permissions are seen for "simple-inner-folder" in the sharing dialog for group "grp3"
+      | edit   | yes |
+      | change | yes |
+      | share  | yes |


### PR DESCRIPTION
This PR adds acceptance test and fix for another corner-case in resharing with groups. Currently on OC10 it fails and we need a fix.
Unfortuntelelly, it might be that when validating permissions for shares we would need to visit **each** incoming mountpoint for the same file but coming from different share, and compute most permissive permission.. similarly as in supershare logic.

**Background:** 
It is continuation of thread started in https://github.com/owncloud/core/pull/38625 and https://github.com/owncloud/core/pull/38651. The PR above were targeting a case with multilevel reshares with cross-member groups by identifying "parent" path by the path length. However, scenario when mountpoint gets moved got overlooked. If reshare mountpoints from multiple multilevel reshare of the same folder nodes gets renamed/moved, we loose track of which mountpoint "is parent". 

- [ ] extend unit tests to cover scenario