### PR TITLE
[tests-only] Tidy up 'on the webUI' in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -994,7 +994,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			$expectedElements,
 			$currentUploadedElements,
 			__METHOD__
-			. " The elements expected to be listed as uploaded items on the webUI do not equal the uploaded elements visible in the webUI"
+			. " The elements expected to be listed as uploaded items on the webUI do not equal the uploaded elements visible on the webUI"
 			. "See the differences below:"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUITagsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUITagsContext.php
@@ -196,7 +196,7 @@ class WebUITagsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the following tags should be displayed in the tag list in the webUI$/
+	 * @Then /^the following tags should be displayed in the tag list on the webUI$/
 	 *
 	 * @param TableNode $tags
 	 *
@@ -210,7 +210,7 @@ class WebUITagsContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the following tags should be displayed in the tag input field in the webUI$/
+	 * @Then /^the following tags should be displayed in the tag input field on the webUI$/
 	 *
 	 * @param TableNode $tags
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIUserContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUserContext.php
@@ -49,7 +49,7 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then :displayname should be shown as the name of the current user on the WebUI
+	 * @Then :displayname should be shown as the name of the current user on the webUI
 	 *
 	 * @param string $displayname
 	 *
@@ -65,7 +65,7 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the display name should (not|)\s?be visible on the WebUI$/
+	 * @Then /^the display name should (not|)\s?be visible on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 *
@@ -89,7 +89,7 @@ class WebUIUserContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^(no|an) avatar should be shown for the current user on the WebUI$/
+	 * @Then /^(no|an) avatar should be shown for the current user on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 *

--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -13,7 +13,7 @@ Feature: edit users
     When the administrator changes the display name of user "Alice" to "New User" using the webUI
     And the administrator logs out of the webUI
     And user "Alice" logs in using the webUI
-    Then "New User" should be shown as the name of the current user on the WebUI
+    Then "New User" should be shown as the name of the current user on the webUI
     And user "Alice" should exist
     And the user attributes returned by the API should include
       | displayname | New User |

--- a/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/accessToChangeFullNameThroughConfig.feature
@@ -13,7 +13,7 @@ Feature: Control access to edit fullname of user through config file
     And the user browses to the personal general settings page
     And the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
     And the user reloads the current page of the webUI
-    Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the WebUI
+    Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the webUI
     And the attributes of user "Alice" returned by the API should include
       | displayname | my#very&weird?नेपालि%name |
 

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnFullName.feature
@@ -13,6 +13,6 @@ Feature: Change own full name on the personal settings page
   Scenario: Change full name
     When the user changes the full name to "my#very&weird?नेपालि%name" using the webUI
     And the user reloads the current page of the webUI
-    Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the WebUI
+    Then "my#very&weird?नेपालि%name" should be shown as the name of the current user on the webUI
     And the attributes of user "Alice" returned by the API should include
       | displayname | my#very&weird?नेपालि%name |

--- a/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
@@ -340,7 +340,7 @@ Feature: Share by public link
     And public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
 
   @skipOnOcV10.3
-  Scenario: sharing detail of items in the webUI shared by public links with empty name
+  Scenario: sharing detail of items on the webUI shared by public links with empty name
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
     And user "Alice" has created a public link share with settings

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -27,11 +27,11 @@ Feature: Creation of tags for the files and folders
     And the user switches to the "tags" tab in the details panel using the webUI
     And the user adds a tag "Top Secret Uppercase" to the file using the webUI
     And the user adds a tag "confidential lowercase" to the file using the webUI
-    Then the following tags should be displayed in the tag list in the webUI
+    Then the following tags should be displayed in the tag list on the webUI
       | name                   |
       | Top Secret Uppercase   |
       | confidential lowercase |
-    And the following tags should be displayed in the tag input field in the webUI
+    And the following tags should be displayed in the tag input field on the webUI
       | name                   |
       | Top Secret Uppercase   |
       | confidential lowercase |
@@ -46,11 +46,11 @@ Feature: Creation of tags for the files and folders
     And the user switches to the "tags" tab in the details panel using the webUI
     And the user adds a tag "Top Secret" to the file using the webUI
     And the user adds a tag "top secret" to the file using the webUI
-    Then the following tags should be displayed in the tag list in the webUI
+    Then the following tags should be displayed in the tag list on the webUI
       | name       |
       | Top Secret |
       | top secret |
-    And the following tags should be displayed in the tag input field in the webUI
+    And the following tags should be displayed in the tag input field on the webUI
       | name       |
       | Top Secret |
       | top secret |


### PR DESCRIPTION
## Description
Consistently use the phrase "on the webUI" in core acceptance tests.

## Related Issue
- part of https://github.com/owncloud/web/issues/5545

## Motivation and Context
Be consistent in core tests.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
