### PR TITLE
[tests-only] Allow for no unit tests with coverage in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -300,6 +300,13 @@ def main(ctx):
 
 	dependsOn(before, coverageTests)
 
+	nonCoverageTests = nonCoveragePipelines(ctx)
+	if (nonCoverageTests == False):
+		print('Errors detected in nonCoveragePipelines. Review messages above.')
+		return []
+
+	dependsOn(before, nonCoverageTests)
+
 	stages = stagePipelines(ctx)
 	if (stages == False):
 		print('Errors detected in stagePipelines. Review messages above.')
@@ -307,11 +314,14 @@ def main(ctx):
 
 	dependsOn(before, stages)
 
-	afterCoverageTests = afterCoveragePipelines(ctx)
-	dependsOn(coverageTests, afterCoverageTests)
+	if (coverageTests == []):
+		afterCoverageTests = []
+	else:
+		afterCoverageTests = afterCoveragePipelines(ctx)
+		dependsOn(coverageTests, afterCoverageTests)
 
 	after = afterPipelines(ctx)
-	dependsOn(afterCoverageTests + stages, after)
+	dependsOn(afterCoverageTests + nonCoverageTests + stages, after)
 
 	return initial + before + coverageTests + afterCoverageTests + stages + after
 
@@ -322,10 +332,20 @@ def beforePipelines(ctx):
 	return codestyle() + changelog(ctx) + phpstan() + phan()
 
 def coveragePipelines(ctx):
-	# All pipelines that might have coverage or other test analysis reported
-	jsPipelines = javascript(ctx)
-	phpUnitPipelines = phpTests(ctx, 'phpunit')
-	phpIntegrationPipelines = phpTests(ctx, 'phpintegration')
+	# All unit test pipelines that have coverage or other test analysis reported
+	jsPipelines = javascript(ctx, True)
+	phpUnitPipelines = phpTests(ctx, 'phpunit', True)
+	phpIntegrationPipelines = phpTests(ctx, 'phpintegration', True)
+	if (jsPipelines == False) or (phpUnitPipelines == False) or (phpIntegrationPipelines == False):
+		return False
+
+	return jsPipelines + phpUnitPipelines + phpIntegrationPipelines
+
+def nonCoveragePipelines(ctx):
+	# All unit test pipelines that do not have coverage or other test analysis reported
+	jsPipelines = javascript(ctx, False)
+	phpUnitPipelines = phpTests(ctx, 'phpunit', False)
+	phpIntegrationPipelines = phpTests(ctx, 'phpintegration', False)
 	if (jsPipelines == False) or (phpUnitPipelines == False) or (phpIntegrationPipelines == False):
 		return False
 
@@ -1002,7 +1022,7 @@ def dav():
 
 	return pipelines
 
-def javascript(ctx):
+def javascript(ctx, withCoverage):
 	pipelines = []
 
 	if 'javascript' not in config:
@@ -1034,6 +1054,14 @@ def javascript(ctx):
 		params[item] = matrix[item] if item in matrix else default[item]
 
 	if params['skip']:
+		return pipelines
+
+	# if we only want pipelines with coverage, and this pipeline does not do coverage, then do not include it
+	if withCoverage and not params['coverage']:
+		return pipelines
+
+	# if we only want pipelines without coverage, and this pipeline does coverage, then do not include it
+	if not withCoverage and params['coverage']:
 		return pipelines
 
 	result = {
@@ -1097,7 +1125,7 @@ def javascript(ctx):
 
 	return [result]
 
-def phpTests(ctx, testType):
+def phpTests(ctx, testType, withCoverage):
 	pipelines = []
 
 	if testType not in config:
@@ -1158,6 +1186,14 @@ def phpTests(ctx, testType):
 			params[item] = matrix[item] if item in matrix else default[item]
 
 		if params['skip']:
+			continue
+
+		# if we only want pipelines with coverage, and this pipeline does not do coverage, then do not include it
+		if withCoverage and not params['coverage']:
+			continue
+
+		# if we only want pipelines without coverage, and this pipeline does coverage, then do not include it
+		if not withCoverage and params['coverage']:
 			continue
 
 		for phpVersion in params['phpVersions']:


### PR DESCRIPTION
## Description
If there are no unit tests with coverage, then the existing `.drone.star` still schedules a sonar-analysis pipeline, which fails. I noticed this in PR #38867 when doing cut-down CI to demonstrate an acceptance test issue.

The starlark logic to decide whether a sonar-analysis pipeline is needed or not was implemented in the activity app last week - https://github.com/owncloud/activity/pull/959 but was not applied to core.

This PR applies the same logic to core.

99.9% of the time this is not an issue in core - unit tests are nearly always run in CI. But we may as well have the logic in `.drone.star` here.

## How Has This Been Tested?
CI of #38867 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
