### PR TITLE
[full-ci] Change remote to federated

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/OcmController.php
+++ b/apps/federatedfilesharing/lib/Controller/OcmController.php
@@ -196,7 +196,7 @@ class OcmController extends Controller {
 				|| !isset($protocol['options']['sharedSecret'])
 			) {
 				throw new BadRequestException(
-					'server can not add remote share, missing parameter'
+					'server can not add federated share, missing parameter'
 				);
 			}
 			if (!\OCP\Util::isValidFileName($name)) {
@@ -247,7 +247,7 @@ class OcmController extends Controller {
 			);
 		} catch (\Exception $e) {
 			$this->logger->error(
-				"server can not add remote share, {$e->getMessage()}",
+				"server can not add federated share, {$e->getMessage()}",
 				['app' => 'federatefilesharing']
 			);
 			return new JSONResponse(
@@ -287,7 +287,7 @@ class OcmController extends Controller {
 		try {
 			if (!\is_array($notification)) {
 				throw new BadRequestException(
-					'server can not add remote share, missing parameter'
+					'server can not add federated share, missing parameter'
 				);
 			}
 

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -166,7 +166,7 @@ class RequestHandlerController extends OCSController {
 		} catch (\Exception $e) {
 			\OCP\Util::writeLog(
 				'federatedfilesharing',
-				'server can not add remote share, ' . $e->getMessage(),
+				'server can not add federated share, ' . $e->getMessage(),
 				\OCP\Util::ERROR
 			);
 			return new Result(

--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -46,7 +46,7 @@ script('federatedfilesharing', 'settings-admin');
 	print_unescaped('checked="checked"');
 } ?> />
 		<label for="autoAcceptTrusted">
-			<?php p($l->t('Automatically accept remote shares from trusted servers'));?>
+			<?php p($l->t('Automatically accept federated shares from trusted servers'));?>
 		</label><br/>
 	</p>
 </div>

--- a/apps/federatedfilesharing/templates/settings-personal-sharing.php
+++ b/apps/federatedfilesharing/templates/settings-personal-sharing.php
@@ -34,7 +34,7 @@ script('federatedfilesharing', 'settings-personal-sharing');
 			<input type="checkbox" name="auto_accept_share_trusted" id="userAutoAcceptShareTrustedInput" class="checkbox" value="1" />
 		<?php endif; ?>
 		<label for="userAutoAcceptShareTrustedInput">
-			<?php p($l->t('Automatically accept remote shares from trusted servers')); ?>
+			<?php p($l->t('Automatically accept federated shares from trusted servers')); ?>
 		</label><br/>
 	<?php endif; ?>
 </form>

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1958,7 +1958,7 @@
 					if (share.share_type === OC.Share.SHARE_TYPE_GROUP) {
 						shareWith += ' (' + t('files', 'group') + ')';
 					} else if (share.share_type === OC.Share.SHARE_TYPE_REMOTE) {
-						shareWith += ' (' + t('files_sharing', 'Remote share') + ')';
+						shareWith += ' (' + t('files_sharing', 'Federated share') + ')';
 					}
 
 					var $path = $('<span>',   { class : 'shareTree-item-path', text : t('files', 'via') + " " + folder.name });

--- a/apps/files_sharing/ajax/external.php
+++ b/apps/files_sharing/ajax/external.php
@@ -102,7 +102,7 @@ try {
 
 	// return JSON response with error
 	\OCP\JSON::error(
-		['data' => ['message' => $l->t('Could not authenticate to remote share, password might be wrong')]]
+		['data' => ['message' => $l->t('Could not authenticate to federated share, password might be wrong')]]
 	);
 	exit();
 } catch (\Exception $e) {
@@ -131,7 +131,7 @@ try {
 		$externalManager->removeShare($mount->getMountPoint());
 		\OCP\Util::writeLog(
 			'files_sharing',
-			'Couldn\'t add remote share',
+			'Couldn\'t add federated share',
 			\OCP\Util::DEBUG
 		);
 	}
@@ -148,5 +148,5 @@ try {
 		'Invalid remote storage: ' . \get_class($e) . ': ' . $e->getMessage(),
 		\OCP\Util::DEBUG
 	);
-	\OCP\JSON::error(['data' => ['message' => $l->t('Couldn\'t add remote share')]]);
+	\OCP\JSON::error(['data' => ['message' => $l->t('Couldn\'t add federated share')]]);
 }

--- a/apps/files_sharing/js/external.js
+++ b/apps/files_sharing/js/external.js
@@ -27,10 +27,10 @@
 			OC.dialogs.confirm(
 				t(
 					'files_sharing',
-					'Do you want to add the remote share {name} from {owner}@{remote}?',
+					'Do you want to add the federated share {name} from {owner}@{remote}?',
 					{name: name, owner: owner, remote: remoteClean}, null, {escape: false}
 				),
-				t('files_sharing','Remote share'),
+				t('files_sharing','Federated share'),
 				function (result) {
 					callback(result, share);
 				},
@@ -40,16 +40,16 @@
 			OC.dialogs.prompt(
 				t(
 					'files_sharing',
-					'Do you want to add the remote share {name} from {owner}@{remote}?',
+					'Do you want to add the federated share {name} from {owner}@{remote}?',
 					{name: name, owner: owner, remote: remoteClean}, null, {escape: false}
 				),
-				t('files_sharing','Remote share'),
+				t('files_sharing','Federated share'),
 				function (result, password) {
 					share.password = password;
 					callback(result, share);
 				},
 				true,
-				t('files_sharing','Remote share password'),
+				t('files_sharing','Federated share password'),
 				true
 			).then(this._adjustDialog);
 		}
@@ -61,7 +61,7 @@
 		// hack the buttons
 		$dialog.find('.ui-icon').remove();
 		$buttons.eq(0).text(t('core', 'Cancel'));
-		$buttons.eq(1).text(t('files_sharing', 'Add remote share'));
+		$buttons.eq(1).text(t('files_sharing', 'Add federated share'));
 	};
 
 	OCA.Sharing.ExternalShareDialogPlugin = {

--- a/apps/files_sharing/lib/Activity.php
+++ b/apps/files_sharing/lib/Activity.php
@@ -198,13 +198,13 @@ class Activity implements IExtension {
 			case self::SUBJECT_REMOTE_SHARE_RECEIVED:
 				if (\sizeof($params) > 1) {
 					// New activity ownCloud 8.2+
-					return (string) $l->t('You received a new remote share %2$s from %1$s', $params);
+					return (string) $l->t('You received a new federated share %2$s from %1$s', $params);
 				}
-				return (string) $l->t('You received a new remote share from %s', $params);
+				return (string) $l->t('You received a new federated share from %s', $params);
 			case self::SUBJECT_REMOTE_SHARE_ACCEPTED:
-				return (string) $l->t('%1$s accepted remote share %2$s', $params);
+				return (string) $l->t('%1$s accepted federated share %2$s', $params);
 			case self::SUBJECT_REMOTE_SHARE_DECLINED:
-				return (string) $l->t('%1$s declined remote share %2$s', $params);
+				return (string) $l->t('%1$s declined federated share %2$s', $params);
 			case self::SUBJECT_REMOTE_SHARE_UNSHARED:
 				return (string) $l->t('%1$s unshared %2$s from you', $params);
 			case self::SUBJECT_PUBLIC_SHARED_FOLDER_DOWNLOADED:

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -64,11 +64,11 @@ class CleanupRemoteStorages extends Command {
 
 		$remoteShareIds = $this->getRemoteShareIds();
 
-		$output->writeln(\count($remoteShareIds) . " remote share(s) exist");
+		$output->writeln(\count($remoteShareIds) . " federated share(s) exist");
 
 		foreach ($remoteShareIds as $id => $remoteShareId) {
 			if (isset($remoteStorages[$remoteShareId])) {
-				$output->writeln("$remoteShareId belongs to remote share $id");
+				$output->writeln("$remoteShareId belongs to federated share $id");
 				unset($remoteStorages[$remoteShareId]);
 			} else {
 				$output->writeln("$remoteShareId for share $id has no matching storage, yet");

--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -178,7 +178,7 @@ class CleanupRemoteStoragesTest extends TestCase {
 		$output
 			->expects($this->at($at++))
 			->method('writeln')
-			->with('5 remote share(s) exist');
+			->with('5 federated share(s) exist');
 
 		$this->command->execute($input, $output);
 

--- a/changelog/unreleased/38877
+++ b/changelog/unreleased/38877
@@ -1,0 +1,10 @@
+Change: Use "federated" rather than ""remote" for shares
+
+Shares from one ownCloud to another ownCloud were referred to in some places as
+remote shares and in other places as federated shares. References to remote
+shares in error messages and on the user interface have been changed to
+references to federated shares. All user-facing text now calls these federated
+shares.
+
+https://github.com/owncloud/core/pull/38877
+https://github.com/owncloud/core/issues/38871

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -471,12 +471,12 @@
 
 			if (this.configModel.get('allowGroupSharing')) {
 				if (this.configModel.get('isRemoteShareAllowed')) {
-					sharePlaceholder = t('core', 'Share with users, groups or remote users…');
+					sharePlaceholder = t('core', 'Share with users, groups or federated users…');
 				} else {
 					sharePlaceholder = t('core', 'Share with users or groups…')
 				}
 			} else if (this.configModel.get('isRemoteShareAllowed')) {
-					sharePlaceholder = t('core', 'Share with users or remote users…');
+					sharePlaceholder = t('core', 'Share with users or federated users…');
 			}
 
 			return sharePlaceholder;

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -61,7 +61,7 @@ describe('OC.Share tests', function() {
 			it('displays the local share owner as is', function() {
 				checkOwner('User One', 'User One', null);
 			});
-			it('displays the user name part of a remote share owner', function() {
+			it('displays the user name part of a federated share owner', function() {
 				checkOwner(
 					'User One@someserver.com',
 					'User One@…',
@@ -78,7 +78,7 @@ describe('OC.Share tests', function() {
 					'User One@someserver.com'
 				);
 			});
-			it('displays the user name part with domain of a remote share owner', function() {
+			it('displays the user name part with domain of a federated share owner', function() {
 				checkOwner(
 					'User One@example.com@someserver.com',
 					'User One@example.com',
@@ -196,7 +196,7 @@ describe('OC.Share tests', function() {
 					'User One@someserver.com'
 				);
 			});
-			it('displays the user name part with domain of a remote share owner', function() {
+			it('displays the user name part with domain of a federated share owner', function() {
 				checkRecipients(
 					'User One@example.com@someserver.com',
 					'Shared with User One@example.com',

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -218,15 +218,15 @@ describe('OC.Share.ShareDialogView', function() {
 			});
 		});
 	});
-	describe('remote sharing', function() {
-		it('shows remote share info when allowed', function() {
+	describe('federated sharing', function() {
+		it('shows federated share info when allowed', function() {
 			configModel.set({
 				isRemoteShareAllowed: true
 			});
 			dialog.render();
 			expect(dialog.$el.find('.shareWithRemoteInfo').length).toEqual(1);
 		});
-		it('does not show remote share info when not allowed', function() {
+		it('does not show federated share info when not allowed', function() {
 			configModel.set({
 				isRemoteShareAllowed: false
 			});
@@ -998,7 +998,7 @@ describe('OC.Share.ShareDialogView', function() {
 						share_with_displayname: "Demo guest",
 					}, {
 						share_type: 6,
-						share_with_displayname: "Demo remote user",
+						share_with_displayname: "Demo federated user",
 					}]
 				}
 			});

--- a/settings/Panels/Admin/FileSharing.php
+++ b/settings/Panels/Admin/FileSharing.php
@@ -117,9 +117,9 @@ class FileSharing implements ISettings {
 		$template->assign('shareExpireAfterNDaysGroupShare', $this->config->getAppValue('core', 'shareapi_expire_after_n_days_group_share', '7'));
 		$template->assign('shareEnforceExpireDateGroupShare', $this->config->getAppValue('core', 'shareapi_enforce_expire_date_group_share', 'no'));
 
-		$template->assign('shareDefaultExpireDateSetRemoteShare', $this->config->getAppValue('core', 'shareapi_default_expire_date_remote_share', 'no'));
-		$template->assign('shareExpireAfterNDaysRemoteShare', $this->config->getAppValue('core', 'shareapi_expire_after_n_days_remote_share', '7'));
-		$template->assign('shareEnforceExpireDateRemoteShare', $this->config->getAppValue('core', 'shareapi_enforce_expire_date_remote_share', 'no'));
+		$template->assign('shareDefaultExpireDateSetFederatedShare', $this->config->getAppValue('core', 'shareapi_default_expire_date_remote_share', 'no'));
+		$template->assign('shareExpireAfterNDaysFederatedShare', $this->config->getAppValue('core', 'shareapi_expire_after_n_days_remote_share', '7'));
+		$template->assign('shareEnforceExpireDateFederatedShare', $this->config->getAppValue('core', 'shareapi_enforce_expire_date_remote_share', 'no'));
 
 		$template->assign('autoAcceptShare', $this->config->getAppValue('core', 'shareapi_auto_accept_share', 'yes'));
 

--- a/settings/js/admin.js
+++ b/settings/js/admin.js
@@ -102,7 +102,7 @@ $(document).ready(function(){
 		$("#setDefaultExpireDateGroupShare").toggleClass('hidden', !this.checked);
 	});
 
-	$('#shareapiExpireAfterNDaysRemoteShare').change(function() {
+	$('#shareapiExpireAfterNDaysFederatedShare').change(function() {
 		var value = parseInt($(this).val(), 10)
 
 		if (value <= 0 || isNaN(value)) {
@@ -110,8 +110,8 @@ $(document).ready(function(){
 		}
 	});
 
-	$('#shareapiDefaultExpireDateRemoteShare').change(function() {
-		$("#setDefaultExpireDateRemoteShare").toggleClass('hidden', !this.checked);
+	$('#shareapiDefaultExpireDateFederatedShare').change(function() {
+		$("#setDefaultExpireDateFederatedShare").toggleClass('hidden', !this.checked);
 	});
 
 	$('#allowLinks').change(function() {

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -145,24 +145,24 @@
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') {
 	p('hidden');
 }?>">
-		<input type="checkbox" name="shareapi_default_expire_date_remote_share" id="shareapiDefaultExpireDateRemoteShare" class="checkbox"
-					   value="1" <?php if ($_['shareDefaultExpireDateSetRemoteShare'] === 'yes') {
+		<input type="checkbox" name="shareapi_default_expire_date_remote_share" id="shareapiDefaultExpireDateFederatedShare" class="checkbox"
+					   value="1" <?php if ($_['shareDefaultExpireDateSetFederatedShare'] === 'yes') {
 	print_unescaped('checked="checked"');
 } ?> />
-		<label for="shareapiDefaultExpireDateRemoteShare"><?php p($l->t('Set default expiration date for remote shares'));?></label><br/>
-		<span id="setDefaultExpireDateRemoteShare" class="indent <?php if ($_['shareDefaultExpireDateSetRemoteShare'] === 'no' || $_['shareAPIEnabled'] === 'no') {
+		<label for="shareapiDefaultExpireDateFederatedShare"><?php p($l->t('Set default expiration date for federated shares'));?></label><br/>
+		<span id="setDefaultExpireDateFederatedShare" class="indent <?php if ($_['shareDefaultExpireDateSetFederatedShare'] === 'no' || $_['shareAPIEnabled'] === 'no') {
 	p('hidden');
 }?>">
 			<?php p($l->t('Expire after ')); ?>
-			<input type="number" name='shareapi_expire_after_n_days_remote_share' id="shareapiExpireAfterNDaysRemoteShare" min="0" placeholder="<?php p('7')?>"
-				   value='<?php p($_['shareExpireAfterNDaysRemoteShare']) ?>' />
+			<input type="number" name='shareapi_expire_after_n_days_remote_share' id="shareapiExpireAfterNDaysFederatedShare" min="0" placeholder="<?php p('7')?>"
+				   value='<?php p($_['shareExpireAfterNDaysFederatedShare']) ?>' />
 			<?php p($l->t('days')); ?><br/>
-			<?php if ($_['shareEnforceExpireDateRemoteShare'] === 'yes'): ?>
-				<input type="checkbox" name="shareapi_enforce_expire_date_remote_share" id="shareapiEnforceExpireDateRemoteShare" class="checkbox" value="1" checked="checked" />
+			<?php if ($_['shareEnforceExpireDateFederatedShare'] === 'yes'): ?>
+				<input type="checkbox" name="shareapi_enforce_expire_date_remote_share" id="shareapiEnforceExpireDateFederatedShare" class="checkbox" value="1" checked="checked" />
 			<?php else: ?>
-				<input type="checkbox" name="shareapi_enforce_expire_date_remote_share" id="shareapiEnforceExpireDateRemoteShare" class="checkbox" value="1" />
+				<input type="checkbox" name="shareapi_enforce_expire_date_remote_share" id="shareapiEnforceExpireDateFederatedShare" class="checkbox" value="1" />
 			<?php endif; ?>
-			<label class="indent" for="shareapiEnforceExpireDateRemoteShare"><?php p($l->t('Enforce as maximum expiration date'));?></label><br/>
+			<label class="indent" for="shareapiEnforceExpireDateFederatedShare"><?php p($l->t('Enforce as maximum expiration date'));?></label><br/>
 		</span>
 	</p>
 	<p class="<?php if ($_['shareAPIEnabled'] === 'no') {

--- a/tests/acceptance/features/apiFederationToRoot1/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federated.feature
@@ -63,7 +63,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: Remote sharee can see the pending share
+  Scenario Outline: Federated sharee can see the pending share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -87,7 +87,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: Remote sharee requests information of only one share
+  Scenario Outline: Federated sharee requests information of only one share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -115,7 +115,7 @@ Feature: federated
       | 2               | 200        |
 
   @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
-  Scenario Outline: Remote sharee requests information of only one share before accepting it
+  Scenario Outline: Federated sharee requests information of only one share before accepting it
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -139,7 +139,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: sending a GET request to a pending remote share is not valid
+  Scenario Outline: sending a GET request to a pending federated share is not valid
     Given using OCS API version "<ocs-api-version>"
     When user "Brian" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/pending/12"
     Then the HTTP status code should be "405"
@@ -149,7 +149,7 @@ Feature: federated
       | 1               |
       | 2               |
 
-  Scenario Outline: sending a GET request to a not existing remote share
+  Scenario Outline: sending a GET request to a not existing federated share
     Given using OCS API version "<ocs-api-version>"
     When user "Brian" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/9999999999"
     Then the OCS status code should be "<ocs-status>"
@@ -159,7 +159,7 @@ Feature: federated
       | 1               | 404        | 200         |
       | 2               | 404        | 404         |
 
-  Scenario Outline: accept a pending remote share
+  Scenario Outline: accept a pending federated share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -305,7 +305,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: Remote sharee deletes an accepted federated share
+  Scenario Outline: Federated sharee deletes an accepted federated share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -327,7 +327,7 @@ Feature: federated
       | 2               | 200        |
 
   @issue-31276 @skipOnOcV10
-  Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password
+  Scenario Outline: Federated sharee tries to delete an accepted federated share sending wrong password
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -359,7 +359,7 @@ Feature: federated
       | 1               |
       | 2               |
 
-  Scenario Outline: Remote sharee deletes a pending federated share
+  Scenario Outline: Federated sharee deletes a pending federated share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -380,7 +380,7 @@ Feature: federated
       | 2               | 200        |
 
   @issue-31276 @skipOnOcV10
-  Scenario Outline: Remote sharee tries to delete a pending federated share sending wrong password
+  Scenario Outline: Federated sharee tries to delete a pending federated share sending wrong password
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -451,7 +451,7 @@ Feature: federated
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
 
-  Scenario Outline: share of a folder to a remote user who already has a folder with the same name
+  Scenario Outline: share of a folder to a federated user who already has a folder with the same name
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
     And user "Alice" has created folder "zzzfolder/Alice"
@@ -480,7 +480,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: share of a file to the remote user who already has a file with the same name
+  Scenario Outline: share of a file to the federated user who already has a file with the same name
     Given using server "REMOTE"
     And user "Alice" has uploaded file with content "remote content" to "/randomfile.txt"
     And using server "LOCAL"
@@ -511,7 +511,7 @@ Feature: federated
       | 2               | 200        |
 
   @issue-35154
-  Scenario: receive a local share that has the same name as a previously received remote share
+  Scenario: receive a local share that has the same name as a previously received federated share
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
     And user "Alice" has created folder "zzzfolder/remote"
@@ -533,7 +533,7 @@ Feature: federated
     And the content of file "/randomfile (2).txt" for user "Carol" on server "LOCAL" should be "remote content"
     And the content of file "/randomfile.txt" for user "Carol" on server "LOCAL" should be "local content"
 
-  Scenario: receive a remote share that has the same name as a previously received local share
+  Scenario: receive a federated share that has the same name as a previously received local share
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
     And user "Alice" has created folder "zzzfolder/remote"

--- a/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
@@ -10,7 +10,7 @@ Feature: current oC10 behavior for issue-31276
     And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
 
   @issue-31276
-  Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password
+  Scenario Outline: Federated sharee tries to delete an accepted federated share sending wrong password
     Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using OCS API version "<ocs-api-version>"
@@ -41,7 +41,7 @@ Feature: current oC10 behavior for issue-31276
       | 2               |
 
   @issue-31276
-  Scenario Outline: Remote sharee tries to delete a pending federated share sending wrong password
+  Scenario Outline: Federated sharee tries to delete a pending federated share sending wrong password
     Given user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last pending federated cloud share with password "invalid" using the sharing API

--- a/tests/acceptance/features/apiFederationToShares1/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares1/federated.feature
@@ -66,7 +66,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: Remote sharee can see the pending share
+  Scenario Outline: Federated sharee can see the pending share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -90,7 +90,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: Remote sharee requests information of only one share
+  Scenario Outline: Federated sharee requests information of only one share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -118,7 +118,7 @@ Feature: federated
       | 2               | 200        |
 
   @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
-  Scenario Outline: Remote sharee requests information of only one share before accepting it
+  Scenario Outline: Federated sharee requests information of only one share before accepting it
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -142,7 +142,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: sending a GET request to a pending remote share is not valid
+  Scenario Outline: sending a GET request to a pending federated share is not valid
     Given using OCS API version "<ocs-api-version>"
     When user "Brian" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/pending/12"
     Then the HTTP status code should be "405"
@@ -152,7 +152,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: sending a GET request to a not existing remote share
+  Scenario Outline: sending a GET request to a not existing federated share
     Given using OCS API version "<ocs-api-version>"
     When user "Brian" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/9999999999"
     Then the OCS status code should be "<ocs-status>"
@@ -162,7 +162,7 @@ Feature: federated
       | 1               | 404        | 200         |
       | 2               | 404        | 404         |
 
-  Scenario Outline: accept a pending remote share
+  Scenario Outline: accept a pending federated share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -308,7 +308,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: Remote sharee deletes an accepted federated share
+  Scenario Outline: Federated sharee deletes an accepted federated share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -330,7 +330,7 @@ Feature: federated
       | 2               | 200        |
 
   @issue-31276 @skipOnOcV10
-  Scenario Outline: Remote sharee tries to delete an accepted federated share sending wrong password
+  Scenario Outline: Federated sharee tries to delete an accepted federated share sending wrong password
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -362,7 +362,7 @@ Feature: federated
       | 1               |
       | 2               |
 
-  Scenario Outline: Remote sharee deletes a pending federated share
+  Scenario Outline: Federated sharee deletes a pending federated share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -383,7 +383,7 @@ Feature: federated
       | 2               | 200        |
 
   @issue-31276 @skipOnOcV10
-  Scenario Outline: Remote sharee tries to delete a pending federated share sending wrong password
+  Scenario Outline: Federated sharee tries to delete a pending federated share sending wrong password
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
@@ -456,7 +456,7 @@ Feature: federated
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/Shares/PARENT/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
 
-  Scenario Outline: share of a folder to a remote user who already has a folder with the same name
+  Scenario Outline: share of a folder to a federated user who already has a folder with the same name
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
     And user "Alice" has created folder "zzzfolder/Alice"
@@ -485,7 +485,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  Scenario Outline: share of a file to the remote user who already has a file with the same name
+  Scenario Outline: share of a file to the federated user who already has a file with the same name
     Given using server "REMOTE"
     And user "Alice" has uploaded file with content "remote content" to "/randomfile.txt"
     And using server "LOCAL"
@@ -516,7 +516,7 @@ Feature: federated
       | 2               | 200        |
 
   @issue-35154
-  Scenario: receive a local share that has the same name as a previously received remote share
+  Scenario: receive a local share that has the same name as a previously received federated share
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
     And user "Alice" has created folder "zzzfolder/remote"
@@ -540,7 +540,7 @@ Feature: federated
     And the content of file "/Shares/randomfile.txt" for user "Carol" on server "LOCAL" should be "remote content"
     And the content of file "/Shares/randomfile (2).txt" for user "Carol" on server "LOCAL" should be "local content"
 
-  Scenario: receive a remote share that has the same name as a previously received local share
+  Scenario: receive a federated share that has the same name as a previously received local share
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
     And user "Alice" has created folder "zzzfolder/remote"

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -411,7 +411,7 @@ Feature: sharees
       | 2               | 200        | 200         |
 
 
-  Scenario Outline: Remote sharee for files
+  Scenario Outline: Federated sharee for files
     Given using OCS API version "<ocs-api-version>"
     When user "Alice" gets the sharees using the sharing API with parameters
       | search   | test@localhost |
@@ -431,7 +431,7 @@ Feature: sharees
       | 2               | 200        | 200         |
 
 
-  Scenario Outline: Remote sharee for calendars not allowed
+  Scenario Outline: Federated sharee for calendars not allowed
     Given using OCS API version "<ocs-api-version>"
     When user "Alice" gets the sharees using the sharing API with parameters
       | search   | test@localhost |

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -185,7 +185,7 @@ trait Provisioning {
 					$this->createdRemoteUsers[$normalizedUsername]['displayname'] = $displayName;
 				} else {
 					throw new \Exception(
-						__METHOD__ . " tried to remember display name '$displayName' for non-existent remote user '$user'"
+						__METHOD__ . " tried to remember display name '$displayName' for non-existent federated user '$user'"
 					);
 				}
 			}
@@ -217,7 +217,7 @@ trait Provisioning {
 					$this->createdRemoteUsers[$normalizedUsername]['email'] = $emailAddress;
 				} else {
 					throw new \Exception(
-						__METHOD__ . " tried to remember email address '$emailAddress' for non-existent remote user '$user'"
+						__METHOD__ . " tried to remember email address '$emailAddress' for non-existent federated user '$user'"
 					);
 				}
 			}

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -132,12 +132,12 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @Then the default expiration date checkbox for remote shares should be enabled on the webUI
+	 * @Then the default expiration date checkbox for federated shares should be enabled on the webUI
 	 *
 	 * @return void
 	 */
-	public function setDefaultExpirationDateForRemoteCheckboxSharesShouldBeEnabled() {
-		$checkboxElement = $this->adminSharingSettingsPage->getDefaultExpirationForRemoteShareElement();
+	public function setDefaultExpirationDateForFederatedCheckboxSharesShouldBeEnabled() {
+		$checkboxElement = $this->adminSharingSettingsPage->getDefaultExpirationForFederatedShareElement();
 		$this->assertCheckBoxIsChecked($checkboxElement);
 	}
 
@@ -162,12 +162,12 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @Then the enforce maximum expiration date checkbox for remote shares should be enabled on the webUI
+	 * @Then the enforce maximum expiration date checkbox for federated shares should be enabled on the webUI
 	 *
 	 * @return void
 	 */
-	public function enforceMaximumExpirationDateForRemoteSharesCheckboxShouldBeEnabled() {
-		$checkboxElement = $this->adminSharingSettingsPage->getEnforceExpireDateRemoteShareElement();
+	public function enforceMaximumExpirationDateForFederatedSharesCheckboxShouldBeEnabled() {
+		$checkboxElement = $this->adminSharingSettingsPage->getEnforceExpireDateFederatedShareElement();
 		$this->assertCheckBoxIsChecked($checkboxElement);
 	}
 
@@ -208,19 +208,19 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @Then the expiration date for remote shares should set to :days days on the webUI
+	 * @Then the expiration date for federated shares should set to :days days on the webUI
 	 *
 	 * @param int $days
 	 *
 	 * @return void
 	 */
-	public function expirationDateForRemoteSharesShouldBeSetToXDays($days) {
-		$expirationDays = $this->adminSharingSettingsPage->getRemoteShareExpirationDays();
+	public function expirationDateForFederatedSharesShouldBeSetToXDays($days) {
+		$expirationDays = $this->adminSharingSettingsPage->getFederatedShareExpirationDays();
 		Assert::assertEquals(
 			$days,
 			$expirationDays,
 			__METHOD__
-			. " The expiration date for remote shares was expected to be set to '$days' days, "
+			. " The expiration date for federated shares was expected to be set to '$days' days, "
 			. "but was actually set to '$expirationDays' days"
 		);
 	}
@@ -410,12 +410,12 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When the administrator enforces maximum expiration date for remote shares using the webUI
+	 * @When the administrator enforces maximum expiration date for federated shares using the webUI
 	 *
 	 * @return void
 	 */
-	public function administratorEnforcesMaximumExpirationDateForRemoteShares() {
-		$this->adminSharingSettingsPage->enforceMaximumExpirationDateForRemoteShares(
+	public function administratorEnforcesMaximumExpirationDateForFederatedShares() {
+		$this->adminSharingSettingsPage->enforceMaximumExpirationDateForFederatedShares(
 			$this->getSession()
 		);
 	}
@@ -443,14 +443,14 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When the administrator updates the remote share expiration date to :days days using the webUI
+	 * @When the administrator updates the federated share expiration date to :days days using the webUI
 	 *
 	 * @param int $days
 	 *
 	 * @return void
 	 */
-	public function administratorUpdatesRemoteShareExpirationTo($days) {
-		$this->adminSharingSettingsPage->setExpirationDaysForRemoteShare($days, $this->getSession());
+	public function administratorUpdatesFederatedShareExpirationTo($days) {
+		$this->adminSharingSettingsPage->setExpirationDaysForFederatedShare($days, $this->getSession());
 	}
 
 	/**
@@ -465,12 +465,12 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @When the administrator enables default expiration date for remote shares using the webUI
+	 * @When the administrator enables default expiration date for federated shares using the webUI
 	 *
 	 * @return void
 	 */
-	public function theAdministratorEnablesDefaultExpirationDateForRemoteShares() {
-		$this->adminSharingSettingsPage->enableDefaultExpirationDateForRemoteShares(
+	public function theAdministratorEnablesDefaultExpirationDateForFederatedShares() {
+		$this->adminSharingSettingsPage->enableDefaultExpirationDateForFederatedShares(
 			$this->getSession()
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
@@ -71,7 +71,7 @@ class WebUIPersonalSharingSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
-	 * @When /^the user (disables|enables) automatically accepting remote shares from trusted servers$/
+	 * @When /^the user (disables|enables) automatically accepting federated shares from trusted servers$/
 	 *
 	 * @param string $action
 	 *

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -966,12 +966,12 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user accepts the offered remote shares using the webUI
-	 * @Given the user has accepted the offered remote shares
+	 * @When the user accepts the offered federated shares using the webUI
+	 * @Given the user has accepted the offered federated shares
 	 *
 	 * @return void
 	 */
-	public function theUserAcceptsTheOfferedRemoteShares() {
+	public function theUserAcceptsTheOfferedFederatedShares() {
 		foreach (\array_reverse($this->filesPage->getOcDialogs()) as $ocDialog) {
 			$ocDialog->accept($this->getSession());
 		}
@@ -1031,12 +1031,12 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user declines the offered remote shares using the webUI
-	 * @Given the user has declined the offered remote shares
+	 * @When the user declines the offered federated shares using the webUI
+	 * @Given the user has declined the offered federated shares
 	 *
 	 * @return void
 	 */
-	public function theUserDeclinesTheOfferedRemoteShares() {
+	public function theUserDeclinesTheOfferedFederatedShares() {
 		foreach (\array_reverse($this->filesPage->getOcDialogs()) as $ocDialog) {
 			$ocDialog->clickButton($this->getSession(), 'Cancel');
 		}
@@ -2245,11 +2245,11 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user accepts the pending remote share using the webUI
+	 * @When the user accepts the pending federated share using the webUI
 	 *
 	 * @return void
 	 */
-	public function theUserAcceptsThePendingRemoteSharesUsingTheWebui() {
+	public function theUserAcceptsThePendingFederatedShareUsingTheWebui() {
 		$this->sharedWithYouPage->acceptPendingShare();
 	}
 

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -88,17 +88,17 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $defaultExpirationDateForUserCheckboxId = 'shareapiDefaultExpireDateUserShare';
 	protected $defaultExpirationDateForGroupCheckboxXpath = '//label[@for="shareapiDefaultExpireDateGroupShare"]';
 	protected $defaultExpirationDateForGroupCheckboxId = 'shareapiDefaultExpireDateGroupShare';
-	protected $defaultExpirationDateForRemoteCheckboxXpath = '//label[@for="shareapiDefaultExpireDateRemoteShare"]';
-	protected $defaultExpirationDateForRemoteCheckboxId = 'shareapiDefaultExpireDateRemoteShare';
+	protected $defaultExpirationDateForFederatedCheckboxXpath = '//label[@for="shareapiDefaultExpireDateFederatedShare"]';
+	protected $defaultExpirationDateForFederatedCheckboxId = 'shareapiDefaultExpireDateFederatedShare';
 	protected $userShareExpirationDateFieldXpath = '//input[@id="shareapiExpireAfterNDaysUserShare"]';
 	protected $groupShareExpirationDateFieldXpath = '//input[@id="shareapiExpireAfterNDaysGroupShare"]';
-	protected $remoteShareExpirationDateFieldXpath = '//input[@id="shareapiExpireAfterNDaysRemoteShare"]';
+	protected $federatedShareExpirationDateFieldXpath = '//input[@id="shareapiExpireAfterNDaysFederatedShare"]';
 	protected $enforceExpirationDateUserShareCheckboxXpath = '//span[@id="setDefaultExpireDateUserShare"]//label[contains(text(),"expiration date")]';
 	protected $enforceExpirationDateUserShareCheckboxId = 'shareapiEnforceExpireDateUserShare';
 	protected $enforceExpirationDateGroupShareCheckboxXpath = '//span[@id="setDefaultExpireDateGroupShare"]//label[contains(text(),"expiration date")]';
 	protected $enforceExpirationDateGroupShareCheckboxId = 'shareapiEnforceExpireDateGroupShare';
-	protected $enforceExpirationDateRemoteShareCheckboxXpath = '//span[@id="setDefaultExpireDateRemoteShare"]//label[contains(text(),"expiration date")]';
-	protected $enforceExpirationDateRemoteShareCheckboxId = 'shareapiEnforceExpireDateRemoteShare';
+	protected $enforceExpirationDateFederatedShareCheckboxXpath = '//span[@id="setDefaultExpireDateFederatedShare"]//label[contains(text(),"expiration date")]';
+	protected $enforceExpirationDateFederatedShareCheckboxId = 'shareapiEnforceExpireDateFederatedShare';
 
 	/**
 	 * toggle the Share API
@@ -380,8 +380,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	/**
 	 * @return NodeElement|null
 	 */
-	public function getDefaultExpirationForRemoteShareElement() {
-		return $this->findById($this->defaultExpirationDateForRemoteCheckboxId);
+	public function getDefaultExpirationForFederatedShareElement() {
+		return $this->findById($this->defaultExpirationDateForFederatedCheckboxId);
 	}
 
 	/**
@@ -401,8 +401,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	/**
 	 * @return NodeElement|null
 	 */
-	public function getEnforceExpireDateRemoteShareElement() {
-		return $this->findById($this->enforceExpirationDateRemoteShareCheckboxId);
+	public function getEnforceExpireDateFederatedShareElement() {
+		return $this->findById($this->enforceExpirationDateFederatedShareCheckboxId);
 	}
 
 	/**
@@ -434,12 +434,12 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	/**
 	 * @return string
 	 */
-	public function getRemoteShareExpirationDays() {
-		$expirationDay = $this->find("xpath", $this->remoteShareExpirationDateFieldXpath);
+	public function getFederatedShareExpirationDays() {
+		$expirationDay = $this->find("xpath", $this->federatedShareExpirationDateFieldXpath);
 		$this->assertElementNotNull(
 			$expirationDay,
 			__METHOD__ .
-			" could not find remote share expiration day field"
+			" could not find federated share expiration day field"
 		);
 		return $expirationDay->getValue($expirationDay);
 	}
@@ -493,18 +493,18 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	}
 
 	/**
-	 * enforce mamixum expiration date for remote share
+	 * enforce mamixum expiration date for federated share
 	 *
 	 * @param Session $session
 	 *
 	 * @return void
 	 */
-	public function enforceMaximumExpirationDateForRemoteShares(Session $session) {
+	public function enforceMaximumExpirationDateForFederatedShares(Session $session) {
 		$this->toggleCheckbox(
 			$session,
 			"enables",
-			$this->enforceExpirationDateRemoteShareCheckboxXpath,
-			$this->enforceExpirationDateRemoteShareCheckboxId
+			$this->enforceExpirationDateFederatedShareCheckboxXpath,
+			$this->enforceExpirationDateFederatedShareCheckboxId
 		);
 	}
 
@@ -543,12 +543,12 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	 * @return NodeElement|NULL
 	 * @throws ElementNotFoundException
 	 */
-	private function findRemoteShareExpirationField() {
-		$expirationDateField = $this->find("xpath", $this->remoteShareExpirationDateFieldXpath);
+	private function findFederatedShareExpirationField() {
+		$expirationDateField = $this->find("xpath", $this->federatedShareExpirationDateFieldXpath);
 		$this->assertElementNotNull(
 			$expirationDateField,
 			__METHOD__ .
-			" xpath $this->remoteShareExpirationDateFieldXpath could not find set-remote-share-expiration-field"
+			" xpath $this->federatedShareExpirationDateFieldXpath could not find set-federated-share-expiration-field"
 		);
 		return $expirationDateField;
 	}
@@ -588,18 +588,18 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	}
 
 	/**
-	 * set expiration date for remote share
+	 * set expiration date for federated share
 	 *
 	 * @param int $date
 	 * @param Session $session
 	 *
 	 * @return void
 	 */
-	public function setExpirationDaysForRemoteShare(
+	public function setExpirationDaysForFederatedShare(
 		$date,
 		Session $session
 	) {
-		$expirationDateField = $this->findRemoteShareExpirationField();
+		$expirationDateField = $this->findFederatedShareExpirationField();
 		$this->fillFieldAndKeepFocus($expirationDateField, $date . "\n", $session);
 		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
@@ -621,18 +621,18 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	}
 
 	/**
-	 * enable default expiration date for remote share
+	 * enable default expiration date for federated share
 	 *
 	 * @param Session $session
 	 *
 	 * @return void
 	 */
-	public function enableDefaultExpirationDateForRemoteShares(Session $session) {
+	public function enableDefaultExpirationDateForFederatedShares(Session $session) {
 		$this->toggleCheckbox(
 			$session,
 			"enables",
-			$this->defaultExpirationDateForRemoteCheckboxXpath,
-			$this->defaultExpirationDateForRemoteCheckboxId
+			$this->defaultExpirationDateForFederatedCheckboxXpath,
+			$this->defaultExpirationDateForFederatedCheckboxId
 		);
 	}
 

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -164,9 +164,9 @@ Feature: admin sharing settings
     Then the config key "shareapi_default_expire_date_group_share" of app "core" should have value "yes"
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
-  Scenario: enable default expiration date for remote shares
+  Scenario: enable default expiration date for federated shares
     Given the administrator has browsed to the admin sharing settings page
-    When the administrator enables default expiration date for remote shares using the webUI
+    When the administrator enables default expiration date for federated shares using the webUI
     Then the config key "shareapi_default_expire_date_remote_share" of app "core" should have value "yes"
 
   @skipOnOcV10.3
@@ -184,10 +184,10 @@ Feature: admin sharing settings
     Then the config key "shareapi_expire_after_n_days_group_share" of app "core" should have value "11"
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
-  Scenario: set a different default expiration days for remote shares
+  Scenario: set a different default expiration days for federated shares
     Given the administrator has browsed to the admin sharing settings page
-    When the administrator enables default expiration date for remote shares using the webUI
-    And the administrator updates the remote share expiration date to "18" days using the webUI
+    When the administrator enables default expiration date for federated shares using the webUI
+    And the administrator updates the federated share expiration date to "18" days using the webUI
     Then the config key "shareapi_expire_after_n_days_remote_share" of app "core" should have value "18"
 
   @skipOnOcV10.3
@@ -205,10 +205,10 @@ Feature: admin sharing settings
     Then the config key "shareapi_enforce_expire_date_group_share" of app "core" should have value "yes"
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
-  Scenario: set default expiration days for remote shares and enforce as maximum expiration days
+  Scenario: set default expiration days for federated shares and enforce as maximum expiration days
     Given the administrator has browsed to the admin sharing settings page
-    When the administrator enables default expiration date for remote shares using the webUI
-    And the administrator enforces maximum expiration date for remote shares using the webUI
+    When the administrator enables default expiration date for federated shares using the webUI
+    And the administrator enforces maximum expiration date for federated shares using the webUI
     Then the config key "shareapi_enforce_expire_date_remote_share" of app "core" should have value "yes"
 
   @skipOnOcV10.3
@@ -226,11 +226,11 @@ Feature: admin sharing settings
     And the expiration date for group shares should set to "7" days on the webUI
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
-  Scenario: check previously set default expiration days for remote shares
+  Scenario: check previously set default expiration days for federated shares
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     When the administrator browses to the admin sharing settings page
-    Then the default expiration date checkbox for remote shares should be enabled on the webUI
-    And the expiration date for remote shares should set to "7" days on the webUI
+    Then the default expiration date checkbox for federated shares should be enabled on the webUI
+    And the expiration date for federated shares should set to "7" days on the webUI
 
   @skipOnOcV10.3
   Scenario: check previously enforced maximum expiration days for user shares
@@ -247,11 +247,11 @@ Feature: admin sharing settings
     Then the enforce maximum expiration date checkbox for group shares should be enabled on the webUI
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
-  Scenario: check previously enforced maximum expiration days for remote shares
+  Scenario: check previously enforced maximum expiration days for federated shares
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     When the administrator browses to the admin sharing settings page
-    Then the enforce maximum expiration date checkbox for remote shares should be enabled on the webUI
+    Then the enforce maximum expiration date checkbox for federated shares should be enabled on the webUI
 
   @skipOnOcV10.3
   Scenario: check previously set expiration days for user shares
@@ -268,8 +268,8 @@ Feature: admin sharing settings
     Then the expiration date for group shares should set to "5" days on the webUI
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
-  Scenario: check previously set expiration days for remote shares
+  Scenario: check previously set expiration days for federated shares
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "5"
     When the administrator browses to the admin sharing settings page
-    Then the expiration date for remote shares should set to "5" days on the webUI
+    Then the expiration date for federated shares should set to "5" days on the webUI

--- a/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
@@ -21,22 +21,22 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
   @skipOnMICROSOFTEDGE @skipOnOcV10.3
-  Scenario: share a folder with an remote user and prohibit deleting - local server shares - remote server receives
+  Scenario: share a folder with a federated user and prohibit deleting - local server shares - remote server receives
     Given using server "REMOTE"
     And user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
     When the user updates the last share using the sharing API with
       | permissions | read |
     And the user re-logs in as "Alice" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
   @skipOnMICROSOFTEDGE
-  Scenario: share a folder with an remote user and prohibit deleting - remote server shares - local server receives
+  Scenario: share a folder with a federated user and prohibit deleting - remote server shares - local server receives
     # permissions read+update+create = 7 (no delete, no (re)share permission)
     Given user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL" with permissions "create,read,update"
     When the user browses to the files page
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
@@ -53,7 +53,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: overwrite a file in a received share - remote server shares - local server receives
     Given user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
     And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
+    When the user accepts the offered federated shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     And using server "REMOTE"
@@ -73,7 +73,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: upload a new file in a received share - remote server shares - local server receives
     Given user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
     And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
+    When the user accepts the offered federated shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user uploads file "new-lorem.txt" using the webUI
     And using server "REMOTE"
@@ -94,7 +94,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: rename a file in a received share - remote server shares - local server receives
     Given user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
     And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
+    When the user accepts the offered federated shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user renames file "lorem.txt" to "renamed file.txt" using the webUI
     And using server "REMOTE"
@@ -116,7 +116,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "Alice" on "REMOTE" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
     And user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
     And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
+    When the user accepts the offered federated shares using the webUI
     And the user opens folder "simple-folder (2)" using the webUI
     And the user deletes file "data.zip" using the webUI
     And using server "REMOTE"
@@ -130,7 +130,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
     And user "Brian" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
     And the user has reloaded the current page of the webUI
-    When the user accepts the offered remote shares using the webUI
+    When the user accepts the offered federated shares using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
     And file "lorem (3).txt" should be listed on the webUI
     And file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
@@ -161,11 +161,11 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given using server "LOCAL"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "simple-folder"
-    When the user shares folder "simple-folder" with remote user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
+    When the user shares folder "simple-folder" with federated user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     And user "Alice" from server "REMOTE" shares "/simple-folder (2)" with user "Brian" from server "LOCAL" using the sharing API
     And the user re-logs in as "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then as "Brian" folder "/simple-folder (2)" should exist
     And as "Brian" file "/simple-folder (2)/lorem.txt" should exist
 
@@ -174,13 +174,13 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given using server "LOCAL"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "simple-folder"
-    When the user shares folder "simple-folder" with remote user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
+    When the user shares folder "simple-folder" with federated user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     And user "Alice" from server "REMOTE" shares "/simple-folder (2)" with user "Brian" from server "LOCAL" using the sharing API
     And the user updates the last share using the sharing API with
       | permissions | read |
     And the user re-logs in as "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then as "Brian" folder "/simple-folder (2)" should exist
     And as "Brian" file "/simple-folder (2)/lorem.txt" should exist
     When the user opens folder "simple-folder (2)" using the webUI
@@ -191,7 +191,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given using server "LOCAL"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "simple-folder"
-    When the user shares folder "simple-folder" with remote user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
+    When the user shares folder "simple-folder" with federated user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     And user "Alice" from server "REMOTE" shares "/simple-folder (2)" with user "Brian" from server "LOCAL" using the sharing API
     And the user re-logs in as "Alice" using the webUI
@@ -199,7 +199,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user sets the sharing permissions of user "Brian@%local_server% (federated)" for "simple-folder" using the webUI to
       | edit | no |
     And the user re-logs in as "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then as "Brian" folder "/simple-folder (2)" should exist
     And as "Brian" file "/simple-folder (2)/lorem.txt" should exist
     When the user opens folder "simple-folder (2)" using the webUI
@@ -209,7 +209,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: test sharing long file names with federation share
     When user "Alice" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
     And the user has reloaded the current page of the webUI
-    And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with remote user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
+    And the user shares file "averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" with federated user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     Then as "Alice" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
 
@@ -243,7 +243,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
     And user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
     When the user re-logs in as "Alice" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     And the user opens folder "simple-folder (2)/simple-empty-folder" using the webUI
     And the user renames file "textfile.txt" to "new-lorem.txt" using the webUI
     And using server "REMOTE"
@@ -257,7 +257,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/simple-empty-folder/textfile.txt"
     And user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
     When the user re-logs in as "Alice" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     And the user opens folder "/simple-folder (2)/simple-empty-folder" using the webUI
     And the user deletes file "textfile.txt" using the webUI
     And using server "REMOTE"

--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
@@ -23,7 +23,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: declining a federation share on the webUI
     Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
     And the user has reloaded the current page of the webUI
-    When the user declines the offered remote shares using the webUI
+    When the user declines the offered federated shares using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
@@ -46,7 +46,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     And parameter "autoAddServers" of app "federation" has been set to "0"
     And the user has browsed to the personal sharing settings page
-    When the user disables automatically accepting remote shares from trusted servers
+    When the user disables automatically accepting federated shares from trusted servers
     And user "Alice" from server "REMOTE" shares "/lorem.txt" with user "Alice" from server "LOCAL" using the sharing API
     Then user "Alice" should not see the following elements
       | /lorem (2).txt |
@@ -61,7 +61,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     And parameter "autoAddServers" of app "federation" has been set to "0"
     And the user has browsed to the personal sharing settings page
-    When the user disables automatically accepting remote shares from trusted servers
+    When the user disables automatically accepting federated shares from trusted servers
     And user "Alice" from server "REMOTE" shares "/lorem.txt" with user "Brian" from server "LOCAL" using the sharing API
     Then user "Brian" should see the following elements
       | /lorem (2).txt |
@@ -81,8 +81,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     And parameter "autoAddServers" of app "federation" has been set to "0"
     And the user has browsed to the personal sharing settings page
-    When the user disables automatically accepting remote shares from trusted servers
-    And the user enables automatically accepting remote shares from trusted servers
+    When the user disables automatically accepting federated shares from trusted servers
+    And the user enables automatically accepting federated shares from trusted servers
     And user "Alice" from server "REMOTE" shares "/lorem.txt" with user "Alice" from server "LOCAL" using the sharing API
     Then user "Alice" should see the following elements
       | /lorem (2).txt |
@@ -92,10 +92,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
     When the user browses to the shared-with-you page
     And the user closes the federation sharing dialog
-    And the user accepts the pending remote share using the webUI
+    And the user accepts the pending federated share using the webUI
     Then file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
 
-  Scenario: Federated share from Local user to remote user
+  Scenario: Federated share from Local user to federated user
     Given user "Alice" from server "LOCAL" has shared "/lorem.txt" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
     When the user browses to the shared-with-others page

--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedSharesOc10Issue34742.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedSharesOc10Issue34742.feature
@@ -25,8 +25,8 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Given parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     And parameter "autoAddServers" of app "federation" has been set to "0"
     And the user has browsed to the personal sharing settings page
-    When the user disables automatically accepting remote shares from trusted servers
-    And the user enables automatically accepting remote shares from trusted servers
+    When the user disables automatically accepting federated shares from trusted servers
+    And the user enables automatically accepting federated shares from trusted servers
     And user "Alice" from server "REMOTE" shares "/lorem.txt" with user "Alice" from server "LOCAL" using the sharing API
     Then user "Alice" should not see the following elements
       | /lorem (2).txt |

--- a/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
@@ -21,9 +21,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
 
   Scenario: test the single steps of sharing a folder to a remote server
     Given user "Alice" has logged in using the webUI
-    When the user shares folder "simple-folder" with remote user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
+    When the user shares folder "simple-folder" with federated user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
-    And the user shares folder "simple-empty-folder" with remote user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
+    And the user shares folder "simple-empty-folder" with federated user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     And using server "REMOTE"
     Then as "Alice" folder "/simple-folder (2)" should exist
@@ -44,10 +44,10 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has logged in using the webUI
     Then dialogs should be displayed on the webUI
       | title        | content                                                                                                  | user  |
-      | Remote share | Do you want to add the remote share /simple-folder from %username%@%remote_server_without_scheme%?       | Alice |
-      | Remote share | Do you want to add the remote share /simple-empty-folder from %username%@%remote_server_without_scheme%? | Brian |
-      | Remote share | Do you want to add the remote share /lorem.txt from %username%@%remote_server_without_scheme%?           | Carol |
-    When the user accepts the offered remote shares using the webUI
+      | Federated share | Do you want to add the federated share /simple-folder from %username%@%remote_server_without_scheme%?       | Alice |
+      | Federated share | Do you want to add the federated share /simple-empty-folder from %username%@%remote_server_without_scheme%? | Brian |
+      | Federated share | Do you want to add the federated share /lorem.txt from %username%@%remote_server_without_scheme%?           | Carol |
+    When the user accepts the offered federated shares using the webUI
     Then file "lorem (2).txt" should be listed on the webUI
     And the content of file "lorem (2).txt" for user "Alice" on server "LOCAL" should be "I am lorem.txt"
     And folder "simple-folder (2)" should be listed on the webUI
@@ -93,9 +93,9 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
     And the user opens the share dialog for folder "sub-folder"
-    Then federated user "Alice" with displayname "%username%@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    Then federated user "Alice" with displayname "%username%@%remote_server% (Federated share)" should be listed as share receiver via "simple-folder" on the webUI
     When the user opens the share dialog for file "textfile.txt"
-    Then federated user "Alice" with displayname "%username%@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    Then federated user "Alice" with displayname "%username%@%remote_server% (Federated share)" should be listed as share receiver via "simple-folder" on the webUI
 
   @skipOnOcV10.3
   Scenario: sharing details of items inside a shared folder shared with local user and federated user
@@ -107,7 +107,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has logged in using the webUI
     When the user opens folder "simple-folder/sub-folder" using the webUI
     And the user opens the share dialog for file "textfile.txt"
-    Then federated user "Alice" with displayname "%username%@%remote_server% (Remote share)" should be listed as share receiver via "simple-folder" on the webUI
+    Then federated user "Alice" with displayname "%username%@%remote_server% (Federated share)" should be listed as share receiver via "simple-folder" on the webUI
     And user "Brian" with displayname "%displayname%" should be listed as share receiver via "sub-folder" on the webUI
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
@@ -218,7 +218,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | uid_owner  | Alice          |
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
-  Scenario: expiration date is enforced for federated remote sharer, local receiver reshares received file with another local user
+  Scenario: expiration date is enforced for federated sharer, local receiver reshares received file with another local user
     Given user "Brian" has been created with default attributes and without skeleton files
     And using server "REMOTE"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -238,7 +238,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | uid_owner  | Alice          |
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
-  Scenario: expiration date is enforced for federated remote sharer, local receiver reshares received file with another federated user
+  Scenario: expiration date is enforced for federated sharer, local receiver reshares received file with another federated user
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/webUISharingPublic2/savePublicLinkShare.feature
+++ b/tests/acceptance/features/webUISharingPublic2/savePublicLinkShare.feature
@@ -18,7 +18,7 @@ Feature: Save public shares created by oC users
       | permissions | read    |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%local_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT" should be listed on the webUI
     When the user opens folder "PARENT" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -36,7 +36,7 @@ Feature: Save public shares created by oC users
       | permissions | read       |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%local_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And the content of file "lorem.txt" for user "Brian" should be "original content"
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
@@ -52,7 +52,7 @@ Feature: Save public shares created by oC users
       | permissions | read,update,create,delete |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%local_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT" should be listed on the webUI
     When the user opens folder "PARENT" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -77,7 +77,7 @@ Feature: Save public shares created by oC users
       | permissions | read,update,create,delete |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%local_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And the content of file "lorem.txt" for user "Brian" should be "original content"
     # overwrite an existing file
@@ -96,7 +96,7 @@ Feature: Save public shares created by oC users
       | permissions | read    |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%local_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT (2)" should be listed on the webUI
     When the user opens folder "PARENT (2)" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -112,7 +112,7 @@ Feature: Save public shares created by oC users
       | permissions | read       |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%local_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "lorem (2).txt" should be listed on the webUI
     And the content of file "lorem (2).txt" for user "Brian" should be "original content"
 
@@ -126,7 +126,7 @@ Feature: Save public shares created by oC users
       | permissions | read    |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%local_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT" should be listed on the webUI
     When the user opens folder "PARENT" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -146,7 +146,7 @@ Feature: Save public shares created by oC users
       | permissions | read    |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%local_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT" should be listed on the webUI
     When the user opens folder "PARENT" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -167,7 +167,7 @@ Feature: Save public shares created by oC users
       | permissions | read    |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%remote_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT (2)" should be listed on the webUI
     When the user opens folder "PARENT (2)" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -185,7 +185,7 @@ Feature: Save public shares created by oC users
       | permissions | read    |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%remote_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT" should be listed on the webUI
     When the user unshares folder "PARENT" using the webUI
     Then folder "PARENT" should not be listed on the webUI
@@ -204,7 +204,7 @@ Feature: Save public shares created by oC users
       | permissions | read    |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%remote_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT" should be listed on the webUI
     When the user opens folder "PARENT" using the webUI
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingPublic2/savePublicLinkShareOc10Issue38763.feature
+++ b/tests/acceptance/features/webUISharingPublic2/savePublicLinkShareOc10Issue38763.feature
@@ -22,7 +22,7 @@ Feature: Save public shares created by oC users
       | permissions | read    |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%local_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT" should be listed on the webUI
     When the user opens folder "PARENT" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -46,7 +46,7 @@ Feature: Save public shares created by oC users
       | permissions | read    |
     And the public has accessed the last created public link using the webUI
     When the public adds the public link to "%remote_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "PARENT" should be listed on the webUI
     When the user opens folder "PARENT" using the webUI
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
@@ -23,7 +23,7 @@ Feature: Share by public link
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
     And the public adds the public link to "%remote_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "simple-folder" should be listed on the webUI
     When the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
@@ -44,7 +44,7 @@ Feature: Share by public link
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
     And the public adds the public link to "%remote_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then file "file-shared-by-public-link.txt" should be listed on the webUI
     And the content of file "file-shared-by-public-link.txt" for user "Brian" on server "REMOTE" should be "text in a file shared by public link"
     And using server "REMOTE"
@@ -64,7 +64,7 @@ Feature: Share by public link
     And the user logs out of the webUI
     And the public accesses the last created public link using the webUI
     And the public adds the public link to "%remote_server%" as user "Brian" using the webUI
-    And the user accepts the offered remote shares using the webUI
+    And the user accepts the offered federated shares using the webUI
     Then folder "simple-folder" should be listed on the webUI
     When the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -1455,7 +1455,7 @@ class ShareTest extends \Test\TestCase {
 		//Try share again
 		try {
 			\OCP\Share::shareItem('test', 'test.txt', \OCP\Share::SHARE_TYPE_REMOTE, 'foo@localhost', \OCP\Constants::PERMISSION_READ);
-			$this->fail('Identical remote shares are not allowed');
+			$this->fail('Identical federated shares are not allowed');
 		} catch (\Exception $e) {
 			$this->assertEquals('Sharing test.txt failed, because this item is already shared with foo@localhost', $e->getMessage());
 		}


### PR DESCRIPTION
## Description
Change remote to federated in user-facing strings - e.g. in the webUI and in exception/error messages that might be reported somewhere. I also changed some JS variables, ids... to try and be consistent. Acceptance test variable names are also changed.

The API remains the same - any endpoint, capability, config setting etc that has "remote" in it remains the same. Internal constants that have `REMOTE_SHARE` in them remain the same. That preserves compatibility for any existing server installation and clients.

Note: if this is done, then there are translation string changes. So it needs to be merged well before a release, to give time for translators to then adjust the translations.

If this is merged, then a doc issue is needed - we need to check what docs have text or screenshots that need "remote" updated to "federated".

## Related Issue
- Fixes #38871 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
