### PR TITLE
[tests-only] [full-ci] Fix notifications tests due to changes in notifications PR 342

### DIFF
--- a/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
@@ -32,7 +32,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
 
   Scenario: share to group sends notification to every member
@@ -46,7 +46,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 2 notifications
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -54,7 +54,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
 
 	# This scenario documents behavior discussed in core issue 31870
@@ -83,7 +83,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 1 notification
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -91,7 +91,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "David" should have 0 notifications
 
@@ -111,7 +111,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 1 notification
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -119,7 +119,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "David" should have 0 notifications
 

--- a/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
@@ -33,7 +33,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
 
   Scenario: share to group sends notification to every member
@@ -47,7 +47,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 2 notifications
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -55,7 +55,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
 
 	# This scenario documents behavior discussed in core issue 31870
@@ -72,7 +72,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 1 notification
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -80,7 +80,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "David" should have 0 notifications
 
@@ -100,7 +100,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "Carol" should have 1 notification
     And the last notification of user "Carol" should match these regular expressions about user "Alice"
@@ -108,7 +108,7 @@ Feature: Display notifications when receiving a share
       | app         | /^files_sharing$/                                |
       | subject     | /^"%displayname%" shared "PARENT" with you$/     |
       | message     | /^"%displayname%" invited you to view "PARENT"$/ |
-      | link        | /^(\/index\.php)?\/f\/(\d+)$/                    |
+      | link        | /^https?:\/\/.+\/f\/(\d+)$/                      |
       | object_type | /^local_share$/                                  |
     And user "David" should have 0 notifications
 


### PR DESCRIPTION
## Description
Notifications PR https://github.com/owncloud/notifications/pull/342 changed the link provided in notification to be a full absolute URL.

Some test in core were effected. See demonstration PR #38895 

This PR adjusts the expected link format in the test scenarios to match the new absolute URLs.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
