### PR TITLE
[tests-only] [full-ci] Split out new chunking tests and tag them notToImplementOnOCIS and newChunking

### DIFF
--- a/tests/TestHelpers/UploadHelper.php
+++ b/tests/TestHelpers/UploadHelper.php
@@ -167,6 +167,7 @@ class UploadHelper extends \PHPUnit\Framework\Assert {
 	 * @param string $xRequestId
 	 * @param bool $overwriteMode when false creates separate files to test uploading brand new files,
 	 *                            when true it just overwrites the same file over and over again with the same name
+	 * @param string $exceptChunkingType empty string or "old" or "new"
 	 *
 	 * @return array of ResponseInterface
 	 */
@@ -177,7 +178,8 @@ class UploadHelper extends \PHPUnit\Framework\Assert {
 		$source,
 		$destination,
 		$xRequestId = '',
-		$overwriteMode = false
+		$overwriteMode = false,
+		$exceptChunkingType = ''
 	) {
 		$responses = [];
 		foreach ([1, 2] as $davPathVersion) {
@@ -187,7 +189,22 @@ class UploadHelper extends \PHPUnit\Framework\Assert {
 				$davHuman = 'new';
 			}
 
+			switch ($exceptChunkingType) {
+				case 'old':
+					$exceptChunkingVersion = 1;
+					break;
+				case 'new':
+					$exceptChunkingVersion = 2;
+					break;
+				default:
+					$exceptChunkingVersion = -1;
+					break;
+			}
+
 			foreach ([null, 1, 2] as $chunkingVersion) {
+				if ($chunkingVersion === $exceptChunkingVersion) {
+					continue;
+				}
 				$valid = WebDavHelper::isValidDavChunkingCombination(
 					$davPathVersion,
 					$chunkingVersion

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -140,7 +140,7 @@ Feature: checksums
     And user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/Shares/myChecksumFile.txt" using the WebDAV API
     Then as user "Alice" the webdav checksum of "/myChecksumFile.txt" via propfind should match "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 MD5:56e57920c3c8c727bfe7a5288cdf61c4 ADLER32:1048035a"
 
-  @issue-ocis-reva-56
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
   Scenario: Upload new DAV chunked file where checksum matches
     Given using new DAV path
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
@@ -149,7 +149,7 @@ Feature: checksums
     And user "Alice" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
     Then the HTTP status code should be "201"
 
-  @issue-ocis-reva-56
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
   Scenario: Upload new DAV chunked file where checksum does not match
     Given using new DAV path
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
@@ -160,7 +160,7 @@ Feature: checksums
     And user "Alice" should not see the following elements
       | /myChunkedFile.txt |
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
   Scenario: Upload new DAV chunked file using async MOVE where checksum matches
     Given using new DAV path
     And the administrator has enabled async operations
@@ -176,7 +176,7 @@ Feature: checksums
       | fileId | /^[0-9a-z]{20,}$/ |
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "BBBBBCCCCC"
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
   Scenario: Upload new DAV chunked file using async MOVE where checksum does not match
     Given using new DAV path
     And the administrator has enabled async operations
@@ -194,7 +194,7 @@ Feature: checksums
     And user "Alice" should not see the following elements
       | /myChunkedFile.txt |
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
   Scenario: Upload new DAV chunked file using async MOVE where checksum does not match - retry with correct checksum
     Given using new DAV path
     And the administrator has enabled async operations
@@ -315,7 +315,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @issue-ocis-reva-56
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
   Scenario: Upload overwriting a file with new chunking and correct checksum
     Given using new DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
@@ -327,7 +327,7 @@ Feature: checksums
     And the content of file "/textfile0.txt" for user "Alice" should be "BBBBBCCCCC"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
-  @issue-ocis-reva-56
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
   Scenario: Upload overwriting a file with new chunking and invalid checksum
     Given using new DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -140,7 +140,7 @@ Feature: checksums
     And user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/Shares/myChecksumFile.txt" using the WebDAV API
     Then as user "Alice" the webdav checksum of "/myChecksumFile.txt" via propfind should match "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 MD5:56e57920c3c8c727bfe7a5288cdf61c4 ADLER32:1048035a"
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file where checksum matches
     Given using new DAV path
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
@@ -149,7 +149,7 @@ Feature: checksums
     And user "Alice" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
     Then the HTTP status code should be "201"
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file where checksum does not match
     Given using new DAV path
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
@@ -160,7 +160,7 @@ Feature: checksums
     And user "Alice" should not see the following elements
       | /myChunkedFile.txt |
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file using async MOVE where checksum matches
     Given using new DAV path
     And the administrator has enabled async operations
@@ -176,7 +176,7 @@ Feature: checksums
       | fileId | /^[0-9a-z]{20,}$/ |
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "BBBBBCCCCC"
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file using async MOVE where checksum does not match
     Given using new DAV path
     And the administrator has enabled async operations
@@ -194,7 +194,7 @@ Feature: checksums
     And user "Alice" should not see the following elements
       | /myChunkedFile.txt |
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file using async MOVE where checksum does not match - retry with correct checksum
     Given using new DAV path
     And the administrator has enabled async operations
@@ -315,7 +315,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload overwriting a file with new chunking and correct checksum
     Given using new DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
@@ -327,7 +327,7 @@ Feature: checksums
     And the content of file "/textfile0.txt" for user "Alice" should be "BBBBBCCCCC"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload overwriting a file with new chunking and invalid checksum
     Given using new DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -7,98 +7,203 @@ Feature: quota
 
     # Owner
 
-  Scenario: Uploading a file as owner having enough quota
+  Scenario: Uploading a file as owner having enough quota (except new chunking)
     Given the quota of user "Alice" has been set to "10 MB"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
 
-  @smokeTest
-  Scenario: Uploading a file as owner having insufficient quota
-    Given the quota of user "Alice" has been set to "20 B"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms using the WebDAV API
-    Then the HTTP status code of all upload responses should be "507"
-    And as "Alice" the files uploaded to "/testquota.txt" with all mechanisms should not exist
+  @notToImplementOnOCIS @newChunking
+  Scenario: Uploading a file as owner having enough quota (new chunking)
+    Given the quota of user "Alice" has been set to "10 MB"
+    And using new DAV path
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be "201"
 
-  Scenario: Overwriting a file as owner having enough quota
+  @smokeTest
+  Scenario: Uploading a file as owner having insufficient quota (except new chunking)
+    Given the quota of user "Alice" has been set to "20 B"
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
+    Then the HTTP status code of all upload responses should be "507"
+    And as "Alice" the files uploaded to "/testquota.txt" with all mechanisms except new chunking should not exist
+
+  @smokeTest @notToImplementOnOCIS @newChunking
+  Scenario: Uploading a file as owner having insufficient quota (new chunking)
+    Given the quota of user "Alice" has been set to "20 B"
+    And using new DAV path
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be "507"
+    And as "Alice" file "/testquota.txt" should not exist
+
+
+  Scenario: Overwriting a file as owner having enough quota (except new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "10 MB"
-    When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
-  Scenario: Overwriting a file as owner having insufficient quota
+  @notToImplementOnOCIS @newChunking
+  Scenario: Overwriting a file as owner having enough quota (new chunking)
+    Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
+    And the quota of user "Alice" has been set to "10 MB"
+    And using new DAV path
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be between "201" and "204"
+
+
+  Scenario: Overwriting a file as owner having insufficient quota (except new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "20 B"
-    When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
+    And the content of file "/testquota.txt" for user "Alice" should be "test"
+
+  @notToImplementOnOCIS @newChunking
+  Scenario: Overwriting a file as owner having insufficient quota (new chunking)
+    Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
+    And the quota of user "Alice" has been set to "20 B"
+    And using new DAV path
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be "507"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
 
 	# Received shared folder
 
   @files_sharing-app-required
-  Scenario: Uploading a file in received folder having enough quota
+  Scenario: Uploading a file in received folder having enough quota (except new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "20 B"
     And the quota of user "Alice" has been set to "10 MB"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
 
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  Scenario: Uploading a file in received folder having enough quota (new chunking)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/testquota"
+    And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
+    And the quota of user "Brian" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 MB"
+    And using new DAV path
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be "201"
+
   @files_sharing-app-required
-  Scenario: Uploading a file in received folder having insufficient quota
+  Scenario: Uploading a file in received folder having insufficient quota (except new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "10 MB"
     And the quota of user "Alice" has been set to "20 B"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
-    And as "Brian" the files uploaded to "/testquota.txt" with all mechanisms should not exist
+    And as "Brian" the files uploaded to "/testquota/testquota.txt" with all mechanisms except new chunking should not exist
+
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  Scenario: Uploading a file in a received folder having insufficient quota (new chunking)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/testquota"
+    And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
+    And the quota of user "Brian" has been set to "10 MB"
+    And the quota of user "Alice" has been set to "20 B"
+    And using new DAV path
+    When user "Brian" uploads file "filesForUpload/davtest.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be "507"
+    And as "Brian" file "/testquota/testquota.txt" should not exist
 
   @files_sharing-app-required
-  Scenario: Overwriting a file in received folder having enough quota
+  Scenario: Overwriting a file in received folder having enough quota (except new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "20 B"
     And the quota of user "Alice" has been set to "10 MB"
-    When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  Scenario: Overwriting a file in received folder having enough quota (new chunking)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/testquota"
+    And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
+    And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
+    And the quota of user "Brian" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 MB"
+    And using new DAV path
+    When user "Brian" uploads file "filesForUpload/davtest.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be between "201" and "204"
+
   @files_sharing-app-required
-  Scenario: Overwriting a file in received folder having insufficient quota
+  Scenario: Overwriting a file in received folder having insufficient quota (except new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "10 MB"
     And the quota of user "Alice" has been set to "20 B"
-    When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
+    And the content of file "/testquota/testquota.txt" for user "Alice" should be "test"
+
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  Scenario: Overwriting a file in received folder having insufficient quota (new chunking)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/testquota"
+    And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
+    And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
+    And the quota of user "Brian" has been set to "10 MB"
+    And the quota of user "Alice" has been set to "20 B"
+    And using new DAV path
+    When user "Brian" uploads file "filesForUpload/davtest.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be "507"
     And the content of file "/testquota/testquota.txt" for user "Alice" should be "test"
 
 	# Received shared file
 
   @files_sharing-app-required
-  Scenario: Overwriting a received file having enough quota
+  Scenario: Overwriting a received file having enough quota (except new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
     And the quota of user "Brian" has been set to "20 B"
     And the quota of user "Alice" has been set to "10 MB"
-    When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  Scenario: Overwriting a received file having enough quota (new chunking)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test" to "/testquota.txt"
+    And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
+    And the quota of user "Brian" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 MB"
+    And using new DAV path
+    When user "Brian" uploads file "filesForUpload/davtest.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be between "201" and "204"
+
   @files_sharing-app-required
-  Scenario: Overwriting a received file having insufficient quota
+  Scenario: Overwriting a received file having insufficient quota (except new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
     And the quota of user "Brian" has been set to "10 MB"
     And the quota of user "Alice" has been set to "20 B"
-    When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms using the WebDAV API
+    When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
+    And the content of file "/testquota.txt" for user "Alice" should be "test"
+
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  Scenario: Overwriting a received file having insufficient quota (new chunking)
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "test" to "/testquota.txt"
+    And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
+    And the quota of user "Brian" has been set to "10 MB"
+    And the quota of user "Alice" has been set to "20 B"
+    And using new DAV path
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the HTTP status code should be "507"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
 
 

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -12,7 +12,7 @@ Feature: quota
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
 
-  @notToImplementOnOCIS @newChunking
+  @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Uploading a file as owner having enough quota (new chunking)
     Given the quota of user "Alice" has been set to "10 MB"
     And using new DAV path
@@ -26,7 +26,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And as "Alice" the files uploaded to "/testquota.txt" with all mechanisms except new chunking should not exist
 
-  @smokeTest @notToImplementOnOCIS @newChunking
+  @smokeTest @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Uploading a file as owner having insufficient quota (new chunking)
     Given the quota of user "Alice" has been set to "20 B"
     And using new DAV path
@@ -41,7 +41,7 @@ Feature: quota
     When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
-  @notToImplementOnOCIS @newChunking
+  @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Overwriting a file as owner having enough quota (new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "10 MB"
@@ -57,7 +57,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
 
-  @notToImplementOnOCIS @newChunking
+  @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Overwriting a file as owner having insufficient quota (new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "20 B"
@@ -78,7 +78,7 @@ Feature: quota
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Uploading a file in received folder having enough quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
@@ -100,7 +100,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And as "Brian" the files uploaded to "/testquota/testquota.txt" with all mechanisms except new chunking should not exist
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Uploading a file in a received folder having insufficient quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
@@ -123,7 +123,7 @@ Feature: quota
     When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Overwriting a file in received folder having enough quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
@@ -147,7 +147,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota/testquota.txt" for user "Alice" should be "test"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Overwriting a file in received folder having insufficient quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
@@ -172,7 +172,7 @@ Feature: quota
     When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Overwriting a received file having enough quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
@@ -194,7 +194,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking
+  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Overwriting a received file having insufficient quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"

--- a/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
@@ -252,7 +252,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @notToImplementOnOCIS @newChunking
+  @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
@@ -252,7 +252,7 @@ Feature: sharing
       | old      |
       | new      |
 
-
+  @notToImplementOnOCIS @newChunking
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -173,7 +173,7 @@ Feature: Restore deleted files/folders
 
   @local_storage
   @skipOnEncryptionType:user-keys @encryption-issue-42
-  @skip_on_objectstore @notToImplementOnOCIS @newChunking
+  @skip_on_objectstore @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored with new chunking
     Given using new DAV path
     And the administrator has invoked occ command "files:scan --all"

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -173,7 +173,7 @@ Feature: Restore deleted files/folders
 
   @local_storage
   @skipOnEncryptionType:user-keys @encryption-issue-42
-  @skip_on_objectstore
+  @skip_on_objectstore @notToImplementOnOCIS @newChunking
   Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored with new chunking
     Given using new DAV path
     And the administrator has invoked occ command "files:scan --all"

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -12,14 +12,18 @@ Feature: dav-versions
     Then the version folder of file "/davtest.txt" for user "Alice" should contain "0" elements
 
   @issue-ocis-reva-17 @issue-ocis-reva-56
-  Scenario: Upload file and no version is available using various chunking methods
-    When user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms using the WebDAV API
+  Scenario: Upload file and no version is available using various chunking methods (except new chunking)
+    When user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms except new chunking using the WebDAV API
     Then the version folder of file "/davtest.txt-olddav-regular" for user "Alice" should contain "0" elements
     And the version folder of file "/davtest.txt-newdav-regular" for user "Alice" should contain "0" elements
     And the version folder of file "/davtest.txt-olddav-oldchunking" for user "Alice" should contain "0" elements
-    And the version folder of file "/davtest.txt-newdav-newchunking" for user "Alice" should contain "0" elements
 
-  @issue-ocis-reva-56
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  Scenario: Upload file and no version is available using new chunking
+    When user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the version folder of file "/davtest.txt" for user "Alice" should contain "0" elements
+
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
   Scenario: Upload file and no version is available using async upload
     Given the administrator has enabled async operations
     When user "Alice" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 3 chunks with new chunking and using the WebDAV API
@@ -33,15 +37,20 @@ Feature: dav-versions
     And the content length of file "/davtest.txt" with version index "1" for user "Alice" in versions folder should be "8"
 
   @issue-ocis-reva-17 @issue-ocis-reva-56
-  Scenario: Upload a file twice and versions are available using various chunking methods
-    When user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms using the WebDAV API
-    And user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms using the WebDAV API
+  Scenario: Upload a file twice and versions are available using various chunking methods (except new chunking)
+    When user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms except new chunking using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms except new chunking using the WebDAV API
     Then the version folder of file "/davtest.txt-olddav-regular" for user "Alice" should contain "1" element
     And the version folder of file "/davtest.txt-newdav-regular" for user "Alice" should contain "1" element
     And the version folder of file "/davtest.txt-olddav-oldchunking" for user "Alice" should contain "1" element
-    And the version folder of file "/davtest.txt-newdav-newchunking" for user "Alice" should contain "1" element
 
-  @issue-ocis-reva-17 @issue-ocis-reva-56
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  Scenario: Upload a file twice and versions are available using new chunking
+    When user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
+    Then the version folder of file "/davtest.txt" for user "Alice" should contain "1" element
+
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
   Scenario: Upload a file twice and versions are available using async upload
     Given the administrator has enabled async operations
     When user "Alice" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
@@ -85,10 +94,13 @@ Feature: dav-versions
     Then the content of file "/textfile0.txt" for user "Alice" should be "Dav-Test"
     Examples:
       | dav-path |
-      | new      |
       | old      |
+    @notToImplementOnOCIS @newChunking
+    Examples:
+      | dav-path |
+      | new      |
 
-  @skipOnStorage:ceph @files_primary_s3-issue-161
+  @skipOnStorage:ceph @files_primary_s3-issue-161 @notToImplementOnOCIS @newChunking
   @issue-ocis-reva-17 @issue-ocis-reva-56
   Scenario: Uploading a file asynchronously does create the correct version that can be restored
     Given the administrator has enabled async operations

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -18,12 +18,12 @@ Feature: dav-versions
     And the version folder of file "/davtest.txt-newdav-regular" for user "Alice" should contain "0" elements
     And the version folder of file "/davtest.txt-olddav-oldchunking" for user "Alice" should contain "0" elements
 
-  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload file and no version is available using new chunking
     When user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the version folder of file "/davtest.txt" for user "Alice" should contain "0" elements
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload file and no version is available using async upload
     Given the administrator has enabled async operations
     When user "Alice" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 3 chunks with new chunking and using the WebDAV API
@@ -44,13 +44,13 @@ Feature: dav-versions
     And the version folder of file "/davtest.txt-newdav-regular" for user "Alice" should contain "1" element
     And the version folder of file "/davtest.txt-olddav-oldchunking" for user "Alice" should contain "1" element
 
-  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload a file twice and versions are available using new chunking
     When user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
     And user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the version folder of file "/davtest.txt" for user "Alice" should contain "1" element
 
-  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload a file twice and versions are available using async upload
     Given the administrator has enabled async operations
     When user "Alice" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
@@ -95,12 +95,12 @@ Feature: dav-versions
     Examples:
       | dav-path |
       | old      |
-    @notToImplementOnOCIS @newChunking
+    @notToImplementOnOCIS @newChunking @issue-ocis-1321
     Examples:
       | dav-path |
       | new      |
 
-  @skipOnStorage:ceph @files_primary_s3-issue-161 @notToImplementOnOCIS @newChunking
+  @skipOnStorage:ceph @files_primary_s3-issue-161 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   @issue-ocis-reva-17 @issue-ocis-reva-56
   Scenario: Uploading a file asynchronously does create the correct version that can be restored
     Given the administrator has enabled async operations

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks asynchronously

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks asynchronously

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names
@@ -9,7 +9,7 @@ Feature: users cannot upload a file to a blacklisted name using new chunking
     And using new DAV path
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @notToImplementOnOCIS
+
   Scenario: Upload a file to a filename that is banned by default using new chunking
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "1" with "AAAAA" to id "chunking-42" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking
+@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks


### PR DESCRIPTION
## Description
The API test scenarios that use new chunking have been split out and tagged `@notToImplementOnOCIS @newChunking`

The `newChunking` tag will help people to understand why the test is `notToImplementOnOCIS`.

This will reduce the number of useless tests being run on OCIS and reva, and they will get removed from the expected-failures files.

Note: there were steps about "using all mechanisms" that had been written some time ago in order to be able to have a single scenario that checks all the ordinary, chunked, old and new WebDav uploads in a single scenario. I made a special case "with all mechanisms except new chunking". It works for now, but those steps are really a bit strange. In a later refactoring we could remove those sort of steps and have the individual upload methods mentioned in a list of steps.

## Related Issue
- Fixes https://github.com/owncloud/ocis/issues/2308 and https://github.com/owncloud/ocis/issues/1321

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
