### PR TITLE
Move all doc-links to a collected space, Add command to verify all available doc links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ TEST_DATABASE=sqlite
 TEST_EXTERNAL_ENV=smb-silvershell
 TEST_PHP_SUITE=
 
+DOC_LINK_VERSION=
+
 # Acceptance test flags (for shells supporting autocompletion of makefiles, eg: zsh)
 TEST_SERVER_URL?=
 TEST_SERVER_FED_URL?=
@@ -133,6 +135,11 @@ help:
 	@echo -e "make test-php-style-fix\t\trun PHP code style checks and fix any issues found"
 	@echo -e "make update-php-license-header\tUpdate license headers"
 	@echo -e "make changelog\t\t\tGenerate the CHANGELOG.md file for testing"
+	@echo
+	@echo -e "make test-doc-links\t\tTest if the doc links are valid"
+	@echo
+	@echo It is also possible to specify the ownCloud version to look for in the docs:
+	@echo -e "make test-doc-links DOC_LINK_VERSION=10.7"
 
 
 #
@@ -260,6 +267,10 @@ docs: docs-js
 .PHONY: clean-docs
 clean-docs:
 	rm -Rf build/jsdocs
+
+.PHONY: test-doc-links
+test-doc-links: 
+	php tests/docs/DocLinksTest.php $(DOC_LINK_VERSION)
 
 #
 # Build distribution

--- a/apps/federatedfilesharing/templates/settings-admin.php
+++ b/apps/federatedfilesharing/templates/settings-admin.php
@@ -8,7 +8,7 @@ script('federatedfilesharing', 'settings-admin');
 	<h2 class="app-name has-documentation"><?php p($l->t('Federated Cloud Sharing'));?></h2>
 	<a target="_blank" rel="noreferrer" class="icon-info"
 		title="<?php p($l->t('Open documentation'));?>"
-		href="<?php p(link_to_docs('admin-sharing-federated')); ?>"></a>
+		href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_SHARING_FEDERATED)); ?>"></a>
 
 	<p>
 		<input type="checkbox" name="cronjob_scan_external_enabled" id="cronjobScanExternalEnabled" class="checkbox"

--- a/apps/files/templates/appnavigation.php
+++ b/apps/files/templates/appnavigation.php
@@ -24,7 +24,7 @@
 			</div>
 			<label for="webdavurl"><?php p($l->t('WebDAV'));?></label>
 			<input id="webdavurl" type="text" readonly="readonly" value="<?php p($_['webdavUrl']); ?>" />
-			<em><?php print_unescaped($l->t('Use this address to <a href="%s" target="_blank" rel="noreferrer">access your Files via WebDAV</a>', [link_to_docs('user-webdav')]));?></em>
+			<em><?php print_unescaped($l->t('Use this address to <a href="%s" target="_blank" rel="noreferrer">access your Files via WebDAV</a>', [link_to_docs(\OCP\Constants::DOCS_USER_WEB_DAV)]));?></em>
 		</div>
 	</div>
 </div>

--- a/changelog/unreleased/39026
+++ b/changelog/unreleased/39026
@@ -1,0 +1,8 @@
+Enhancement: Add command to verify all available doc links
+
+All available doc links can now be tested and verified via `make test-doc-links`. It is also possible to 
+specify the ownCloud version to look for in the docs via `make test-doc-links DOC_LINK_VERSION=10.7`.
+It defaults to the ownCloud version of the current installation.
+
+https://github.com/owncloud/core/pull/39026
+https://github.com/owncloud/enterprise/issues/4671

--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -8,7 +8,7 @@ style('core', ['styles', 'header']);
 	<h2><strong><?php p($l->t('Internal Server Error')) ?></strong></h2>
 		<p><?php p($l->t('The server encountered an internal error and was unable to complete your request.')) ?></p>
 		<p><?php p($l->t('Please contact the server administrator if this error reappears multiple times and include the technical details below in your report.')) ?></p>
