### PR TITLE
Fix file_exists call to avoid open_basedir log message

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -114,7 +114,7 @@ class ViewController extends Controller {
 		$content = '';
 		$appPath = \OC_App::getAppPath($appName);
 		$scriptPath = $appPath . '/' . $scriptName;
-		if (\file_exists($scriptPath)) {
+		if ($appPath !== false && \file_exists($scriptPath)) {
 			// TODO: sanitize path / script name ?
 			\ob_start();
 			include $scriptPath;

--- a/changelog/unreleased/39034
+++ b/changelog/unreleased/39034
@@ -1,0 +1,11 @@
+Bugfix: avoid potential open_basedir errors after upgrade to PHP 7.4.21
+
+PHP 7.4.21 checks open_basedir settings more exactly. Calls to file_exists can
+emit log messages like "file_exists(): open_basedir restriction in effect" that
+were not emitted by PHP 7.4.20.
+
+This change fixes an incorrect file_exists check. The open_basedir message will
+no longer be emitted in this case.
+
+https://github.com/owncloud/core/issues/39034
+https://github.com/owncloud/core/pull/39035

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -222,7 +222,7 @@ class Installer {
 		$info = self::checkAppsIntegrity($info, $extractDir, $path, $isShipped);
 
 		$currentDir = OC_App::getAppPath($info['id']);
-		if (\is_dir("$currentDir/.git")) {
+		if ($currentDir !== false && \is_dir("$currentDir/.git")) {
 			throw new AppAlreadyInstalledException("App <{$info['id']}> is a git clone - it will not be updated.");
 		}
 
@@ -529,7 +529,7 @@ class Installer {
 			$ms = new MigrationService($app, \OC::$server->getDatabaseConnection());
 			$ms->migrate();
 		} else {
-			if (\is_file($appPath.'/appinfo/database.xml')) {
+			if ($appPath !== false && \is_file($appPath.'/appinfo/database.xml')) {
 				\OC::$server->getLogger()->debug('Create app database from schema file');
 				OC_DB::createDbFromStructure($appPath . '/appinfo/database.xml');
 			}

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -130,8 +130,9 @@ class Router implements IRouter {
 			if (isset($this->loadedApps[$app])) {
 				return;
 			}
-			$file = \OC_App::getAppPath($app) . '/appinfo/routes.php';
-			if ($file !== false && \file_exists($file)) {
+			$appPath = \OC_App::getAppPath($app);
+			$file = $appPath . '/appinfo/routes.php';
+			if ($appPath !== false && \file_exists($file)) {
 				$routingFiles = [$app => $file];
 			} else {
 				$routingFiles = [];

--- a/settings/Controller/SettingsPageController.php
+++ b/settings/Controller/SettingsPageController.php
@@ -122,7 +122,7 @@ class SettingsPageController extends Controller {
 		$icon = $section->getIconName() . '.svg';
 		$appPath = \OC_App::getAppPath($section->getID());
 
-		if (\file_exists($appPath . '/img/' . $icon)) {
+		if ($appPath !== false && \file_exists($appPath . '/img/' . $icon)) {
 			$icon = $this->urlGenerator->imagePath($section->getID(), $icon);
 		} else {
 			$icon = $section->getIconName();


### PR DESCRIPTION
## Description
PHP 7.4.21 checks open_basedir settings more exactly. Calls to file_exists can
emit log messages like "file_exists(): open_basedir restriction in effect" that
were not emitted by PHP 7.4.20. 

This change fixes an incorrect file_exists check. The open_basedir message will
no longer be emitted in this case.

The PHP 7.4.21 changelog https://www.php.net/ChangeLog-7.php has a fix https://bugs.php.net/bug.php?id=76359
The code of that is https://github.com/php/php-src/pull/7024/files

But I don't see exactly how that change is causing open_basedir to start complaining now.

## Related Issue
- potential fix for #39034 

OP has confirmed that fix works for them: https://github.com/owncloud/core/issues/39034#issuecomment-883359624

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
