### PR TITLE
[tests-only] Match getcontenttype starting with text/plain in test

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-57
+@api
 Feature: set file properties
   As a user
   I want to be able to set meta-information about files

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -242,7 +242,7 @@ Feature: get file properties
       | /remote.php/dav/files/does-not-exist | Principal with name does-not-exist not found |
       | /remote.php/dav/does-not-exist       | File not found: does-not-exist in 'root'     |
 
-  @issue-ocis-reva-57 @issue-ocis-reva-217
+  @issue-ocis-reva-217
   Scenario: add, receive multiple custom meta properties to a file
     Given user "Alice" has created folder "/TestFolder"
     And user "Alice" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
@@ -262,7 +262,7 @@ Feature: get file properties
       | /TestFolder/test1.txt | status       | HTTP/1.1 200 OK |
 
   @issue-36920
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-reva-57 @issue-ocis-reva-217
+  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-reva-217
   Scenario: add multiple properties to files inside a folder and do a propfind of the parent folder
     Given user "Alice" has created folder "/TestFolder"
     And user "Alice" has uploaded file with content "test data one" to "/TestFolder/test1.txt"
@@ -288,7 +288,7 @@ Feature: get file properties
       | /TestFolder/test2.txt | testprop2    | DDDDD                  |
       | /TestFolder/          | status       | HTTP/1.1 404 Not Found |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the last modified date of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -301,7 +301,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the content type of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -314,14 +314,14 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the content type of a file using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     When user "Alice" gets the following properties of folder "file.txt" using the WebDAV API
       | propertyName     |
       | d:getcontenttype |
-    Then the single response should contain a property "d:getcontenttype" with value "text/plain"
+    Then the single response should contain a property "d:getcontenttype" with value "text/plain.*"
     Examples:
       | dav_version |
       | old         |
@@ -363,7 +363,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the size of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -376,7 +376,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the file id of a file using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
@@ -389,7 +389,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the file id of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -402,7 +402,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the owner display name of a file using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
@@ -415,7 +415,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the owner display name of a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"
@@ -428,7 +428,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the permissions on a file using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
@@ -441,7 +441,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-57
+
   Scenario Outline: Propfind the permissions on a folder using webdav api
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test"


### PR DESCRIPTION
## Description
See https://github.com/owncloud/ocis/issues/1302#issuecomment-884259331

The `getcontenttype` attribute can be just `text/plain` or can have other parameters, for example `text/plain; charset=utf-8`. The test has been adjusted to allow any string starting with `text/plain`.

I also removed all the `issue-ocis-reva-57` tags. They are very outdated, and we have expected-failures files nowadays that look after recording which test failures are related to which issues.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/1302

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