-		<p><?php print_unescaped($l->t('More details can be found in the <a target="_blank" rel="noreferrer" href="%s">server log</a>.', [link_to_docs('admin-logfiles')])); ?></p>
+		<p><?php print_unescaped($l->t('More details can be found in the <a target="_blank" rel="noreferrer" href="%s">server log</a>.', [link_to_docs(\OCP\Constants::DOCS_ADMIN_LOG_FILES)])); ?></p>
 	<br>
 
 	<h2><strong><?php p($l->t('Technical details')) ?></strong></h2>

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -77,7 +77,7 @@ script('core', [
 		<p class="info">
 			<?php p($l->t('Only %s is available.', [$label])); ?>
 			<?php p($l->t('Install and activate additional PHP modules to choose other database types.')); ?><br>
-			<a href="<?php print_unescaped(link_to_docs('admin-source_install')); ?>" target="_blank" rel="noreferrer">
+			<a href="<?php print_unescaped(link_to_docs(\OCP\Constants::DOCS_ADMIN_SOURCE_INSTALL)); ?>" target="_blank" rel="noreferrer">
 				<?php p($l->t('For more details check out the documentation.')); ?> ↗</a>
 		</p>
 		<input type="hidden" id="dbtype" name="dbtype" value="<?php p($type) ?>">
@@ -164,6 +164,6 @@ script('core', [
 	<p class="info">
 		<span class="icon-info-white"></span>
 		<?php p($l->t('Need help?'));?>
-		<a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('admin-install')); ?>"><?php p($l->t('See the documentation'));?> ↗</a>
+		<a target="_blank" rel="noreferrer" href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_INSTALL)); ?>"><?php p($l->t('See the documentation'));?> ↗</a>
 	</p>
 </form>

--- a/core/templates/untrustedDomain.php
+++ b/core/templates/untrustedDomain.php
@@ -6,7 +6,7 @@
 
 		<p class='hint'>
 			<?php p($l->t('Please contact your administrator. If you are an administrator of this instance, configure the "trusted_domains" setting in config/config.php. ')) ?>
-			<?php print_unescaped($l->t('An example configuration is provided in config/config.sample.php or at the <a target="_blank" rel="noreferrer" href="%s">documentation</a>.', [link_to_docs('admin-untrusted-domain')])); ?>
+			<?php print_unescaped($l->t('An example configuration is provided in config/config.sample.php or at the <a target="_blank" rel="noreferrer" href="%s">documentation</a>.', [link_to_docs(\OCP\Constants::DOCS_ADMIN_UNTRUSTED_DOMAIN)])); ?>
 		</p>
 	</li>
 </ul>

--- a/core/templates/update.use-cli.php
+++ b/core/templates/update.use-cli.php
@@ -8,7 +8,7 @@
 	p($l->t('Automatic updating is disabled in config.php. To upgrade your instance, please use the command line updater (occ upgrade).'));
 } ?><br><br>
 			<?php
