### PR TITLE
[Tests-Only]Adjust federation sharing test scenarios

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -759,6 +759,25 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * for a folder or individual file that is shared as federated share,, the receiver of the share
+	 * has an "Unshare" entry in the file actions menu of the share in the
+	 * sharedwithme page. Clicking it works just like delete.
+	 *
+	 * @When the user deletes/unshares file/folder :name received as federated share using the webUI
+	 *
+	 * @param string $name
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function userDeletesFileReceivedAsFederatedShareUsingTheWebUI($name) {
+		$pageObject = $this->getCurrentPageObject();
+		$session = $this->getSession();
+		$pageObject->waitTillPageIsLoaded($session);
+		$this->sharedWithYouPage->deleteFileFromSharedWithYou($name, $session);
+	}
+
+	/**
 	 * @When the user deletes the following file/folder using the webUI
 	 *
 	 * @param TableNode $namePartsTable table of parts of the file name

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -759,7 +759,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * for a folder or individual file that is shared as federated share,, the receiver of the share
+	 * for a folder or individual file that is shared as federated share, the receiver of the share
 	 * has an "Unshare" entry in the file actions menu of the share in the
 	 * sharedwithme page. Clicking it works just like delete.
 	 *

--- a/tests/acceptance/features/lib/SharedWithYouPage.php
+++ b/tests/acceptance/features/lib/SharedWithYouPage.php
@@ -159,11 +159,11 @@ class SharedWithYouPage extends FilesPageBasic {
 				$row->delete($session);
 				$this->waitForAjaxCallsToStartAndFinish($session);
 				$countXHRRequests = $this->getSumStartedAjaxRequests($session);
-				//if no XHR Request were fired we assume the delete action
+				//if no XHR Request was fired we assume the delete action
 				//did not work and we retry
 				if ($countXHRRequests === 0) {
 					if ($expectToDeleteFile) {
-						\error_log("Error while deleting file");
+						\error_log("Error while deleting/unsharing file from shared-with-you");
 					}
 				} else {
 					break;
@@ -172,7 +172,7 @@ class SharedWithYouPage extends FilesPageBasic {
 				$this->closeFileActionsMenu();
 				if ($expectToDeleteFile) {
 					\error_log(
-						"Error while deleting file"
+						"Error while deleting/unsharing file from shared-with-you."
 						. "\n-------------------------\n"
 						. $e->getMessage()
 						. "\n-------------------------\n"
@@ -185,7 +185,7 @@ class SharedWithYouPage extends FilesPageBasic {
 			if (\is_array($name)) {
 				$name = \implode('', $name);
 			}
-			$message = "INFORMATION: retried to delete file '$name' $counter times";
+			$message = "INFORMATION: retried deleting/unsharing file '$name' from shared-with-you $counter times";
 			echo $message;
 			\error_log($message);
 			if ($counter === $maxRetries) {

--- a/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
@@ -137,7 +137,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And file "lorem (3).txt" should be listed in the shared-with-you page on the webUI
 
 
-  Scenario: unshare a federation share
+  Scenario: unshare a federation share from files page and check in the files page as well as in "shared-with-you" page
     Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
     And user "Alice" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
@@ -155,15 +155,6 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user unshares file "lorem (2).txt" received as federated share using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "lorem (2).txt" should not be listed in the files page on the webUI
-
-
-  Scenario: unshare a federation share from "files" page and check in the "shared-with-you" page
-    Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
-    And user "Alice" from server "LOCAL" has accepted the last pending share
-    And the user has reloaded the current page of the webUI
-    When the user unshares file "lorem (2).txt" using the webUI
-    Then file "lorem (2).txt" should not be listed on the webUI
-    And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
 
   Scenario: test sharing folder to a remote server and resharing it back to the local
@@ -259,7 +250,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then as "Alice" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
     But as "Alice" file "simple-folder/simple-empty-folder/textfile.txt" should not exist
 
-    
+
   Scenario: delete a file in a folder inside a shared folder
     Given using server "REMOTE"
     And user "Alice" has created folder "simple-folder/simple-empty-folder"

--- a/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
@@ -40,6 +40,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
+
   Scenario: overwrite a file in a received share - local server shares - remote server receives
     Given user "Alice" from server "LOCAL" has shared "simple-folder" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
@@ -47,6 +48,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user opens folder "simple-folder" using the webUI
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" on the local server should be the same as the local "lorem.txt"
+
 
   Scenario: overwrite a file in a received share - remote server shares - local server receives
     Given user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
@@ -58,6 +60,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then as "Alice" file "simple-folder/lorem.txt" should exist
     And the content of "simple-folder/lorem.txt" on the remote server for user "Alice" should be the same as the local "lorem.txt"
 
+
   Scenario: upload a new file in a received share - local server shares - remote server receives
     Given user "Alice" from server "LOCAL" has shared "simple-folder" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
@@ -65,6 +68,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user opens folder "simple-folder" using the webUI
     Then file "new-lorem.txt" should be listed on the webUI
     And the content of "new-lorem.txt" on the local server should be the same as the local "new-lorem.txt"
+
 
   Scenario: upload a new file in a received share - remote server shares - local server receives
     Given user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
@@ -75,6 +79,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And using server "REMOTE"
     Then as "Alice" file "simple-folder/new-lorem.txt" should exist
     And the content of "simple-folder/new-lorem.txt" on the remote server for user "Alice" should be the same as the local "new-lorem.txt"
+
 
   Scenario: rename a file in a received share - local server shares - remote server receives
     Given user "Alice" from server "LOCAL" has shared "simple-folder" with user "Alice" from server "REMOTE"
@@ -97,6 +102,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the content of file "simple-folder/renamed file.txt" for user "Alice" on server "REMOTE" should be "I am lorem.txt inside simple-folder"
     But as "Alice" file "simple-folder/lorem.txt" should not exist
 
+
   Scenario: delete a file in a received share - local server shares - remote server receives
     Given user "Alice" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
     And user "Alice" from server "LOCAL" has shared "simple-folder" with user "Alice" from server "REMOTE"
@@ -104,6 +110,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When user "Alice" on "REMOTE" deletes file "simple-folder (2)/data.zip" using the WebDAV API
     And the user opens folder "simple-folder" using the webUI
     Then file "data.zip" should not be listed on the webUI
+
 
   Scenario: delete a file in a received share - remote server shares - local server receives
     Given user "Alice" on "REMOTE" has uploaded file "filesForUpload/data.zip" to "/simple-folder/data.zip"
@@ -114,6 +121,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user deletes file "data.zip" using the webUI
     And using server "REMOTE"
     Then as "Alice" file "simple-folder/data.zip" should not exist
+
 
   Scenario: receive same name federation share from two users
     Given using server "REMOTE"
@@ -128,6 +136,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And file "lorem (2).txt" should be listed in the shared-with-you page on the webUI
     And file "lorem (3).txt" should be listed in the shared-with-you page on the webUI
 
+
   Scenario: unshare a federation share
     Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
     And user "Alice" from server "LOCAL" has accepted the last pending share
@@ -138,13 +147,15 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
-  Scenario: unshare a federation share from "share-with-you" page
+
+  Scenario: unshare a federation share from "shared-with-you" page
     Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
     And user "Alice" from server "LOCAL" has accepted the last pending share
     And the user has browsed to the shared-with-you page
     When the user unshares file "lorem (2).txt" received as federated share using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "lorem (2).txt" should not be listed in the files page on the webUI
+
 
   Scenario: unshare a federation share from "files" page and check in the "shared-with-you" page
     Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
@@ -153,6 +164,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user unshares file "lorem (2).txt" using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
     And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
+
 
   Scenario: test sharing folder to a remote server and resharing it back to the local
     Given using server "LOCAL"
@@ -165,6 +177,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user accepts the offered remote shares using the webUI
     Then as "Brian" folder "/simple-folder (2)" should exist
     And as "Brian" file "/simple-folder (2)/lorem.txt" should exist
+
 
   Scenario: test resharing folder as readonly and set it as readonly by resharer
     Given using server "LOCAL"
@@ -209,6 +222,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" from server "REMOTE" accepts the last pending share using the sharing API
     Then as "Alice" file "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" should exist
 
+
   Scenario: sharee should be able to access the files/folders inside other folder
     Given user "Alice" has created folder "simple-folder/simple-empty-folder"
     And user "Alice" has created folder "simple-folder/simple-empty-folder/finalfolder"
@@ -219,6 +233,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then as "Alice" file "simple-folder (2)/lorem.txt" should exist
     And as "Alice" file "simple-folder (2)/simple-empty-folder/textfile.txt" should exist
     And as "Alice" folder "simple-folder (2)/simple-empty-folder/finalfolder" should exist
+
 
   Scenario: sharee uploads a file inside a folder of a folder
     Given user "Alice" has created folder "simple-folder/simple-empty-folder"
@@ -244,6 +259,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then as "Alice" file "simple-folder/simple-empty-folder/new-lorem.txt" should exist
     But as "Alice" file "simple-folder/simple-empty-folder/textfile.txt" should not exist
 
+    
   Scenario: delete a file in a folder inside a shared folder
     Given using server "REMOTE"
     And user "Alice" has created folder "simple-folder/simple-empty-folder"
@@ -255,6 +271,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And the user deletes file "textfile.txt" using the webUI
     And using server "REMOTE"
     Then as "Alice" file "/simple-folder/simple-empty-folder/textfile.txt" should not exist
+
 
   Scenario: delete shared folder and create a folder for federation sharing with same name
     Given user "Alice" from server "LOCAL" has shared "simple-folder" with user "Alice" from server "REMOTE"

--- a/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
@@ -141,10 +141,18 @@ Feature: Federation Sharing - sharing with users on other cloud storages
   Scenario: unshare a federation share from "share-with-you" page
     Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
     And user "Alice" from server "LOCAL" has accepted the last pending share
+    And the user has browsed to the shared-with-you page
+    When the user unshares file "lorem (2).txt" received as federated share using the webUI
+    Then file "lorem (2).txt" should not be listed on the webUI
+    And file "lorem (2).txt" should not be listed in the files page on the webUI
+
+  Scenario: unshare a federation share from "files" page and check in the "shared-with-you" page
+    Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
+    And user "Alice" from server "LOCAL" has accepted the last pending share
     And the user has reloaded the current page of the webUI
     When the user unshares file "lorem (2).txt" using the webUI
     Then file "lorem (2).txt" should not be listed on the webUI
-    And file "lorem (2).txt" should not be listed in the files page on the webUI
+    And file "lorem (2).txt" should not be listed in the shared-with-you page on the webUI
 
   Scenario: test sharing folder to a remote server and resharing it back to the local
     Given using server "LOCAL"


### PR DESCRIPTION
## Description
This PR adjusts the test steps for the scenarios in federation sharing feature.

## Motivation and Context
The scenarios in the federation sharing were misleading.

## How Has This Been Tested?
- CI
- In ocis: https://github.com/owncloud/ocis/pull/2255/files 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
