### PR TITLE
Fix errors reported by phpstan 0.12.92

### DIFF
--- a/apps/dav/lib/Command/CleanupChunks.php
+++ b/apps/dav/lib/Command/CleanupChunks.php
@@ -81,5 +81,6 @@ class CleanupChunks extends Command {
 			$p->finish();
 			$output->writeln('');
 		});
+		return 0;
 	}
 }

--- a/apps/dav/lib/Command/CreateAddressBook.php
+++ b/apps/dav/lib/Command/CreateAddressBook.php
@@ -73,5 +73,6 @@ class CreateAddressBook extends Command {
 
 		$name = $input->getArgument('name');
 		$this->cardDavBackend->createAddressBook("principals/users/$user", $name, []);
+		return 0;
 	}
 }

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -89,5 +89,6 @@ class CreateCalendar extends Command {
 		$name = $input->getArgument('name');
 		$caldav = new CalDavBackend($this->dbConnection, $principalBackend, $groupPrincipalBackend, $random);
 		$caldav->createCalendar("principals/users/$user", $name, []);
+		return 0;
 	}
 }

--- a/apps/dav/lib/Command/SyncBirthdayCalendar.php
+++ b/apps/dav/lib/Command/SyncBirthdayCalendar.php
@@ -62,6 +62,8 @@ class SyncBirthdayCalendar extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 *
+	 * @return int 0 if everything went fine, or an exit code
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$user = $input->getArgument('user');
@@ -71,7 +73,7 @@ class SyncBirthdayCalendar extends Command {
 			}
 			$output->writeln("Start birthday calendar sync for $user");
 			$this->birthdayService->syncUser($user);
-			return;
+			return 0;
 		}
 		$output->writeln("Start birthday calendar sync for all users ...");
 		$p = new ProgressBar($output);
@@ -84,5 +86,6 @@ class SyncBirthdayCalendar extends Command {
 
 		$p->finish();
 		$output->writeln('');
+		return 0;
 	}
 }

