### PR TITLE
[tests-only] Adjust minor words in API sharing test steps

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareResourceCaseSensitiveName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareResourceCaseSensitiveName.feature
@@ -1,5 +1,5 @@
 @api @files_sharing-app-required @notToImplementOnOCIS
-Feature: Sharing resources with different case names with the sharee and checking the coexistence of resources on sharee/receviers side
+Feature: Sharing resources with different case names with the sharee and checking the coexistence of resources on sharee/receivers side
 
   Background:
     Given using OCS API version "1"

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
@@ -1,5 +1,5 @@
 @api @files_sharing-app-required
-Feature: Sharing resources with different case names with the sharee and checking the coexistence of resources on sharee/receviers side
+Feature: Sharing resources with different case names with the sharee and checking the coexistence of resources on sharee/receivers side
 
   Background:
     Given the administrator has set the default folder for received shares to "Shares"
@@ -31,7 +31,7 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | TEXT_FILE.txt    |
       | 123TEXTFILE.txt  |
       | TEXTFILE.xyz.txt |
-    And user "Brian" accepts all following shares offered by user "Alice" using the sharing API
+    And user "Brian" accepts the following shares offered by user "Alice" using the sharing API
       | path              |
       | /textfile.txt     |
       | /text_file.txt    |
@@ -74,7 +74,7 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /f_o    |
       | /123fo  |
       | /fo.xyz |
-    And user "Brian" accepts all following shares offered by user "Alice" using the sharing API
+    And user "Brian" accepts the following shares offered by user "Alice" using the sharing API
       | path    |
       | /FO     |
       | /F_O    |
@@ -121,7 +121,7 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /CASE_SENSITIVE    |
       | /123case_sensitive |
       | /CASESENSITIVE.xyz |
-    And user "Brian" accepts all following shares offered by user "Alice" using the sharing API
+    And user "Brian" accepts the following shares offered by user "Alice" using the sharing API
       | path                   |
       | /casesensitive.txt     |
       | /case_sensitive.txt    |
@@ -168,7 +168,7 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | TEXT_FILE.txt    |
       | 123TEXTFILE.txt  |
       | TEXTFILE.xyz.txt |
-    And user "Brian" accepts all following shares offered by user "Alice" using the sharing API
+    And user "Brian" accepts the following shares offered by user "Alice" using the sharing API
       | path              |
       | /textfile.txt     |
       | /text_file.txt    |
@@ -213,7 +213,7 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /f_o    |
       | /123fo  |
       | /fo.xyz |
-    And user "Brian" accepts all following shares offered by user "Alice" using the sharing API
+    And user "Brian" accepts the following shares offered by user "Alice" using the sharing API
       | path    |
       | /FO     |
       | /F_O    |
@@ -262,7 +262,7 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /CASE_SENSITIVE    |
       | /123case_sensitive |
       | /CASESENSITIVE.xyz |
-    And user "Brian" accepts all following shares offered by user "Alice" using the sharing API
+    And user "Brian" accepts the following shares offered by user "Alice" using the sharing API
       | path                   |
       | /casesensitive.txt     |
       | /case_sensitive.txt    |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1353,8 +1353,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares the following (?:files|folders|entities) with user "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
-	 * @When /^user "([^"]*)" shares the following (?:files|folders|entities) with user "([^"]*)" with permissions "([^"]*)" using the sharing API$/
+	 * @When /^user "([^"]*)" shares the following (?:files|folders|entries) with user "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
+	 * @When /^user "([^"]*)" shares the following (?:files|folders|entries) with user "([^"]*)" with permissions "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $sharer
 	 * @param string $sharee
@@ -1616,8 +1616,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" shares the following (?:files|folders|entities) with group "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
-	 * @When /^user "([^"]*)" shares the following (?:files|folders|entities) with group "([^"]*)" with permissions "([^"]*)" using the sharing API$/
+	 * @When /^user "([^"]*)" shares the following (?:files|folders|entries) with group "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
+	 * @When /^user "([^"]*)" shares the following (?:files|folders|entries) with group "([^"]*)" with permissions "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -2876,7 +2876,7 @@ trait Sharing {
 	}
 
 	/**
-	 * @When /^user "([^"]*)" (declines|accepts) all following shares offered by user "([^"]*)" using the sharing API$/
+	 * @When /^user "([^"]*)" (declines|accepts) the following shares offered by user "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user
 	 * @param string $action
@@ -2886,7 +2886,7 @@ trait Sharing {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function userReactsToAllFollowingSharesOfferedBy($user, $action, $offeredBy, TableNode $table) {
+	public function userReactsToTheFollowingSharesOfferedBy($user, $action, $offeredBy, TableNode $table) {
 		$this->verifyTableNodeColumns($table, ["path"]);
 		$paths = $table->getHash();
 


### PR DESCRIPTION
## Description
Minor adjustments to test step wording that was introduced in PR #38950 

Note: there are a lot of uses of `file|folder|entry` or `files|folders|entries` in the core test code. But in `owncloud/web` we call "file or folder" a "resource", which is also the way we commonly refer to "file or folder" in reva, OCIS etc. So we should update that in the core tests to be consistent. But that can wait until after 10.8.0 is released - we don't want to do big test-code-refactoring until after `release-10.8.0` branch is merged back to `master` 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
