### PR TITLE
[Tests-Only] Add new env variable to specify the wait times between uploads and deletes

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -123,8 +123,8 @@ Feature: files and folders exist in the trashbin after being deleted
       | new      |
 
   @local_storage
-    @skipOnEncryptionType:user-keys @encryption-issue-42
-    @skip_on_objectstore
+  @skipOnEncryptionType:user-keys @encryption-issue-42
+  @skip_on_objectstore
   Scenario Outline: Deleting a folder into external storage moves it to the trashbin
     Given using <dav-path> DAV path
     And the administrator has invoked occ command "files:scan --all"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -4473,8 +4473,12 @@ trait WebDav {
 	 */
 	public function pauseUploadDelete() {
 		$time = \time();
-		if ($this->lastUploadDeleteTime !== null && $time - $this->lastUploadDeleteTime < 1) {
-			\sleep(1);
+		$uploadWaitTime = \getenv("UPLOAD_DELETE_WAIT_TIME");
+
+		$uploadWaitTime = $uploadWaitTime ? (int)$uploadWaitTime : 1;
+
+		if ($this->lastUploadDeleteTime !== null && $time - $this->lastUploadDeleteTime < $uploadWaitTime) {
+			\sleep($uploadWaitTime);
 		}
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -4466,8 +4466,15 @@ trait WebDav {
 	}
 
 	/**
-	 * prevent creating two uploads with the same "stime" which is
-	 * based on seconds, this prevents creation of uploads with same etag
+	 * Prevent creating two uploads and/or deletes with the same "stime"
+	 * That is based on seconds in some implementations.
+	 * This prevents duplication of etags or other problems with
+	 * trashbin/versions save/restore.
+	 *
+	 * Set env var UPLOAD_DELETE_WAIT_TIME to 1 to activate a 1-second pause.
+	 * By default, there is no pause. That allows testing of implementations
+	 * which should be able to cope with multiple upload/delete actions in the
+	 * same second.
 	 *
 	 * @return void
 	 */
@@ -4475,9 +4482,12 @@ trait WebDav {
 		$time = \time();
 		$uploadWaitTime = \getenv("UPLOAD_DELETE_WAIT_TIME");
 
-		$uploadWaitTime = $uploadWaitTime ? (int)$uploadWaitTime : 1;
+		$uploadWaitTime = $uploadWaitTime ? (int)$uploadWaitTime : 0;
 
-		if ($this->lastUploadDeleteTime !== null && $time - $this->lastUploadDeleteTime < $uploadWaitTime) {
+		if (($this->lastUploadDeleteTime !== null)
+			&& ($uploadWaitTime > 0)
+			&& (($time - $this->lastUploadDeleteTime) < $uploadWaitTime)
+		) {
 			\sleep($uploadWaitTime);
 		}
 	}

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1199,6 +1199,14 @@ export IPV4_URL
 export IPV6_URL
 export FILES_FOR_UPLOAD="${SCRIPT_PATH}/filesForUpload/"
 
+if [ "${TEST_OCIS}" != "true" ] && [ "${TEST_REVA}" != "true" ]
+then
+	# We are testing on an ownCloud core server.
+	# Tell the tests to wait 1 second between each upload/delete action
+	# to avoid problems with actions that depend on timestamps in seconds.
+	export UPLOAD_DELETE_WAIT_TIME=1
+fi
+
 TEST_LOG_FILE=$(mktemp)
 SCENARIOS_THAT_PASSED=0
 SCENARIOS_THAT_FAILED=0


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Introduce a new env variable UPLOAD_DELETE_WAIT_TIME for tests so that we can specify the wait times between uploads and deletes..

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related https://github.com/owncloud/ocis/issues/2219

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ocis doesn't requires to wait between uploads for some storage drivers so we do need to be able to set this value for testind different servers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
:robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
