### PR TITLE
[tests-only] Include nonCoverageTests in CI pipelines

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -330,7 +330,7 @@ def main(ctx):
 	after = afterPipelines(ctx)
 	dependsOn(afterCoverageTests + nonCoverageTests + stages, after)
 
-	return initial + before + coverageTests + afterCoverageTests + stages + after
+	return initial + before + coverageTests + afterCoverageTests + nonCoverageTests + stages + after
 
 def initialPipelines(ctx):
 	return dependencies(ctx)


### PR DESCRIPTION
## Description
If I switch some PHP unit test pipelines to have no coverage, then those pipelines do not end up being included in the drone build. I noticed this when doing PR #39010 which proposes to switch off coverage for the PHPunit+Oracle pipeline.

Add the missing `nonCoverageTests` pipelines to the build matrix!

Note: I checked `.drone.star` in the oC10 apps and it has the correct code there. The bug seems to have only happened in core.

## How Has This Been Tested?
CI - see #39010 for a demonstration that this works

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
