### PR TITLE
Add cancel / create button on fileMenu form

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -890,15 +890,21 @@ html.ie8 #controls .button.new {
 }
 
 .newFileMenu {
-	width: 140px;
+	min-width: 140px;
 	margin-left: -56px;
 	margin-top: 25px;
 	z-index: 1001;
+	right: initial;
 }
 
 .newFileMenu .menuitem {
 	white-space: nowrap;
 	overflow: hidden;
+	display: flex;
+}
+
+.newFileMenu .menuitem .icon{
+	margin-top: 7px;
 }
 
 .newFileMenu.popovermenu .menuitem,
@@ -923,12 +929,8 @@ html.ie8 #controls .button.new {
 	right: auto;
 }
 
-.newFileMenu .filenameform {
-	display: inline-block;
-}
-
-.newFileMenu .filenameform input {
-	width: 100px;
+.newFileMenu .action-menu button {
+	font-size: 11px;
 }
 
 #fileList .popovermenu .action {

--- a/apps/files/js/newfilemenu.js
+++ b/apps/files/js/newfilemenu.js
@@ -28,6 +28,10 @@
 		'<form class="filenameform" autocapitalize="none">' +
 		'<label class="hidden-visually" for="{{cid}}-input-{{fileType}}">{{fileName}}</label>' +
 		'<input id="{{cid}}-input-{{fileType}}" type="text" value="{{fileName}}" autocomplete="off">' +
+		'<div class="action-menu">' +
+		'<button type="button" class="cancel"> {{cancelLabel}} </button>' +
+		'<button type="submit" class="create primary"> {{createLabel}} </button>' +
+		'</div>' +
 		'</form>';
 
 	/**
@@ -41,7 +45,7 @@
 		className: 'newFileMenu popovermenu bubble hidden open menu',
 
 		events: {
-			'click .menuitem': '_onClickAction'
+			'click .menuitem': '_onClickAction',
 		},
 
 		/**
@@ -90,6 +94,11 @@
 		 */
 		_onClickAction: function(event) {
 			var $target = $(event.target);
+
+			if($target.hasClass('cancel') || $target.hasClass('create')){
+				return;
+			}
+
 			if (!$target.hasClass('menuitem')) {
 				$target = $target.closest('.menuitem');
 			}
@@ -115,7 +124,7 @@
 			}
 
 			if ($target.find('form').length) {
-				$target.find('input').focus();
+				$target.find('input[type=text]').focus();
 				return;
 			}
 
@@ -130,14 +139,16 @@
 			var $form = $(OCA.Files.NewFileMenu._TEMPLATE_FORM({
 				fileName: newName,
 				cid: this.cid,
-				fileType: fileType
+				fileType: fileType,
+				cancelLabel: t('files', 'Cancel'),
+				createLabel: t('files', 'Create')
 			}));
 
 			//this.trigger('actionPerformed', action);
 			$target.append($form);
 
 			// here comes the OLD code
-			var $input = $form.find('input');
+			var $input = $form.find('input[type=text]');
 
 			var lastPos;
 			var checkInput = function () {
@@ -160,8 +171,19 @@
 				return false;
 			};
 
+			var closeForm = function (){
+				$form.remove();
+				$target.find('.displayname').removeClass('hidden');
+			};
+
+
 			// verify filename on typing
-			$input.keyup(function() {
+			$input.keyup(function(e) {
+				if(e.key === 'Escape'){
+					closeForm();
+					return;
+				}
+
 				if (checkInput()) {
 					$input.tooltip('hide');
 					$input.removeClass('error');
@@ -175,6 +197,8 @@
 				lastPos = newName.length;
 			}
 			$input.selectRange(0, lastPos);
+
+			$form.find('.cancel').click(closeForm);
 
 			$form.submit(function(event) {
 				event.stopPropagation();

--- a/apps/files/tests/js/newfilemenuSpec.js
+++ b/apps/files/tests/js/newfilemenuSpec.js
@@ -95,6 +95,30 @@ describe('OCA.Files.NewFileMenu', function() {
 			expect(createDirectoryStub.calledOnce).toEqual(true);
 			expect(createDirectoryStub.getCall(0).args[0]).toEqual('some folder');
 		});
+		it('shows create and cancel button', function() {
+			var $createBtn = menu.$el.find('.action-menu .create');
+			var $cancelBtn = menu.$el.find('.action-menu .cancel');
+
+			expect($createBtn.length).toEqual(1);
+			expect($cancelBtn.length).toEqual(1);
+		});
+		it('creates directory when clicking on create button', function() {
+			$input = menu.$el.find('form.filenameform input');
+			$input.val('some folder');
+
+			var $createBtn = menu.$el.find('.action-menu .create');
+			$createBtn.click();
+
+			expect(createDirectoryStub.calledOnce).toEqual(true);
+			expect(createDirectoryStub.getCall(0).args[0]).toEqual('some folder');
+		});
+		it('destroys from element when clicking on cancel button', function() {
+			var $cancelBtn = menu.$el.find('.action-menu .cancel');
+			$cancelBtn.click();
+			var $form = menu.$el.find('form');
+
+			expect($form.length).toEqual(0);
+		});
 	});
 	describe('custom entries', function() {
 		var oldPlugins;

--- a/changelog/unreleased/39056
+++ b/changelog/unreleased/39056
@@ -1,0 +1,11 @@
+Enhancement: Show create and cancel buttons in the 'New file menu'
+
+If the user hits the '+' button in the UI, a context menu will be shown,
+where the user is able to choose for example 'Folder'.
+A form will show up to set the new folder name, the user needs to confirm
+by hitting the enter key.
+This might not been understood by every user at the first glance.
+Therefore, with this PR a create and cancel button has been added.
+
+https://github.com/owncloud/core/pull/39056
+https://github.com/owncloud/enterprise/issues/4684

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -786,6 +786,7 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUISharingContext:
+        - WebUINewFileMenuContext:
 
     webUIFavorites:
       paths:

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -543,15 +543,48 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @param string $name
+	 * @When /^the user creates a folder with the (invalid|)\s?name ((?:'[^']*')|(?:"[^"]*")) using the webUI via create button$/
+	 * @Given /^the user has created a folder with the (invalid|)\s?name ((?:'[^']*')|(?:"[^"]*")) using the webUI via create button$/
+	 *
+	 * @param string $invalid contains "invalid"
+	 *                        if the folder creation is expected to fail
+	 * @param string $name enclosed in single or double quotes
 	 *
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function createAFolder($name) {
+	public function theUserCreatesAFolderUsingTheWebUIViaCreateButton($invalid, $name) {
+		// The capturing group of the regex always includes the quotes at each
+		// end of the captured string, so trim them.
+		$name = \trim($name, $name[0]);
+		try {
+			$this->createAFolder($name, true);
+			if ($invalid === "invalid") {
+				throw new Exception(
+					"folder '$name' should not have been created but was"
+				);
+			}
+		} catch (Exception $e) {
+			//do not throw the exception if we expect the folder creation to fail
+			if ($invalid !== "invalid"
+				|| $e->getMessage() !== "could not create folder '$name'"
+			) {
+				throw $e;
+			}
+		}
+	}
+
+	/**
+	 * @param string $name
+	 * @param boolean $useCreateButton
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function createAFolder($name, $useCreateButton = false) {
 		$session = $this->getSession();
 		$pageObject = $this->getCurrentPageObject();
-		$pageObject->createFolder($session, $name);
+		$pageObject->createFolder($session, $name, STANDARD_UI_WAIT_TIMEOUT_MILLISEC, $useCreateButton);
 		$pageObject->waitTillPageIsLoaded($session);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebUINewFileMenuContext.php
+++ b/tests/acceptance/features/bootstrap/WebUINewFileMenuContext.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Jan Ackermann <jackermann@owncloud.com>
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+use Behat\Behat\Context\Context;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Page\FilesPage;
+use Page\FilesPageElement\NewFileMenu;
+use PHPUnit\Framework\Assert;
+
+require_once 'bootstrap.php';
+
+/**
+ * Context for new file menu
+ */
+class WebUINewFileMenuContext extends RawMinkContext implements Context {
+
+	/**
+	 *
+	 * @var FilesPage
+	 */
+	private $filesPage;
+
+	/**
+	 *
+	 * @var NewFileMenu
+	 */
+	private $newFileMenu;
+
+	/**
+	 * WebUINewFileMenuContext constructor.
+	 *
+	 * @param FilesPage $filesPage
+	 * @param NewFileMenu $newFileMenu
+	 *
+	 * @return void
+	 */
+	public function __construct(
+		FilesPage $filesPage,
+		NewFileMenu $newFileMenu
+	) {
+		$this->filesPage = $filesPage;
+		$this->newFileMenu = $newFileMenu;
+	}
+
+	/**
+	 * @When the user opens the newFileMenu using the webUI
+	 *
+	 * @return void
+	 */
+	public function theUserOpensTheNewfilemenuUsingTheWebUI() {
+		$this->newFileMenu->openNewFileMenu();
+	}
+
+	/**
+	 * @Then the newFileMenu should be displayed on the webUI
+	 *
+	 * @return void
+	 */
+	public function theNewFilemenuShouldBeDisplayedOnTheWebUI() {
+		Assert::assertNotNull(
+			$this->newFileMenu->getNewFileMenu(),
+			'New file menu is expected to be visible but is not'
+		);
+	}
+
+	/**
+	 * @Given the user clicks folder in the newFileMenu using the webUI
+	 *
+	 * @return void
+	 */
+	public function theUserClicksFolderInTheNewFileMenuUsingTheWebUI() {
+		$this->newFileMenu->clickFolder();
+	}
+
+	/**
+	 * @Then the newFileMenu filename form should be displayed on the webUI
+	 *
+	 * @return void
+	 */
+	public function theNewFileMenuFilenameFormShouldBeDisplayedOnTheWebUI() {
+		Assert::assertNotNull(
+			$this->newFileMenu->getNewFileMenuFilenameForm(),
+			'New file menu filename form is expected to be visible but is not'
+		);
+	}
+
+	/**
+	 * @Then the newFileMenu filename form should not be displayed on the webUI
+	 *
+	 * @return void
+	 */
+	public function theNewFileMenuFilenameFormShouldNotBeDisplayedOnTheWebUI() {
+		Assert::assertNull(
+			$this->newFileMenu->getNewFileMenuFilenameForm(),
+			'New file menu filename form is expected to be not visible but is'
+		);
+	}
+
+	/**
+	 * @Given the user clicks cancel in newFileMenu filename form using the webUI
+	 *
+	 * @return void
+	 */
+	public function theUserClicksCancelInTheNewFileMenuFilenameFormUsingTheWebUI() {
+		$this->newFileMenu->clickCancelFilenameForm();
+	}
+}

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -120,6 +120,7 @@ class FilesPage extends FilesPageBasic {
 	 * @param Session $session
 	 * @param string $name
 	 * @param int $timeoutMsec
+	 * @param boolean $useCreateButton
 	 *
 	 * @return string name of the created file
 	 * @throws ElementNotFoundException|\Exception
@@ -127,12 +128,14 @@ class FilesPage extends FilesPageBasic {
 	public function createFolder(
 		Session $session,
 		$name = null,
-		$timeoutMsec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+		$timeoutMsec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
+		$useCreateButton = false
 	) {
 		return $this->filesPageCRUDFunctions->createFolder(
 			$session,
 			$name,
-			$timeoutMsec
+			$timeoutMsec,
+			$useCreateButton,
 		);
 	}
 

--- a/tests/acceptance/features/lib/FilesPageElement/NewFileMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/NewFileMenu.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Jan Ackermann <jackermann@owncloud.com>
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page\FilesPageElement;
+
+use ast\Node;
+use Behat\Mink\Session;
+use Behat\Mink\Element\NodeElement;
+use Page\OwncloudPage;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
+/**
+ * PageObject for new file menu on the FilesPage
+ *
+ */
+class NewFileMenu extends OwncloudPage {
+	/**
+	 * @var NodeElement of this action menu
+	 */
+	protected $newButtonXpath = "//a[@class='button new']";
+	protected $newFileMenuXpath = "//div[contains(@class, 'newFileMenu')]";
+	protected $newFileMenuFolderMenuItemXpath = "//div[contains(@class, 'newFileMenu')]//a[@data-action='folder']";
+	protected $newFileMenuFilenameFormXpath = "//form[@class='filenameform']";
+	protected $newFileMenuFilenameFormButtonXpath = "//form[@class='filenameform']//button[@class='cancel']";
+
+	/**
+	 * Find new button and open new file menu
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function openNewFileMenu() {
+		$newButtonElement = $this->find("xpath", $this->newButtonXpath);
+
+		$this->assertElementNotNull(
+			$newButtonElement,
+			__METHOD__ .
+			" xpath $this->newButtonXpath " .
+			"could not find new button"
+		);
+
+		$newButtonElement->click();
+	}
+
+	/**
+	 * Find and return new file menu
+	 *
+	 * @return NodeElement | null
+	 */
+	public function getNewFileMenu() {
+		$newFileMenuElement = $this->find("xpath", $this->newFileMenuXpath);
+		return $newFileMenuElement;
+	}
+
+	/**
+	 * Find directory menu item and open filename form
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function clickFolder() {
+		$newFileMenuFolderMenuItemElement = $this->find("xpath", $this->newFileMenuFolderMenuItemXpath);
+
+		$this->assertElementNotNull(
+			$newFileMenuFolderMenuItemElement,
+			__METHOD__ .
+			" xpath $this->newFileMenuFolderMenuItemXpath " .
+			"could not find folder menu item"
+		);
+
+		$newFileMenuFolderMenuItemElement->click();
+	}
+
+	/**
+	 * Find and return new filename form
+	 *
+	 * @return NodeElement | null
+	 */
+	public function getNewFileMenuFilenameForm() {
+		$newFileMenuFolderFilenameFormElement = $this->find("xpath", $this->newFileMenuFilenameFormXpath);
+		return $newFileMenuFolderFilenameFormElement;
+	}
+
+	/**
+	 * Find cancel button and close the filename form
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException
+	 */
+	public function clickCancelFilenameForm() {
+		$newFileMenuFilenameFormButtonElement = $this->find("xpath", $this->newFileMenuFilenameFormButtonXpath);
+
+		$this->assertElementNotNull(
+			$newFileMenuFilenameFormButtonElement,
+			__METHOD__ .
+			" xpath $this->newFileMenuFilenameFormButtonXpath " .
+			"could not find cancel button"
+		);
+
+		$newFileMenuFilenameFormButtonElement->click();
+	}
+}

--- a/tests/acceptance/features/webUICreateDelete/createFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFolders.feature
@@ -19,6 +19,26 @@ Feature: create folders
       | folder-!@#$%^&* ! |
       | नेपालि            |
 
+  @skipOnOcV10.6 @skipOnOcV10.7
+  Scenario Outline: Create a folder using the create button
+    When the user creates a folder with the name "<folder-name>" using the webUI via create button
+    Then folder "<folder-name>" should be listed on the webUI
+    When the user reloads the current page of the webUI
+    Then folder "<folder-name>" should be listed on the webUI
+    Examples:
+      | folder-name       |
+      | folder-!@#$%^&*( ! |
+
+  @skipOnOcV10.6 @skipOnOcV10.7
+  Scenario: Abort create folder using the cancel button
+    When the user opens the newFileMenu using the webUI
+    Then the newFileMenu should be displayed on the webUI
+    And the user clicks folder in the newFileMenu using the webUI
+    Then the newFileMenu filename form should be displayed on the webUI
+    And the user clicks cancel in newFileMenu filename form using the webUI
+    Then the newFileMenu filename form should not be displayed on the webUI
+
+
   @smokeTest @skipOnLDAP
   Scenario: Create a folder inside another folder
     When the user creates a folder with the name "top-folder" using the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Enhancement: Show create and cancel buttons in the 'New file menu'

If the user hits the '+' button in the UI, a context menu will be shown,
where the user is able to choose for example 'Directory'.
A form will show up to set the new directory name, the user needs to confirm
by hitting the enter key.
This might not been understood by every user at the first glance.
Therefore, with this PR a create and cancel button has been added.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4684

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
![2021-07-26_23-58-13 (1)](https://user-images.githubusercontent.com/26610733/127064997-ea5bda25-4b51-4ce0-8960-935c23f9876c.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