--- a/apps/dav/lib/Command/SyncSystemAddressBook.php
+++ b/apps/dav/lib/Command/SyncSystemAddressBook.php
@@ -48,6 +48,8 @@ class SyncSystemAddressBook extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
+	 *
+	 * @return int 0 if everything went fine, or an exit code
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$output->writeln('Syncing users ...');
@@ -59,5 +61,6 @@ class SyncSystemAddressBook extends Command {
 
 		$progress->finish();
 		$output->writeln('');
+		return 0;
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/AppEnabledPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/AppEnabledPlugin.php
@@ -78,7 +78,7 @@ class AppEnabledPlugin extends ServerPlugin {
 	 * This method is called before any HTTP after auth and checks if the user has access to the app
 	 *
 	 * @throws \Sabre\DAV\Exception\Forbidden
-	 * @return bool
+	 * @return void
 	 */
 	public function checkAppEnabled() {
 		if (!$this->appManager->isEnabledForUser($this->app)) {

--- a/apps/dav/lib/Connector/Sabre/CorsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/CorsPlugin.php
@@ -150,7 +150,7 @@ class CorsPlugin extends ServerPlugin {
 	 * @param RequestInterface $request
 	 * @param ResponseInterface $response
 	 *
-	 * @return false
+	 * @return false|void
 	 * @throws \InvalidArgumentException
 	 */
 	public function setOptionsRequestHeaders(RequestInterface $request, ResponseInterface $response) {

--- a/apps/files/lib/Command/CheckCache.php
+++ b/apps/files/lib/Command/CheckCache.php
@@ -99,5 +99,6 @@ class CheckCache extends Command {
 			$output->writeln("$targetFile has been accessed properly");
 			\fclose($stream);
 		}
+		return 0;
 	}
 }

--- a/apps/files/lib/Command/DeleteOrphanedFiles.php
+++ b/apps/files/lib/Command/DeleteOrphanedFiles.php
@@ -76,5 +76,6 @@ class DeleteOrphanedFiles extends Command {
 		}
 
 		$output->writeln("$deletedEntries orphaned file cache entries deleted");
+		return 0;
 	}
 }

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -327,6 +327,7 @@ class Scan extends Base {
 		if (\count($groups) === 0) {
 			$this->processUserChunks($input, $output, $users, $inputPath, $shouldRepairStoragesIndividually);
 		}
+		return 0;
 	}
 
 	protected function processUserChunks($input, $output, $users, $inputPath, $shouldRepairStoragesIndividually, $group = null) {

--- a/apps/files_external/lib/Command/Applicable.php
+++ b/apps/files_external/lib/Command/Applicable.php
@@ -103,7 +103,7 @@ class Applicable extends Base {
 			$mount = $this->globalService->getStorage($mountId);
 		} catch (NotFoundException $e) {
 			$output->writeln('<error>Mount with id "' . $mountId . ' not found, check "occ files_external:list" to get available mounts</error>');
-			return 404;
+			return 1;
 		}
 
 		if ($mount->getType() === IStorageConfig::MOUNT_TYPE_PERSONAl) {
@@ -123,13 +123,13 @@ class Applicable extends Base {
 			foreach ($addUsers as $addUser) {
 				if (!$this->userManager->userExists($addUser)) {
 					$output->writeln('<error>User "' . $addUser . '" not found</error>');
-					return 404;
+					return 1;
 				}
 			}
 			foreach ($addGroups as $addGroup) {
 				if (!$this->groupManager->groupExists($addGroup)) {
 					$output->writeln('<error>Group "' . $addGroup . '" not found</error>');
-					return 404;
+					return 1;
 				}
 			}
 
@@ -151,5 +151,6 @@ class Applicable extends Base {
 			'users' => $applicableUsers,
 			'groups' => $applicableGroups
 		]);
+		return 0;
 	}
 }

--- a/apps/files_external/lib/Command/Backends.php
+++ b/apps/files_external/lib/Command/Backends.php
@@ -87,6 +87,7 @@ class Backends extends Base {
 		}
 
 		$this->writeArrayInOutputFormat($input, $output, $data);
+		return 0;
 	}
 
 	private function serializeAuthBackend(\JsonSerializable $backend) {

--- a/apps/files_external/lib/Command/Config.php
+++ b/apps/files_external/lib/Command/Config.php
@@ -68,7 +68,7 @@ class Config extends Base {
 			$mount = $this->globalService->getStorage($mountId);
 		} catch (NotFoundException $e) {
 			$output->writeln('<error>Mount with id "' . $mountId . ' not found, check "occ files_external:list" to get available mounts"</error>');
-			return 404;
+			return 1;
 		}
 
 		$value = $input->getArgument('value');
@@ -78,6 +78,7 @@ class Config extends Base {
 		} else {
 			$this->getOption($mount, $key, $output);
 		}
+		return 0;
 	}
 
 	/**

--- a/apps/files_external/lib/Command/Delete.php
+++ b/apps/files_external/lib/Command/Delete.php
@@ -87,7 +87,7 @@ class Delete extends Base {
 			$mount = $this->globalService->getStorage($mountId);
 		} catch (NotFoundException $e) {
 			$output->writeln('<error>Mount with id "' . $mountId . ' not found, check "occ files_external:list" to get available mounts"</error>');
-			return 404;
+			return 1;
 		}
 
 		$noConfirm = $input->getOption('yes');
@@ -102,10 +102,11 @@ class Delete extends Base {
 			$question = new ConfirmationQuestion('Delete this mount? [y/N] ', false);
 
 			if (!$questionHelper->ask($input, $output, $question)) {
-				return;
+				return 1;
 			}
 		}
 
 		$this->globalService->removeStorage($mountId);
+		return 0;
 	}
 }

--- a/apps/files_external/lib/Command/Export.php
+++ b/apps/files_external/lib/Command/Export.php
@@ -54,5 +54,6 @@ class Export extends ListCommand {
 		$listInput->setOption('full', true);
 		$listInput->setOption('importable-format', true);
 		$listCommand->execute($listInput, $output);
+		return 0;
 	}
 }

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -125,6 +125,7 @@ class ListCommand extends Base {
 		}
 
 		$this->listMounts($userId, $mounts, $input, $output);
+		return 0;
 	}
 
 	/**
@@ -187,7 +188,7 @@ class ListCommand extends Base {
 		// default output style
 		$full = $input->getOption('full');
 		$showMountOptions = $input->getOption('mount-options');
-		
+
 		$defaultMountOptions = [
 			'encrypt' => true,
 			'previews' => true,

--- a/apps/files_external/lib/Command/Verify.php
+++ b/apps/files_external/lib/Command/Verify.php
@@ -71,7 +71,7 @@ class Verify extends Base {
 			$mount = $this->globalService->getStorage($mountId);
 		} catch (NotFoundException $e) {
 			$output->writeln('<error>Mount with id "' . $mountId . ' not found, check "occ files_external:list" to get available mounts"</error>');
-			return 404;
+			return 1;
 		}
 
 		$this->updateStorageStatus($mount, $configInput, $output);
@@ -81,6 +81,7 @@ class Verify extends Base {
 			'code' => $mount->getStatus(),
 			'message' => $mount->getStatusMessage()
 		]);
+		return 0;
 	}
 
 	private function manipulateStorageConfig(IStorageConfig $storage) {

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -88,6 +88,7 @@ class CleanupRemoteStorages extends Command {
 				}
 			}
 		}
+		return 0;
 	}
 
 	public function countFiles($numericId, OutputInterface $output) {

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -375,7 +375,7 @@ class ShareesController extends OCSController {
 
 	/**
 	 * @param string $search
-	 * @return array possible sharees
+	 * @return void
 	 */
 	protected function getRemote($search) {
 		$this->result['remotes'] = [];

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -108,7 +108,6 @@ class SharedMount extends MountPoint implements MoveableMount {
 	 *
 	 * @param string $newPath
 	 * @param \OCP\Share\IShare $share
-	 * @return bool
 	 */
 	private function updateFileTarget($newPath, &$share) {
 		$share->setTarget($newPath);

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -479,6 +479,6 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 	}
 
 	public function unlockNodePersistent($internalPath, array $lockInfo) {
-		parent::unlockNodePersistent($this->getSourcePath($internalPath), $lockInfo);
+		return parent::unlockNodePersistent($this->getSourcePath($internalPath), $lockInfo);
 	}
 }

--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -96,6 +96,7 @@ class CleanUp extends Command {
 				} while (\count($users) >= $limit);
 			}
 		}
+		return 0;
 	}
 
 	/**

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -72,7 +72,7 @@ class ExpireTrash extends Command {
 		$retentionEnabled = $this->trashExpiryManager->retentionEnabled();
 		if (!$retentionEnabled) {
 			$output->writeln("Auto expiration is configured - expiration will be handled automatically.");
-			return;
+			return 1;
 		}
 
 		$users = $input->getArgument('user_id');

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -37,7 +37,7 @@ class ExpireTrash extends Command {
 	 * @var TrashExpiryManager
 	 */
 	private $trashExpiryManager;
