### PR TITLE
[tests-only] skip new configKey scenarios on old oC10

### DIFF
--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -37,16 +37,19 @@ Feature: add and delete app configs using occ command
     And the command output should contain the text 'System config value con set to empty string'
     And system config key "con" should have value ""
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: admin tries to add an empty config key for an app using the occ command
     When the administrator adds config key "''" with value "conkey" in app "core" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Config name must not be empty.'
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: admin tries to add a config key and specifying the empty string as the app name using the occ command
     When the administrator adds config key "con" with value "conkey" in app "''" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'App name must not be empty.'
 
+  @skipOnOcV10.6 @skipOnOcV10.7
   Scenario: admin tries to add an empty system config key using the occ command
     When the administrator adds system config key "''" with value "conkey" using the occ command
     Then the command should have failed with exit code 1


### PR DESCRIPTION
## Description
PR #38996 added some extra validation of ``occ` `config` set commands. The new test scenarios for thta do not pass against old oC10 versions, so skip them in that case.

https://drone.owncloud.com/owncloud/user_ldap/3340/124/12
```
runsh: Total unexpected failed scenarios throughout the test run:
cliMain/configKey.feature:40
cliMain/configKey.feature:45
cliMain/configKey.feature:50
runsh: There were no unexpected success.
```


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
