### PR TITLE
[tests-only] [full-ci] Ignore new php-webdriver 1.4.9

### DIFF
--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -49,7 +49,7 @@ Feature: restrict Sharing
     And the user re-logs in as "David" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
-  @smokeTest @skip @issue-38908
+  @smokeTest
   Scenario: Forbid sharing with groups
     Given the setting "Allow sharing with groups" in the section "Sharing" has been disabled
     When the user browses to the files page

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -17,6 +17,7 @@
         "ankitpokhrel/tus-php": "^2.1"
     },
     "conflict": {
-        "instaclick/php-webdriver": "1.4.8 || 1.4.9"
+        "instaclick/php-webdriver": "1.4.8 || 1.4.9",
+        "nesbot/carbon": "2.50.0"
     }
 }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -15,5 +15,8 @@
         "phpunit/phpunit": "^9.4",
         "laminas/laminas-ldap": "^2.10",
         "ankitpokhrel/tus-php": "^2.1"
+    },
+    "conflict": {
+        "instaclick/php-webdriver": "1.4.9"
     }
 }

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -17,6 +17,6 @@
         "ankitpokhrel/tus-php": "^2.1"
     },
     "conflict": {
-        "instaclick/php-webdriver": "1.4.9"
+        "instaclick/php-webdriver": "1.4.8 || 1.4.9"
     }
 }


### PR DESCRIPTION
## Description
New patch releases of https://github.com/instaclick/php-webdriver/tags v1.4.8 and v1.4.9 were released late yesterday.

It seems that they may be the cause of the linked issue - somehow they are now thinking that an element is not clickable.

Do not use these patch releases:

Commit 1) try just excluding 1.4.9

Commit 2) also exclude 1.4.8

Commit 3) I noticed that `nesbot/carbon` had a minor version 2.50.0 - I blocked that also

We need to exclude both of them to get CI passing - there is some "issue" in 1.4.8 which will also be present in 1.4.9.

Do this for now. I will investigate more about what actually goes wrong and sort out what to do next (is it our tests, or the upstream code that has a problem). But that can happen in "slower time".

## Related Issue
- Fixes #38908 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