-	
+
 	/**
 	 * @var IUserManager
 	 */
@@ -96,6 +96,7 @@ class ExpireTrash extends Command {
 			$p->finish();
 			$output->writeln('');
 		}
+		return 0;
 	}
 
 	public function expireTrashForUser(IUser $user) {

--- a/apps/files_versions/lib/Command/CleanUp.php
+++ b/apps/files_versions/lib/Command/CleanUp.php
@@ -92,6 +92,7 @@ class CleanUp extends Command {
 				} while (\count($users) >= $limit);
 			}
 		}
+		return 0;
 	}
 
 	/**

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -73,7 +73,7 @@ class ExpireVersions extends Command {
 		$maxAge = $this->expiration->getMaxAgeAsTimestamp();
 		if (!$maxAge) {
 			$output->writeln("Auto expiration is configured - expiration will be handled automatically.");
-			return;
+			return 1;
 		}
 
 		$users = $input->getArgument('user_id');

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -38,7 +38,7 @@ class ExpireVersions extends Command {
 	 * @var Expiration
 	 */
 	private $expiration;
-	
+
 	/**
 	 * @var IUserManager
 	 */
@@ -97,6 +97,7 @@ class ExpireVersions extends Command {
 			$p->finish();
 			$output->writeln('');
 		}
+		return 0;
 	}
 
 	public function expireVersionsForUser(IUser $user) {

--- a/core/Command/App/Disable.php
+++ b/core/Command/App/Disable.php
@@ -67,5 +67,6 @@ class Disable extends Command {
 		} else {
 			$output->writeln('No such app enabled: ' . $appId);
 		}
+		return 0;
 	}
 }

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -137,6 +137,7 @@ class ListApps extends Base {
 		}
 
 		$this->writeAppList($input, $output, $apps);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Background/Base.php
+++ b/core/Command/Background/Base.php
@@ -71,5 +71,6 @@ abstract class Base extends Command {
 		$mode = $this->getMode();
 		$this->config->setAppValue('core', 'backgroundjobs_mode', $mode);
 		$output->writeln("Set mode for background jobs to '$mode'");
+		return 0;
 	}
 }

