### PR TITLE
[tests-only] Add test scenarios for trashbinSkip issue-38952

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
@@ -10,6 +10,7 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "lorem-folder"
 
+
   Scenario Outline: Skip trashbin based on extensions
     Given the administrator has set the following file extensions to be skipped from the trashbin
       | extension |
@@ -39,6 +40,61 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | old      |
       | new      |
 
+
+  Scenario Outline: Skip trashbin based on extensions - match is case-sensitive
+    Given the administrator has set the following file extensions to be skipped from the trashbin
+      | extension |
+      | dat       |
+      | php       |
+      | go        |
+    And user "Alice" has uploaded file with content "sample delete file 1" to "sample.TXT"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "sample.DAT"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "sample.PHP"
+    And user "Alice" has uploaded file with content "sample delete file 4" to "sample.GO"
+    And user "Alice" has uploaded file with content "sample delete file 5" to "sample.PY"
+    And using <dav-path> DAV path
+    When user "Alice" deletes the following files
+      | path       |
+      | sample.TXT |
+      | sample.DAT |
+      | sample.PHP |
+      | sample.GO  |
+      | sample.PY  |
+    Then as "Alice" the file with original path "/sample.TXT" should exist in the trashbin
+    And as "Alice" the file with original path "/sample.DAT" should exist in the trashbin
+    And as "Alice" the file with original path "/sample.PHP" should exist in the trashbin
+    And as "Alice" the file with original path "/sample.GO" should exist in the trashbin
+    And as "Alice" the file with original path "/sample.PY" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @issue-38952 @skipOnOcV10
+  Scenario Outline: Skip trashbin based on extensions when deleting the parent folder
+    Given the administrator has set the following file extensions to be skipped from the trashbin
+      | extension |
+      | dat       |
+      | php       |
+      | go        |
+    And user "Alice" has uploaded file with content "sample delete file 1" to "PARENT/sample.txt"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "PARENT/sample.php"
+    And user "Alice" has uploaded file with content "sample delete file 4" to "PARENT/sample.go"
+    And user "Alice" has uploaded file with content "sample delete file 5" to "PARENT/sample.py"
+    And using <dav-path> DAV path
+    When user "Alice" deletes folder "PARENT" using the WebDAV API
+    Then as "Alice" the file with original path "PARENT/sample.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.py" should exist in the trashbin
+    But as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.php" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.go" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
   Scenario Outline: Skip trashbin based on directory
     Given the administrator has set the following directories to be skipped from the trashbin
       | directory     |
@@ -67,7 +123,28 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | old      |
       | new      |
 
-  Scenario Outline: Delete a folder skipped from trashbin
+
+  Scenario Outline: Skip trashbin based on directory should match only the root folder name
+    Given the administrator has set the following directories to be skipped from the trashbin
+      | directory     |
+      | simple-folder |
+    And using <dav-path> DAV path
+    And user "Alice" has created folder "PARENT/simple-folder"
+    And user "Alice" has uploaded file with content "sample delete file 1" to "PARENT/p.txt"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/simple-folder/sub.txt"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "simple-folder/s.txt"
+    When user "Alice" deletes folder "PARENT" using the WebDAV API
+    And user "Alice" deletes folder "simple-folder" using the WebDAV API
+    Then as "Alice" the file with original path "PARENT/p.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/simple-folder/sub.txt" should exist in the trashbin
+    But as "Alice" the file with original path "simple-folder/s.txt" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: Delete a file in a folder skipped from trashbin
     Given the administrator has set the following directories to be skipped from the trashbin
       | directory |
       | PARENT    |
@@ -80,6 +157,7 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | dav-path |
       | old      |
       | new      |
+
 
   Scenario Outline: Delete a file with same name as folder skipped from trashbin
     Given the administrator has set the following directories to be skipped from the trashbin
@@ -94,6 +172,7 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | old      |
       | new      |
 
