### PR TITLE
Bump oc10 version to 10.8.1 for development

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 8, 0, 4];
+$OC_Version = [10, 8, 1, 0];
 
 // The human readable string
-$OC_VersionString = '10.8.0';
+$OC_VersionString = '10.8.1 prealpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
We are getting some new tests added that are only applicable to code that is currently in `master`. The new tests are not relevant to version 10.8.0. We need some way for the test runner to understand that we are moving forward from 10.8.0.

This PR bumps the version in `master` to "10.8.1 prealpha" for development purposes.

Note: the actual next release might be 10.9.0 - we are not deciding that here. This bump is just making the minimal bump for development.

Note: this replaces #39048 which suggested bumping now to "10.9.0 prealpha"

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
