### PR TITLE
[tests-only] Adjust php unit tests

### DIFF
--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -33,6 +33,7 @@ use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use PHPUnit\Util\Test as TestUtil;
 
 abstract class TestCase extends BaseTestCase {
 	/** @var \OC\Command\QueueBus */
@@ -451,7 +452,10 @@ abstract class TestCase extends BaseTestCase {
 		if (\getenv('CI') !== false) {
 			return true;
 		}
-		$annotations = $this->getAnnotations();
+		$annotations = TestUtil::parseTestMethodAnnotations(
+			static::class,
+			$this->getName()
+		);
 		if (isset($annotations['class']['group']) && \in_array('DB', $annotations['class']['group'])) {
 			return true;
 		}

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -13,7 +13,6 @@
 		<directory suffix='.php'>lib/</directory>
 		<directory suffix='.php'>Settings/</directory>
 		<directory suffix='.php'>Core/</directory>
-		<directory suffix='.php'>ocs-provider/</directory>
 		<file>apps.php</file>
 	</testsuite>
 	<!-- filters for code coverage -->


### PR DESCRIPTION
## Description
`getAnnotations()` is being removed in PHPunit9. We may as well refactor it now (with PHPunit8)

The PHPunit setup xml has a reference to `ocs-provider` in the `tests` directory. That does not exist. PHPunit9 complains about it. We may as well clean it up now. Some time in the past there were unit tests in `tests/ocs-provider` - but not any more.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
