### PR TITLE
Remove scrollable scrollbar

### DIFF
--- a/changelog/unreleased/39052
+++ b/changelog/unreleased/39052
@@ -1,0 +1,10 @@
+Bugfix: Scrollable Login screen
+
+Current login screen has an always visible scrollbar to prevent a "jumping" of the login form. 
+Certain constallations of notices and error messages can exceed the screens height which 
+will result in a horiztonal jump of the login form (when scrollbar is added). Until now this 
+was done via setting a height of 101% which made the scrollbar always visible - but also scrollable. 
+This fix makes the scrollbar visible any time but not scrollable if not needed.
+
+https://github.com/owncloud/core/issues/39043
+https://github.com/owncloud/core/pull/39052

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -216,7 +216,7 @@ a.two-factor-cancel {
 
 #body-login {
 	background-attachment: fixed; /* fix background gradient */
-	height: 101%; /* fix sticky footer */
+	overflow-y: scroll;
 }
 
 /* Dark subtle label text */


### PR DESCRIPTION
## Description
Current login screen has an always visible scrollbar to prevent a "jumping" of the login form. Certain constallations of notices and error messages can exceed the screens height which will result in a horiztonal jump of the login form (when scrollbar is added). Until now this was done via setting a height of 101% which made the scrollbar always visible - but also scrollable. This fix makes the scrollbar visible any time but not scrollable if not needed.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/39043

## How Has This Been Tested?
Major browsers


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
