### PR TITLE
Feature - Allow subadmins to create groups

### DIFF
--- a/apps/provisioning_api/tests/GroupsTest.php
+++ b/apps/provisioning_api/tests/GroupsTest.php
@@ -446,6 +446,12 @@ class GroupsTest extends \Test\TestCase {
 			->method('getUser')
 			->willReturn($iUser);
 
+		$this->subAdminManager
+			->expects($this->once())
+			->method('isSubAdmin')
+			->with($iUser)
+			->willReturn(true);
+
 		$result = $this->api->addGroup([]);
 		$this->assertInstanceOf('OC_OCS_Result', $result);
 		$this->assertTrue($result->succeeded());
@@ -479,6 +485,12 @@ class GroupsTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('getUser')
 			->willReturn($iUser);
+
+		$this->subAdminManager
+			->expects($this->once())
+			->method('isSubAdmin')
+			->with($iUser)
+			->willReturn(true);
 
 		$result = $this->api->addGroup([]);
 		$this->assertInstanceOf('OC_OCS_Result', $result);

--- a/changelog/unreleased/39023
+++ b/changelog/unreleased/39023
@@ -1,0 +1,6 @@
+Enhancement: Allow subadmins to create and remove groups
+
+This allows subadmins the ability to create groups, so that they can assign users to those groups.
+This makes the subadmin feature much more concrete and useful for administration, without needing to use global admins accounts.
+
+https://github.com/owncloud/core/pull/39023

--- a/settings/Controller/GroupsController.php
+++ b/settings/Controller/GroupsController.php
@@ -97,6 +97,8 @@ class GroupsController extends Controller {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 *
 	 * @param string $id
 	 * @return DataResponse
 	 */
@@ -130,6 +132,8 @@ class GroupsController extends Controller {
 	}
 
 	/**
+	 * @NoAdminRequired
+	 *
 	 * @param string $id
 	 * @return DataResponse
 	 */

--- a/settings/templates/users/part.grouplist.php
+++ b/settings/templates/users/part.grouplist.php
@@ -1,14 +1,10 @@
 <ul id="usergrouplist" data-sort-groups="<?php p($_['sortGroups']); ?>">
 	<!-- Add new group -->
-	<?php if ($_['isAdmin']) {
-	?>
 	<li id="newgroup-init">
 		<a href="#">
 			<span><?php p($l->t('Add Group'))?></span>
 		</a>
 	</li>
-	<?php
-} ?>
 	<li id="newgroup-form" style="display: none">
 		<form>
 			<input type="text" id="newgroupname" placeholder="<?php p($l->t('Group')); ?>..." />
@@ -32,13 +28,13 @@
 	<!-- The Admin Group -->
 	<?php foreach ($_["adminGroup"] as $adminGroup): ?>
 		<li data-gid="admin" data-usercount="<?php if ($adminGroup['usercount'] > 0) {
-		p($adminGroup['usercount']);
-	} ?>" class="isgroup">
+	p($adminGroup['usercount']);
+} ?>" class="isgroup">
 			<a href="#"><span class="groupname"><?php p($l->t('Admins')); ?></span></a>
 			<span class="utils">
 				<span class="usercount"><?php if ($adminGroup['usercount'] > 0) {
-		p($adminGroup['usercount']);
-	} ?></span>
+	p($adminGroup['usercount']);
+} ?></span>
 			</span>
 		</li>
 	<?php endforeach; ?>
@@ -51,13 +47,11 @@
 			</a>
 			<span class="utils">
 				<span class="usercount"><?php if ($group['usercount'] > 0) {
-		p($group['usercount']);
-	} ?></span>
-				<?php if ($_['isAdmin']): ?>
+	p($group['usercount']);
+} ?></span>
 				<a href="#" class="action delete" original-title="<?php p($l->t('Delete'))?>">
 					<img src="<?php print_unescaped(image_path('core', 'actions/delete.svg')) ?>" />
 				</a>
-				<?php endif; ?>
 			</span>
 		</li>
 	<?php endforeach; ?>

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -150,6 +150,7 @@ Feature: add groups
     And group "brand-new-group" has been created
     And user "subadmin" has been made a subadmin of group "brand-new-group"
     When user "subadmin" tries to send a group creation request for group "another-new-group" using the provisioning API
-    Then the OCS status code should be "997"
-    And the HTTP status code should be "401"
-    And group "another-new-group" should not exist
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group "another-new-group" should exist
+    And user "subadmin" should be a subadmin of group "another-new-group"


### PR DESCRIPTION
## Description
This allows subadmins the ability to create groups, so that they can assign users to those groups.  This makes the subadmin 
feature much more *concrete* and useful for administration, without needing to use risky global admins accounts.

## Motivation and Context
Global admin accounts should be used sparingly and with a large userbase, using 'managers' aka subadmins alleviates this need greatly.  Subadmins are currently very limited, this PR enables us to use subadmins to create groups (becoming subadmins) and also remove groups they are managers of (this was already existing functionality).

This is also an approach to tackle the 'resharing' issue we have had raised many times (ie. A shares resource (1) with B, B shares (1) with C, A can't see that (1) was shared with C.  By sharing with groups this changes the approach and solves the problem.  If only global admins can create groups, this severely limits this approach in terms of practicality.

I plan to add unit tests once I know this concept is blessed.

## How Has This Been Tested?
Tested via OC10 UI and **owncloud-sdk** API.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added (I will look at this once I know the concept is blessed)
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