--- a/core/Command/Config/Import.php
+++ b/core/Command/Config/Import.php
@@ -65,7 +65,7 @@ class Import extends Command {
 			$configs = $this->validateFileContent($content);
 		} catch (\UnexpectedValueException $e) {
 			$output->writeln('<error>' . $e->getMessage(). '</error>');
-			return;
+			return 1;
 		}
 
 		if (!empty($configs['system'])) {
@@ -85,6 +85,7 @@ class Import extends Command {
 		}
 
 		$output->writeln('<info>Config successfully imported from: ' . $importFile . '</info>');
+		return 0;
 	}
 
 	/**

--- a/core/Command/Config/ListConfigs.php
+++ b/core/Command/Config/ListConfigs.php
@@ -100,6 +100,7 @@ class ListConfigs extends Base {
 		}
 
 		$this->writeArrayInOutputFormat($input, $output, $configs);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Db/Migrations/ExecuteCommand.php
+++ b/core/Command/Db/Migrations/ExecuteCommand.php
@@ -61,5 +61,6 @@ class ExecuteCommand extends Command {
 		$version = $input->getArgument('version');
 
 		$ms->executeStep($version);
+		return 0;
 	}
 }

--- a/core/Command/Db/Migrations/GenerateCommand.php
+++ b/core/Command/Db/Migrations/GenerateCommand.php
@@ -118,6 +118,7 @@ class Version<version> implements ISqlMigration {
 		$path = $this->generateMigration($ms, $version, $kind);
 
 		$output->writeln("New migration class has been generated to <info>$path</info>");
+		return 0;
 	}
 
 	/**

--- a/core/Command/Db/Migrations/MigrateCommand.php
+++ b/core/Command/Db/Migrations/MigrateCommand.php
@@ -58,5 +58,6 @@ class MigrateCommand extends Command {
 		$version = $input->getArgument('version');
 
 		$ms->migrate($version);
+		return 0;
 	}
 }

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -57,6 +57,7 @@ class StatusCommand extends Command {
 		foreach ($infos as $key => $value) {
 			$output->writeln("    <comment>>></comment> $key: " . \str_repeat(' ', 50 - \strlen($key)) . $value);
 		}
+		return 0;
 	}
 
 	/**

--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -87,7 +87,7 @@ class ChangeKeyStorageRoot extends Command {
 		if ($newRoot === null) {
 			$question = new ConfirmationQuestion('No storage root given, do you want to reset the key storage root to the default location? (y/n) ', false);
 			if (!$this->questionHelper->ask($input, $output, $question)) {
-				return;
+				return 0;
 			}
 			$newRoot = '';
 		}
@@ -100,7 +100,9 @@ class ChangeKeyStorageRoot extends Command {
 			$this->util->setKeyStorageRoot($newRoot);
 			$output->writeln('');
 			$output->writeln("Key storage root successfully changed to <info>$newRootDescription</info>");
+			return 0;
 		}
+		return 1;
 	}
 
 	/**

--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -137,7 +137,7 @@ class DecryptAll extends Command {
 		$confirmed = $input->getOption('continue');
 		if (($confirmed !== 'yes') && ($confirmed !== 'no')) {
 			$output->writeln('Continue can accept either yes or no');
-			return null;
+			return 2;
 		}
 
 		try {
@@ -147,7 +147,7 @@ class DecryptAll extends Command {
 				$output->writeln('done.');
 			} else {
 				$output->writeln('Server side encryption not enabled. Nothing to do.');
-				return;
+				return 0;
 			}
 
 			$uid = $input->getArgument('user');
@@ -189,5 +189,6 @@ class DecryptAll extends Command {
 			$this->resetSingleUserAndTrashbin();
 			throw $e;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Encryption/Enable.php
+++ b/core/Command/Encryption/Enable.php
@@ -75,5 +75,6 @@ class Enable extends Command {
 				$output->writeln('Default module: ' . $defaultModule);
 			}
 		}
+		return 0;
 	}
 }

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -143,6 +143,8 @@ class EncryptAll extends Command {
 			$this->resetSingleUserAndTrashbin();
 		} else {
 			$output->writeln('aborted');
+			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Encryption/ListModules.php
+++ b/core/Command/Encryption/ListModules.php
@@ -58,6 +58,7 @@ class ListModules extends Base {
 			$encModules[$module['id']]['default'] = $module['id'] === $defaultEncryptionModuleId;
 		}
 		$this->writeModuleList($input, $output, $encModules);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Encryption/SetDefaultModule.php
+++ b/core/Command/Encryption/SetDefaultModule.php
@@ -62,6 +62,8 @@ class SetDefaultModule extends Command {
 			$output->writeln('<info>Set default module to "' . $moduleId . '"</info>');
 		} else {
 			$output->writeln('<error>The specified module "' . $moduleId . '" does not exist</error>');
+			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Encryption/ShowKeyStorageRoot.php
+++ b/core/Command/Encryption/ShowKeyStorageRoot.php
@@ -52,5 +52,6 @@ class ShowKeyStorageRoot extends Command {
 		$rootDescription = $currentRoot !== '' ? $currentRoot : 'default storage location (data/)';
 
 		$output->writeln("Current key storage root:  <info>$rootDescription</info>");
+		return 0;
 	}
 }

--- a/core/Command/Encryption/Status.php
+++ b/core/Command/Encryption/Status.php
@@ -52,5 +52,6 @@ class Status extends Base {
 			'enabled' => $this->encryptionManager->isEnabled(),
 			'defaultModule' => $this->encryptionManager->getDefaultEncryptionModuleId(),
 		]);
+		return 0;
 	}
 }

--- a/core/Command/Group/Add.php
+++ b/core/Command/Group/Add.php
@@ -66,5 +66,6 @@ class Add extends Command {
 			$output->writeln('<error>The group "' . $group->getGID() . '" already exists</error>');
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Group/AddMember.php
+++ b/core/Command/Group/AddMember.php
@@ -65,15 +65,22 @@ class AddMember extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$groupName = $input->getArgument('group');
 		$group = $this->groupManager->get($groupName);
+		$errorFound = false;
 		if (!$group) {
 			$output->writeln('<error>Group "' . $groupName . '" does not exist</error>');
-			return 1;
+			$errorFound = true;
 		}
 
-		$members = $input->getOption('member');
+		if (!$errorFound) {
+			$members = $input->getOption('member');
 
-		if (!\count($members)) {
-			$output->writeln('<error>No members specified</error>');
+			if (!\count($members)) {
+				$output->writeln('<error>No members specified</error>');
+				$errorFound = true;
+			}
+		}
+
+		if ($errorFound) {
 			return 1;
 		}
 
@@ -95,9 +102,11 @@ class AddMember extends Command {
 		}
 
 		if ($memberExistsError) {
-			return 1;
+			$exitCode = 1;
+		} else {
+			$exitCode = 0;
 		}
 
-		return 0;
+		return $exitCode;
 	}
 }

--- a/core/Command/Group/AddMember.php
+++ b/core/Command/Group/AddMember.php
@@ -93,9 +93,11 @@ class AddMember extends Command {
 				$memberExistsError = true;
 			}
 		}
-		
+
 		if ($memberExistsError) {
 			return 1;
 		}
+
+		return 0;
 	}
 }

--- a/core/Command/Group/Delete.php
+++ b/core/Command/Group/Delete.php
@@ -60,7 +60,7 @@ class Delete extends Command {
 
 		if ($group->delete()) {
 			$output->writeln('<info>The specified group was deleted</info>');
-			return;
+			return 0;
 		}
 
 		$output->writeln('<error>The specified group could not be deleted. Please check the logs.</error>');

--- a/core/Command/Group/ListGroupMembers.php
+++ b/core/Command/Group/ListGroupMembers.php
@@ -63,5 +63,6 @@ class ListGroupMembers extends Base {
 
 		$displayNames = $this->groupManager->displayNamesInGroup($group->getGID());
 		parent::writeArrayInOutputFormat($input, $output, $displayNames, self::DEFAULT_OUTPUT_PREFIX, true);
+		return 0;
 	}
 }

--- a/core/Command/Group/ListGroups.php
+++ b/core/Command/Group/ListGroups.php
@@ -22,6 +22,7 @@
 namespace OC\Core\Command\Group;
 
 use OC\Core\Command\Base;
+use OCP\IGroup;
 use OCP\IGroupManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -61,5 +62,6 @@ class ListGroups extends Base {
 			return $group->getGID();
 		}, $groups);
 		parent::writeArrayInOutputFormat($input, $output, $groups);
+		return 0;
 	}
 }

--- a/core/Command/Group/RemoveMember.php
+++ b/core/Command/Group/RemoveMember.php
@@ -65,15 +65,22 @@ class RemoveMember extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$groupName = $input->getArgument('group');
 		$group = $this->groupManager->get($groupName);
+		$errorFound = false;
 		if (!$group) {
 			$output->writeln('<error>Group "' . $groupName . '" does not exist</error>');
-			return 1;
+			$errorFound = true;
 		}
 
-		$members = $input->getOption('member');
+		if (!$errorFound) {
+			$members = $input->getOption('member');
 
-		if (!\count($members)) {
-			$output->writeln('<error>No members specified</error>');
+			if (!\count($members)) {
+				$output->writeln('<error>No members specified</error>');
+				$errorFound = true;
+			}
+		}
+
+		if ($errorFound) {
 			return 1;
 		}
 
@@ -95,9 +102,11 @@ class RemoveMember extends Command {
 		}
 
 		if ($memberExistsError) {
-			return 1;
+			$exitCode = 1;
+		} else {
+			$exitCode = 0;
 		}
 
-		return 0;
+		return $exitCode;
 	}
 }

--- a/core/Command/Group/RemoveMember.php
+++ b/core/Command/Group/RemoveMember.php
@@ -93,9 +93,11 @@ class RemoveMember extends Command {
 				$memberExistsError = true;
 			}
 		}
-		
+
 		if ($memberExistsError) {
 			return 1;
 		}
+
+		return 0;
 	}
 }

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -44,7 +44,7 @@ class CheckApp extends Base {
 		parent::__construct();
 		$this->checker = $checker;
 	}
-	
+
 	/**
 	 * {@inheritdoc }
 	 */
