### PR TITLE
[Tests-Only] adds tests for accepting or declining share which is already removed

### DIFF
--- a/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
+++ b/tests/acceptance/features/webUISharingAcceptShares/acceptShares.feature
@@ -316,3 +316,41 @@ Feature: accept/decline shares coming from internal users
     And file "testimage.jpg" should be listed in the shared-with-you page on the webUI
     And folder "simple-folder" should be in state "Pending" in the shared-with-you page on the webUI
     And file "testimage.jpg" should be in state "Pending" in the shared-with-you page on the webUI
+
+  @issue-36181
+  Scenario: user cannot decline a share which is already deleted by the sharer (without any page-reload in between)
+    Given user "Brian" has shared folder "/simple-folder" with user "Alice"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the shared-with-you page
+    And user "Brian" has unshared folder "/simple-folder"
+    When the user declines share "simple-folder" offered by user "Brian" using the webUI
+    Then a notification should be displayed on the webUI with the text 'An error occurred while updating share state:'
+
+  @issue-36181
+  Scenario: user cannot accept a share which is already deleted by the sharer (without any page-reload in between)
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "Brian" has shared folder "/simple-folder" with user "Alice"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the shared-with-you page
+    And user "Brian" has unshared folder "/simple-folder"
+    When the user accepts share "simple-folder" offered by user "Brian" using the webUI
+    Then a notification should be displayed on the webUI with the text 'An error occurred while updating share state:'
+
+  @issue-36181
+  Scenario: user cannot decline a group share which is already deleted by the sharer (without any page-reload in between)
+    Given user "Brian" has shared folder "/simple-folder" with group "grp1"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the shared-with-you page
+    And user "Brian" has unshared folder "/simple-folder"
+    When the user declines share "simple-folder" offered by user "Brian" using the webUI
+    Then a notification should be displayed on the webUI with the text 'An error occurred while updating share state:'
+
+  @issue-36181
+  Scenario: user cannot accept a group share which is already deleted by the sharer (without any page-reload in between)
+    Given the setting "Automatically accept new incoming local user shares" in the section "Sharing" has been disabled
+    And user "Brian" has shared folder "/simple-folder" with group "grp1"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the shared-with-you page
+    And user "Brian" has unshared folder "/simple-folder"
+    When the user accepts share "simple-folder" offered by user "Brian" using the webUI
+    Then a notification should be displayed on the webUI with the text 'An error occurred while updating share state:'


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
- Adds UI test for accepting or declining share which is already deleted by the sharee
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Tests for issue https://github.com/owncloud/core/issues/36181

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
