### PR TITLE
[tests-only] Run federated tests against latest and 10.7.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -173,7 +173,7 @@ config = {
                 "apiFederationToShares2",
             ],
             "federatedServerNeeded": True,
-            "federatedServerVersions": ["git", "latest", "10.6.0"],
+            "federatedServerVersions": ["git", "latest", "10.7.0"],
         },
         "cli": {
             "suites": [
@@ -196,7 +196,7 @@ config = {
                 "cliExternalStorage",
             ],
             "federatedServerNeeded": True,
-            "federatedServerVersions": ["git", "latest", "10.6.0"],
+            "federatedServerVersions": ["git", "latest", "10.7.0"],
         },
         "webUI": {
             "suites": {
@@ -259,7 +259,7 @@ config = {
                 "webUISharingExternal2": "webUISharingExt2",
             },
             "federatedServerNeeded": True,
-            "federatedServerVersions": ["git", "latest", "10.6.0"],
+            "federatedServerVersions": ["git", "latest", "10.7.0"],
         },
         "webUIFirefox": {
             "suites": {


### PR DESCRIPTION
## Description
ownCloud 10.8.0 has been released and is now the version that is pointed to by "latest". The next previous version is now 10.7.0.
Change federated tests from testing against 10.6.0 to 10.7.0

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
