### PR TITLE
fix file/foldername ellipsis

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -408,6 +408,7 @@ table td.filename .nametext {
 	text-overflow: clip;
 	max-width: 800px;
 	height: 100%;
+	width: 100%;
 }
 
 .has-favorites #fileList td.filename a.name {


### PR DESCRIPTION
## Description
Fixes over-eager long file/folder names truncation

## Related Issue
https://github.com/owncloud/core/issues/38988

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
