### PR TITLE
Move preview content to docs

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -966,69 +966,7 @@ $CONFIG = [
  *  - OC\Preview\MP3
  *  - OC\Preview\TXT
  *
- * The following providers are available, but disabled by default due to performance or privacy concerns:
- *
- *  - OC\Preview\Illustrator
- *  - OC\Preview\Movie
- *  - OC\Preview\MSOfficeDoc
- *  - OC\Preview\MSOffice2003
- *  - OC\Preview\MSOffice2007
- *  - OC\Preview\OpenDocument
- *  - OC\Preview\StarOffice
- *  - OC\Preview\PDF
- *  - OC\Preview\Photoshop
- *  - OC\Preview\Postscript
- *  - OC\Preview\SVG
- *  - OC\Preview\TIFF
- *  - OC\Preview\Font
- *
- * The following providers are only available if either LibreOffice or OpenOffice is installed on the server:
- *
- *  - OC\Preview\MSOfficeDoc
- *  - OC\Preview\MSOffice2003
- *  - OC\Preview\MSOffice2007
- *  - OC\Preview\OpenDocument
- *  - OC\Preview\StarOffice
- *
- * The following providers require the php `imagick` extension:
- *
- *  - OC\Preview\SVG
- *  - OC\Preview\TIFF
- *  - OC\Preview\PDF
- *  - OC\Preview\AI
- *  - OC\Preview\PSD
- *  - OC\Preview\EPS
- *  - OC\Preview\TTF
- *  - OC\Preview\Heic
- *  - OC\Preview\SGI
- *
- * Install the following additional imagick library when using SVG.
- * This library adds imagick support for SVG, WMF, OpenEXR, DjVu and Graphviz:
- *
- * `sudo apt install -y libmagickcore-6.q16-3-extra`
- *
- * Change the following imagick security policy when using PDF.
- * Use the editor of your choice, the example uses `vi`.
- *
- * `sudo vi /etc/ImageMagick-6/policy.xml`
- *
- * `<policy domain="coder" rights="none" pattern="PDF" />`
- *
- * `rights="none"` -> `rights="read|write"`
- *
- * Install `ffmpeg` when using the `OC\Preview\Movie` provider.
- *
- * `sudo apt install -y ffmpeg`
- *
- * To get a list of file extensions linked to the image provider, change into the `owncloud`
- * directory and run the following example command. Use a different filter for other provider types.
- *
- * `cat resources/config/mimetypemapping.dist.json | grep image`
- *
- * If you want to add a preview provider to the default ones, you must add all default ones too,
- * else they will get disabled!
- *
- * To disable all preview providers set `'enabledPreviewProviders' => false,`
+ * See the Previews Configuration documentation for more details.
  */
 'enabledPreviewProviders' => [
 	'OC\Preview\PDF',

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -318,7 +318,7 @@ class PreviewManager implements IPreview {
 		$this->registerCoreProvider('OC\Preview\MP3', '/audio\/mpeg/');
 
 		// SVG, Office and Bitmap require imagick
-		// Either use the additional library mention below when using imagick 6, or use imagick 7
+		// Either use the additional library mentioned below when using imagick 6, or use imagick 7
 		// which does not need this library. See the installation and preview documentation for more details.
 		// Install `libmagickcore-6.q16-3-extra` additional to the imagick library when using SVG.
 		// This library adds imagick support for SVG, WMF, OpenEXR, DjVu and Graphviz:

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -318,6 +318,8 @@ class PreviewManager implements IPreview {
 		$this->registerCoreProvider('OC\Preview\MP3', '/audio\/mpeg/');
 
 		// SVG, Office and Bitmap require imagick
+		// Either use the additional library mention below when using imagick 6, or use imagick 7
+		// which does not need this library. See the installation and preview documentation for more details.
 		// Install `libmagickcore-6.q16-3-extra` additional to the imagick library when using SVG.
 		// This library adds imagick support for SVG, WMF, OpenEXR, DjVu and Graphviz:
 		


### PR DESCRIPTION
## Description
This PR makes the preview config mauch smaller and points to the documentation for more in depth details. Note, a config-to-docs run will be made to transport the changes to docs. In addition, the preview documentation in docs will be improved with the content removed from here.

## Related Issue
- Fixes https://github.com/owncloud/docs/issues/3674 (Previews Configuration updation)

## Motivation and Context
Make config text better readable

## How Has This Been Tested?
Text changes only

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
