### PR TITLE
[Tests-Only]Add tests to overwrite a received file share

### DIFF
--- a/tests/acceptance/features/apiShareOperationsToRoot1/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/changingFilesShare.feature
@@ -92,3 +92,11 @@ Feature: sharing
     Then as "Carol" file "PARENT (3)/shared_file.txt" should exist
     And as "Brian" file "PARENT/shared_file.txt" should exist
     But as "Alice" file "PARENT/shared_file.txt" should not exist
+
+  Scenario: overwrite a received file share
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    When user "Brian" uploads file with content "this is a new content" to "/textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Brian" file "/textfile0.txt" should exist
+    And the content of file "/textfile0.txt" for user "Brian" should be "this is a new content"

--- a/tests/acceptance/features/apiShareOperationsToRoot1/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/changingFilesShare.feature
@@ -56,6 +56,7 @@ Feature: sharing
       | old              |
       | new              |
 
+
   Scenario: Move files between shares by same user
     Given user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
@@ -68,6 +69,7 @@ Feature: sharing
     And as "Alice" file "share1/shared_file.txt" should not exist
     But as "Alice" file "share2/shared_file.txt" should exist
 
+
   Scenario: Move files between shares by same user added by sharee
     Given user "Alice" has created folder "share1"
     And user "Alice" has created folder "share2"
@@ -79,6 +81,7 @@ Feature: sharing
     When user "Brian" moves file "share1/shared_file.txt" to "share2/shared_file.txt" using the WebDAV API
     Then as "Brian" file "share2/shared_file.txt" should exist
     And as "Alice" file "share2/shared_file.txt" should exist
+
 
   Scenario: Move files between shares by different users
     Given user "Carol" has been created with default attributes and without skeleton files
@@ -93,10 +96,12 @@ Feature: sharing
     And as "Brian" file "PARENT/shared_file.txt" should exist
     But as "Alice" file "PARENT/shared_file.txt" should not exist
 
+
   Scenario: overwrite a received file share
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
-    When user "Brian" uploads file with content "this is a new content" to "/textfile0.txt" using the WebDAV API
+    Given user "Alice" has uploaded file with content "this is the old content" to "/textfile1.txt"
+    And user "Alice" has shared file "/textfile1.txt" with user "Brian"
+    When user "Brian" uploads file with content "this is a new content" to "/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" file "/textfile0.txt" should exist
-    And the content of file "/textfile0.txt" for user "Brian" should be "this is a new content"
+    And as "Brian" file "/textfile1.txt" should exist
+    And the content of file "/textfile1.txt" for user "Brian" should be "this is a new content"
+    And the content of file "/textfile1.txt" for user "Alice" should be "this is a new content"

--- a/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
@@ -112,10 +112,11 @@ Feature: sharing
 
 
   Scenario: overwrite a received file share
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
-    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
-    When user "Brian" uploads file with content "this is a new content" to "/Shares/textfile0.txt" using the WebDAV API
+    Given user "Alice" has uploaded file with content "this is the old content" to "/textfile1.txt"
+    And user "Alice" has shared file "/textfile1.txt" with user "Brian"
+    And user "Brian" has accepted share "/textfile1.txt" offered by user "Alice"
+    When user "Brian" uploads file with content "this is a new content" to "/Shares/textfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" file "Shares/textfile0.txt" should exist
-    And the content of file "Shares/textfile0.txt" for user "Brian" should be "this is a new content"
+    And as "Brian" file "Shares/textfile1.txt" should exist
+    And the content of file "Shares/textfile1.txt" for user "Brian" should be "this is a new content"
+    And the content of file "textfile1.txt" for user "Alice" should be "this is a new content"

--- a/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
@@ -109,3 +109,13 @@ Feature: sharing
     Then as "Carol" file "/Shares/PARENT (2)/shared_file.txt" should exist
     And as "Brian" file "PARENT/shared_file.txt" should exist
     But as "Alice" file "PARENT/shared_file.txt" should not exist
+
+
+  Scenario: overwrite a received file share
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When user "Brian" uploads file with content "this is a new content" to "/Shares/textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Brian" file "Shares/textfile0.txt" should exist
+    And the content of file "Shares/textfile0.txt" for user "Brian" should be "this is a new content"


### PR DESCRIPTION
## Description
This PR adds API tests to overwrite a received file share

## Related Issue
- https://github.com/owncloud/ocis/issues/2267

## How Has This Been Tested?
- CI
- In OCIS: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
