### PR TITLE
[tests-only] Cleanup good scenario for trashbinRestore issue-35974

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -101,15 +101,7 @@ Feature: Restore deleted files/folders
     And user "Alice" has deleted file <delete-path>
     When user "Alice" restores the file with original path <delete-path> to <upload-path> using the trashbin API
     Then the HTTP status code should be "204"
-    # Sometimes <upload-path> is found in the trashbin. Should it? Or not?
-    # That seems to be what happens when the restore-overwrite happens properly,
-    # The original <upload-path> seems to be "deleted" and so goes to the trashbin
-    And as "Alice" the file with original path <upload-path> should not exist in the trashbin
     And as "Alice" file <upload-path> should exist
-    # sometimes the restore from trashbin does overwrite the existing file, but sometimes it does not. That is also surprising.
-    # the current observed behavior is that if the original <upload-path> ended up in the trashbin,
-    # then the new <upload-path> has the "file to delete" content.
-    # otherwise <upload-path> has its old content
     And the content of file <upload-path> for user "Alice" should be "file to delete"
     Examples:
       | dav-path | upload-path                | delete-path        |


### PR DESCRIPTION
## Description
This scenario is supposed to describe the desired good behavior when restoring a file to an already existing path. The existing file should be over-written with the content of the restored file.

There happens to be another side-effect on oC10 - the original file (sometimes) gets put into the trashbin. That side-effect has not been decided to be "required behavior". Maybe the original file should end up in the trashbin, maybe it should be available as an old version of the file, or maybe it should just be thrown away.

This PR removes the check "file should not exist in the trashbin". That makes the scenario suitable as a test for implementations, for example OCIS.

See more notes and discussion in #38867 and https://github.com/cs3org/reva/pull/1795

## Related Issue
- #35974

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
