### PR TITLE
Verify filename while chunking and show detailed error message if filename is too long 

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Exception/FileNameTooLong.php
+++ b/apps/dav/lib/Connector/Sabre/Exception/FileNameTooLong.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @author Jan Ackermann <jackermann@owncloud.com>
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Connector\Sabre\Exception;
+
+/**
+ * File name too long
+ *
+ * This exception is thrown whenever a user tries to upload a file with a name which exceeds hard limitations
+ *
+ */
+class FileNameTooLong extends \Sabre\DAV\Exception {
+
+	/**
+	 * Returns the HTTP status code for this exception
+	 *
+	 * @return int
+	 */
+	public function getHTTPCode() {
+		return 400;
+	}
+}

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1227,6 +1227,19 @@ OC.Uploader.prototype = _.extend({
 						// not enough space
 						OC.Notification.show(t('files', 'Not enough free space'), {type: 'error'});
 						self.cancelUploads();
+					} else if (status === 400) {
+						var message = '';
+						if (upload) {
+							var response = upload.getResponse();
+							message = response.message;
+						}
+
+						// file name too long
+						if (message === 'File name is too long') {
+							message = t('files', 'File name is too long');
+						}
+
+						OC.Notification.show(t('files', message), {type: 'error'});
 					} else {
 						// HTTP connection problem or other error
 						var message = '';

--- a/changelog/unreleased/39806
+++ b/changelog/unreleased/39806
@@ -1,6 +1,6 @@
 Enhancement: Show appropriate error message if uploaded file name too long
 
-While uploading a file, the internal file name could be longer as the original
+While uploading a file, the internal file name could be longer than the original
 file name due to chunking. This PR verifies the file name of the chunks and
 shows an appropriate error message, if too long.
 

--- a/changelog/unreleased/39806
+++ b/changelog/unreleased/39806
@@ -1,0 +1,8 @@
+Enhancement: Show appropriate error message if uploaded file name too long
+
+While uploading a file, the internal file name could be longer as the original
+file name due to chunking. This PR verifies the file name of the chunks and
+shows an appropriate error message, if too long.
+
+https://github.com/owncloud/core/pull/39086
+https://github.com/owncloud/enterprise/issues/4692

--- a/lib/public/Files/FileNameTooLongException.php
+++ b/lib/public/Files/FileNameTooLongException.php
@@ -36,4 +36,15 @@ namespace OCP\Files;
  * @since 8.1.0
  */
 class FileNameTooLongException extends InvalidPathException {
+
+	/**
+	 * @since 8.1.0
+	 * @param string $message [optional] The Exception message to throw.
+	 * @param int $code [optional] The Exception code.
+	 * @param \Throwable $previous [optional] The previous throwable used for the exception chaining.
+	 */
+	public function __construct($message = '', int $code = 0, \Throwable $previous = null) {
+		$message = $message ? $message: 'File name is too long';
+		parent::__construct($message, $code, $previous);
+	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
While uploading a file, the internal file name could be longer as the original
file name due to chunking. This PR verifies the file name of the chunks and
shows an appropriate error message, if too long.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
