### PR TITLE
Do not try to remove the same file twice

### DIFF
--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -197,9 +197,7 @@ class Storage extends Wrapper {
 			if ($filesPath = $view->getRelativePath($normalized)) {
 				$filesPath = \trim($filesPath, '/');
 				$result = \OCA\Files_Trashbin\Trashbin::move2trash($filesPath);
-				// in cross-storage cases the file will be copied
-				// but not deleted, so we delete it here
-				if ($result) {
+				if ($result === null) {
 					\call_user_func_array([$this->storage, $method], [$path]);
 				}
 			} else {

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -274,7 +274,8 @@ class Trashbin {
 	 * move file to the trash bin
 	 *
 	 * @param string $file_path path to the deleted file/directory relative to the files root directory
-	 * @return bool
+	 * @return bool|null true if the file is moved, false if there is an error, null if there
+	 * isn't any trashbin available
 	 */
 	public static function move2trash($file_path) {
 		// get the user for which the filesystem is setup
@@ -298,8 +299,8 @@ class Trashbin {
 			// trashbin not usable for user (ex: guest), switch to owner only
 			$user = $owner;
 			if (!self::setUpTrash($owner)) {
-				// nothing to do as no trash is available anywheree
-				return true;
+				// nothing to do as no trash is available anywhere
+				return null;
 			}
 		}
 		if ($owner !== $user) {

--- a/changelog/unreleased/39070
+++ b/changelog/unreleased/39070
@@ -1,0 +1,11 @@
+Bugfix: Do not try to delete the folder twice
+
+Previously, when a folder was moved to the trashbin from an external storage, the usual
+action was to copy the contents to the trashbin and then remove them from the source, and
+additionally another remove operation on the source was triggered. This second delete
+request was performed but the result was ignored, and the storages didn't log anything.
+
+With this change, this second delete request won't happen. The behaviour is still the same:
+copy to the trashbin and then remove from the source.
+
+https://github.com/owncloud/core/pull/39070


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Do not try to remove the file twice while moving it to the trashbin

## Related Issue
https://github.com/owncloud/core/issues/38923

## Motivation and Context
While removing a file and moving it to the trashbin, the source file or folder was deleted twice. The second call was failing because the file was already removed in the first call. This problem was ignored in the storage (which would try to remove the file again without logging the failure) and in the trashbin (ignoring the related failure).

Since the `move2trash` function already takes care of removing the source (for whatever reason) in case the move fails, we only need to take care of the deletion in case the trashbin isn't setup properly. In order to distinguish this case, the `move2trash` function will return null instead of the true. Trashbin storage is adjusted for this case.

The overall behaviour remains compatible with the previous assumptions.

## How Has This Been Tested?
Manually tested following steps described in https://github.com/owncloud/core/issues/38923

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
