### PR TITLE
Detect LDAP connection errors during `occ user:sync`

### DIFF
--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -219,7 +219,6 @@ class SyncBackend extends Command {
 
 		$output->writeln('');
 		$backendClass = \get_class($backend);
-
 		if ($input->getOption('seenOnly')) {
 			$output->writeln("Updating seen accounts from $backendClass ...");
 			$iterator = new SeenUsersIterator($this->accountMapper, $backendClass);

--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -219,12 +219,13 @@ class SyncBackend extends Command {
 
 		$output->writeln('');
 		$backendClass = \get_class($backend);
+
 		if ($input->getOption('seenOnly')) {
 			$output->writeln("Updating seen accounts from $backendClass ...");
 			$iterator = new SeenUsersIterator($this->accountMapper, $backendClass);
 		} else {
 			$output->writeln("Inserting new and updating all known users from $backendClass ...");
-			$iterator = new BackendUsersIterator($backend);
+			$iterator = new BackendUsersIterator($backend, '', true);
 		}
 
 		$progress = new ProgressBar($output);

--- a/lib/private/User/Sync/BackendUsersIterator.php
+++ b/lib/private/User/Sync/BackendUsersIterator.php
@@ -44,11 +44,11 @@ class BackendUsersIterator extends UsersIterator {
 	/** @var string search for the uid string in backend */
 	private $search;
 
-	/** @throws \Exception for the uid string in backend */
-	private $testConnection;
+	/** @var boolean check if backend encountered connections errors */
+	private $checkForConnectionErrors;
 
-	public function __construct(UserInterface $backend, $filterUID = '', $testConnection = false) {
-		$this->testConnection = $testConnection;
+	public function __construct(UserInterface $backend, $filterUID = '', $checkForConnectionErrors = false) {
+		$this->checkForConnectionErrors = $checkForConnectionErrors;
 		$this->backend = $backend;
 		$this->search = $filterUID;
 	}
@@ -57,8 +57,8 @@ class BackendUsersIterator extends UsersIterator {
 		parent::rewind();
 		$this->data = $this->backend->getUsers($this->search, self::LIMIT, 0);
 
-		if($this->testConnection && method_exists($this->backend,'testConnection')){
-			$this->backend->testConnection();
+		if($this->checkForConnectionErrors && method_exists($this->backend,'checkForConnectionErrors')){
+			$this->backend->checkForConnectionErrors();
 		}
 
 		$this->dataPos = 0;
@@ -75,8 +75,8 @@ class BackendUsersIterator extends UsersIterator {
 
 			$this->data = $this->backend->getUsers($this->search, self::LIMIT, $offset);
 
-			if($this->testConnection && method_exists($this->backend,'testConnection')){
-				$this->backend->testConnection();
+			if($this->checkForConnectionErrors && method_exists($this->backend,'testConnection')){
+				$this->backend->checkForConnectionErrors();
 			}
 
 			$this->dataPos = 0;

--- a/lib/private/User/Sync/BackendUsersIterator.php
+++ b/lib/private/User/Sync/BackendUsersIterator.php
@@ -73,7 +73,6 @@ class BackendUsersIterator extends UsersIterator {
 		if ($this->hasMoreData && $this->dataPos >= $this->endPos) {
 			$this->page++;
 			$offset = $this->page * self::LIMIT;
-
 			$this->data = $this->backend->getUsers($this->search, self::LIMIT, $offset);
 
 			// Used to detect LDAP errors, see https://github.com/owncloud/enterprise/issues/4642#issuecomment-885642746

--- a/lib/private/User/Sync/BackendUsersIterator.php
+++ b/lib/private/User/Sync/BackendUsersIterator.php
@@ -44,7 +44,7 @@ class BackendUsersIterator extends UsersIterator {
 	/** @var string search for the uid string in backend */
 	private $search;
 
-	/** @var boolean check if backend encountered connections errors */
+	/** @var boolean check if the backend encountered connection errors after each page */
 	private $checkForConnectionErrors;
 
 	public function __construct(UserInterface $backend, $filterUID = '', $checkForConnectionErrors = false) {
@@ -57,7 +57,8 @@ class BackendUsersIterator extends UsersIterator {
 		parent::rewind();
 		$this->data = $this->backend->getUsers($this->search, self::LIMIT, 0);
 
-		if($this->checkForConnectionErrors && method_exists($this->backend,'checkForConnectionErrors')){
+		// Used to detect LDAP errors, see https://github.com/owncloud/enterprise/issues/4642#issuecomment-885642746
+		if ($this->checkForConnectionErrors && method_exists($this->backend, 'checkForConnectionErrors')) {
 			$this->backend->checkForConnectionErrors();
 		}
 
@@ -75,7 +76,8 @@ class BackendUsersIterator extends UsersIterator {
 
 			$this->data = $this->backend->getUsers($this->search, self::LIMIT, $offset);
 
-			if($this->checkForConnectionErrors && method_exists($this->backend,'testConnection')){
+			// Used to detect LDAP errors, see https://github.com/owncloud/enterprise/issues/4642#issuecomment-885642746
+			if ($this->checkForConnectionErrors && method_exists($this->backend, 'checkForConnectionErrors')) {
 				$this->backend->checkForConnectionErrors();
 			}
 

--- a/lib/private/User/Sync/BackendUsersIterator.php
+++ b/lib/private/User/Sync/BackendUsersIterator.php
@@ -44,7 +44,11 @@ class BackendUsersIterator extends UsersIterator {
 	/** @var string search for the uid string in backend */
 	private $search;
 
-	public function __construct(UserInterface $backend, $filterUID = '') {
+	/** @throws \Exception for the uid string in backend */
+	private $testConnection;
+
+	public function __construct(UserInterface $backend, $filterUID = '', $testConnection = false) {
+		$this->testConnection = $testConnection;
 		$this->backend = $backend;
 		$this->search = $filterUID;
 	}
@@ -52,6 +56,11 @@ class BackendUsersIterator extends UsersIterator {
 	public function rewind() {
 		parent::rewind();
 		$this->data = $this->backend->getUsers($this->search, self::LIMIT, 0);
+
+		if($this->testConnection && method_exists($this->backend,'testConnection')){
+			$this->backend->testConnection();
+		}
+
 		$this->dataPos = 0;
 		$this->endPos = \count($this->data);
 		$this->hasMoreData = $this->endPos >= self::LIMIT;
@@ -63,7 +72,13 @@ class BackendUsersIterator extends UsersIterator {
 		if ($this->hasMoreData && $this->dataPos >= $this->endPos) {
 			$this->page++;
 			$offset = $this->page * self::LIMIT;
+
 			$this->data = $this->backend->getUsers($this->search, self::LIMIT, $offset);
+
+			if($this->testConnection && method_exists($this->backend,'testConnection')){
+				$this->backend->testConnection();
+			}
+
 			$this->dataPos = 0;
 			$this->endPos = \count($this->data);
 			$this->hasMoreData = $this->endPos >= self::LIMIT;


### PR DESCRIPTION
## Description
Needs https://github.com/owncloud/user_ldap/pull/669 to work properly.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4642

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
