### PR TITLE
[10.8] [tests-only] pin phpstan to 0.12.91 for now

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^0.12.71"
+        "phpstan/phpstan": "0.12.91"
     }
 }


### PR DESCRIPTION
## Description
`phpstan` 0.12.92 reports a lot of new things about missing return statements. That requires a lot of code adjustments to fix - see PR #38972 

For now, to get CI green, pin `phpstan` to the version of last week - 0.12.91

This is a "backport" of #38973 to the `release-10.8.0` branch so that CI will be green there.

No changelog needed - this is just a pinning of a development tool dependency.

## Related Issue
Interim "solution" for issue #38971 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
