### PR TITLE
Prevent checksum verify command from crashing on single files

### DIFF
--- a/apps/files/lib/Command/VerifyChecksums.php
+++ b/apps/files/lib/Command/VerifyChecksums.php
@@ -155,7 +155,14 @@ class VerifyChecksums extends Command {
 			return;
 		}
 
-		if (!self::fileExistsOnDisk($file)) {
+		try {
+			$fileExistsOnDisk = self::fileExistsOnDisk($file);
+		} catch (StorageNotAvailableException $e) {
+			$output->writeln("Skipping $storageId/$path => Storage is not available", OutputInterface::VERBOSITY_VERBOSE);
+			return;
+		}
+
+		if (!$fileExistsOnDisk) {
 			$output->writeln("Skipping $storageId/$path => File is in file-cache but doesn't exist on storage/disk", OutputInterface::VERBOSITY_VERBOSE);
 			return;
 		}

--- a/changelog/unreleased/38785
+++ b/changelog/unreleased/38785
@@ -4,4 +4,5 @@ The command now skips files with exceptions instead of crashing.
 A proper message will be displayed to the user who fires the command.
 
 https://github.com/owncloud/core/pull/38785
+https://github.com/owncloud/core/pull/39004
 https://github.com/owncloud/core/issues/38782


### PR DESCRIPTION
## Description
In addition to https://github.com/owncloud/core/pull/38785: Catch `StorageNotAvailableException` not only for folders, but also single files.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/38979

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