-			print_unescaped($l->t('For help, see the  <a target="_blank" rel="noreferrer" href="%s">documentation</a>.', [link_to_docs('admin-cli-upgrade')])); ?><br><br>
+			print_unescaped($l->t('For help, see the  <a target="_blank" rel="noreferrer" href="%s">documentation</a>.', [link_to_docs(\OCP\Constants::DOCS_ADMIN_CLI_UPGRADE)])); ?><br><br>
 		</div>
 	</div>
 </div>

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -256,10 +256,11 @@ class URLGenerator implements IURLGenerator {
 
 	/**
 	 * @param string $key
+	 * @param string|null $ocVersion ownCloud version to look for in the docs. Defaults to the version of this onwCloud instance
 	 * @return string url to the online documentation
 	 */
-	public function linkToDocs($key) {
+	public function linkToDocs($key, $ocVersion = null) {
 		$theme = new OC_Defaults();
-		return $theme->buildDocLinkToKey($key);
+		return $theme->buildDocLinkToKey($key, $ocVersion);
 	}
 }

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -285,12 +285,20 @@ class OC_Defaults {
 
 	/**
 	 * @param string $key
+	 * @param string|null $ocVersion ownCloud version to look for in the docs. Defaults to the version of this onwCloud instance
 	 */
-	public function buildDocLinkToKey($key) {
+	public function buildDocLinkToKey($key, $ocVersion = null) {
 		if ($this->themeExist('buildDocLinkToKey')) {
 			return $this->theme->buildDocLinkToKey($key);
 		}
-		return $this->getDocBaseUrl() . '/server/' . $this->defaultDocVersion . '/go.php?to=' . $key;
+
+		if ($ocVersion) {
+			$version = $ocVersion;
+		} else {
+			$version = $this->defaultDocVersion;
+		}
+
+		return $this->getDocBaseUrl() . '/server/' . $version . '/go.php?to=' . $key;
 	}
 
 	/**

--- a/lib/public/Constants.php
+++ b/lib/public/Constants.php
@@ -52,4 +52,30 @@ class Constants {
 	 * longer support windows as server platform.
 	 */
 	public const FILENAME_INVALID_CHARS = "\\/";
+
+	/**
+	 * Doc links.
+	 * @since 10.9.0
+	 */
+	public const DOCS_ADMIN_EMAIL = 'admin-email';
+	public const DOCS_ADMIN_BACKUP = 'admin-backup';
+	public const DOCS_ADMIN_CONFIG = 'admin-config';
+	public const DOCS_ADMIN_SHARING = 'admin-sharing';
+	public const DOCS_ADMIN_PHP_FPM = 'admin-php-fpm';
+	public const DOCS_ADMIN_INSTALL = 'admin-install';
+	public const DOCS_ADMIN_SECURITY = 'admin-security';
+	public const DOCS_ADMIN_LOG_FILES = 'admin-logfiles';
+	public const DOCS_ADMIN_ENCRYPTION = 'admin-encryption';
+	public const DOCS_ADMIN_PERFORMANCE = 'admin-performance';
+	public const DOCS_ADMIN_CLI_UPGRADE = 'admin-cli-upgrade';
+	public const DOCS_ADMIN_DB_CONVERSION = 'admin-db-conversion';
+	public const DOCS_ADMIN_SOURCE_INSTALL = 'admin-source_install';
+	public const DOCS_ADMIN_BACKGROUND_JOBS = 'admin-background-jobs';
+	public const DOCS_ADMIN_UNTRUSTED_DOMAIN = 'admin-untrusted-domain';
+	public const DOCS_ADMIN_SHARING_FEDERATED = 'admin-sharing-federated';
+	public const DOCS_ADMIN_TRANSACTIONAL_LOCKING = 'admin-transactional-locking';
+
+	public const DOCS_USER_WEB_DAV = 'user-webdav';
+
+	public const DOCS_DEVELOPER_THEMING = 'developer-theming';
 }

--- a/lib/public/IURLGenerator.php
+++ b/lib/public/IURLGenerator.php
@@ -85,8 +85,9 @@ interface IURLGenerator {
 
 	/**
 	 * @param string $key
+	 * @param string|null $ocVersion ownCloud version to look for in the docs. Defaults to the version of this onwCloud instance
 	 * @return string url to the online documentation
 	 * @since 8.0.0
 	 */
-	public function linkToDocs($key);
+	public function linkToDocs($key, $ocVersion = null);
 }

--- a/settings/templates/panels/admin/backgroundjobs.php
+++ b/settings/templates/panels/admin/backgroundjobs.php
@@ -31,7 +31,7 @@ script('settings', 'panels/backgroundjobs');
 	<?php endif; ?>
 	<a target="_blank" rel="noreferrer" class="icon-info"
 		title="<?php p($l->t('Open documentation'));?>"
-		href="<?php p(link_to_docs('admin-background-jobs')); ?>"></a>
+		href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_BACKGROUND_JOBS)); ?>"></a>
 	<p>
 		<input type="radio" name="mode" class="radio" value="ajax"
 			   id="backgroundjobs_ajax" <?php if ($_['backgroundjobs_mode'] === "ajax") {

--- a/settings/templates/panels/admin/encryption.php
+++ b/settings/templates/panels/admin/encryption.php
@@ -2,7 +2,7 @@
 	<h2 class="app-name has-documentation"><?php p($l->t('Server-side encryption')); ?></h2>
 	<a target="_blank" rel="noreferrer" class="icon-info"
 		title="<?php p($l->t('Open documentation'));?>"
-		href="<?php p(link_to_docs('admin-encryption')); ?>"></a>
+		href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_ENCRYPTION)); ?>"></a>
 
 	<p id="enable">
 		<input type="checkbox"

--- a/settings/templates/panels/admin/filesharing.php
+++ b/settings/templates/panels/admin/filesharing.php
@@ -6,7 +6,7 @@
 	<h2 class="app-name has-documentation"><?php p($l->t('Sharing'));?></h2>
 	<a target="_blank" rel="noreferrer" class="icon-info"
 		title="<?php p($l->t('Open documentation'));?>"
-		href="<?php p(link_to_docs('admin-sharing')); ?>"></a>
+		href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_SHARING)); ?>"></a>
 	<p id="enable">
 		<input type="checkbox" name="shareapi_enabled" id="shareAPIEnabled" class="checkbox"
 			   value="1" <?php if ($_['shareAPIEnabled'] === 'yes') {

--- a/settings/templates/panels/admin/mail.php
+++ b/settings/templates/panels/admin/mail.php
@@ -25,7 +25,7 @@ if ($_['mail_smtpmode'] == 'qmail') {
 	<h2 class="app-name has-documentation"><?php p($l->t('Email server'));?></h2>
 	<a target="_blank" rel="noreferrer" class="icon-info"
 	   title="<?php p($l->t('Open documentation'));?>"
-	   href="<?php p(link_to_docs('admin-email')); ?>"></a>
+	   href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_EMAIL)); ?>"></a>
 	<?php if ($_['read-only']) : ?>
 		<p>
 			<?php p($l->t('The config file is read only. Please adjust your setup by editing the config file manually.')); ?>

