### PR TITLE
Do not allow empty system or app config key

### DIFF
--- a/changelog/unreleased/38996
+++ b/changelog/unreleased/38996
@@ -1,0 +1,6 @@
+Bugfix: Do not allow empty system or app config keys
+
+It was possible to add empty config keys with the occ config:app:set or
+config:system:set commands. That is no longer allowed.
+
+https://github.com/owncloud/core/pull/38996

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -75,6 +75,16 @@ class SetConfig extends Base {
 		$appName = $input->getArgument('app');
 		$configName = $input->getArgument('name');
 
+		if ($appName === '') {
+			$output->writeln('<comment>App name must not be empty.</comment>');
+			return 1;
+		}
+
+		if ($configName === '') {
+			$output->writeln('<comment>Config name must not be empty.</comment>');
+			return 1;
+		}
+
 		if (!\in_array($configName, $this->config->getAppKeys($appName)) && $input->hasParameterOption('--update-only')) {
 			$output->writeln('<comment>Config value ' . $configName . ' for app ' . $appName . ' not updated, as it has not been set before.</comment>');
 			return 1;

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -76,12 +76,12 @@ class SetConfig extends Base {
 		$configName = $input->getArgument('name');
 
 		if ($appName === '') {
-			$output->writeln('<comment>App name must not be empty.</comment>');
+			$output->writeln('<error>App name must not be empty.</error>');
 			return 1;
 		}
 
 		if ($configName === '') {
-			$output->writeln('<comment>Config name must not be empty.</comment>');
+			$output->writeln('<error>Config name must not be empty.</error>');
 			return 1;
 		}
 

--- a/core/Command/Config/System/SetConfig.php
+++ b/core/Command/Config/System/SetConfig.php
@@ -80,6 +80,11 @@ class SetConfig extends Base {
 		$configValue = $this->castValue($input->getOption('value'), $input->getOption('type'));
 		$updateOnly = $input->getOption('update-only');
 
+		if ($configName === '') {
+			$output->writeln('<comment>Config name must not be empty.</comment>');
+			return 1;
+		}
+
 		if (\sizeof($configNames) > 1) {
 			$existingValue = $this->systemConfig->getValue($configName);
 

--- a/core/Command/Config/System/SetConfig.php
+++ b/core/Command/Config/System/SetConfig.php
@@ -81,7 +81,7 @@ class SetConfig extends Base {
 		$updateOnly = $input->getOption('update-only');
 
 		if ($configName === '') {
-			$output->writeln('<comment>Config name must not be empty.</comment>');
+			$output->writeln('<error>Config name must not be empty.</error>');
 			return 1;
 		}
 

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -25,6 +25,33 @@ Feature: add and delete app configs using occ command
     And the command output should contain the text 'System config value con deleted'
     And system config key "con" should not exist
 
+  Scenario: admin adds a config key for an app with an empty value using the occ command
+    When the administrator adds config key "con" with value "''" in app "core" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'Config value con for app core set to'
+    And the config key "con" of app "core" should have value ""
+
+  Scenario: admin adds a system config with an empty value
+    When the administrator adds system config key "con" with value "" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text 'System config value con set to empty string'
+    And system config key "con" should have value ""
+
+  Scenario: admin tries to add an empty config key for an app using the occ command
+    When the administrator adds config key "''" with value "conkey" in app "core" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'Config name must not be empty.'
+
+  Scenario: admin tries to add a config key and specifying the empty string as the app name using the occ command
+    When the administrator adds config key "con" with value "conkey" in app "''" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'App name must not be empty.'
+
+  Scenario: admin tries to add an empty system config key using the occ command
+    When the administrator adds system config key "''" with value "conkey" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'Config name must not be empty.'
+
   Scenario: admin can list system config keys
     When the administrator lists the config keys
     Then the command should have been successful


### PR DESCRIPTION
## Description
Currently this sort of thing works:
```
$ php occ config:app:set "" ""
Config value  for app  set to 
$ php occ config:list ""
{
    "apps": {
        "": {
            "": null
        }
    }
}
```

The app name and config key should not be able to be the empty string. There is never a need to have an app named "" or a key "". This had somehow happened in one developers install, and caused issues when trying to get the config settings.

This PR disallows using an app name or config key that is the empty string. That will avoid accidentally making such settings.

I did not change the corresponding `config:delete` commands - if someone does somehow have one of these "empty string" set, they need to be able to delete it.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
