### PR TITLE
[tests-only] skip tests for new public link sharing options on old oC10

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink2/allowGroupToCreatePublicLinks.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/allowGroupToCreatePublicLinks.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: public share sharers groups setting
   As an admin
   I should be able to allow only certain groups to create public links

--- a/tests/acceptance/features/webUISharingPublic2/allowGroupToCreatePublicLinks.feature
+++ b/tests/acceptance/features/webUISharingPublic2/allowGroupToCreatePublicLinks.feature
@@ -1,4 +1,4 @@
-@webUI @files_sharing-app-required
+@webUI @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: public share sharers groups setting
   As an admin
   I should be able to allow only certain groups to create public links


### PR DESCRIPTION
## Description
PR #38980 was merged a couple of days ago. The new acceptance are not applicable on older versions of oC10, so skip in that case. That will stop the failures in nightly CI against older oC10 like https://drone.owncloud.com/owncloud/encryption/2018


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
