### PR TITLE
[tests-only] Added acceptance tests for allow certain groups to create link share

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink2/allowGroupToCreatePublicLinks.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/allowGroupToCreatePublicLinks.feature
@@ -1,0 +1,113 @@
+@api @files_sharing-app-required
+Feature: public share sharers groups setting
+  As an admin
+  I should be able to allow only certain groups to create public links
+  So that random links are not generated on my file system
+
+  Background:
+    Given group "grp1" has been created
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "file to share with user" to "/fileToShare.txt"
+
+
+  Scenario: users present in public share shares groups can create new public link shares
+    Given parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
+    And user "Alice" has been added to group "grp1"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | fileToShare.txt |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | item_type              | file             |
+      | mimetype               | text/plain       |
+      | file_target            | /fileToShare.txt |
+      | path                   | /fileToShare.txt |
+      | permissions            | read             |
+      | share_type             | public_link      |
+      | displayname_file_owner | %displayname%    |
+      | displayname_owner      | %displayname%    |
+      | uid_file_owner         | %username%       |
+      | uid_owner              | %username%       |
+      | name                   |                  |
+
+
+  Scenario: users not present in public share shares groups cannot create a new public link share
+    Given parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | fileToShare.txt |
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "200"
+    And the OCS status message should be "Public upload is only possible for certain groups"
+
+
+  Scenario: existing links can still be updated by sharers even if they are not present in public share sharers groups
+    Given user "Alice" has created a public link share with settings
+      | path        | /fileToShare.txt |
+      | permissions | read             |
+    And parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
+    When user "Alice" updates the last share using the sharing API with
+      | expireDate | +3 days |
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And the fields of the last response to user "Alice" should include
+      | expiration | +3 days |
+
+
+  Scenario: existing links can still be deleted by sharers even if they are not present in public share sharers groups
+    Given user "Alice" has created a public link share with settings
+      | path        | /fileToShare.txt |
+      | permissions | read             |
+      | name        | shared-link       |
+    And parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
+    When user "Alice" deletes public link share named "shared-link" in file "fileToShare.txt" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "100"
+    And as user "Alice" the file "fileToShare.txt" should not have any shares
+
+
+  Scenario: creating a new link share is not restricted if no groups are inside the allowed public share sharers groups even if allowlist is enabled
+    Given parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | fileToShare.txt |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" should include
+      | item_type              | file             |
+      | mimetype               | text/plain       |
+      | file_target            | /fileToShare.txt |
+      | path                   | /fileToShare.txt |
+      | permissions            | read             |
+      | share_type             | public_link      |
+      | displayname_file_owner | %displayname%    |
+      | displayname_owner      | %displayname%    |
+      | uid_file_owner         | %username%       |
+      | uid_owner              | %username%       |
+      | name                   |                  |
+
+  Scenario: multiple groups can be added to public share sharers groups allow list
+    Given parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Brian" has uploaded file with content "file to share with user" to "/fileToShare.txt"
+    And user "Carol" has uploaded file with content "file to share with user" to "/fileToShare.txt"
+    And group "grp2" has been created
+    And user "Alice" has been added to group "grp1"
+    And user "Brian" has been added to group "grp2"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1", "grp2"]'
+    When user "Alice" creates a public link share using the sharing API with settings
+      | path | fileToShare.txt |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    When user "Brian" creates a public link share using the sharing API with settings
+      | path | fileToShare.txt |
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    When user "Carol" creates a public link share using the sharing API with settings
+      | path | fileToShare.txt |
+    Then the OCS status code should be "403"
+    And the HTTP status code should be "200"
+    And the OCS status message should be "Public upload is only possible for certain groups"

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1755,6 +1755,18 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then the public link with name :entryName should be in the public links list on the webUI
+	 *
+	 * @param string $entryName
+	 *
+	 * @return void
+	 */
+	public function thePublicLinkWithNameShouldBeInPublicLinksList(string $entryName) {
+		$isPresent = $this->sharingDialog->checkThatNameIsInPublicLinkList($this->getSession(), $entryName);
+		Assert::assertTrue($isPresent, "Expected " . $entryName . " in public link lists, but not found.");
+	}
+
+	/**
 	 * @Then the number of public links should be :count
 	 *
 	 * @param integer $count
@@ -2224,5 +2236,25 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 */
 	public function theUserAcceptsThePendingRemoteSharesUsingTheWebui() {
 		$this->sharedWithYouPage->acceptPendingShare();
+	}
+
+	/**
+	 * @Then user should not see public link share tab on the webUI
+	 *
+	 * @return void
+	 */
+	public function userShouldNotBeAbleToCreateNewPublicLink() {
+		$is_visible = $this->sharingDialog->isPublicLinkTabVisible();
+		Assert::assertFalse($is_visible, "Public link tab is expected to be not present but found visible.");
+	}
+
+	/**
+	 * @Then the user should not see create public link button on the webUI
+	 *
+	 * @return void
+	 */
+	public function theUserShouldSeeCreatePublicLinkButtonOnTheWebui() {
+		$is_visible = $this->publicShareTab->isCreateLinkShareButtonPresent();
+		Assert::assertFalse($is_visible, "Create public link button is expected to be not present but found visible.");
 	}
 }

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -731,6 +731,20 @@ class SharingDialog extends OwncloudPage {
 	}
 
 	/**
+	 * returns visibility of public link share tab
+	 *
+	 * @return bool
+	 */
+	public function isPublicLinkTabVisible() {
+		$publicLinksShareTab = $this->find("xpath", $this->publicLinksShareTabXpath);
+		if ($publicLinksShareTab) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
 	 * @param Session $session
 	 * @param integer $number
 	 *
@@ -821,6 +835,23 @@ class SharingDialog extends OwncloudPage {
 				throw new \Exception("Public link with title" . $entryName . "is present");
 			}
 		}
