### PR TITLE
[tests-only]Add webui test lock breaker group

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -1173,6 +1173,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - WebDavLockingContext:
+        - WebUIAdminGeneralSettingsContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:

--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -157,6 +157,49 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @When the administrator adds group :lockBreakerGroup to the lock breakers groups using the webUI
+	 *
+	 * @param string $lockBreakerGroup
+	 *
+	 * @return void
+	 */
+	public function theAdministratorAddsGroupToLockBreakersGroupUsingTheWebui($lockBreakerGroup) {
+		$this->adminGeneralSettingsPage-> addGroupLockBreakersGroup(
+			$this->getSession(),
+			$lockBreakerGroup
+		);
+	}
+
+	/**
+	 * @Then group :expectedGroup should be listed in the lock breakers groups in the webUI
+	 *
+	 * @param $expectedGroup
+	 *
+	 * @return void
+	 */
+	public function groupShouldBeListedAsLockBreakersGroupInTheWebui($expectedGroup) {
+		$actualGroup = $this->adminGeneralSettingsPage-> getLockBreakersGroups();
+		if (!\in_array($expectedGroup, $actualGroup)) {
+			Assert::assertFalse(
+				"$expectedGroup should be present in lock breakers groups, but it isn't"
+			);
+		}
+	}
+
+	/**
+	 * @Then following groups should be listed in the lock breakers groups in the webUI
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function followingGroupsShouldBeListedInTheLockBreakersGroupsInTheWebui(TableNode $table) {
+		foreach ($table as $row) {
+			$this->groupShouldBeListedAsLockBreakersGroupInTheWebui($row["groups"]);
+		}
+	}
+
+	/**
 	 * This will run before EVERY scenario.
 	 * It will set the properties for this object.
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -171,7 +171,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @Then group :expectedGroup should be listed in the lock breakers groups in the webUI
+	 * @Then group :expectedGroup should be listed in the lock breakers groups on the webUI
 	 *
 	 * @param $expectedGroup
 	 *
@@ -187,7 +187,7 @@ class WebUIAdminGeneralSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
-	 * @Then following groups should be listed in the lock breakers groups in the webUI
+	 * @Then the following groups should be listed in the lock breakers groups on the webUI
 	 *
 	 * @param TableNode $table
 	 *

--- a/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
@@ -60,6 +60,9 @@ class AdminGeneralSettingsPage extends OwncloudPage {
 
 	protected $logLevelId = 'loglevel';
 
+	protected $lockBreakerXpath = '//div[@id="persistentlocking"]/p[@id="lock-breakers"]/div//li[contains(@class, "select2-search-field")]';
+	protected $lockBreakerGroups = '//div[@id="persistentlocking"]/p[@id="lock-breakers"]/div//li[contains(@class, "select2-search-choice")]';
+
 	protected $ownCloudVersionXpath = '//td[text() = "version"]/following-sibling::td';
 	protected $ownCloudVersionStringXpath = '//td[text() = "versionstring"]/following-sibling::td';
 
@@ -299,5 +302,42 @@ class AdminGeneralSettingsPage extends OwncloudPage {
 			$this->ownCloudVersionStringXpath,
 			$timeout_msec
 		);
+	}
+
+	/**
+	 * add group to lock breakers group
+	 *
+	 * @param Session $session
+	 * @param string $groupName
+	 *
+	 * @return void
+	 */
+	public function addGroupLockBreakersGroup(
+		Session $session,
+		$groupName
+	) {
+		$this->getPage('AdminSharingSettingsPage')->addGroupToInputField($groupName, $this->lockBreakerXpath);
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * get lock breakers group
+	 *
+	 * @return array
+	 */
+	public function getLockBreakersGroups() {
+		$this->waitTillElementIsNotNull($this->lockBreakerGroups);
+		$groupList = $this->findAll("xpath", $this->lockBreakerGroups);
+		$this->assertElementNotNull(
+			$groupList,
+			__METHOD__ .
+			" xpath $this->lockBreakerGroups " .
+			"could not find xpath for lock breaker groups"
+		);
+
+		foreach ($groupList as $group) {
+			$groups[] = $this->getTrimmedText($group);
+		}
+		return $groups;
 	}
 }

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -710,6 +710,7 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 		foreach ($groupList as $group) {
 			if ($this->getTrimmedText($group) === $groupName) {
 				$group->click();
+				break;
 			}
 		}
 	}

