### PR TITLE
Make text for the http.cookie.samesite config value more clear

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -264,10 +264,11 @@ $CONFIG = [
 /**
  * Define how to relax same site cookie settings
  *
- * Possible values: Strict, Lax or None
- * Setting the same site cookie to None is necessary in case of OpenID Connect.
+ * Possible values: `Strict`, `Lax` or `None`.
+ * Setting the same site cookie to `None` is necessary in case of OpenID Connect.
  * For more information about the impact of the values see:
- * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#values and
+ * https://web.dev/schemeful-samesite/
  */
 
 'http.cookie.samesite' => 'Strict',


### PR DESCRIPTION
## Description
Make the values more distinctable.
Adding a supportive website for oidc, same we have already in docs.
Text change only.

## Related Issue
- Fixes #38852 (Missing period or other sentence separator)
- References: https://github.com/owncloud/docs/pull/3708

## Motivation and Context
Better readbility

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
