### PR TITLE
[tests-only] Do not try to access the log file when isTestingOnOcisOrReva

### DIFF
--- a/tests/TestHelpers/LoggingHelper.php
+++ b/tests/TestHelpers/LoggingHelper.php
@@ -48,6 +48,10 @@ class LoggingHelper {
 	 * @return string
 	 */
 	public static function getLogFilePath() {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// Currently we don't interact with the log file on reva or OCIS
+			return "";
+		}
 		$result = SetupHelper::runOcc(['log:owncloud']);
 		if ($result["code"] != 0) {
 			throw new \Exception(
@@ -132,6 +136,10 @@ class LoggingHelper {
 	 * @throws \Exception
 	 */
 	public static function setLogLevel($logLevel) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// Currently we can't manage log file settings on reva or OCIS
+			return;
+		}
 		if (!\in_array($logLevel, self::LOG_LEVEL_ARRAY)) {
 			throw new \InvalidArgumentException("invalid log level");
 		}
@@ -184,6 +192,10 @@ class LoggingHelper {
 		if (!\in_array($backend, ["owncloud", "syslog", "errorlog"])) {
 			throw new \InvalidArgumentException("invalid log backend");
 		}
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// Currently we can't manage log file settings on reva or OCIS
+			return;
+		}
 		$result = SetupHelper::runOcc(["log:manage", "--backend=$backend"]);
 		if ($result["code"] != 0) {
 			throw new \Exception(
@@ -229,6 +241,10 @@ class LoggingHelper {
 	 * @throws \Exception
 	 */
 	public static function setLogTimezone($timezone) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// Currently we can't manage log file settings on reva or OCIS
+			return;
+		}
 		$result = SetupHelper::runOcc(["log:manage", "--timezone=$timezone"]);
 		if ($result["code"] != 0) {
 			throw new \Exception(
@@ -248,6 +264,10 @@ class LoggingHelper {
 	 * @throws \Exception
 	 */
 	public static function clearLogFile($baseUrl, $adminUsername, $adminPassword) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// Currently we don't interact with the log file on reva or OCIS
+			return;
+		}
 		$result = OcsApiHelper::sendRequest(
 			$baseUrl,
 			$adminUsername,
@@ -270,6 +290,10 @@ class LoggingHelper {
 	 * @throws \Exception
 	 */
 	public static function restoreLoggingStatus($logLevel, $backend, $timezone) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// Currently we don't interact with the log file on reva or OCIS
+			return;
+		}
 		if (!\in_array(\strtolower($logLevel), self::LOG_LEVEL_ARRAY)) {
 			throw new \InvalidArgumentException("invalid log level");
 		}
@@ -303,8 +327,8 @@ class LoggingHelper {
 	/**
 	 * returns the currently set log level, backend and timezone
 	 *
+	 * @return array|string[]
 	 * @throws \Exception
-	 * @return string
 	 */
 	public static function getLogInfo() {
 		if (OcisHelper::isTestingOnOcisOrReva()) {

--- a/tests/acceptance/features/bootstrap/LoggingContext.php
+++ b/tests/acceptance/features/bootstrap/LoggingContext.php
@@ -25,6 +25,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use TestHelpers\LoggingHelper;
+use TestHelpers\OcisHelper;
 use TestHelpers\SetupHelper;
 
 require_once 'bootstrap.php';
@@ -64,6 +65,11 @@ class LoggingContext implements Context {
 		$ignoredLines = 0,
 		TableNode $expectedLogEntries = null
 	) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// Currently we don't interact with the log file on reva or OCIS
+			// So skip processing this test step.
+			return;
+		}
 		$ignoredLines = (int) $ignoredLines;
 		//-1 because getRows gives also the header
 		$linesToRead = \count($expectedLogEntries->getRows()) - 1 + $ignoredLines;
@@ -270,6 +276,11 @@ class LoggingContext implements Context {
 		TableNode $expectedLogEntries,
 		$regexCompare = false
 	) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// Currently we don't interact with the log file on reva or OCIS
+			// So skip processing this test step.
+			return;
+		}
 		$logLines = LoggingHelper::getLogFileContent(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),
@@ -372,6 +383,11 @@ class LoggingContext implements Context {
 		$withOrContaining,
 		TableNode $logEntriesExpectedNotToExist
 	) {
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			// Currently we don't interact with the log file on reva or OCIS
+			// So skip processing this test step.
+			return;
+		}
 		$logLines = LoggingHelper::getLogFileContent(
 			$this->featureContext->getBaseUrl(),
 			$this->featureContext->getAdminUsername(),


### PR DESCRIPTION
## Description
There are test steps that set ownClouf10 log file options, clear the log file, and get/examine log file contents. Those are all (currently) specific to the ownCloud10 implementation. They fail, or do unexpected things when executed against the reva or OCIS implementation.

One day we might want to examine log files when testing reva or OCIS, but not yet. For now, make these test steps do nothing and not fail when `isTestingOnOcisOrReva()`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
