### PR TITLE
[tests-only] skip helpAndTips tests on old oC10

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
+++ b/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
@@ -7,6 +7,7 @@ Feature: Help and tips page
   Background:
     Given the administrator has browsed to the help and tips page
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: Admin can view links in help and tips page
     Then the link for "<linkName>" should be shown on the webUI
     And the link for "<linkName>" should be valid


### PR DESCRIPTION
## Description
PR #38962 changed the tests for help links to check for `doc.owncloud.com` instead of `doc.owncloud.org` - that is the now-correct home of the documentation.

But existing releases (10.7 10.6 etc) of course still point to `doc.owncloud.org`. So the adjusted test scenarios will fail against those releases. Skip the test scenarios in that case.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
