### PR TITLE
Allow copying file keys when storage has multiple mount points

### DIFF
--- a/changelog/unreleased/39058
+++ b/changelog/unreleased/39058
@@ -1,0 +1,3 @@
+Bugfix: Allow copying file keys when storage has multiple mount points
+
+https://github.com/owncloud/core/pull/39058

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -776,7 +776,8 @@ class Encryption extends Wrapper {
 		// first copy the keys that we reuse the existing file key on the target location
 		// and don't create a new one which would break versions for example.
 		$mount = $this->mountManager->findByStorageId($sourceStorage->getId());
-		if (\is_array($mount) && \count($mount) === 1) {
+		if (\is_array($mount) && \count($mount) > 0) {
+			// multiple mount points still refer to the same storage, so pick the first
 			$mountPoint = $mount[0]->getMountPoint();
 			$source = $mountPoint . '/' . $sourceInternalPath;
 			$target = $this->getFullPath($targetInternalPath);

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -776,7 +776,7 @@ class Encryption extends Wrapper {
 		// first copy the keys that we reuse the existing file key on the target location
 		// and don't create a new one which would break versions for example.
 		$mount = $this->mountManager->findByStorageId($sourceStorage->getId());
-		if (\is_array($mount) && \count($mount) > 0) {
+		if (\count($mount) > 0) {
 			// multiple mount points still refer to the same storage, so pick the first
 			$mountPoint = $mount[0]->getMountPoint();
 			$source = $mountPoint . '/' . $sourceInternalPath;
@@ -799,7 +799,7 @@ class Encryption extends Wrapper {
 		} else {
 			try {
 				$source = $sourceStorage->fopen($sourceInternalPath, 'r');
-				if ($isRename && (\count($mount) === 1)) {
+				if ($isRename && (\count($mount) > 0)) {
 					$sourceStorageMountPoint = $mount[0]->getMountPoint();
 					$this->sourcePath[$targetInternalPath] = $sourceStorageMountPoint . '/' . $sourceInternalPath;
 				} else {


### PR DESCRIPTION
cc @IljaN @cdamken 
In the old logic might break when a group share has been mounted by multiple users and files are repeatedly moved in and out of that group share while encryption is enabled.

- [ ] Needs a Unit test that reproduces this bug
    - enable encryption
    - create group share, accept it for multiple users
    - might depend on order of acceptance (which is the order read from db)
    - has to do with additional user filesystem initializations in https://github.com/owncloud/core/blob/78fcc9e0a92329ecbb2aca750210db817dfa6263/lib/private/Encryption/Keys/Storage.php#L386, called by https://github.com/owncloud/core/blob/78fcc9e0a92329ecbb2aca750210db817dfa6263/lib/private/Encryption/Keys/Storage.php#L344, called by https://github.com/owncloud/core/blob/78fcc9e0a92329ecbb2aca750210db817dfa6263/lib/private/Encryption/Keys/Storage.php#L319-L320 (which initializes source & target), called by https://github.com/owncloud/core/blob/d329971010ec6443d1e924ed989d0ec2ec27d69d/lib/private/Files/Storage/Wrapper/Encryption.php#L783