### PR TITLE
fix: file size in cache is set back to zero if empty content is writt…

### DIFF
--- a/changelog/unreleased/39016
+++ b/changelog/unreleased/39016
@@ -1,0 +1,3 @@
+Bugfix: Update file size in cache after writing empty content to non-empty file
+
+https://github.com/owncloud/core/pull/39016

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -359,6 +359,9 @@ class Cache implements ICache {
 				if ($value === '') {
 					$data[$param] = null;
 				}
+				if ($value === null && \in_array($param, ['mtime', 'storage_mtime'], true)) {
+					$data[$param] = 0;
+				}
 			}
 		}
 
@@ -429,7 +432,7 @@ class Cache implements ICache {
 		$params = [];
 		$queryParts = [];
 		foreach ($data as $name => $value) {
-			if (\array_search($name, $fields) !== false) {
+			if (\in_array($name, $fields, true)) {
 				if ($name === 'path') {
 					$params[] = \md5($value);
 					$queryParts[] = '`path_hash`';

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1233,7 +1233,7 @@ class View {
 					throw $e;
 				}
 
-				if ($result) {
+				if ($result !== false) {
 					if (\in_array('delete', $hooks)) {
 						$this->removeUpdate($storage, $internalPath);
 					}


### PR DESCRIPTION
…en to a non-empty file


## Description
When writing zero length content to a non-empty file the file size in the file cache was not updated.

## How Has This Been Tested?
see provided test 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
