### PR TITLE
[tests-only] Exclude javascript spec-files from SonarCloud test coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -34,4 +34,4 @@ sonar.php.coverage.reportPaths=results/clover-phpunit-php7.2-mariadb10.2.xml,res
 sonar.javascript.lcov.reportPaths=results/lcov.info
 
 # Exclude translation, dependency, 3rd-party and test files
-sonar.exclusions=build/**,changelog/**,config/**,core/l10n/**,core/vendor/**,l10n/**,lib/l10n/**,lib/composer/**,settings/l10n/**,resources/**,settings/tests/**,tests/**,vendor-bin/**,apps/files_external/3rdparty/**,apps/**/l10n/**,apps/**/tests/**,apps/**/vendor/**
+sonar.exclusions=build/**,changelog/**,config/**,core/l10n/**,core/vendor/**,l10n/**,lib/l10n/**,lib/composer/**,settings/l10n/**,resources/**,settings/tests/**,tests/**,vendor-bin/**,apps/files_external/3rdparty/**,apps/**/l10n/**,apps/**/tests/**,apps/**/vendor/**,core/js/tests/**


### PR DESCRIPTION
Noticed in https://github.com/owncloud/core/pull/38877 and https://github.com/owncloud/core/pull/39067

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