--- a/tests/acceptance/features/webUIWebdavLocks/lockBreakerGroup.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/lockBreakerGroup.feature
@@ -1,0 +1,122 @@
+@webUI @insulated @disablePreviews
+Feature: Unlock locked files and folders
+  As a member of lock breaker group
+  I would like to be able to unlock files and folders
+  So that I can access them
+
+
+  Scenario: Add a group to lock breakers group
+    Given group "grp1" has been created
+    And the administrator has browsed to the admin general settings page
+    When the administrator adds group "grp1" to the lock breakers groups using the webUI
+    Then group "grp1" should be listed in the lock breakers groups in the webUI
+    And group "grp1" should exist as a lock breaker group
+
+
+  Scenario: Add multiple groups to lock breakers group
+    Given group "grp1" has been created
+    And group "grp2" has been created
+    And group "grp3" has been created
+    And the administrator has browsed to the admin general settings page
+    When the administrator adds group "grp1" to the lock breakers groups using the webUI
+    And the administrator adds group "grp2" to the lock breakers groups using the webUI
+    Then following groups should be listed in the lock breakers groups in the webUI
+      | groups |
+      | grp1 |
+      | grp2 |
+    And following groups should exist as lock breaker groups
+      | groups |
+      | grp1 |
+      | grp2 |
+
+
+  Scenario Outline: members from lock breaker groups can unlock a locked folder/file shared to them
+    Given group "grp1" has been created
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And parameter "lock-breaker-groups" of app "core" has been set to '["grp1"]'
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has locked folder "simple-folder" setting the following properties
+      | lockscope | <lockscope> |
+    And user "Alice" has locked file "lorem.txt" setting the following properties
+      | lockscope | <lockscope> |
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Alice" has shared file "lorem.txt" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    When the user unlocks the lock no 1 of file "lorem.txt" on the webUI
+    And the user unlocks the lock no 1 of folder "simple-folder" on the webUI
+    And the user reloads the current page of the webUI
+    Then file "lorem.txt" should not be marked as locked on the webUI
+    And folder "simple-folder" should not be marked as locked on the webUI
+    And 0 locks should be reported for file "lorem.txt" of user "Brian" by the WebDAV API
+    And 0 locks should be reported for file "lorem.txt" of user "Alice" by the WebDAV API
+    And 0 locks should be reported for folder "simple-folder" of user "Brain" by the WebDAV API
+    And 0 locks should be reported for folder "simple-folder" of user "Alice" by the WebDAV API
+    Examples:
+      | lockscope |
+      | exclusive |
+      | shared    |
+
+
+  Scenario Outline:  as a member of lock breaker group unlocking a folder/file in a share locked by the folder owner is possible
+    Given group "grp1" has been created
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "simple-folder"
+    And user "Alice" has created folder "simple-folder/sub-folder"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "simple-folder/lorem.txt"
+    And parameter "lock-breaker-groups" of app "core" has been set to '["grp1"]'
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has locked folder "simple-folder/sub-folder" setting the following properties
+      | lockscope | <lockscope> |
+    And user "Alice" has locked file "simple-folder/lorem.txt" setting the following properties
+      | lockscope | <lockscope> |
+    And user "Alice" has shared folder "simple-folder" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    When the user opens folder "simple-folder" using the webUI
+    When the user unlocks the lock no 1 of file "lorem.txt" on the webUI
+    And the user unlocks the lock no 1 of folder "sub-folder" on the webUI
+    And the user reloads the current page of the webUI
+    Then file "lorem.txt" should not be marked as locked on the webUI
+    And folder "sub-folder" should not be marked as locked on the webUI
+    And 0 locks should be reported for folder "simple-folder" of user "Brain" by the WebDAV API
+    And 0 locks should be reported for folder "simple-folder" of user "Alice" by the WebDAV API
+    Examples:
+      | lockscope |
+      | exclusive |
+      | shared    |
+
+
+  Scenario Outline: user that isn't member of lock breakers group cannot unlock a file/folder shared to them
+    Given group "grp1" has been created
+    And parameter "lock-breaker-groups" of app "core" has been set to '["grp1"]'
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
+    And user "Alice" has locked folder "FOLDER" setting the following properties
+      | lockscope | <lockscope> |
+    And user "Alice" has locked file "lorem.txt" setting the following properties
+      | lockscope | <lockscope> |
+    And user "Alice" has shared folder "FOLDER" with user "Brian"
+    And user "Alice" has shared file "lorem.txt" with user "Brian"
+    And user "Brian" has logged in using the webUI
+    When the user unlocks the lock no 1 of folder "FOLDER" on the webUI
+    Then notifications should be displayed on the webUI with the text
+      | Could not unlock, please contact the lock owner Alice Hansen (alice@example.org) |
+    And the user unlocks the lock no 1 of file "lorem.txt" on the webUI
+    And notifications should be displayed on the webUI with the text
+      | Could not unlock, please contact the lock owner Alice Hansen (alice@example.org) |
+    And the user reloads the current page of the webUI
+    And file "lorem.txt" should be marked as locked on the webUI
+    And folder "FOLDER" should be marked as locked on the webUI
+    When the administrator gets all the members of group "grp1" using the provisioning API
+    Then the users returned by the API should be
+      | Alice |
+    Examples:
+      | lockscope |
+      | exclusive |
+      | shared    |