@@ -68,5 +68,6 @@ class CheckApp extends Base {
 		if (\count($result)>0) {
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/Integrity/CheckCore.php
+++ b/core/Command/Integrity/CheckCore.php
@@ -63,5 +63,6 @@ class CheckCore extends Base {
 		if (\count($result)>0) {
 			return 1;
 		}
+		return 0;
 	}
 }

--- a/core/Command/L10n/CreateJs.php
+++ b/core/Command/L10n/CreateJs.php
@@ -54,7 +54,7 @@ class CreateJs extends Command {
 		$path = \OC_App::getAppPath($app);
 		if ($path === false) {
 			$output->writeln("The app <$app> is unknown.");
-			return;
+			return 1;
 		}
 		$languages = $lang;
 		if (empty($lang)) {
@@ -64,6 +64,7 @@ class CreateJs extends Command {
 		foreach ($languages as $lang) {
 			$this->writeFiles($app, $path, $lang, $output);
 		}
+		return 0;
 	}
 
 	private function getAllLanguages($path) {

--- a/core/Command/Log/Manage.php
+++ b/core/Command/Log/Manage.php
@@ -109,6 +109,7 @@ class Manage extends Command {
 
 		$timezone = $this->config->getSystemValue('logtimezone', self::DEFAULT_TIMEZONE);
 		$output->writeln('Log timezone: '.$timezone);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Log/OwnCloud.php
+++ b/core/Command/Log/OwnCloud.php
@@ -104,6 +104,7 @@ class OwnCloud extends Command {
 			$rotateString = 'disabled';
 		}
 		$output->writeln('Rotate at: '.$rotateString);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Maintenance/DataFingerprint.php
+++ b/core/Command/Maintenance/DataFingerprint.php
@@ -73,6 +73,8 @@ EOD;
 			$fingerprint = \md5($this->timeFactory->getTime());
 			$this->config->setSystemValue('data-fingerprint', $fingerprint);
 			$this->logger->info("Data fingerprint was set by $osUser@$server to $fingerprint");
+			return 0;
 		}
+		return 1;
 	}
 }

--- a/core/Command/Maintenance/Mimetype/UpdateDB.php
+++ b/core/Command/Maintenance/Mimetype/UpdateDB.php
@@ -94,5 +94,6 @@ class UpdateDB extends Command {
 
 		$output->writeln('Added '.$totalNewMimetypes.' new mimetypes');
 		$output->writeln('Updated '.$totalFilecacheUpdates.' filecache rows');
+		return 0;
 	}
 }

--- a/core/Command/Maintenance/Mode.php
+++ b/core/Command/Maintenance/Mode.php
@@ -72,5 +72,6 @@ class Mode extends Command {
 				$output->writeln('Maintenance mode is currently disabled');
 			}
 		}
+		return 0;
 	}
 }

--- a/core/Command/Maintenance/SingleUser.php
+++ b/core/Command/Maintenance/SingleUser.php
@@ -74,5 +74,6 @@ class SingleUser extends Command {
 				$output->writeln('Single user mode is currently disabled');
 			}
 		}
+		return 0;
 	}
 }

--- a/core/Command/Security/ImportCertificate.php
+++ b/core/Command/Security/ImportCertificate.php
@@ -60,5 +60,6 @@ class ImportCertificate extends Base {
 		$name = \basename($path);
 
 		$this->certificateManager->addCertificate($certData, $name);
+		return 0;
 	}
 }

