### PR TITLE
[tests-only] skip new configKey CLI tests on 10.8

### DIFF
--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -37,19 +37,19 @@ Feature: add and delete app configs using occ command
     And the command output should contain the text 'System config value con set to empty string'
     And system config key "con" should have value ""
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8
   Scenario: admin tries to add an empty config key for an app using the occ command
     When the administrator adds config key "''" with value "conkey" in app "core" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Config name must not be empty.'
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8
   Scenario: admin tries to add a config key and specifying the empty string as the app name using the occ command
     When the administrator adds config key "con" with value "conkey" in app "''" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'App name must not be empty.'
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8
   Scenario: admin tries to add an empty system config key using the occ command
     When the administrator adds system config key "''" with value "conkey" using the occ command
     Then the command should have failed with exit code 1


### PR DESCRIPTION
## Description
These configKey test scenarios, and the code changes that go with them, were added to master only recently and are not in 10.8.0. Since last night, the `latest` release tarball is 10.8.0 and the tests tries to run in that case:
https://drone.owncloud.com/owncloud/user_ldap/3368/124/12
```
runsh: Total unexpected failed scenarios throughout the test run:
cliMain/configKey.feature:41
cliMain/configKey.feature:47
cliMain/configKey.feature:53
runsh: There were no unexpected success.
```

Skip these scenarios when running with core 10.8.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
