### PR TITLE
[tests-only] Fix lock timeout for external storage tests

### DIFF
--- a/apps/files_external/tests/Storage/OwncloudTest.php
+++ b/apps/files_external/tests/Storage/OwncloudTest.php
@@ -45,6 +45,9 @@ class OwncloudTest extends \Test\Files\Storage\Storage {
 		if (! \is_array($this->config) or ! isset($this->config['owncloud']) or ! $this->config['owncloud']['run']) {
 			$this->markTestSkipped('ownCloud backend not configured');
 		}
+		if (isset($this->config['owncloud']['wait'])) {
+			$this->waitDelay = $this->config['owncloud']['wait'];
+		}
 		$this->config['owncloud']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
 		$this->instance = new OwnCloud($this->config['owncloud']);
 		$this->instance->mkdir('/');
@@ -52,6 +55,7 @@ class OwncloudTest extends \Test\Files\Storage\Storage {
 
 	protected function tearDown(): void {
 		if ($this->instance) {
+			$this->wait();
 			$this->instance->rmdir('/');
 		}
 

--- a/tests/drone/configs/config.files_external.owncloud.php
+++ b/tests/drone/configs/config.files_external.owncloud.php
@@ -6,5 +6,6 @@ return [
 		'user'=>'test',
 		'password'=>'test',
 		'root'=>'',
+		'wait'=> 0.2,
 	]
 ];

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -37,7 +37,7 @@ abstract class Storage extends \Test\TestCase {
 	 */
 	protected function wait() {
 		if ($this->waitDelay > 0) {
-			\sleep($this->waitDelay);
+			\usleep($this->waitDelay * 1000000);
 		}
 	}
 


### PR DESCRIPTION
## Description
Add a small wait period to prevent the database from running into a lock exception during external storage tests.

Did several tests in https://github.com/owncloud/core/pull/39069, this **should** be fixed. Maybe we can decrease the 0.2s period, but I suggest to try and observe with this number for now.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/39046

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
