### PR TITLE
[tests-only][full-ci] test downloading old file versions

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -415,3 +415,40 @@ Feature: dav-versions
     Then the HTTP status code should be "207"
     And the number of etag elements in the response should be "2"
     And the number of versions should be "2"
+
+
+  Scenario: download old versions of a file
+    Given user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 1" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 2" to "textfile0.txt"
+    When user "Alice" downloads the version of file "textfile0.txt" with the index "1"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "version 1"
+    When user "Alice" downloads the version of file "textfile0.txt" with the index "2"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "uploaded content"
+
+
+  Scenario: download an old version of a restored file
+    Given user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 1" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 2" to "textfile0.txt"
+    And user "Alice" has restored version index "1" of file "textfile0.txt"
+    When user "Alice" downloads the version of file "textfile0.txt" with the index "1"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "version 2"
+    When user "Alice" downloads the version of file "textfile0.txt" with the index "2"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "uploaded content"

--- a/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
@@ -296,3 +296,24 @@ Feature: dav-versions
     Then the HTTP status code should be "204"
     And the version folder of file "/Shares/sharefile.txt" for user "Brian" should contain "1" element
     And the version folder of file "/sharefile.txt" for user "Alice" should contain "1" element
+
+  @issue-36228 @skipOnOcV10
+  Scenario: download old versions of a shared file as share receiver
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 1" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 2" to "textfile0.txt"
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" downloads the version of file "/Shares/textfile0.txt" with the index "1"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "version 1"
+    When user "Brian" downloads the version of file "/Shares/textfile0.txt" with the index "2"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "uploaded content"