+	}
+
+	/**
+	 * @param Session $session
+	 * @param $entryName
+	 *
+	 * @return bool
+	 */
+	public function checkThatNameIsInPublicLinkList(Session $session, $entryName) {
+		$publicLinkTitles = $this->findAll("xpath", $this->publicLinkTitleXpath);
+		$found = false;
+		foreach ($publicLinkTitles as $publicLinkTitle) {
+			if ($entryName === $publicLinkTitle->getText()) {
+				$found = true;
+			}
+		}
+		return $found;
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -178,6 +178,23 @@ class PublicLinkTab extends OwncloudPage {
 	}
 
 	/**
+	 * return if create link share button is present or not
+	 *
+	 * @return bool
+	 */
+	public function isCreateLinkShareButtonPresent() {
+		$createLinkBtn = $this->publicLinkTabElement->find(
+			"xpath",
+			$this->createLinkBtnXpath
+		);
+		if ($createLinkBtn) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
 	 * Updates sharing popup as popup may change
 	 *
 	 * @param Session $session

--- a/tests/acceptance/features/webUISharingPublic2/allowGroupToCreatePublicLinks.feature
+++ b/tests/acceptance/features/webUISharingPublic2/allowGroupToCreatePublicLinks.feature
@@ -1,0 +1,79 @@
+@webUI @files_sharing-app-required
+Feature: public share sharers groups setting
+  As an admin
+  I should be able to allow only certain groups to create public links
+  So that random links are not generated on my file system
+
+  Background:
+    Given group "grp1" has been created
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FolderToShare"
+    And user "Alice" has uploaded file with content "file to share with user" to "FolderToShare/fileToShare.txt"
+
+
+  Scenario: users present in public share shares groups can create new public link shares using webUI
+    Given parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
+    And user "Alice" has been added to group "grp1"
+    And user "Alice" has logged in using the webUI
+    When the user creates a new public link for folder "FolderToShare" using the webUI
+    And the public accesses the last created public link using the webUI
+    Then file "fileToShare.txt" should be listed on the webUI
+
+
+  Scenario: users not present in public share shares groups cannot create a new public link share using webUI
+    Given parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
+    And user "Alice" has logged in using the webUI
+    When the user opens the share dialog for folder "FolderToShare"
+    Then user should not see public link share tab on the webUI
+
+
+  Scenario: sharer not present in public share shares groups can still access existing share but cannot create new link share
+    Given user "Alice" has created a public link share with settings
+      | path        | /FolderToShare |
+      | permissions | read           |
+      | name        | shared-link    |
+    And parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
+    And user "Alice" has logged in using the webUI
+    When the user opens the share dialog for folder "FolderToShare"
+    And the user has opened the public link share tab
+    Then the public link with name "shared-link" should be in the public links list on the webUI
+    But the user should not see create public link button on the webUI
+
+
+  Scenario: existing links are still accessible for sharers even if not present in public share shares groups using webUI
+    Given user "Alice" has created a public link share with settings
+      | path        | /FolderToShare |
+      | permissions | read,delete    |
+      | name        | Public link    |
+    And parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
+    And user "Alice" has logged in using the webUI
+    And the user has opened the share dialog for folder "FolderToShare"
+    And the user has opened the public link share tab
+    When the user changes the permission of the public link named "Public link" to "read"
+    And the public accesses the last created public link using the webUI
+    Then file "fileToShare.txt" should be listed on the webUI
+    And it should not be possible to delete file "fileToShare.txt" using the webUI
+
+
+  Scenario: existing links can still be deleted by sharers even if not present in public share shares groups using webUI
+    Given user "Alice" has created a public link share with settings
+      | path        | /FolderToShare |
+      | permissions | read,delete    |
+      | name        | Public link    |
+    And parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
+    And user "Alice" has logged in using the webUI
+    When the user removes the public link of folder "FolderToShare" using the webUI
+    Then the public should see an error message "File not found" while accessing last created public link using the webUI
+
+
+  Scenario: creating new link shares is not restricted if no groups are inside the allowed public share sharers groups even if allowlist is enabled
+    Given parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
+    And user "Alice" has logged in using the webUI
+    When the user creates a new public link for folder "FolderToShare" using the webUI
+    And the public accesses the last created public link using the webUI
+    Then file "fileToShare.txt" should be listed on the webUI


### PR DESCRIPTION
## Description
Acceptance tests have been added to the new feature at https://github.com/owncloud/core/pull/38980

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39002

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