--- a/tests/acceptance/features/webUIWebdavLocks/lockBreakerGroup.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/lockBreakerGroup.feature
@@ -1,6 +1,6 @@
 @webUI @insulated @disablePreviews
 Feature: Unlock locked files and folders
-  As a member of lock breaker group
+  As a member of a lock breaker group
   I would like to be able to unlock files and folders
   So that I can access them
 
@@ -9,7 +9,7 @@ Feature: Unlock locked files and folders
     Given group "grp1" has been created
     And the administrator has browsed to the admin general settings page
     When the administrator adds group "grp1" to the lock breakers groups using the webUI
-    Then group "grp1" should be listed in the lock breakers groups in the webUI
+    Then group "grp1" should be listed in the lock breakers groups on the webUI
     And group "grp1" should exist as a lock breaker group
 
 
@@ -20,7 +20,7 @@ Feature: Unlock locked files and folders
     And the administrator has browsed to the admin general settings page
     When the administrator adds group "grp1" to the lock breakers groups using the webUI
     And the administrator adds group "grp2" to the lock breakers groups using the webUI
-    Then following groups should be listed in the lock breakers groups in the webUI
+    Then the following groups should be listed in the lock breakers groups on the webUI
       | groups |
       | grp1   |
       | grp2   |
@@ -76,7 +76,7 @@ Feature: Unlock locked files and folders
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     And user "Brian" has logged in using the webUI
     When the user opens folder "simple-folder" using the webUI
-    When the user unlocks the lock no 1 of file "lorem.txt" on the webUI
+    And the user unlocks the lock no 1 of file "lorem.txt" on the webUI
     And the user unlocks the lock no 1 of folder "sub-folder" on the webUI
     And the user reloads the current page of the webUI
     Then file "lorem.txt" should not be marked as locked on the webUI

--- a/tests/acceptance/features/webUIWebdavLocks/lockBreakerGroup.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/lockBreakerGroup.feature
@@ -22,12 +22,12 @@ Feature: Unlock locked files and folders
     And the administrator adds group "grp2" to the lock breakers groups using the webUI
     Then following groups should be listed in the lock breakers groups in the webUI
       | groups |
-      | grp1 |
-      | grp2 |
+      | grp1   |
+      | grp2   |
     And following groups should exist as lock breaker groups
       | groups |
-      | grp1 |
-      | grp2 |
+      | grp1   |
+      | grp2   |
 
 
   Scenario Outline: members from lock breaker groups can unlock a locked folder/file shared to them
@@ -92,8 +92,10 @@ Feature: Unlock locked files and folders
   Scenario Outline: user that isn't member of lock breakers group cannot unlock a file/folder shared to them
     Given group "grp1" has been created
     And parameter "lock-breaker-groups" of app "core" has been set to '["grp1"]'
-    And user "Alice" has been created with default attributes and without skeleton files
-    And user "Brian" has been created with default attributes and without skeleton files
+    And these users have been created without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
     And user "Alice" has been added to group "grp1"
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
@@ -106,16 +108,13 @@ Feature: Unlock locked files and folders
     And user "Brian" has logged in using the webUI
     When the user unlocks the lock no 1 of folder "FOLDER" on the webUI
     Then notifications should be displayed on the webUI with the text
-      | Could not unlock, please contact the lock owner Alice Hansen (alice@example.org) |
+      | Could not unlock, please contact the lock owner Alice |
     And the user unlocks the lock no 1 of file "lorem.txt" on the webUI
     And notifications should be displayed on the webUI with the text
-      | Could not unlock, please contact the lock owner Alice Hansen (alice@example.org) |
+      | Could not unlock, please contact the lock owner Alice |
     And the user reloads the current page of the webUI
     And file "lorem.txt" should be marked as locked on the webUI
     And folder "FOLDER" should be marked as locked on the webUI
-    When the administrator gets all the members of group "grp1" using the provisioning API
-    Then the users returned by the API should be
-      | Alice |
     Examples:
       | lockscope |
       | exclusive |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
PR https://github.com/owncloud/core/pull/38222 adds a new feature that allows groups of users to be lock breakers. Previously only the owner of file could unlock it. This feature allows members of lock breakers group to unlock a file/folder shared to them.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/38985

## Motivation and Context
This PR adds UI tests for the lock breakers groups to ensure that everything works as desired.
This PR adds tests that checks following:
- one or more group can be added in lock breakers group
- members from lock breaker groups can unlock a locked folder/file shared to them

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally 
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