--- a/core/Command/Security/ListCertificates.php
+++ b/core/Command/Security/ListCertificates.php
@@ -90,5 +90,6 @@ class ListCertificates extends Base {
 			$table->setRows($rows);
 			$table->render();
 		}
+		return 0;
 	}
 }

--- a/core/Command/Security/ListRoutes.php
+++ b/core/Command/Security/ListRoutes.php
@@ -119,6 +119,7 @@ class ListRoutes extends Base {
 			$table->addRows($rows);
 			$table->render();
 		}
+		return 0;
 	}
 
 	private function buildController($name) {

--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -47,5 +47,6 @@ class Status extends Base {
 		];
 
 		$this->writeArrayInOutputFormat($input, $output, $values);
+		return 0;
 	}
 }

--- a/core/Command/TwoFactorAuth/Disable.php
+++ b/core/Command/TwoFactorAuth/Disable.php
@@ -55,9 +55,10 @@ class Disable extends Base {
 		$user = $this->userManager->get($uid);
 		if ($user === null) {
 			$output->writeln("<error>Invalid UID</error>");
-			return;
+			return 1;
 		}
 		$this->manager->disableTwoFactorAuthentication($user);
 		$output->writeln("Two-factor authentication disabled for user $uid");
+		return 0;
 	}
 }

--- a/core/Command/TwoFactorAuth/Enable.php
+++ b/core/Command/TwoFactorAuth/Enable.php
@@ -55,9 +55,10 @@ class Enable extends Base {
 		$user = $this->userManager->get($uid);
 		if ($user === null) {
 			$output->writeln("<error>Invalid UID</error>");
-			return;
+			return 1;
 		}
 		$this->manager->enableTwoFactorAuthentication($user);
 		$output->writeln("Two-factor authentication enabled for user $uid");
+		return 0;
 	}
 }

--- a/core/Command/User/Add.php
+++ b/core/Command/User/Add.php
@@ -180,5 +180,6 @@ class Add extends Command {
 			$group->addUser($user);
 			$output->writeln('User "' . $user->getUID() . '" added to group "' . $group->getGID() . '"');
 		}
+		return 0;
 	}
 }

--- a/core/Command/User/Disable.php
+++ b/core/Command/User/Disable.php
@@ -54,10 +54,11 @@ class Disable extends Command {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if ($user === null) {
 			$output->writeln('<error>User does not exist</error>');
-			return;
+			return 1;
 		}
 
 		$user->setEnabled(false);
 		$output->writeln('<info>The specified user is disabled</info>');
+		return 0;
 	}
 }

--- a/core/Command/User/Enable.php
+++ b/core/Command/User/Enable.php
@@ -54,10 +54,11 @@ class Enable extends Command {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if ($user === null) {
 			$output->writeln('<error>User does not exist</error>');
-			return;
+			return 1;
 		}
 
 		$user->setEnabled(true);
 		$output->writeln('<info>The specified user is enabled</info>');
+		return 0;
 	}
 }

--- a/core/Command/User/Inactive.php
+++ b/core/Command/User/Inactive.php
@@ -76,5 +76,6 @@ class Inactive extends Base {
 		});
 
 		$this->writeArrayInOutputFormat($input, $output, $inactive);
+		return 0;
 	}
 }

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -57,7 +57,7 @@ class LastSeen extends Command {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if ($user === null) {
 			$output->writeln('<error>User does not exist</error>');
-			return;
+			return 1;
 		}
 
 		$lastLogin = $user->getLastLogin();
@@ -70,5 +70,6 @@ class LastSeen extends Command {
 			$output->writeln($user->getUID() .
 				'`s last login: ' . $date->format('d.m.Y H:i'));
 		}
+		return 0;
 	}
 }

--- a/core/Command/User/ListUserGroups.php
+++ b/core/Command/User/ListUserGroups.php
@@ -69,5 +69,6 @@ class ListUserGroups extends Base {
 		$user = $this->userManager->get($uid);
 		$groupNames = $this->groupManager->getUserGroupIds($user);
 		parent::writeArrayInOutputFormat($input, $output, $groupNames);
+		return 0;
 	}
 }

--- a/core/Command/User/ListUsers.php
+++ b/core/Command/User/ListUsers.php
@@ -150,5 +150,6 @@ class ListUsers extends Base {
 			return $row;
 		}, $users);
 		parent::writeArrayInOutputFormat($input, $output, $users, self::DEFAULT_OUTPUT_PREFIX, true);
+		return 0;
 	}
 }