--- a/settings/templates/panels/admin/securitywarning.php
+++ b/settings/templates/panels/admin/securitywarning.php
@@ -16,7 +16,7 @@ script('settings', 'panels/setupchecks');
 		?>
 		<li>
 			<?php p($l->t('php does not seem to be setup properly to query system environment variables. The test with getenv("PATH") only returns an empty response.')); ?><br>
-			<?php print_unescaped($l->t('Please check the <a target="_blank" rel="noreferrer" href="%s">installation documentation ↗</a> for php configuration notes and the php configuration of your server, especially when using php-fpm.', link_to_docs('admin-php-fpm'))); ?>
+			<?php print_unescaped($l->t('Please check the <a target="_blank" rel="noreferrer" href="%s">installation documentation ↗</a> for php configuration notes and the php configuration of your server, especially when using php-fpm.', link_to_docs(\OCP\Constants::DOCS_ADMIN_PHP_FPM))); ?>
 		</li>
 	<?php
 	}
@@ -65,13 +65,13 @@ script('settings', 'panels/setupchecks');
 	if ($_['fileLockingType'] === 'none') {
 		?>
 		<li>
-			<?php print_unescaped($l->t('Transactional file locking is disabled, this might lead to issues with race conditions. Enable \'filelocking.enabled\' in config.php to avoid these problems. See the <a target="_blank" rel="noreferrer" href="%s">documentation ↗</a> for more information.', link_to_docs('admin-transactional-locking'))); ?>
+			<?php print_unescaped($l->t('Transactional file locking is disabled, this might lead to issues with race conditions. Enable \'filelocking.enabled\' in config.php to avoid these problems. See the <a target="_blank" rel="noreferrer" href="%s">documentation ↗</a> for more information.', link_to_docs(\OCP\Constants::DOCS_ADMIN_TRANSACTIONAL_LOCKING))); ?>
 		</li>
 		<?php
 	} elseif ($_['fileLockingType'] === 'db') {
 		?>
 		<li>
-			<?php print_unescaped($l->t('Transactional file locking should be configured to use memory-based locking, not the default slow database-based locking. See the <a target="_blank" rel="noreferrer" href="%s">documentation ↗</a> for more information.', link_to_docs('admin-transactional-locking'))); ?>
+			<?php print_unescaped($l->t('Transactional file locking should be configured to use memory-based locking, not the default slow database-based locking. See the <a target="_blank" rel="noreferrer" href="%s">documentation ↗</a> for more information.', link_to_docs(\OCP\Constants::DOCS_ADMIN_TRANSACTIONAL_LOCKING))); ?>
 		</li>
 		<?php
 	}
@@ -105,7 +105,7 @@ script('settings', 'panels/setupchecks');
 		<li>
 			<?php p($l->t('SQLite is used as database. For larger installations we recommend to switch to a different database backend.')); ?><br>
 			<?php p($l->t('Especially when using the desktop client for file syncing the use of SQLite is discouraged.')); ?><br>
-			<?php print_unescaped($l->t('To migrate to another database use the command line tool: \'occ db:convert-type\', or see the <a target="_blank" rel="noreferrer" href="%s">documentation ↗</a>.', link_to_docs('admin-db-conversion'))); ?>
+			<?php print_unescaped($l->t('To migrate to another database use the command line tool: \'occ db:convert-type\', or see the <a target="_blank" rel="noreferrer" href="%s">documentation ↗</a>.', link_to_docs(\OCP\Constants::DOCS_ADMIN_DB_CONVERSION))); ?>
 		</li>
 
 		<?php
@@ -148,7 +148,7 @@ script('settings', 'panels/setupchecks');
 		<ul class="warnings hidden"></ul>
 		<ul class="info hidden"></ul>
 		<p class="hint hidden">
-			<?php print_unescaped($l->t('Please double check the <a target="_blank" rel="noreferrer" href="%s">installation guides ↗</a>, and check for any errors or warnings in the <a href="#log-section">log</a>.', link_to_docs('admin-install'))); ?>
+			<?php print_unescaped($l->t('Please double check the <a target="_blank" rel="noreferrer" href="%s">installation guides ↗</a>, and check for any errors or warnings in the <a href="#log-section">log</a>.', link_to_docs(\OCP\Constants::DOCS_ADMIN_INSTALL))); ?>
 		</p>
 	</div>
 	<div id="security-warning-state">

