### PR TITLE
Log number of mounts when moving encryption keys fails 

### DIFF
--- a/changelog/unreleased/39015
+++ b/changelog/unreleased/39015
@@ -1,0 +1,6 @@
+Enhancement: Log number of mounts when moving encryption keys fails
+
+Due to wrong configuration or bugs it is possible that more than one mount
+is returned. In this case we should log the mount-count for easier debugging.
+
+https://github.com/owncloud/core/pull/39015

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -782,7 +782,7 @@ class Encryption extends Wrapper {
 			$target = $this->getFullPath($targetInternalPath);
 			$this->copyKeys($source, $target);
 		} else {
-			$this->logger->error('Could not find mount point, can\'t keep encryption keys');
+			$this->logger->error(\sprintf('Could not find mount point, can\'t keep encryption keys. MountCount: %s', \count($mount)));
 		}
 
 		if ($sourceStorage->is_dir($sourceInternalPath)) {


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Due to wrong configuration or bugs it is possible that more than one mount is returned. In this case we should log the mount-count for easier debugging.

## Motivation and Context
Ease the debugging process in production-systems.

## How Has This Been Tested?
More info in log-line no additional tests needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
