### PR TITLE
Added password option to redis cluster mode

### DIFF
--- a/changelog/unreleased/38917
+++ b/changelog/unreleased/38917
@@ -1,0 +1,5 @@
+Enhancement: Allow to pass password on redis cluster connection
+
+
+https://github.com/owncloud/core/pull/38917
+https://github.com/owncloud/enterprise/issues/4658

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1189,6 +1189,7 @@ $CONFIG = [
 	'timeout' => 0.0,
 	'read_timeout' => 0.0,
 	'failover_mode' => \RedisCluster::FAILOVER_DISTRIBUTE,
+	'password' => '', // Optional, if not defined no password will be used.
 	 // Optional config option
 	 // In order to use connection_parameters php-redis extension >= 5.3.0 is required
 	 // In order to use SSL/TLS redis server >= 6.0 is required

--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -74,10 +74,16 @@ class RedisFactory {
 				$connectionParameters = null;
 			}
 
+			$auth = null;
+
+			if (isset($config['password']) && $config['password'] !== '') {
+				$auth = $config['password'];
+			}
+
 			if ($connectionParameters && $isConnectionParametersSupported) {
-				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, false, null, $connectionParameters); // @phan-suppress-current-line PhanParamTooManyInternal
+				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, false, $auth, $connectionParameters); // @phan-suppress-current-line PhanParamTooManyInternal
 			} else {
-				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout);
+				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, false, $auth);
 			}
 
 			if (isset($config['failover_mode'])) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Enable password on redis clustered mode

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4658

## How Has This Been Tested?
1. Manually set up Redis cluster with 3 nodes with enabled password
2. Set password in redis.cluster->password **Works**
3. Unset password in redis.cluster->password **Does not work**
4. Set wrong password in redis.cluster->password **Does not work**


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/3756
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
