### PR TITLE
[full-ci] Trigger file scan after accepting a federated share

### DIFF
--- a/apps/federatedfilesharing/lib/FedShareManager.php
+++ b/apps/federatedfilesharing/lib/FedShareManager.php
@@ -159,7 +159,7 @@ class FedShareManager {
 		$this->publishActivity(
 			$shareWith,
 			Activity::SUBJECT_REMOTE_SHARE_RECEIVED,
-			[$ownerAddress->getCloudId(), \trim($name, '/')],
+			[$ownerAddress->getCloudId(), \trim($name, '/'), ['shareId' => $shareId]],
 			'files',
 			'',
 			'',

--- a/apps/files_sharing/lib/Activity.php
+++ b/apps/files_sharing/lib/Activity.php
@@ -309,6 +309,13 @@ class Activity implements IExtension {
 			case self::SUBJECT_SHARED_EMAIL:
 				return (string) $l->t('Shared with %2$s', $params);
 
+			case self::SUBJECT_REMOTE_SHARE_RECEIVED:
+				if (\sizeof($params) === 2) {
+					// New activity ownCloud 8.2+
+					return (string) $l->t('Received remote share from %1$s', $params);
+				}
+				return (string) $l->t('Received remote share from %s', $params);
+
 			default:
 				return false;
 		}

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -144,7 +144,18 @@ class ManagerTest extends TestCase {
 				}
 			));
 
-		$event = new GenericEvent(null, ['sharedItem' => '/SharedFolder', 'shareAcceptedFrom' => 'foobar', 'remoteUrl' => 'http://localhost']);
+		$event = new GenericEvent(
+			null,
+			[
+				'sharedItem' => '/SharedFolder',
+				'shareAcceptedFrom' => 'foobar',
+				'remoteUrl' => 'http://localhost',
+				'fileId' => null,
+				'shareId' => $openShares[0]['id'],
+				'shareRecipient' => $this->uid,
+			]
+		);
+
 		$this->eventDispatcher->expects($this->at(1))
 			->method('dispatch')
 			->with('remoteshare.accepted', $event);
@@ -188,7 +199,15 @@ class ManagerTest extends TestCase {
 				}
 			));
 
-		$event = new GenericEvent(null, ['sharedItem' => '/SharedFolder', 'shareAcceptedFrom' => 'foobar', 'remoteUrl' => 'http://localhost']);
+		$event = new GenericEvent(
+			null,
+			[
+				'sharedItem' => '/SharedFolder',
+				'shareAcceptedFrom' => 'foobar',
+				'remoteUrl' => 'http://localhost',
+			]
+		);
+
 		$this->eventDispatcher->expects($this->at(1))
 			->method('dispatch')
 			->with('remoteshare.declined', $event);

--- a/changelog/unreleased/38880
+++ b/changelog/unreleased/38880
@@ -1,0 +1,10 @@
+Enhancement: Trigger file scan after accepting a federated share
+
+This is necessary as we need the fileId to pass it to the `remoteshare.accepted`
+event. The activity app can then hook onto this event and update the activity
+by setting the correct fileId.
+
+Also added a short translation for the SUBJECT_REMOTE_SHARE_RECEIVED activity.
+
+https://github.com/owncloud/core/pull/38880
+https://github.com/owncloud/activity/issues/970

--- a/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
+++ b/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
@@ -23,7 +23,7 @@ Feature: poll incoming shares
     And user "Brian" from server "LOCAL" has accepted the last pending share
     When user "Alice" on "REMOTE" uploads file "filesForUpload/lorem.txt" to "/really/very/deeply/nested/folder/with/sub/folders/lorem.txt" using the WebDAV API
     And using server "LOCAL"
-    Then the etag of element "/" of user "Brian" should not have changed
+    Then the etag of element "/" of user "Brian" should have changed
     When the administrator invokes occ command "incoming-shares:poll"
     Then the etag of element "/" of user "Brian" should have changed
 
@@ -38,7 +38,7 @@ Feature: poll incoming shares
     And user "Alice" from server "REMOTE" has shared "/shareFolder" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    Then the etag of element "/" of user "Brian" should not have changed
+    Then the etag of element "/" of user "Brian" should have changed
     When the administrator invokes occ command "incoming-shares:poll"
     Then the etag of element "/" of user "Brian" should have changed
 


### PR DESCRIPTION
## Description
This is necessary as we need the `fileId` to pass it to the `remoteshare.accepted` event. The activity app can then hook in to this event and update the activity by setting the correct `fileId` (see https://github.com/owncloud/activity/pull/972). The `shareId` has been added to the published activity which is used to retrieve the activity later when it is updated.

Also added a short translation for the `SUBJECT_REMOTE_SHARE_RECEIVED` activity.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/activity/issues/970

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
