### PR TITLE
[tests-only] skip on old oC10 the test scenarios modified in PR 38880

### DIFF
--- a/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
+++ b/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
@@ -4,7 +4,7 @@ Feature: poll incoming shares
   I want to be able to poll incoming shares manually
   So that I can make sure all shares are up-to-date
 
-  @files_sharing-app-required
+  @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7.0
   Scenario: poll incoming share with a federation share of deep nested folders when there is a file change in remote end
     Given using server "REMOTE"
     And user "Alice" has been created with default attributes and small skeleton files
@@ -27,7 +27,7 @@ Feature: poll incoming shares
     When the administrator invokes occ command "incoming-shares:poll"
     Then the etag of element "/" of user "Brian" should have changed
 
-  @files_sharing-app-required
+  @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7.0
   Scenario: poll incoming share with a federation share and no file change
     Given using server "REMOTE"
     And user "Alice" has been created with default attributes and small skeleton files


### PR DESCRIPTION
## Description
Some test scenarios were modified in PR #38880 yesterday. They no longer apply to old oC10 versions, so skip in that case.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
