### PR TITLE
[tests-only] Skip intermittent test on oc storage

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinRestore.feature
@@ -92,7 +92,7 @@ Feature: Restore deleted files/folders
       | old      | /textfile0.txt          | PARENT/textfile0.txt |
       | new      | /textfile0.txt          | PARENT/textfile0.txt |
 
-  @skipOnOcV10 @issue-35974
+  @skipOnOcV10 @issue-35974 @skipOnOcis-OC-Storage @issue-ocis-2221
   Scenario Outline: restoring a file to an already existing path overrides the file
     Given user "Alice" has uploaded file with content "file to delete" to "/.hiddenfile0.txt"
     And using <dav-path> DAV path


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
trashbin restore scenario is skipped on ocis oc storage
`Scenario Outline: restoring a file to an already existing path overrides the file`

## Related Issue


## Motivation and Context
https://github.com/owncloud/ocis/pull/2211#issuecomment-869491800

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
