### PR TITLE
Adjust PHP versions to min 7.2.5 and max <8.0.0

### DIFF
--- a/changelog/unreleased/38934
+++ b/changelog/unreleased/38934
@@ -1,0 +1,11 @@
+Change: Update PHP minimum version to 7.2.5
+
+The minimum supported PHP version is now 7.2.5. This supports some dependencies
+that require at least 7.2.5.
+
+PHP 7.2 security patches finished in December 2020.
+PHP 7.3 security patches finish on 6 December 2021.
+It is recommended that you plan an upgrade to PHP 7.4 now.
+
+https://github.com/owncloud/core/pull/38934
+https://www.php.net/supported-versions.php

--- a/console.php
+++ b/console.php
@@ -33,17 +33,17 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 
 \define('OC_CONSOLE', 1);
 
-// Show warning if a PHP version below 7.2.0 is used, this has to happen here
+// Show warning if a PHP version below 7.2.5 is used, this has to happen here
 // because base.php will already use 7.2 syntax.
-if (\version_compare(PHP_VERSION, '7.2.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.2.0'.PHP_EOL;
+if (\version_compare(PHP_VERSION, '7.2.5') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.2.5'.PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.'.PHP_EOL;
 	exit(1);
 }
 
-// Show warning if PHP 7.5 or later is used as ownCloud is not compatible with PHP 7.5
-if (\version_compare(PHP_VERSION, '7.5.0alpha1') !== -1) {
-	echo 'This version of ownCloud is not compatible with PHP 7.5' . PHP_EOL;
+// Show warning if PHP 8.0 or later is used as ownCloud is not compatible with PHP 8.0
+if (\version_compare(PHP_VERSION, '8.0.0') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 8.0' . PHP_EOL;
 	echo 'You are currently running PHP ' . PHP_VERSION . '.' . PHP_EOL;
 	exit(1);
 }

--- a/index.php
+++ b/index.php
@@ -27,17 +27,17 @@
  *
  */
 
-// Show warning if a PHP version below 7.2.0 is used, this has to happen here
+// Show warning if a PHP version below 7.2.5 is used, this has to happen here
 // because base.php will already use 7.2 syntax.
-if (\version_compare(PHP_VERSION, '7.2.0') === -1) {
-	echo 'This version of ownCloud requires at least PHP 7.2.0<br/>';
+if (\version_compare(PHP_VERSION, '7.2.5') === -1) {
+	echo 'This version of ownCloud requires at least PHP 7.2.5<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '. Please update your PHP version.';
 	return;
 }
 
-// Show warning if PHP 7.5 or later is used as ownCloud is not compatible with PHP 7.5
-if (\version_compare(PHP_VERSION, '7.5.0alpha1') !== -1) {
-	echo 'This version of ownCloud is not compatible with PHP 7.5<br/>';
+// Show warning if PHP 8.0 or later is used as ownCloud is not compatible with PHP 8.0
+if (\version_compare(PHP_VERSION, '8.0.0') !== -1) {
+	echo 'This version of ownCloud is not compatible with PHP 8.0<br/>';
 	echo 'You are currently running PHP ' . PHP_VERSION . '.';
 	return;
 }


### PR DESCRIPTION
## Description
1) PR #38891 had to change the min PHP version from 7.2 to 7.2.5. We need to do the same in `console.php`  and `index.php` to be consistent. Anyone running PHP 7.2 should already be well past patch 5!

2) When we first did the PHP 7.4 support, we were not 100% sure if the next annual PHP  release would be 7.5 or 8.0. So we put a max version check of PHP <7.5. That looks a bit confusing now that there really is no PHP 7.5 and PHP 8.0 has been released for quite a while. The check is adjusted to be max version <8.0.0.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
