### PR TITLE
Permit subadmins to add accessible users to groups they manage

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -486,13 +486,13 @@ class Users {
 			return new Result(null, 102);
 		}
 
-		if (!$this->groupManager->isAdmin($user->getUID())) {
-			return new Result(null, 104);
-		}
-
 		$targetUser = $this->userManager->get($parameters['userid']);
 		if ($targetUser === null) {
 			return new Result(null, 103);
+		}
+
+		if (!$this->groupManager->isAdmin($user->getUID()) && !$this->groupManager->getSubAdmin()->isUserAccessible($user, $targetUser)) {
+			return new Result(null, 104);
 		}
 
 		// Add user to group

--- a/changelog/unreleased/39013
+++ b/changelog/unreleased/39013
@@ -1,0 +1,3 @@
+Bugfix: Allow subadministrators to add users to groups they manage
+
+https://github.com/owncloud/core/pull/39013

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -199,6 +199,22 @@ Feature: add users to group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
+  @skipOnLDAP
+  Scenario: a subadmin can add users to other groups the subadmin is responsible for
+    Given these users have been created with default attributes and without skeleton files:
+      | username         |
+      | brand-new-user   |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And group "another-new-group" has been created
+    And user "brand-new-user" has been added to group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "another-new-group"
+    When user "another-subadmin" tries to add user "brand-new-user" to group "another-new-group" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should belong to group "brand-new-group"
+
   # merge this with scenario on line 62 once the issue is fixed
   @issue-31015 @skipOnLDAP @toImplementOnOCIS @issue-product-284
   Scenario Outline: adding a user to a group that has a forward-slash and dot in the group name

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -190,6 +190,22 @@ Feature: add users to group
     And the HTTP status code should be "403"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
+  @skipOnLDAP
+  Scenario: a subadmin can add users to other groups the subadmin is responsible for
+    Given these users have been created with default attributes and without skeleton files:
+      | username         |
+      | brand-new-user   |
+      | another-subadmin |
+    And group "brand-new-group" has been created
+    And group "another-new-group" has been created
+    And user "brand-new-user" has been added to group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "brand-new-group"
+    And user "another-subadmin" has been made a subadmin of group "another-new-group"
+    When user "another-subadmin" tries to add user "brand-new-user" to group "another-new-group" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And user "brand-new-user" should belong to group "brand-new-group"
+
   # merge this with scenario on line 62 once the issue is fixed
   @issue-31015 @skipOnLDAP @toImplementOnOCIS @issue-product-284
   Scenario Outline: adding a user to a group that has a forward-slash and dot in the group name


### PR DESCRIPTION


This change aligns the provisioning API (and by extension, the **owncloud-sdk**) to allow subadministrators of groups (not just admins) to add users to groups they are a subadministrator of, *providing that the user is already a member of a group managed by the subadmin*. This is already permitted via the OC10 UI (which uses the PHP API directly `toggleGroups`).

## Related Issue
- Fixes https://github.com/owncloud/core/issues/38279 (incorporates all discussion points to date)

## How Has This Been Tested?
Tested manually and updated and added several unit tests.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
