### PR TITLE
[10.8] Replace owncloud.org with owncloud.com

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you have questions about how to install or use ownCloud, please direct these 
   - You can also filter by appending e. g. "state:open" to the search string.
   - More info on [search syntax within github](https://help.github.com/articles/searching-issues)
 * This repository ([core](https://github.com/owncloud/core/issues)) is *only* for issues within the ownCloud core code. This also includes the apps: files, external storage, sharing, deleted files, versions, comments, tags and WebDAV Auth
-* __SECURITY__: Report any potential security bug to us via [our HackerOne page](https://hackerone.com/owncloud) or security@owncloud.com following our [security policy](https://owncloud.org/security/) instead of filing an issue in our bug tracker
+* __SECURITY__: Report any potential security bug to us via [our HackerOne page](https://hackerone.com/owncloud) or security@owncloud.com following our [security policy](https://owncloud.com/security/) instead of filing an issue in our bug tracker
 * The issues in other components should be reported in their respective repositories: 
   - [Android client](https://github.com/owncloud/android/issues)
   - [iOS client](https://github.com/owncloud/ios/issues)
@@ -25,7 +25,6 @@ If you have questions about how to install or use ownCloud, please direct these 
 Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
 
 [template]: https://raw.github.com/owncloud/core/master/.github/issue_template.md
-[mailinglist]: https://mailman.owncloud.org/mailman/listinfo/owncloud
 [forum]: https://central.owncloud.org/
 [irc]: https://webchat.freenode.net/?channels=owncloud&uio=d4
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://central.owncloud.org/
     about: If you have any support question. Please ask and answer questions here.
   - name: Report security issue
-    url: https://owncloud.org/security/
+    url: https://owncloud.com/security/
     about: For reporting potential security issues.

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -7,15 +7,15 @@ assignees: ''
 ---
 
 <!--
-Thanks for reporting issues back to ownCloud! This is the issue tracker of ownCloud, if you have any support question please check out https://owncloud.org/support
+Thanks for reporting issues back to ownCloud! This is the issue tracker of ownCloud, if you have any support question please check out https://owncloud.com/support
 
 This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines
 
-For reporting potential security issues please see https://owncloud.org/security/
+For reporting potential security issues please see https://owncloud.com/security/
 
 To make it possible for us to help you please fill out below information carefully.
 
-Before reporting any issues please make sure that you're using the latest available version of ownCloud, see https://owncloud.org/changelog/
+Before reporting any issues please make sure that you're using the latest available version of ownCloud, see https://owncloud.com/changelog/
 --> 
 ### Steps to reproduce
 1.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thanks for submitting a change to ownCloud!
 
 This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines
 
-For fixing potential security issues please see https://owncloud.org/security/
+For fixing potential security issues please see https://owncloud.com/security/
 
 To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -12,4 +12,4 @@
 When you've encountered a security vulnerability, please disclose it securely.
 
 The security process is described at: 
-[https://owncloud.org/security/](https://owncloud.org/security/)
+[https://owncloud.com/security/](https://owncloud.com/security/)

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,8 @@
 #      - testing targets
 
 # Detailed documentation in https://github.com/owncloud/documentation:
-#      - https://doc.owncloud.org/server/latest/developer_manual/general/devenv.html#check-out-the-code
-#      - https://doc.owncloud.org/server/latest/developer_manual/core/unit-testing.html#running-unit-tests-for-the-owncloud-core-project
+#      - https://doc.owncloud.com/server/latest/developer_manual/general/devenv.html#check-out-the-code
+#      - https://doc.owncloud.com/server/latest/developer_manual/testing/unit-testing.html#running-unit-tests-for-owncloud-core
 #
 
 NODE_PREFIX=build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_core&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_core)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_core&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_core)
 
-**[ownCloud](http://ownCloud.org) gives you freedom and control over your own data.
+**[ownCloud](http://ownCloud.com) gives you freedom and control over your own data.
 A personal cloud which runs on your own server.**
 
 ![](https://github.com/owncloud/screenshots/blob/master/files/sidebar_1.png)
@@ -20,17 +20,16 @@ A personal cloud which runs on your own server.**
 * ...
 
 ## Installation instructions
-https://doc.owncloud.org/server/latest/admin_manual/installation/
+https://doc.owncloud.com/server/latest/admin_manual/installation/
 
 ## Contribution Guidelines
-https://owncloud.org/contribute/
+https://owncloud.com/contribute/
 
 ## Support
-Learn about the different ways you can get support for ownCloud: https://owncloud.org/support/
+Learn about the different ways you can get support for ownCloud: https://owncloud.com/support/
 
 ## Get in touch
-* :clipboard: [Forum](https://central.owncloud.org)
-* :envelope: [Mailing list](https://mailman.owncloud.org/mailman/listinfo)
+* :clipboard: [Forum](https://central.owncloud.com)
 * :hash: [IRC channel](https://web.libera.chat/?channels=#owncloud)
 * :busts_in_silhouette: [Facebook](https://facebook.com/ownclouders)
 * :hatching_chick: [Twitter](https://twitter.com/ownCloud)
@@ -40,4 +39,4 @@ Please submit translations via Transifex:
 https://www.transifex.com/projects/p/owncloud/
 
 For detailed information about translations:
-https://doc.owncloud.org/server/latest/developer_manual/core/translation.html
+https://doc.owncloud.com/server/latest/developer_manual/core/translation.html

--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>WebDAV</name>
 	<description>ownCloud WebDAV endpoint</description>
 	<licence>AGPL</licence>
-	<author>owncloud.org</author>
+	<author>owncloud.com</author>
 	<version>0.6.0</version>
 	<default_enable/>
 	<use-migrations>true</use-migrations>

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -497,7 +497,7 @@ class CardDavBackendTest extends TestCase {
 		$vCards[0] = new VCard();
 		$vCards[0]->add(new Text($vCards[0], 'UID', 'uid'));
 		$vCards[0]->add(new Text($vCards[0], 'FN', 'John Doe'));
-		$vCards[0]->add(new Text($vCards[0], 'CLOUD', 'john@owncloud.org'));
+		$vCards[0]->add(new Text($vCards[0], 'CLOUD', 'john@owncloud.com'));
 		$vCards[1] = new VCard();
 		$vCards[1]->add(new Text($vCards[1], 'UID', 'uid'));
 		$vCards[1]->add(new Text($vCards[1], 'FN', 'John M. Doe'));
@@ -537,7 +537,7 @@ class CardDavBackendTest extends TestCase {
 								'addressbookid' => $query->createNamedParameter(0),
 								'cardid' => $query->createNamedParameter($vCardIds[0]),
 								'name' => $query->createNamedParameter('CLOUD'),
-								'value' => $query->createNamedParameter('John@owncloud.org'),
+								'value' => $query->createNamedParameter('John@owncloud.com'),
 								'preferred' => $query->createNamedParameter(0)
 						]
 				);

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -79,7 +79,7 @@ class PrincipalTest extends TestCase {
 		$barUser
 				->expects($this->exactly(1))
 				->method('getEMailAddress')
-				->will($this->returnValue('bar@owncloud.org'));
+				->will($this->returnValue('bar@owncloud.com'));
 		$this->userManager
 			->expects($this->once())
 			->method('search')
@@ -94,7 +94,7 @@ class PrincipalTest extends TestCase {
 			1 => [
 				'uri' => 'principals/users/bar',
 				'{DAV:}displayname' => 'bar',
-				'{http://sabredav.org/ns}email-address' => 'bar@owncloud.org'
+				'{http://sabredav.org/ns}email-address' => 'bar@owncloud.com'
 			]
 		];
 		$response = $this->connector->getPrincipalsByPrefix('principals/users');
@@ -139,7 +139,7 @@ class PrincipalTest extends TestCase {
 		$fooUser
 				->expects($this->exactly(1))
 				->method('getEMailAddress')
-				->will($this->returnValue('foo@owncloud.org'));
+				->will($this->returnValue('foo@owncloud.com'));
 		$fooUser
 				->expects($this->exactly(1))
 				->method('getUID')
@@ -153,7 +153,7 @@ class PrincipalTest extends TestCase {
 		$expectedResponse = [
 			'uri' => 'principals/users/foo',
 			'{DAV:}displayname' => 'foo',
-			'{http://sabredav.org/ns}email-address' => 'foo@owncloud.org'
+			'{http://sabredav.org/ns}email-address' => 'foo@owncloud.com'
 		];
 		$response = $this->connector->getPrincipalByPath('principals/users/foo');
 		$this->assertSame($expectedResponse, $response);

--- a/apps/federatedfilesharing/lib/Panels/GeneralPersonalPanel.php
+++ b/apps/federatedfilesharing/lib/Panels/GeneralPersonalPanel.php
@@ -70,7 +70,7 @@ class GeneralPersonalPanel implements ISettings {
 			$isIE8 = true;
 		}
 		$cloudID = $this->userSession->getUser()->getCloudId();
-		$url = 'https://owncloud.org/federation#' . $cloudID;
+		$url = 'https://owncloud.com/federation#' . $cloudID;
 		$ownCloudLogoPath = $this->urlGenerator->imagePath('core', 'logo-icon.svg');
 		$tmpl = new Template('federatedfilesharing', 'settings-personal-general');
 		$tmpl->assign('outgoingServer2serverShareEnabled', $this->shareProvider->isOutgoingServer2serverShareEnabled());

--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -133,9 +133,9 @@ class AddressHandlerTest extends \Test\TestCase {
 
 	public function dataTestRemoveProtocolFromUrl() {
 		return [
-			['http://owncloud.org', 'owncloud.org'],
-			['https://owncloud.org', 'owncloud.org'],
-			['owncloud.org', 'owncloud.org'],
+			['http://owncloud.com', 'owncloud.com'],
+			['https://owncloud.com', 'owncloud.com'],
+			['owncloud.com', 'owncloud.com'],
 		];
 	}
 

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -89,9 +89,9 @@ class DbHandlerTest extends TestCase {
 
 	public function dataTestAddServer() {
 		return [
-				['http://owncloud.org', 'http://owncloud.org', \sha1('owncloud.org')],
-				['https://owncloud.org', 'https://owncloud.org', \sha1('owncloud.org')],
-				['http://owncloud.org/', 'http://owncloud.org', \sha1('owncloud.org')],
+				['http://owncloud.com', 'http://owncloud.com', \sha1('owncloud.com')],
+				['https://owncloud.com', 'https://owncloud.com', \sha1('owncloud.com')],
+				['http://owncloud.com/', 'http://owncloud.com', \sha1('owncloud.com')],
 		];
 	}
 
@@ -284,11 +284,11 @@ class DbHandlerTest extends TestCase {
 
 	public function dataTestNormalizeUrl() {
 		return [
-			['owncloud.org', 'owncloud.org'],
-			['http://owncloud.org', 'owncloud.org'],
-			['https://owncloud.org', 'owncloud.org'],
-			['https://owncloud.org//mycloud', 'owncloud.org/mycloud'],
-			['https://owncloud.org/mycloud/', 'owncloud.org/mycloud'],
+			['owncloud.com', 'owncloud.com'],
+			['http://owncloud.com', 'owncloud.com'],
+			['https://owncloud.com', 'owncloud.com'],
+			['https://owncloud.com//mycloud', 'owncloud.com/mycloud'],
+			['https://owncloud.com/mycloud/', 'owncloud.com/mycloud'],
 		];
 	}
 

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -369,9 +369,9 @@ class TrustedServersTest extends TestCase {
 
 	public function dataTestUpdateProtocol() {
 		return [
-			['http://owncloud.org', 'http://owncloud.org'],
-			['https://owncloud.org', 'https://owncloud.org'],
-			['owncloud.org', 'https://owncloud.org'],
+			['http://owncloud.com', 'http://owncloud.com'],
+			['https://owncloud.com', 'https://owncloud.com'],
+			['owncloud.com', 'https://owncloud.com'],
 			['httpserver', 'https://httpserver'],
 		];
 	}

--- a/apps/files_sharing/tests/Controllers/ExternalShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ExternalShareControllerTest.php
@@ -156,7 +156,7 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			->method('newClient')
 			->will($this->returnValue($client));
 
-		$this->assertEquals(new DataResponse('https'), $this->getExternalShareController()->testRemote('owncloud.org'));
+		$this->assertEquals(new DataResponse('https'), $this->getExternalShareController()->testRemote('owncloud.com'));
 	}
 
 	public function testRemoteWithWorkingHttp() {
@@ -176,7 +176,7 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			->method('newClient')
 			->will($this->returnValue($client));
 
-		$this->assertEquals(new DataResponse('http'), $this->getExternalShareController()->testRemote('owncloud.org'));
+		$this->assertEquals(new DataResponse('http'), $this->getExternalShareController()->testRemote('owncloud.com'));
 	}
 
 	public function testRemoteWithInvalidRemote() {
@@ -196,7 +196,7 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			->method('newClient')
 			->will($this->returnValue($client));
 
-		$this->assertEquals(new DataResponse(false), $this->getExternalShareController()->testRemote('owncloud.org'));
+		$this->assertEquals(new DataResponse(false), $this->getExternalShareController()->testRemote('owncloud.com'));
 	}
 
 	public function testRemoteIsCleanedUp() {
@@ -210,8 +210,8 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			->expects($this->any())
 			->method('get')
 			->withConsecutive(
-				['https://owncloud.org/ocs-provider/'],
-				['https://owncloud.org/ocs-provider/index.php']
+				['https://owncloud.com/ocs-provider/'],
+				['https://owncloud.com/ocs-provider/index.php']
 			)
 			->will($this->returnValue($response));
 
@@ -219,7 +219,7 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			->expects($this->exactly(2))
 			->method('newClient')
 			->will($this->returnValue($client));
-		$response = $this->getExternalShareController()->testRemote('owncloud.org?app=files#anchor');
+		$response = $this->getExternalShareController()->testRemote('owncloud.com?app=files#anchor');
 		$this->assertEquals(new DataResponse('https'), $response);
 	}
 }

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -694,7 +694,7 @@ class UsersTest extends OriginalTest {
 		$targetUser = $this->createMock(IUser::class);
 		$targetUser->expects($this->once())
 			->method('getEMailAddress')
-			->willReturn('demo@owncloud.org');
+			->willReturn('demo@owncloud.com');
 		$targetUser->expects($this->once())
 			->method('getHome')
 			->willReturn('/var/ocdata/UserToGet');
@@ -730,7 +730,7 @@ class UsersTest extends OriginalTest {
 			[
 				'enabled' => 'true',
 				'quota' => ['DummyValue', 'definition' => null],
-				'email' => 'demo@owncloud.org',
+				'email' => 'demo@owncloud.com',
 				'displayname' => 'Demo User',
 				'home' => '/var/ocdata/UserToGet',
 				'two_factor_auth_enabled' => 'false',
@@ -749,7 +749,7 @@ class UsersTest extends OriginalTest {
 		$targetUser
 			->expects($this->once())
 			->method('getEMailAddress')
-			->willReturn('demo@owncloud.org');
+			->willReturn('demo@owncloud.com');
 		$targetUser->expects($this->once())
 			->method('getHome')
 			->willReturn('/var/ocdata/UserToGet');
@@ -797,7 +797,7 @@ class UsersTest extends OriginalTest {
 			[
 				'enabled' => 'true',
 				'quota' => ['DummyValue', 'definition' => null],
-				'email' => 'demo@owncloud.org',
+				'email' => 'demo@owncloud.com',
 				'home' => '/var/ocdata/UserToGet',
 				'displayname' => 'Demo User',
 				'two_factor_auth_enabled' => 'false'
@@ -892,11 +892,11 @@ class UsersTest extends OriginalTest {
 		$targetUser
 			->expects($this->once())
 			->method('getEMailAddress')
-			->will($this->returnValue('subadmin@owncloud.org'));
+			->will($this->returnValue('subadmin@owncloud.com'));
 
 		$expected = new Result([
 			'quota' => ['DummyValue', 'definition' => null],
-			'email' => 'subadmin@owncloud.org',
+			'email' => 'subadmin@owncloud.com',
 			'displayname' => 'Subadmin User',
 			'home' => '/var/ocdata/UserToGet',
 			'two_factor_auth_enabled' => 'false',
@@ -983,10 +983,10 @@ class UsersTest extends OriginalTest {
 		$targetUser
 			->expects($this->once())
 			->method('setEMailAddress')
-			->with('demo@owncloud.org');
+			->with('demo@owncloud.com');
 
 		$expected = new Result(null, 100);
-		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'email', 'value' => 'demo@owncloud.org']]));
+		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'email', 'value' => 'demo@owncloud.com']]));
 	}
 
 	public function testEditUserRegularUserSelfEditClearEmail() {

--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -129,8 +129,7 @@ class AdminController extends Controller implements ISettings {
 			$varsionParts = \explode(' ', $newVersionString);
 			if (\count($varsionParts) >= 2) {
 				$versionParts = \explode('.', $varsionParts[1]); // remove the 'ownCloud' prefix
-				\array_splice($versionParts, 2); // remove minor version info from parts
-				$changeLogUrl = 'https://owncloud.org/changelog/#latest' . \implode('.', $versionParts);
+				$changeLogUrl = 'https://owncloud.com/changelog/server/#' . \implode('.', $versionParts);
 			}
 		}
 

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -113,15 +113,15 @@ class AdminControllerTest extends TestCase {
 		$this->updateChecker
 			->expects($this->once())
 			->method('getUpdateState')
-			->willReturn(['updateVersion' => 'ownCloud 8.1.2']);
+			->willReturn(['updateVersion' => 'ownCloud 10.7.0']);
 
 		$params = [
 			'isNewVersionAvailable' => true,
 			'lastChecked' => 'LastCheckedReturnValue',
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
-			'newVersionString' => 'ownCloud 8.1.2',
-			'changeLogUrl' => 'https://owncloud.org/changelog/#latest8.1',
+			'newVersionString' => 'ownCloud 10.7.0',
+			'changeLogUrl' => 'https://owncloud.com/changelog/server/#10.7.0',
 			'notify_groups' => 'admin'
 		];
 

--- a/apps/updatenotification/tests/UpdateCheckerTest.php
+++ b/apps/updatenotification/tests/UpdateCheckerTest.php
@@ -64,13 +64,13 @@ class UpdateCheckerTest extends TestCase {
 			->willReturn([
 				'version' => 123,
 				'versionstring' => 'ownCloud 123',
-				'web'=> 'https://owncloud.org/myUrl',
+				'web'=> 'https://owncloud.com/myUrl',
 			]);
 
 		$expected = [
 			'updateAvailable' => true,
 			'updateVersion' => 'ownCloud 123',
-			'updateLink' => 'https://owncloud.org/myUrl',
+			'updateLink' => 'https://owncloud.com/myUrl',
 		];
 		$this->assertSame($expected, $this->updateChecker->getUpdateState());
 	}

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -163,7 +163,7 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					isUrandomAvailable: true,
 					serverHasInternetConnection: false,
-					memcacheDocs: 'https://doc.owncloud.org/server/go.php?to=admin-performance',
+					memcacheDocs: 'https://doc.owncloud.com/server/go.php?to=admin-performance',
 					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
@@ -176,7 +176,7 @@ describe('OC.SetupChecks tests', function() {
 						msg: 'This server has no working Internet connection. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. We suggest to enable Internet connection for this server if you want to have all features.',
 						type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 					}, {
-						msg: 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a target="_blank" rel="noreferrer" href="https://doc.owncloud.org/server/go.php?to=admin-performance">documentation</a>.',
+						msg: 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/go.php?to=admin-performance">documentation</a>.',
 						type: OC.SetupChecks.MESSAGE_TYPE_INFO
 					}]);
 				done();
@@ -194,7 +194,7 @@ describe('OC.SetupChecks tests', function() {
 				JSON.stringify({
 					isUrandomAvailable: true,
 					serverHasInternetConnection: false,
-					memcacheDocs: 'https://doc.owncloud.org/server/go.php?to=admin-performance',
+					memcacheDocs: 'https://doc.owncloud.com/server/go.php?to=admin-performance',
 					forwardedForHeadersWorking: true,
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
@@ -208,7 +208,7 @@ describe('OC.SetupChecks tests', function() {
 						type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 					},
 					{
-						msg: 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a target="_blank" rel="noreferrer" href="https://doc.owncloud.org/server/go.php?to=admin-performance">documentation</a>.',
+						msg: 'No memory cache has been configured. To enhance your performance please configure a memcache if available. Further information can be found in our <a target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/go.php?to=admin-performance">documentation</a>.',
 						type: OC.SetupChecks.MESSAGE_TYPE_INFO
 					}]);
 				done();
@@ -254,7 +254,7 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isUrandomAvailable: false,
-					securityDocs: 'https://docs.owncloud.org/myDocs.html',
+					securityDocs: 'https://docs.owncloud.com/myDocs.html',
 					serverHasInternetConnection: true,
 					isMemcacheConfigured: true,
 					forwardedForHeadersWorking: true,
@@ -265,7 +265,7 @@ describe('OC.SetupChecks tests', function() {
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
-					msg: '/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a target="_blank" rel="noreferrer" href="https://docs.owncloud.org/myDocs.html">documentation</a>.',
+					msg: '/dev/urandom is not readable by PHP which is highly discouraged for security reasons. Further information can be found in our <a target="_blank" rel="noreferrer" href="https://docs.owncloud.com/myDocs.html">documentation</a>.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 				}]);
 				done();
@@ -282,7 +282,7 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isUrandomAvailable: true,
-					securityDocs: 'https://docs.owncloud.org/myDocs.html',
+					securityDocs: 'https://docs.owncloud.com/myDocs.html',
 					serverHasInternetConnection: true,
 					isMemcacheConfigured: true,
 					forwardedForHeadersWorking: true,
@@ -313,7 +313,7 @@ describe('OC.SetupChecks tests', function() {
 					serverHasInternetConnection: true,
 					isMemcacheConfigured: true,
 					forwardedForHeadersWorking: false,
-					reverseProxyDocs: 'https://docs.owncloud.org/foo/bar.html',
+					reverseProxyDocs: 'https://docs.owncloud.com/foo/bar.html',
 					isCorrectMemcachedPHPModuleInstalled: true,
 					hasPassedCodeIntegrityCheck: true,
 				})
@@ -321,7 +321,7 @@ describe('OC.SetupChecks tests', function() {
 
 			async.done(function( data, s, x ){
 				expect(data).toEqual([{
-					msg: 'The reverse proxy headers configuration is incorrect, or you are accessing ownCloud from a trusted proxy. If you are not accessing ownCloud from a trusted proxy, this is a security issue and can allow an attacker to spoof their IP address as visible to ownCloud. Further information can be found in our <a target="_blank" rel="noreferrer" href="https://docs.owncloud.org/foo/bar.html">documentation</a>.',
+					msg: 'The reverse proxy headers configuration is incorrect, or you are accessing ownCloud from a trusted proxy. If you are not accessing ownCloud from a trusted proxy, this is a security issue and can allow an attacker to spoof their IP address as visible to ownCloud. Further information can be found in our <a target="_blank" rel="noreferrer" href="https://docs.owncloud.com/foo/bar.html">documentation</a>.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 				}]);
 				done();
@@ -358,7 +358,7 @@ describe('OC.SetupChecks tests', function() {
 				},
 				JSON.stringify({
 					isUrandomAvailable: true,
-					securityDocs: 'https://docs.owncloud.org/myDocs.html',
+					securityDocs: 'https://docs.owncloud.com/myDocs.html',
 					serverHasInternetConnection: true,
 					isMemcacheConfigured: true,
 					forwardedForHeadersWorking: true,

--- a/l10n/l10n.pl
+++ b/l10n/l10n.pl
@@ -137,7 +137,7 @@ if( $task eq 'read' ){
 			my $language = ( $file =~ /\.js$/ ? 'Javascript' : 'PHP');
 			my $joinexisting = ( -e $output ? '--join-existing' : '');
 			print "    Reading $file\n";
-			`xgettext --output="$output" $joinexisting $keywords --language=$language "$file" --add-comments=TRANSLATORS --from-code=UTF-8 --package-version="8.0.0" --package-name="ownCloud Core" --msgid-bugs-address="translations\@owncloud.org"`;
+			`xgettext --output="$output" $joinexisting $keywords --language=$language "$file" --add-comments=TRANSLATORS --from-code=UTF-8 --package-version="8.0.0" --package-name="ownCloud Core" --msgid-bugs-address="translations\@owncloud.com"`;
 		}
 		chdir( $whereami );
 	}

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -63,7 +63,7 @@ class OC_Defaults {
 		$this->defaultEntity = 'ownCloud'; /* e.g. company name, used for footers and copyright notices */
 		$this->defaultName = 'ownCloud'; /* short name, used when referring to the software */
 		$this->defaultTitle = 'ownCloud'; /* can be a longer name, for titles */
-		$this->defaultBaseUrl = 'https://owncloud.org';
+		$this->defaultBaseUrl = 'https://owncloud.com';
 		$this->defaultSyncClientUrl = 'https://owncloud.com/desktop-app/';
 		$this->defaultiOSClientUrl = 'https://apps.apple.com/app/id1359583808';
 		$this->defaultiTunesAppId = '1359583808';

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -96,8 +96,8 @@ class CheckSetupController extends Controller {
 
 		try {
 			$client = $this->clientService->newClient();
-			$client->get('https://www.owncloud.org/');
-			$client->get('http://www.owncloud.org/');
+			$client->get('https://www.owncloud.com/');
+			$client->get('http://www.owncloud.com/');
 			return true;
 		} catch (\Exception $e) {
 			return false;
@@ -182,10 +182,10 @@ class CheckSetupController extends Controller {
 		if (\strpos($versionString, 'NSS/') === 0) {
 			try {
 				$firstClient = $this->clientService->newClient();
-				$firstClient->get('https://www.owncloud.org/');
+				$firstClient->get('https://www.owncloud.com/');
 
 				$secondClient = $this->clientService->newClient();
-				$secondClient->get('https://owncloud.org/');
+				$secondClient->get('https://owncloud.com/');
 			} catch (ClientException $e) {
 				if ($e->getResponse()->getStatusCode() === 400) {
 					return (string) $this->l10n->t('cURL is using an outdated %s version (%s). Please update your operating system or features such as %s will not work reliably.', ['NSS', $versionString, $features]);

--- a/settings/templates/panels/admin/apps.php
+++ b/settings/templates/panels/admin/apps.php
@@ -18,7 +18,7 @@ script('settings', 'admin-apps');
 		{{/each}}
 
 		<li>
-			<a class="app-external" target="_blank" rel="noreferrer" href="https://owncloud.org/dev"><?php p($l->t('Developer documentation'));?> ↗</a>
+			<a class="app-external" target="_blank" rel="noreferrer" href="https://doc.owncloud.com/server/latest/developer_manual"><?php p($l->t('Developer documentation'));?> ↗</a>
 		</li>
 	</script>
 

--- a/settings/templates/panels/personal/clients.php
+++ b/settings/templates/panels/personal/clients.php
@@ -15,10 +15,10 @@
 	<?php if (OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY): ?>
 		<p>
 			<?php print_unescaped($l->t('If you want to support the project
-			<a href="https://owncloud.org/contribute"
+			<a href="https://owncloud.com/contribute"
 			target="_blank" rel="noreferrer">join development</a>
 			or
-			<a href="https://owncloud.org/promote"
+			<a href="https://owncloud.com/promote"
 			target="_blank" rel="noreferrer">spread the word</a>!'));?>
 		</p>
 	<?php endif; ?>

--- a/settings/templates/panels/personal/settings.development.notice.php
+++ b/settings/templates/panels/personal/settings.development.notice.php
@@ -8,7 +8,7 @@
 				'{linkclose}',
 			],
 	[
-				'<a href="https://owncloud.org/contact" target="_blank" rel="noreferrer">',
+				'<a href="https://owncloud.com/contact-us" target="_blank" rel="noreferrer">',
 				'<a href="https://github.com/owncloud" target="_blank" rel="noreferrer">',
 				'<a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noreferrer">',
 				'</a>',

--- a/settings/tests/js/apps/appSettingsSpec.js
+++ b/settings/tests/js/apps/appSettingsSpec.js
@@ -36,7 +36,7 @@ describe('App Settings tests', function() {
 				"Author 2",
 				{
 					"@attributes": {
-						"email": "author3@owncloud.org"
+						"email": "author3@owncloud.com"
 					},
 					"@value": "Author 3"
 				}

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -122,10 +122,10 @@ class CheckSetupControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$client->expects($this->at(0))
 			->method('get')
-			->with('https://www.owncloud.org/', []);
+			->with('https://www.owncloud.com/', []);
 		$client->expects($this->at(1))
 			->method('get')
-			->with('http://www.owncloud.org/', []);
+			->with('http://www.owncloud.com/', []);
 
 		$this->clientService->expects($this->once())
 			->method('newClient')
@@ -149,7 +149,7 @@ class CheckSetupControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$client->expects($this->at(0))
 			->method('get')
-			->with('https://www.owncloud.org/', [])
+			->with('https://www.owncloud.com/', [])
 			->will($this->throwException(new \Exception()));
 
 		$this->clientService->expects($this->once())
@@ -174,10 +174,10 @@ class CheckSetupControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$client->expects($this->at(0))
 			->method('get')
-			->with('https://www.owncloud.org/', []);
+			->with('https://www.owncloud.com/', []);
 		$client->expects($this->at(1))
 			->method('get')
-			->with('http://www.owncloud.org/', [])
+			->with('http://www.owncloud.com/', [])
 			->will($this->throwException(new \Exception()));
 
 		$this->clientService->expects($this->once())
@@ -309,10 +309,10 @@ class CheckSetupControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$client->expects($this->at(0))
 			->method('get')
-			->with('https://www.owncloud.org/', []);
+			->with('https://www.owncloud.com/', []);
 		$client->expects($this->at(1))
 			->method('get')
-			->with('http://www.owncloud.org/', [])
+			->with('http://www.owncloud.com/', [])
 			->will($this->throwException(new \Exception()));
 
 		$this->clientService->expects($this->once())
@@ -321,11 +321,11 @@ class CheckSetupControllerTest extends TestCase {
 		$this->urlGenerator->expects($this->at(0))
 			->method('linkToDocs')
 			->with('admin-performance')
-			->willReturn('http://doc.owncloud.org/server/go.php?to=admin-performance');
+			->willReturn('http://doc.owncloud.com/server/go.php?to=admin-performance');
 		$this->urlGenerator->expects($this->at(1))
 			->method('linkToDocs')
 			->with('admin-security')
-			->willReturn('https://doc.owncloud.org/server/8.1/admin_manual/configuration_server/hardening.html');
+			->willReturn('https://doc.owncloud.com/server/8.1/admin_manual/configuration_server/hardening.html');
 		$this->checkSetupController
 			->expects($this->once())
 			->method('isEndOfLive')
@@ -339,9 +339,9 @@ class CheckSetupControllerTest extends TestCase {
 			[
 				'serverHasInternetConnection' => false,
 				'isMemcacheConfigured' => true,
-				'memcacheDocs' => 'http://doc.owncloud.org/server/go.php?to=admin-performance',
+				'memcacheDocs' => 'http://doc.owncloud.com/server/go.php?to=admin-performance',
 				'isUrandomAvailable' => self::invokePrivate($this->checkSetupController, 'isUrandomAvailable'),
-				'securityDocs' => 'https://doc.owncloud.org/server/8.1/admin_manual/configuration_server/hardening.html',
+				'securityDocs' => 'https://doc.owncloud.com/server/8.1/admin_manual/configuration_server/hardening.html',
 				'isUsedTlsLibOutdated' => '',
 				'phpSupported' => [
 					'eol' => true,
@@ -465,7 +465,7 @@ class CheckSetupControllerTest extends TestCase {
 
 		$client->expects($this->at(0))
 			->method('get')
-			->with('https://www.owncloud.org/', [])
+			->with('https://www.owncloud.com/', [])
 			->will($this->throwException($exception));
 
 		$this->clientService->expects($this->once())
@@ -499,7 +499,7 @@ class CheckSetupControllerTest extends TestCase {
 
 		$client->expects($this->at(0))
 			->method('get')
-			->with('https://www.owncloud.org/', [])
+			->with('https://www.owncloud.com/', [])
 			->will($this->throwException($exception));
 
 		$this->clientService->expects($this->once())

--- a/tests/Settings/Controller/MailSettingsControllerTest.php
+++ b/tests/Settings/Controller/MailSettingsControllerTest.php
@@ -58,7 +58,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			'@',
 			'smtp',
 			'ssl',
-			'mx.owncloud.org',
+			'mx.owncloud.com',
 			'NTLM',
 			1,
 			'25'
@@ -72,7 +72,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			'@',
 			'smtp',
 			'ssl',
-			'mx.owncloud.org',
+			'mx.owncloud.com',
 			'NTLM',
 			0,
 			'25'
@@ -99,7 +99,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 				array($this->equalTo('mail_from_address'), $this->equalTo('demo')),
 				array($this->equalTo('mail_smtpmode'), $this->equalTo('smtp')),
 				array($this->equalTo('mail_smtpsecure'), $this->equalTo('ssl')),
-				array($this->equalTo('mail_smtphost'), $this->equalTo('mx.owncloud.org')),
+				array($this->equalTo('mail_smtphost'), $this->equalTo('mx.owncloud.com')),
 				array($this->equalTo('mail_smtpauthtype'), $this->equalTo('NTLM')),
 				array($this->equalTo('mail_smtpauth'), $this->equalTo(1)),
 				array($this->equalTo('mail_smtpport'), $this->equalTo('25')),
@@ -107,7 +107,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 				array($this->equalTo('mail_from_address'), $this->equalTo('demo@owncloud.com')),
 				array($this->equalTo('mail_smtpmode'), $this->equalTo('smtp')),
 				array($this->equalTo('mail_smtpsecure'), $this->equalTo('ssl')),
-				array($this->equalTo('mail_smtphost'), $this->equalTo('mx.owncloud.org')),
+				array($this->equalTo('mail_smtphost'), $this->equalTo('mx.owncloud.com')),
 				array($this->equalTo('mail_smtpauthtype'), $this->equalTo('NTLM')),
 				array($this->equalTo('mail_smtpport'), $this->equalTo('25'))
 			);
@@ -131,7 +131,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 					'mail_from_address' => 'demo',
 					'mail_smtpmode' => 'smtp',
 					'mail_smtpsecure' => 'ssl',
-					'mail_smtphost' => 'mx.owncloud.org',
+					'mail_smtphost' => 'mx.owncloud.com',
 					'mail_smtpauthtype' => 'NTLM',
 					'mail_smtpauth' => 1,
 					'mail_smtpport' => '25',
@@ -141,7 +141,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 					'mail_from_address' => 'demo',
 					'mail_smtpmode' => 'smtp',
 					'mail_smtpsecure' => 'ssl',
-					'mail_smtphost' => 'mx.owncloud.org',
+					'mail_smtphost' => 'mx.owncloud.com',
 					'mail_smtpauthtype' => 'NTLM',
 					'mail_smtpauth' => null,
 					'mail_smtpport' => '25',
@@ -157,7 +157,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			'demo',
 			'smtp',
 			'ssl',
-			'mx.owncloud.org',
+			'mx.owncloud.com',
 			'NTLM',
 			1,
 			'25'
@@ -171,7 +171,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			'demo',
 			'smtp',
 			'ssl',
-			'mx.owncloud.org',
+			'mx.owncloud.com',
 			'NTLM',
 			0,
 			'25'

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -174,7 +174,7 @@ Feature: edit users
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the display name of user "another-subadmin" should be "Regular User"
-    And the email address of user "another-subadmin" should be "another-subadmin@owncloud.org"
+    And the email address of user "another-subadmin" should be "another-subadmin@owncloud.com"
     And the quota definition of user "another-subadmin" should be "default"
 
   Scenario: a normal user should not be able to edit another user's information

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -174,7 +174,7 @@ Feature: edit users
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the display name of user "another-subadmin" should be "Regular User"
-    And the email address of user "another-subadmin" should be "another-subadmin@owncloud.org"
+    And the email address of user "another-subadmin" should be "another-subadmin@owncloud.com"
     And the quota definition of user "another-subadmin" should be "default"
 
   Scenario: a normal user should not be able to edit another user's information

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -646,7 +646,7 @@ trait Provisioning {
 			} elseif ($setDefaultAttributes) {
 				$userAttribute['email'] = $this->getEmailAddressForUser($row['username']);
 				if ($userAttribute['email'] === null) {
-					$userAttribute['email'] = $row['username'] . '@owncloud.org';
+					$userAttribute['email'] = $row['username'] . '@owncloud.com';
 				}
 			} else {
 				$userAttribute['email'] = null;
@@ -951,7 +951,7 @@ trait Provisioning {
 							$userAttributes,
 							__METHOD__ . " userAttributes array does not have key 'userid'"
 						);
-						$attributesToCreateUser['email'] = $userAttributes['userid'] . '@owncloud.org';
+						$attributesToCreateUser['email'] = $userAttributes['userid'] . '@owncloud.com';
 					} else {
 						$attributesToCreateUser['email'] = $userAttributes['email'];
 					}
@@ -1314,7 +1314,7 @@ trait Provisioning {
 
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			if ($email === null) {
-				$email = $username . '@owncloud.org';
+				$email = $username . '@owncloud.com';
 			}
 			$userAttributes["username"] = $username;
 			$userAttributes["email"] = $email;
@@ -1351,7 +1351,7 @@ trait Provisioning {
 		$user = $this->getActualUsername($user);
 		$password = $this->getActualPassword($password);
 		if (OcisHelper::isTestingOnOcisOrReva()) {
-			$email = $user . '@owncloud.org';
+			$email = $user . '@owncloud.com';
 			$bodyTable = new TableNode(
 				[
 					['userid', $user],
@@ -1415,7 +1415,7 @@ trait Provisioning {
 		$userToCreate = $this->getActualUsername($userToCreate);
 		$password = $this->getActualPassword($password);
 		if (OcisHelper::isTestingOnOcisOrReva()) {
-			$email = $userToCreate . '@owncloud.org';
+			$email = $userToCreate . '@owncloud.com';
 			$bodyTable = new TableNode(
 				[
 					['userid', $userToCreate],
@@ -1461,7 +1461,7 @@ trait Provisioning {
 		$user = $this->getActualUsername($user);
 		$password = $this->getActualPassword($password);
 		if (OcisHelper::isTestingOnOcisOrReva()) {
-			$email = $user . '@owncloud.org';
+			$email = $user . '@owncloud.com';
 			$bodyTable = new TableNode(
 				[
 					['userid', $user],
@@ -1515,7 +1515,7 @@ trait Provisioning {
 		$userToCreate = $this->getActualUsername($userToCreate);
 		$password = $this->getActualPassword($password);
 		if (OcisHelper::isTestingOnOcisOrReva()) {
-			$email = $userToCreate . '@owncloud.org';
+			$email = $userToCreate . '@owncloud.com';
 			$bodyTable = new TableNode(
 				[
 					['userid', $userToCreate],
@@ -1569,7 +1569,7 @@ trait Provisioning {
 		$userToCreate = $this->getActualUsername($userToCreate);
 		$password = $this->getActualPassword($password);
 		if (OcisHelper::isTestingOnOcisOrReva()) {
-			$email = $userToCreate . '@owncloud.org';
+			$email = $userToCreate . '@owncloud.com';
 			$bodyTable = new TableNode(
 				[
 					['userid', $userToCreate],
@@ -2944,7 +2944,7 @@ trait Provisioning {
 
 			if ($email === null) {
 				// escape @ & space if present in userId
-				$email = \str_replace(["@", " "], "", $user) . '@owncloud.org';
+				$email = \str_replace(["@", " "], "", $user) . '@owncloud.com';
 			}
 		}
 

--- a/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
@@ -39,10 +39,10 @@ class ContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyScriptDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' www.owncloud.com www.owncloud.org 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' www.owncloud.com www.owncloud.online 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -58,7 +58,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' www.owncloud.com 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -66,7 +66,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org')->disallowScriptDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.com')->disallowScriptDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -101,10 +101,10 @@ class ContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyStyleDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com www.owncloud.org 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com www.owncloud.online 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -120,7 +120,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -128,7 +128,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org')->disallowStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.com')->disallowStyleDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -161,10 +161,10 @@ class ContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyImageDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com www.owncloud.org;font-src 'self';connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com www.owncloud.online;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -180,7 +180,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -188,7 +188,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org')->disallowImageDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.online')->disallowImageDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -200,10 +200,10 @@ class ContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyFontDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' www.owncloud.com www.owncloud.org;connect-src 'self';media-src 'self'";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' www.owncloud.com www.owncloud.online;connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -219,7 +219,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' www.owncloud.com;connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -227,7 +227,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org')->disallowFontDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.online')->disallowFontDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -239,10 +239,10 @@ class ContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyConnectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self' www.owncloud.com www.owncloud.org;media-src 'self'";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self' www.owncloud.com www.owncloud.online;media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -258,7 +258,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self' www.owncloud.com;media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -266,7 +266,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org')->disallowConnectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.online')->disallowConnectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -278,10 +278,10 @@ class ContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyMediaDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self' www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self' www.owncloud.com www.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -297,7 +297,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self' www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -305,7 +305,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org')->disallowMediaDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.online')->disallowMediaDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -317,10 +317,10 @@ class ContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyObjectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';object-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';object-src www.owncloud.com www.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -336,7 +336,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';object-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -344,7 +344,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org')->disallowObjectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.online')->disallowObjectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -356,10 +356,10 @@ class ContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyFrameDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';frame-src www.owncloud.com www.owncloud.org blob:";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';frame-src www.owncloud.com www.owncloud.online blob:";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -375,7 +375,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';frame-src www.owncloud.com blob:";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -383,7 +383,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org')->disallowFrameDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.online')->disallowFrameDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -395,10 +395,10 @@ class ContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyChildSrcValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';child-src child.owncloud.com child.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';child-src child.owncloud.com child.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -414,7 +414,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self';child-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -422,7 +422,7 @@ class ContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src 'self' 'unsafe-eval';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self';connect-src 'self';media-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.online')->disallowChildSrcDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 }

--- a/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
@@ -39,10 +39,10 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyScriptDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src www.owncloud.com www.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -58,7 +58,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';script-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -66,7 +66,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org')->disallowScriptDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.online')->disallowScriptDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -101,10 +101,10 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyStyleDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';style-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';style-src www.owncloud.com www.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -120,7 +120,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';style-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -128,7 +128,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org')->disallowStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.online')->disallowStyleDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -162,10 +162,10 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyImageDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';img-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';img-src www.owncloud.com www.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -181,7 +181,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';img-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -189,7 +189,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org')->disallowImageDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.online')->disallowImageDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -201,10 +201,10 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyFontDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';font-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';font-src www.owncloud.com www.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -220,7 +220,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';font-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -228,7 +228,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org')->disallowFontDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.online')->disallowFontDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -240,10 +240,10 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyConnectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';connect-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';connect-src www.owncloud.com www.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -259,7 +259,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';connect-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -267,7 +267,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org')->disallowConnectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.online')->disallowConnectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -279,10 +279,10 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyMediaDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';media-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';media-src www.owncloud.com www.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -298,7 +298,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';media-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -306,7 +306,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org')->disallowMediaDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.online')->disallowMediaDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -318,10 +318,10 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyObjectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';object-src www.owncloud.com www.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';object-src www.owncloud.com www.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -337,7 +337,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';object-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -345,7 +345,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org')->disallowObjectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.online')->disallowObjectDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -357,10 +357,10 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyFrameDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';frame-src www.owncloud.com www.owncloud.org blob:";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';frame-src www.owncloud.com www.owncloud.online blob:";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -376,7 +376,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';frame-src www.owncloud.com blob:";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -384,7 +384,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org')->disallowFrameDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.online')->disallowFrameDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -396,10 +396,10 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 	}
 
 	public function testGetPolicyChildSrcValidMultiple() {
-		$expectedPolicy = "default-src 'none';manifest-src 'self';child-src child.owncloud.com child.owncloud.org";
+		$expectedPolicy = "default-src 'none';manifest-src 'self';child-src child.owncloud.com child.owncloud.online";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -415,7 +415,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self';child-src www.owncloud.com";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.online');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -423,7 +423,7 @@ class EmptyContentSecurityPolicyTest extends TestCase {
 		$expectedPolicy = "default-src 'none';manifest-src 'self'";
 
 		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.online')->disallowChildSrcDomain('www.owncloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 }

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -1147,7 +1147,7 @@ class RequestTest extends TestCase {
 			->expects($this->at(0))
 			->method('getSystemValue')
 			->with('overwritehost')
-			->will($this->returnValue('www.owncloud.org'));
+			->will($this->returnValue('www.owncloud.com'));
 		$this->config
 			->expects($this->at(1))
 			->method('getSystemValue')
@@ -1157,7 +1157,7 @@ class RequestTest extends TestCase {
 			->expects($this->at(2))
 			->method('getSystemValue')
 			->with('overwritehost')
-			->will($this->returnValue('www.owncloud.org'));
+			->will($this->returnValue('www.owncloud.com'));
 
 		$request = new Request(
 			[],
@@ -1167,7 +1167,7 @@ class RequestTest extends TestCase {
 			$this->stream
 		);
 
-		$this->assertSame('www.owncloud.org', self::invokePrivate($request, 'getOverwriteHost'));
+		$this->assertSame('www.owncloud.com', self::invokePrivate($request, 'getOverwriteHost'));
 	}
 
 	public function testGetPathInfoWithSetEnv() {

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -256,10 +256,10 @@ class ConfigTest extends TestCase {
 		$this->assertStringEqualsFile($this->configFile, self::TESTCONTENT);
 
 		// Write a new value to the config
-		$this->config->setValue('CoolWebsites', ['demo.owncloud.org', 'owncloud.org', 'owncloud.com']);
+		$this->config->setValue('CoolWebsites', ['demo.owncloud.com', 'owncloud.com', 'owncloud.com']);
 		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'bar',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
 			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'php53' => 'totallyOutdated',\n  'CoolWebsites' => \n  array (\n  " .
-			"  0 => 'demo.owncloud.org',\n    1 => 'owncloud.org',\n    2 => 'owncloud.com',\n  ),\n);\n";
+			"  0 => 'demo.owncloud.com',\n    1 => 'owncloud.com',\n    2 => 'owncloud.com',\n  ),\n);\n";
 		$this->assertStringEqualsFile($this->configFile, $expected);
 
 		// Cleanup

--- a/tests/lib/ErrorHandlerTest.php
+++ b/tests/lib/ErrorHandlerTest.php
@@ -31,7 +31,7 @@ class ErrorHandlerTest extends \Test\TestCase {
 	public function passwordProvider() {
 		return [
 			['user', 'password'],
-			['user@owncloud.org', 'password'],
+			['user@owncloud.com', 'password'],
 			['user', 'pass@word'],
 			['us:er', 'password'],
 			['user', 'pass:word'],
@@ -44,8 +44,8 @@ class ErrorHandlerTest extends \Test\TestCase {
 	 * @param string $password
 	 */
 	public function testRemovePassword($username, $password) {
-		$url = 'http://'.$username.':'.$password.'@owncloud.org';
-		$expectedResult = 'http://xxx:xxx@owncloud.org';
+		$url = 'http://'.$username.':'.$password.'@owncloud.com';
+		$expectedResult = 'http://xxx:xxx@owncloud.com';
 		$result = TestableErrorHandler::testRemovePassword($url);
 
 		$this->assertEquals($expectedResult, $result);

--- a/tests/lib/HTTPHelperTest.php
+++ b/tests/lib/HTTPHelperTest.php
@@ -31,14 +31,14 @@ class HTTPHelperTest extends \Test\TestCase {
 
 	public function isHttpTestData() {
 		return [
-			['http://wwww.owncloud.org/enterprise/', true],
-			['https://wwww.owncloud.org/enterprise/', true],
-			['HTTPS://WWW.OWNCLOUD.ORG', true],
-			['HTTP://WWW.OWNCLOUD.ORG', true],
-			['FILE://WWW.OWNCLOUD.ORG', false],
-			['file://www.owncloud.org', false],
-			['FTP://WWW.OWNCLOUD.ORG', false],
-			['ftp://www.owncloud.org', false],
+			['http://wwww.owncloud.com/enterprise/', true],
+			['https://wwww.owncloud.com/enterprise/', true],
+			['HTTPS://WWW.OWNCLOUD.COM', true],
+			['HTTP://WWW.OWNCLOUD.COM', true],
+			['FILE://WWW.OWNCLOUD.COM', false],
+			['file://www.owncloud.com', false],
+			['FTP://WWW.OWNCLOUD.COM', false],
+			['ftp://www.owncloud.com', false],
 		];
 	}
 
@@ -62,7 +62,7 @@ class HTTPHelperTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('post')
 			->with(
-				'https://owncloud.org',
+				'https://owncloud.com',
 				[
 					'body' => [
 						'Foo' => 'Bar',
@@ -77,7 +77,7 @@ class HTTPHelperTest extends \Test\TestCase {
 			->method('getBody')
 			->will($this->returnValue('Body of the requested page'));
 
-		$response = $this->httpHelperMock->post('https://owncloud.org', ['Foo' => 'Bar']);
+		$response = $this->httpHelperMock->post('https://owncloud.com', ['Foo' => 'Bar']);
 		$expected = [
 			'success' => true,
 			'result' => 'Body of the requested page'
@@ -96,7 +96,7 @@ class HTTPHelperTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('post')
 			->with(
-				'https://owncloud.org',
+				'https://owncloud.com',
 				[
 					'body' => [
 						'Foo' => 'Bar',
@@ -107,7 +107,7 @@ class HTTPHelperTest extends \Test\TestCase {
 			)
 			->will($this->throwException(new \Exception('Something failed')));
 
-		$response = $this->httpHelperMock->post('https://owncloud.org', ['Foo' => 'Bar']);
+		$response = $this->httpHelperMock->post('https://owncloud.com', ['Foo' => 'Bar']);
 		$expected = [
 			'success' => false,
 			'result' => 'Something failed'

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -102,7 +102,7 @@ class MailerTest extends TestCase {
 			['lukas@éxämplè.com', true],
 			['españa@domain.com', true],
 			['asdf', false],
-			['lukas@owncloud.org@owncloud.com', false]
+			['lukas@domain.com@owncloud.com', false]
 		];
 	}
 

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -948,9 +948,9 @@ class ShareTest extends \Test\TestCase {
 
 	public function urls() {
 		return [
-			['http://owncloud.org', 'owncloud.org'],
-			['https://owncloud.org', 'owncloud.org'],
-			['owncloud.org', 'owncloud.org'],
+			['http://owncloud.com', 'owncloud.com'],
+			['https://owncloud.com', 'owncloud.com'],
+			['owncloud.com', 'owncloud.com'],
 		];
 	}
 

--- a/tests/lib/Updater/VersionCheckTest.php
+++ b/tests/lib/Updater/VersionCheckTest.php
@@ -60,8 +60,8 @@ class VersionCheckTest extends TestCase {
 		$expectedResult = [
 			'version' => '8.0.4.2',
 			'versionstring' => 'ownCloud 8.0.4',
-			'url' => 'https://download.owncloud.org/community/owncloud-8.0.4.zip',
-			'web' => 'http://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
+			'url' => 'https://download.owncloud.com/community/owncloud-8.0.4.zip',
+			'web' => 'http://doc.owncloud.com/server/8.0/admin_manual/maintenance/upgrade.html',
 		];
 
 		$this->config
@@ -82,8 +82,8 @@ class VersionCheckTest extends TestCase {
 		$expectedResult = [
 			'version' => '8.0.4.2',
 			'versionstring' => 'ownCloud 8.0.4',
-			'url' => 'https://download.owncloud.org/community/owncloud-8.0.4.zip',
-			'web' => 'http://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html',
+			'url' => 'https://download.owncloud.com/community/owncloud-8.0.4.zip',
+			'web' => 'http://doc.owncloud.com/server/8.0/admin_manual/maintenance/upgrade.html',
 		];
 
 		$this->config
@@ -119,8 +119,8 @@ class VersionCheckTest extends TestCase {
 <owncloud>
   <version>8.0.4.2</version>
   <versionstring>ownCloud 8.0.4</versionstring>
-  <url>https://download.owncloud.org/community/owncloud-8.0.4.zip</url>
-  <web>http://doc.owncloud.org/server/8.0/admin_manual/maintenance/upgrade.html</web>
+  <url>https://download.owncloud.com/community/owncloud-8.0.4.zip</url>
+  <web>http://doc.owncloud.com/server/8.0/admin_manual/maintenance/upgrade.html</web>
 </owncloud>';
 		$this->updater
 			->expects($this->once())


### PR DESCRIPTION
## Description
Backport #39014 to `release-10.8.0`

Some of the changes here actually end up in the release tarball. So backporting this means that 10.8.0 will have better working links into `owncloud.com` docs, changelog and other areas.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