--- a/tests/acceptance/features/apiVersions/fileVersionsSharingToSharesIssue36228.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsSharingToSharesIssue36228.feature
@@ -1,0 +1,28 @@
+@api @files_versions-app-required @issue-36228 @notToImplementOnOCIS
+
+Feature: dav-versions
+
+  Background:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Alice" has been created with default attributes and without skeleton files
+
+  Scenario: download old versions of a shared file as share receiver
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 1" to "textfile0.txt"
+    And user "Alice" has uploaded file with content "version 2" to "textfile0.txt"
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" downloads the version of file "/Shares/textfile0.txt" with the index "1"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                      |
+      | Content-Disposition | attachment; filename*=UTF-8''; filename="" |
+    And the downloaded content should be "version 1"
+    When user "Brian" downloads the version of file "/Shares/textfile0.txt" with the index "2"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                      |
+      | Content-Disposition | attachment; filename*=UTF-8''; filename="" |
+    And the downloaded content should be "uploaded content"

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -32,12 +32,63 @@ require_once 'bootstrap.php';
  * Steps that relate to files_versions app
  */
 class FilesVersionsContext implements Context {
-
 	/**
 	 *
 	 * @var FeatureContext
 	 */
 	private $featureContext;
+
+	/**
+	 * @When user :user tries to get versions of file :file from :fileOwner
+	 *
+	 * @param string $user
+	 * @param string $file
+	 * @param string $fileOwner
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userTriesToGetFileVersions($user, $file, $fileOwner) {
+		$user = $this->featureContext->getActualUsername($user);
+		$fileOwner = $this->featureContext->getActualUsername($fileOwner);
+		$fileId = $this->featureContext->getFileIdForPath($fileOwner, $file);
+		$path = "/meta/" . $fileId . "/v";
+		$response = $this->featureContext->makeDavRequest(
+			$user,
+			"PROPFIND",
+			$path,
+			null,
+			null,
+			null,
+			2
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
+	 * @When user :user gets the number of versions of file :file
+	 *
+	 * @param string $user
+	 * @param string $file
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userGetsFileVersions($user, $file) {
+		$user = $this->featureContext->getActualUsername($user);
+		$fileId = $this->featureContext->getFileIdForPath($user, $file);
+		$path = "/meta/" . $fileId . "/v";
+		$response = $this->featureContext->makeDavRequest(
+			$user,
+			"PROPFIND",
+			$path,
+			null,
+			null,
+			null,
+			2
+		);
+		$this->featureContext->setResponse($response);
+	}
 
 	/**
 	 * @When user :user restores version index :versionIndex of file :path using the WebDAV API

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -39,11 +39,11 @@ class FilesVersionsContext implements Context {
 	private $featureContext;
 
 	/**
-	 * @param int $fileId
+	 * @param string $fileId
 	 *
 	 * @return string
 	 */
-	private function getVersionsPathForFileId(int $fileId) {
+	private function getVersionsPathForFileId(string $fileId) {
 		return "/meta/$fileId/v";
 	}
 
@@ -110,7 +110,7 @@ class FilesVersionsContext implements Context {
 	public function userRestoresVersionIndexOfFile($user, $versionIndex, $path) {
 		$user = $this->featureContext->getActualUsername($user);
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
-		$responseXml = $this->listVersionFolder($user, (int)$fileId, 1);
+		$responseXml = $this->listVersionFolder($user, $fileId, 1);
 		$xmlPart = $responseXml->xpath("//d:response/d:href");
 		//restoring the version only works with dav path v2
 		$destinationUrl = $this->featureContext->getBaseUrl() . "/" .
@@ -149,7 +149,7 @@ class FilesVersionsContext implements Context {
 	/**
 	 * @Then the version folder of fileId :fileId for user :user should contain :count element(s)
 	 *
-	 * @param int $fileId
+	 * @param string $fileId
 	 * @param string $user
 	 * @param int $count
 	 *
@@ -160,7 +160,7 @@ class FilesVersionsContext implements Context {
 		$user,
 		$count
 	) {
-		$responseXml = $this->listVersionFolder($user, (int)$fileId, 1);
+		$responseXml = $this->listVersionFolder($user, $fileId, 1);
 		$xmlPart = $responseXml->xpath("//d:prop/d:getetag");
 		Assert::assertEquals(
 			$count,
@@ -189,7 +189,7 @@ class FilesVersionsContext implements Context {
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
 		$responseXml = $this->listVersionFolder(
 			$user,
-			(int)$fileId,
+			$fileId,
 			1,
 			['getcontentlength']
 		);
@@ -239,7 +239,7 @@ class FilesVersionsContext implements Context {
 	 * with an registered namespace with 'd' as prefix and 'DAV:' as namespace
 	 *
 	 * @param string $user
-	 * @param int $fileId
+	 * @param string $fileId
 	 * @param int $folderDepth
 	 * @param string[]|null $properties
 	 *
@@ -247,7 +247,7 @@ class FilesVersionsContext implements Context {
 	 */
 	public function listVersionFolder(
 		string $user,
-		int $fileId,
+		string $fileId,
 		int $folderDepth,
 		array $properties = null
 	) {

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -39,6 +39,15 @@ class FilesVersionsContext implements Context {
 	private $featureContext;
 
 	/**
+	 * @param int $fileId
+	 *
+	 * @return string
+	 */
+	private function getVersionsPathForFileId(int $fileId) {
+		return "/meta/$fileId/v";
+	}
+
+	/**
 	 * @When user :user tries to get versions of file :file from :fileOwner
 	 *
 	 * @param string $user
@@ -52,11 +61,10 @@ class FilesVersionsContext implements Context {
 		$user = $this->featureContext->getActualUsername($user);
 		$fileOwner = $this->featureContext->getActualUsername($fileOwner);
 		$fileId = $this->featureContext->getFileIdForPath($fileOwner, $file);
-		$path = "/meta/" . $fileId . "/v";
 		$response = $this->featureContext->makeDavRequest(
 			$user,
 			"PROPFIND",
-			$path,
+			$this->getVersionsPathForFileId($fileId),
 			null,
 			null,
 			null,
@@ -77,11 +85,10 @@ class FilesVersionsContext implements Context {
 	public function userGetsFileVersions($user, $file) {
 		$user = $this->featureContext->getActualUsername($user);
 		$fileId = $this->featureContext->getFileIdForPath($user, $file);
-		$path = "/meta/" . $fileId . "/v";
 		$response = $this->featureContext->makeDavRequest(
 			$user,
 			"PROPFIND",
-			$path,
+			$this->getVersionsPathForFileId($fileId),
 			null,
 			null,
 			null,
@@ -223,7 +230,7 @@ class FilesVersionsContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$password,
-			"/meta/$fileId/v",
+			$this->getVersionsPathForFileId($fileId),
 			$properties,
 			$folderDepth,
 			"versions"

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -203,6 +203,38 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
+	 * @When user :user downloads the version of file :path with the index :index
+	 *
+	 * @param string $user
+	 * @param string $path
+	 * @param string $index
+	 *
+	 * @return void
+	 */
+	public function downloadVersion(string $user, string $path, string $index) {
+		$user = $this->featureContext->getActualUsername($user);
+		$fileId = $this->featureContext->getFileIdForPath($user, $path);
+		$index = (int)$index;
+		$responseXml = $this->listVersionFolder($user, $fileId, 1);
+		$xmlPart = $responseXml->xpath("//d:response/d:href");
+		if (!isset($xmlPart[$index])) {
+			Assert::fail(
+				'could not find version of path "' . $path . '" with index "' . $index . '"'
+			);
+		}
+		// the href already contains the path
+		$url = WebDavHelper::sanitizeUrl(
+			$this->featureContext->getBaseUrlWithoutPath() . $xmlPart[$index]
+		);
+		$response = HttpRequestHelper::get(
+			$url,
+			$user,
+			$this->featureContext->getPasswordForUser($user)
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * returns the result parsed into an SimpleXMLElement
 	 * with an registered namespace with 'd' as prefix and 'DAV:' as namespace
 	 *

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -52,7 +52,7 @@ class FilesVersionsContext implements Context {
 	public function userRestoresVersionIndexOfFile($user, $versionIndex, $path) {
 		$user = $this->featureContext->getActualUsername($user);
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
-		$responseXml = $this->listVersionFolder($user, "/meta/$fileId/v", 1);
+		$responseXml = $this->listVersionFolder($user, (int)$fileId, 1);
 		$xmlPart = $responseXml->xpath("//d:response/d:href");
 		//restoring the version only works with dav path v2
 		$destinationUrl = $this->featureContext->getBaseUrl() . "/" .
@@ -102,7 +102,7 @@ class FilesVersionsContext implements Context {
 		$user,
 		$count
 	) {
-		$responseXml = $this->listVersionFolder($user, "/meta/$fileId/v", 1);
+		$responseXml = $this->listVersionFolder($user, (int)$fileId, 1);
 		$xmlPart = $responseXml->xpath("//d:prop/d:getetag");
 		Assert::assertEquals(
 			$count,
@@ -131,7 +131,7 @@ class FilesVersionsContext implements Context {
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
 		$responseXml = $this->listVersionFolder(
 			$user,
-			"/meta/$fileId/v",
+			(int)$fileId,
 			1,
 			['getcontentlength']
 		);
@@ -149,17 +149,17 @@ class FilesVersionsContext implements Context {
 	 * with an registered namespace with 'd' as prefix and 'DAV:' as namespace
 	 *
 	 * @param string $user
-	 * @param string $path
+	 * @param int $fileId
 	 * @param int $folderDepth
-	 * @param string[] $properties
+	 * @param string[]|null $properties
 	 *
 	 * @return SimpleXMLElement
 	 */
 	public function listVersionFolder(
-		$user,
-		$path,
-		$folderDepth,
-		$properties = null
+		string $user,
+		int $fileId,
+		int $folderDepth,
+		array $properties = null
 	) {
 		if (!$properties) {
 			$properties = [
@@ -172,7 +172,7 @@ class FilesVersionsContext implements Context {
 			$this->featureContext->getBaseUrl(),
 			$user,
 			$password,
-			$path,
+			"/meta/$fileId/v",
 			$properties,
 			$folderDepth,
 			"versions"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -397,58 +397,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @When user :user tries to get versions of file :file from :fileOwner
-	 *
-	 * @param string $user
-	 * @param string $file
-	 * @param string $fileOwner
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userTriesToGetFileVersions($user, $file, $fileOwner) {
-		$user = $this->getActualUsername($user);
-		$fileOwner = $this->getActualUsername($fileOwner);
-		$fileId = $this->getFileIdForPath($fileOwner, $file);
-		$path = "/meta/" . $fileId . "/v";
-		$response = $this->makeDavRequest(
-			$user,
-			"PROPFIND",
-			$path,
-			null,
-			null,
-			null,
-			2
-		);
-		$this->setResponse($response);
-	}
-
-	/**
-	 * @When user :user gets the number of versions of file :file
-	 *
-	 * @param string $user
-	 * @param string $file
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userGetsFileVersions($user, $file) {
-		$user = $this->getActualUsername($user);
-		$fileId = $this->getFileIdForPath($user, $file);
-		$path = "/meta/" . $fileId . "/v";
-		$response = $this->makeDavRequest(
-			$user,
-			"PROPFIND",
-			$path,
-			null,
-			null,
-			null,
-			2
-		);
-		$this->setResponse($response);
-	}
-
-	/**
 	 * @Then the number of versions should be :arg1
 	 *
 	 * @param int $number


### PR DESCRIPTION
## Description
tests to check if downloading an old version of a file works correctly
the issue #36228 is demonstrated by checking the header

## Related Issue
tests for #36228

## How Has This Been Tested?
- CI here
- CI of ocis: https://github.com/owncloud/ocis/pull/2262

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
