### PR TITLE
[10.8] Fixes a config sample typo

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -597,7 +597,7 @@ $CONFIG = [
  * The setting expects folder names with or without trailing slash.
  * All the content of such directories including their subdirectories will also skip the trashbin.
  *
-*/
+ */
 'trashbin_skip_directories' => [
 	'temp',
 ],


### PR DESCRIPTION
## Description
Backport #38975 to `release-10.8.0` branch.

This will ensure that this release branch and the docs 10.8 branch can be exactly matching.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
