### PR TITLE
[tests-only] Skip on old oC10 public link tests changed by PR 38922

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -26,7 +26,7 @@ Feature: persistent-locking in case of a public link
       | new      | shared     | old                |
       | new      | exclusive  | old                |
 
-
+    @skipOnOcV10.6 @skipOnOcV10.7
     Examples:
       | dav-path | lock-scope | webdav_api_version |
       | old      | shared     | new                |
@@ -34,7 +34,7 @@ Feature: persistent-locking in case of a public link
       | new      | shared     | new                |
       | new      | exclusive  | new                |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: Uploading a file into a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
@@ -49,7 +49,7 @@ Feature: persistent-locking in case of a public link
       | new                       | shared     |
       | new                       | exclusive  |
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: Overwrite a file inside a locked public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT" setting the following properties
@@ -67,7 +67,7 @@ Feature: persistent-locking in case of a public link
       | new                       | shared     |
       | new                       | exclusive  |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -100,7 +100,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | shared     | old                | 423              |
       | exclusive  | old                | 423              |
 
-
+    @skipOnOcV10.6 @skipOnOcV10.7
     Examples:
       | lock-scope | webdav_api_version | http_status_code |
       | shared     | new                | 423              |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
@@ -54,7 +54,7 @@ Feature: lock should propagate correctly if a share is reshared
       | new      | shared     |
       | new      | exclusive  |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: public uploads to a reshared share that was locked by original owner
     Given using <dav-path> DAV path
     And user "Alice" has shared folder "PARENT" with user "Brian"

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -60,7 +60,7 @@ Feature: lock should propagate correctly if a share is reshared
       | new      | shared     |
       | new      | exclusive  |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: public uploads to a reshared share that was locked by original owner
     Given using <dav-path> DAV path
     And user "Alice" has shared folder "PARENT" with user "Brian"


### PR DESCRIPTION
## Description
PR #38922 fixed some public link behavior and changed the relevant tests. Of course, they will not pass on older ownCloud10 releases. So skip them in that case.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
