### PR TITLE
Bump version to 10.9.0 prealpha

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 8, 0, 4];
+$OC_Version = [10, 9, 0, 0];
 
 // The human readable string
-$OC_VersionString = '10.8.0';
+$OC_VersionString = '10.9.0 prealpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
`release-10.8.0`  branch was merged back to master yesterday. And we are already merging things to master that are not just bugfixes. So the next version out of `master` will be 10.9.0. Bump the version now to `10.9.0 prealpha`. (Similar to what was done in PR #38745 )

Note: if there is some bug found that requires a 10.8.1 then IMO that would be done with a branch from the `v10.8.0` tag and some special cherry-pick of bug-fix commits.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
