### PR TITLE
[tests-only] skip new create-folder-with-create-button tests on oC10.8.0

### DIFF
--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -37,19 +37,19 @@ Feature: add and delete app configs using occ command
     And the command output should contain the text 'System config value con set to empty string'
     And system config key "con" should have value ""
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: admin tries to add an empty config key for an app using the occ command
     When the administrator adds config key "''" with value "conkey" in app "core" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Config name must not be empty.'
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: admin tries to add a config key and specifying the empty string as the app name using the occ command
     When the administrator adds config key "con" with value "conkey" in app "''" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'App name must not be empty.'
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: admin tries to add an empty system config key using the occ command
     When the administrator adds system config key "''" with value "conkey" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/webUICreateDelete/createFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFolders.feature
@@ -19,7 +19,7 @@ Feature: create folders
       | folder-!@#$%^&* ! |
       | नेपालि            |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Create a folder using the create button
     When the user creates a folder with the name "<folder-name>" using the webUI via create button
     Then folder "<folder-name>" should be listed on the webUI
@@ -29,7 +29,7 @@ Feature: create folders
       | folder-name       |
       | folder-!@#$%^&*( ! |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: Abort create folder using the cancel button
     When the user opens the newFileMenu using the webUI
     Then the newFileMenu should be displayed on the webUI


### PR DESCRIPTION
## Description
PR #39056 added these tests yesterday, but we know that they will not work against a 10.8.0 system. Skip them in that case.
They will work on any later version - called 10.8.1 or 10.9.0 or whatever.

There were a few CLI tests that specified skip on 10.8. I changed that to 10.8.0.

That allows us to temporarily set the version in `master` to 10.8.1 and all these tagged tests will run. We can later make the release version whatever is needed (e.g. 10.9.0).

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
