### PR TITLE
Fixes a config sample typo

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -597,7 +597,7 @@ $CONFIG = [
  * The setting expects folder names with or without trailing slash.
  * All the content of such directories including their subdirectories will also skip the trashbin.
  *
-*/
+ */
 'trashbin_skip_directories' => [
 	'temp',
 ],


### PR DESCRIPTION
## Description
This is just a minor text fix in `config.sample.php`.
The impact here is very small as just one white space was added.
The impact on the following `config-to-docs` run is bigger, because there it fixes a rendering issue

## Related Issue
- Fixes https://github.com/owncloud/docs/pull/3793 (add code snippet rendering)

## Motivation and Context
Fix render issue

## How Has This Been Tested?
Text change only

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation PR: https://github.com/owncloud/docs/pull/3814
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

Not necessarily need to go into 10.8, but if there is an additional backport for the final release, it would be nice to take it.