--- a/core/Command/User/Report.php
+++ b/core/Command/User/Report.php
@@ -90,6 +90,7 @@ class Report extends Command {
 
 		$table->setRows($rows);
 		$table->render($output);
+		return 0;
 	}
 
 	private function countUsers() {

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -203,6 +203,7 @@ class ResetPassword extends Command {
 			$output->writeln("<error>Error while resetting password!</error>");
 			return 1;
 		}
+		return 0;
 	}
 
 	/**

--- a/core/Migrations/Version20180302155233.php
+++ b/core/Migrations/Version20180302155233.php
@@ -51,5 +51,8 @@ class Version20180302155233 implements ISqlMigration {
 			->where($qb->expr()->eq('share_type', $qb->expr()->literal(2)))
 			->andWhere($qb->expr()->eq('permissions', $qb->expr()->literal(0)))
 			->execute();
+		// This sql() method is supposed to return an array of sql statements
+		// The needed update has been done above, so return an empty array.
+		return [];
 	}
 }

--- a/lib/private/Cache/CappedMemoryCache.php
+++ b/lib/private/Cache/CappedMemoryCache.php
@@ -47,6 +47,7 @@ class CappedMemoryCache implements ICache, \ArrayAccess {
 	public function set($key, $value, $ttl = 0) {
 		$this->cache[$key] = $value;
 		$this->garbageCollect();
+		return true;
 	}
 
 	public function remove($key) {

--- a/lib/private/Console/TimestampFormatter.php
+++ b/lib/private/Console/TimestampFormatter.php
@@ -76,7 +76,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 	 * @return bool
 	 */
 	public function hasStyle($name) {
-		$this->formatter->hasStyle($name);
+		return $this->formatter->hasStyle($name);
 	}
 
 	/**

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -154,6 +154,7 @@ class Storage implements IStorage {
 			// user's home is gone and so are the keys
 			//
 			// So there is nothing to do, just ignore.
+			return true;
 		}
 	}
 
@@ -200,6 +201,7 @@ class Storage implements IStorage {
 
 			return false;
 		}
+		return false;
 	}
 
 	/**

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -416,6 +416,7 @@ class DAV extends Common {
 				self::$tempFiles[$tmpFile] = $path;
 				return \fopen('close://' . $tmpFile, $mode);
 		}
+		return false;
 	}
 
 	/**

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -637,8 +637,9 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IPersistent
 		$storage = $this->getWrapperStorage();
 		if ($storage->instanceOfStorage(IPersistentLockingStorage::class)) {
 			'@phan-var \OCP\Files\Storage\IPersistentLockingStorage $storage';
-			$storage->unlockNodePersistent($internalPath, $lockInfo);
+			return $storage->unlockNodePersistent($internalPath, $lockInfo);
 		}
+		return false;
 	}
 
 	public function getLocks($internalPath, $returnChildLocks = false) {

--- a/lib/private/Repair/RepairMismatchFileCachePath.php
+++ b/lib/private/Repair/RepairMismatchFileCachePath.php
@@ -110,7 +110,6 @@ class RepairMismatchFileCachePath implements IRepairStep {
 	 * @param string $wrongPath wrong path of the entry to fix
 	 * @param int $correctStorageNumericId numeric idea of the correct storage
 	 * @param string $correctPath value to which to set the path of the entry
-	 * @return bool true for success
 	 */
 	private function fixEntryPath(IOutput $out, $fileId, $wrongPath, $correctStorageNumericId, $correctPath) {
 		// delete target if exists

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -226,6 +226,7 @@ class SettingsManager implements ISettingsManager {
 				new Section('additional', $this->l->t('Additional'), -10, 'more'),
 			];
 		}