+
   Scenario Outline: Delete a file from a folder skipped from trashbin but different case
     Given the administrator has set the following directories to be skipped from the trashbin
       | directory |
@@ -106,6 +185,7 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | dav-path |
       | old      |
       | new      |
+
 
   Scenario Outline: Skip file from trashbin based on size threshold
     Given the administrator has set the trashbin skip size threshold to "10"
@@ -120,6 +200,21 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | dav-path |
       | old      |
       | new      |
+
+  @issue-38952 @skipOnOcV10
+  Scenario Outline: Skip file from trashbin based on size threshold when deleting the parent folder
+    Given the administrator has set the trashbin skip size threshold to "10"
+    And using <dav-path> DAV path
+    And user "Alice" has uploaded file with content "sample" to "PARENT/lorem.txt"
+    And user "Alice" has uploaded file with content "sample delete file" to "PARENT/lorem.dat"
+    When user "Alice" deletes folder "PARENT" using the WebDAV API
+    Then as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
+    But as "Alice" the file with original path "PARENT/lorem.dat" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
 
   Scenario Outline: Delete files when multiple skip trashbin rules are set
     Given the administrator has set the following directories to be skipped from the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinSkipOc10Isssue38952.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSkipOc10Isssue38952.feature
@@ -1,0 +1,55 @@
+@api @files_trashbin-app-required @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7
+Feature: files and folders can be deleted completely skipping the trashbin
+  As an admin
+  I want to configure some files to be deleted without the trashbin
+  So that I can control my trashbin space and which files are kept in that space
+
+  These scenarios demonstrate the unwanted behavior described in issue-38952.
+  To fix the issue, delete these scenarios, and enable the corresponding good
+  scenarios in trashbinSkip.feature. Then make those scenarios pass.
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
+
+  @issue-38952
+  Scenario Outline: Skip trashbin based on extensions when deleting the parent folder
+    Given the administrator has set the following file extensions to be skipped from the trashbin
+      | extension |
+      | dat       |
+      | php       |
+      | go        |
+    And user "Alice" has uploaded file with content "sample delete file 1" to "PARENT/sample.txt"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "PARENT/sample.php"
+    And user "Alice" has uploaded file with content "sample delete file 4" to "PARENT/sample.go"
+    And user "Alice" has uploaded file with content "sample delete file 5" to "PARENT/sample.py"
+    And using <dav-path> DAV path
+    When user "Alice" deletes folder "PARENT" using the WebDAV API
+    Then as "Alice" the file with original path "PARENT/sample.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.py" should exist in the trashbin
+    #But as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
+    #And as "Alice" the file with original path "PARENT/sample.php" should not exist in the trashbin
+    #And as "Alice" the file with original path "PARENT/sample.go" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.dat" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.php" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.go" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+  @issue-38952
+  Scenario Outline: Skip file from trashbin based on size threshold when deleting the parent folder
+    Given the administrator has set the trashbin skip size threshold to "10"
+    And using <dav-path> DAV path
+    And user "Alice" has uploaded file with content "sample" to "PARENT/lorem.txt"
+    And user "Alice" has uploaded file with content "sample delete file" to "PARENT/lorem.dat"
+    When user "Alice" deletes folder "PARENT" using the WebDAV API
+    Then as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
+    #But as "Alice" the file with original path "PARENT/lorem.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/lorem.dat" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |


### PR DESCRIPTION
## Description
Add trashbin-skip test scenarios to demonstrate issue-38952.

Some of the added scenarios also add a bit more coverage of the good behavior:
- trashbin-skip by directory only applies to directory names at the root of the user's file system (that is already documented in `config/config.sample.php` and works)
- trashbin-skip of file extensions matches case-sensitive - for example, skip trashbin for "dat" files, and the trashbin is not skipped for "Dat" or "DAT" files. That is not explicitly mentioned anywhere - I guess it is "assumed behavior"

## Related Issue
- tests for #38952 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