--- a/settings/templates/panels/admin/tips.php
+++ b/settings/templates/panels/admin/tips.php
@@ -8,10 +8,10 @@
 <div id="admin-tips" class="section">
 	<h2 class="app-name"><?php p($l->t('Tips & tricks'));?></h2>
 	<ul>
-		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('admin-backup')); ?>"><?php p($l->t('How to do backups'));?> ↗</a></li>
-		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('admin-performance')); ?>"><?php p($l->t('Performance tuning'));?> ↗</a></li>
-		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('admin-config')); ?>"><?php p($l->t('Improving the config.php'));?> ↗</a></li>
-		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('developer-theming')); ?>"><?php p($l->t('Theming'));?> ↗</a></li>
-		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs('admin-security')); ?>"><?php p($l->t('Hardening and security guidance'));?> ↗</a></li>
+		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_BACKUP)); ?>"><?php p($l->t('How to do backups'));?> ↗</a></li>
+		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_PERFORMANCE)); ?>"><?php p($l->t('Performance tuning'));?> ↗</a></li>
+		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_CONFIG)); ?>"><?php p($l->t('Improving the config.php'));?> ↗</a></li>
+		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs(\OCP\Constants::DOCS_DEVELOPER_THEMING)); ?>"><?php p($l->t('Theming'));?> ↗</a></li>
+		<li><a target="_blank" rel="noreferrer" href="<?php p(link_to_docs(\OCP\Constants::DOCS_ADMIN_SECURITY)); ?>"><?php p($l->t('Hardening and security guidance'));?> ↗</a></li>
 	</ul>
 </div>

--- a/tests/docs/DocLinksTest.php
+++ b/tests/docs/DocLinksTest.php
@@ -25,7 +25,7 @@ class TestDocLinksCommand extends Command {
 			->addArgument(
 				'version',
 				InputArgument::OPTIONAL,
-				'The ownCloud version to look for in the docs. Defaults to the latest version.'
+				'The ownCloud version to look for in the docs. Defaults to the current version of this ownCloud instance.'
 			);
 	}
 

--- a/tests/docs/DocLinksTest.php
+++ b/tests/docs/DocLinksTest.php
@@ -1,0 +1,73 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+
+require_once __DIR__ . '/../../lib/base.php';
+
+\set_time_limit(0);
+
+if (!\OC::$CLI) {
+	echo "This script can be run from the command line only" . PHP_EOL;
+	exit(1);
+}
+
+class TestDocLinksCommand extends Command {
+	protected static $defaultName = 'testDocLinks';
+
+	protected function configure() {
+		$this
+			->addArgument(
+				'version',
+				InputArgument::OPTIONAL,
+				'The ownCloud version to look for in the docs. Defaults to the latest version.'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$ocVersion = $input->getArgument('version');
+		if (!$ocVersion) {
+			$versionArr = \OCP\Util::getVersion();
+			$ocVersion = $versionArr[0] . '.' . $versionArr[1];
+		}
+
+		$urlGenerator = \OC::$server->getURLGenerator();
+		$client = \OC::$server->getHTTPClientService()->newClient();
+
+		$reflectionClass = new \ReflectionClass(\OCP\Constants::class);
+		$constants = $reflectionClass->getConstants();
+		$errorsOccurred = false;
+
+		foreach ($constants as $constName => $identifier) {
+			if (strpos($constName, 'DOCS_') === 0) {
+				$docLink = $urlGenerator->linkToDocs($identifier, $ocVersion);
+				try {
+					$client->head($docLink);
+				} catch (\Exception $e) {
+					$errorsOccurred = true;
+					$errCode = $e->getCode();
+					$output->writeln("<error>Doclink for '$identifier' failed with status code $errCode: $docLink</error>");
+				}
+			}
+		}
+
+		if (!$errorsOccurred) {
+			$output->writeln("<info>All doclinks are valid!</info>");
+		}
+
+		return Command::SUCCESS;
+	}
+}
+
+$application = new Application();
+
+$command = new TestDocLinksCommand();
+
+$application->add($command);
+$application->setDefaultCommand($command->getName(), true);
+$application->run(new ArgvInput());


### PR DESCRIPTION
## Description
All available doc links can now be tested and verified via `make test-doc-links`. It is also possible to 
specify the ownCloud version to look for in the docs via `make test-doc-links DOC_LINK_VERSION=10.7`.
It defaults to the ownCloud version of the current installation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Links with https://github.com/owncloud/enterprise/issues/4671

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/3900 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