+		return [];
 	}
 
 	/**
@@ -262,6 +263,7 @@ class SettingsManager implements ISettingsManager {
 				Quota::class
 			];
 		}
+		return [];
 	}
 
 	/**
@@ -378,7 +380,7 @@ class SettingsManager implements ISettingsManager {
 	 * Attempts to load a ISettings using the class name
 	 * @param string $className
 	 * @throws QueryException
-	 * @return ISettings
+	 * @return ISettings|false
 	 */
 	protected function loadPanel($className) {
 		try {
@@ -390,6 +392,7 @@ class SettingsManager implements ISettingsManager {
 					'Class: {class} not an instance of OCP\Settings\ISettings',
 					['class' => $className]
 				);
+				return false;
 			} else {
 				return $panel;
 			}
@@ -425,10 +428,11 @@ class SettingsManager implements ISettingsManager {
 			// Attempt to load the panel
 			try {
 				$panel = $this->loadPanel($panelClassName);
-				$section = $this->loadSection($type, $panel->getSectionID());
-				$this->panels[$type][$section->getID()][] = $panel;
-				$this->sections[$type][$section->getID()] = $section;
-				// Now try and initialise the ISection from the panel
+				if ($panel !== false) {
+					$section = $this->loadSection($type, $panel->getSectionID());
+					$this->panels[$type][$section->getID()][] = $panel;
+					$this->sections[$type][$section->getID()] = $section;
+				}
 			} catch (QueryException $e) {
 				// Just skip this panel, either its section or panel could not be loaded
 			}

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -137,7 +137,6 @@ class MySQL extends AbstractDatabase {
 	/**
 	 * @param $username
 	 * @param IDBConnection $connection
-	 * @return array
 	 */
 	private function createSpecificUser($username, $connection) {
 		try {

--- a/lib/private/Theme/Theme.php
+++ b/lib/private/Theme/Theme.php
@@ -63,7 +63,6 @@ class Theme implements ITheme {
 
 	/**
 	 * @param string $baseDirectory
-	 * @return string
 	 */
 	public function setBaseDirectory($baseDirectory) {
 		$this->baseDirectory = $baseDirectory;

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -52,7 +52,7 @@ class URLGenerator implements IURLGenerator {
 	private $router;
 	/** @var ITheme */
 	private $theme;
-	
+
 	/** @var EnvironmentHelper */
 	private $environmentHelper;
 
@@ -205,20 +205,21 @@ class URLGenerator implements IURLGenerator {
 			$file = $directory . $imageName;
 
 			if ($themeDirectory !== ''
-				&& $imagePath = $this->getImagePathOrFallback($this->theme->getBaseDirectory() . '/' . $themeDirectory . $file)
+				&& $this->getImagePathOrFallback($this->theme->getBaseDirectory() . '/' . $themeDirectory . $file)
 			) {
 				return $this->theme->getWebPath() . $file;
 			}
 
-			if ($imagePath = $this->getImagePathOrFallback($this->environmentHelper->getServerRoot() . $file)) {
+			if ($this->getImagePathOrFallback($this->environmentHelper->getServerRoot() . $file)) {
 				return $webRoot . $file;
 			}
 		}
+		return '';
 	}
 
 	/**
 	 * @param string $file
-	 * @return string
+	 * @return string|false
 	 */
 	private function getImagePathOrFallback($file) {
 		$fallback = \substr($file, 0, -3) . 'png';
@@ -228,6 +229,7 @@ class URLGenerator implements IURLGenerator {
 				return $location;
 			}
 		}
+		return false;
 	}
 
 	/**

--- a/lib/private/User/RemoteUser.php
+++ b/lib/private/User/RemoteUser.php
@@ -107,6 +107,7 @@ class RemoteUser implements IUser {
 	 * @inheritdoc
 	 */
 	public function getHome() {
+		return '';
 	}
 
 	/**

--- a/lib/public/JSON.php
+++ b/lib/public/JSON.php
@@ -93,11 +93,10 @@ class JSON {
 	/**
 	 * Send json success msg
 	 *
-	 * Return a json success message with optional extra data.
 	 * @see OCP\JSON::error()		for the format to use.
 	 *
 	 * @param array $data The data to use
-	 * @return string json formatted string.
+	 * @return void
 	 * @deprecated 8.1.0 Use a AppFramework JSONResponse instead
 	 */
 	public static function success($data = []) {
@@ -107,7 +106,7 @@ class JSON {
 	/**
 	 * Send json error msg
 	 *
-	 * Return a json error message with optional extra data for
+	 * Send a json error message with optional extra data for
 	 * error message or app specific data.
 	 *
 	 * Example use:
@@ -115,12 +114,12 @@ class JSON {
 	 *     $id = [some value]
 	 *     OCP\JSON::error(array('data':array('message':'An error happened', 'id': $id)));
 	 *
-	 * Will return the json formatted string:
+	 * Will send the json formatted string:
 	 *
 	 *     {"status":"error","data":{"message":"An error happened", "id":[some value]}}
 	 *
 	 * @param array $data The data to use
-	 * @return string json formatted error string.
+	 * @return void
 	 * @deprecated 8.1.0 Use a AppFramework JSONResponse instead
 	 */
 	public static function error($data = []) {

--- a/lib/public/Search/PagedProvider.php
+++ b/lib/public/Search/PagedProvider.php
@@ -52,7 +52,7 @@ abstract class PagedProvider extends Provider {
 	 */
 	public function search($query) {
 		// old apps might assume they get all results, so we use SIZE_ALL
-		$this->searchPaged($query, 1, self::SIZE_ALL);
+		return $this->searchPaged($query, 1, self::SIZE_ALL);
 	}
 
 	/**

--- a/tests/Core/Command/Encryption/DecryptAllTest.php
+++ b/tests/Core/Command/Encryption/DecryptAllTest.php
@@ -226,9 +226,9 @@ class DecryptAllTest extends TestCase {
 
 	public function providesConfirmVal() {
 		return [
-			['yes'],
-			['no'],
-			['foo']
+			['yes', 0],
+			['no', 0],
+			['foo', 2]
 		];
 	}
 
@@ -237,7 +237,7 @@ class DecryptAllTest extends TestCase {
 	 * @param $confirmVal
 	 */
 
-	public function testExecuteConfirm($confirmVal) {
+	public function testExecuteConfirm($confirmVal, $expectedExitCode) {
 		$instance = new DecryptAll(
 			$this->encryptionManager,
 			$this->appManager,
@@ -255,6 +255,9 @@ class DecryptAllTest extends TestCase {
 			->method('isEnabled')
 			->willReturn(true);
 
-		$this->assertNull($this->invokePrivate($instance, 'execute', [$this->consoleInput, $this->consoleOutput]));
+		$this->assertEquals(
+			$expectedExitCode,
+			$this->invokePrivate($instance, 'execute', [$this->consoleInput, $this->consoleOutput])
+		);
 	}
 }

--- a/tests/Core/Command/User/ResetPasswordTest.php
+++ b/tests/Core/Command/User/ResetPasswordTest.php
@@ -96,7 +96,7 @@ class ResetPasswordTest extends TestCase {
 			->method('get')
 			->willReturn($user);
 
-		$this->assertNull($this->invokePrivate($this->resetPassword, 'execute', [$input, $output]));
+		$this->assertEquals(0, $this->invokePrivate($this->resetPassword, 'execute', [$input, $output]));
 	}
 
 	public function testDisplayLink() {

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "0.12.91"
+        "phpstan/phpstan": "^0.12.92"
     }
 }


### PR DESCRIPTION
## Description
`phpstan` released 0.12.92 last night. That "fixed/enhanced" checks on methods that should return something, but do not.

This PR fixes the errors that were reported.

Many of the errors were the `execute()` method of Symfony commands. That method should return `0` on success, but many of the commands did not have a `return 0` at the end of the `execute()` method when the command has finished. Those were easy to fix.

I made comments through the diff listing to explain what I did.

Note: CI currently fails in `master` and in `release-10.8.0` - we need to either apply fixes like these, or pin `phpstan` to `0.12.91` in each branch.

Note: if we apply these fixes, what do I put in a changelog?

## Related Issue
- Fixes #38971 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
