### PR TITLE
[tests-only] Fix timing of browseToHomePage in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -244,7 +244,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @throws \Exception
 	 */
 	public function theUserBrowsesToTheHomePage() {
-		$this->filesPage->browseToHomePage();
+		$this->filesPage->browseToHomePage($this->getSession());
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -378,10 +378,12 @@ class FilesPage extends FilesPageBasic {
 	/**
 	 * Browse to Home Page by clicking on home icon.
 	 *
+	 * @param Session $session
+	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function browseToHomePage() {
+	public function browseToHomePage($session) {
 		$homePageIcon = $this->find("xpath", $this->homePageIconXpath);
 		$this->assertElementNotNull(
 			$homePageIcon,
@@ -390,6 +392,10 @@ class FilesPage extends FilesPageBasic {
 			"could not find home page icon."
 		);
 		$homePageIcon->click();
+		// The home page icon takes us to the top-level files page.
+		// Wait for it to be properly loaded, so that the next step(s) can run
+		// without timing problems.
+		$this->waitTillPageIsLoaded($session);
 	}
 
 	/**


### PR DESCRIPTION
## Description
The test step "the user browses to the home page" does not wait for the "home" page (=top-level files page) to actually load. If the system-under-test is slow, then the next step in the test scenario might fail, because the expected file or folder is not yet visible.

This is happening in the encryption app with a new scenario that was added last week. See the linked issue below.

This PR makes the test code wait for the files page to load, after the home page button is clicked.

## Related Issue
- Fixes https://github.com/owncloud/encryption/issues/289

## How Has This Been Tested?
CI - see demo PR in encryption: https://github.com/owncloud/encryption/pull/290
The flaky test scenario was failing more than 50% of the time in encryption: https://drone.owncloud.com/owncloud/encryption/1947/15/17
`16 scenarios (5 passed, 11 failed)`

With the core change in this PR, it passed 16 times: https://drone.owncloud.com/owncloud/encryption/1949/9/17
`16 scenarios (16 passed)`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
