### PR TITLE
Use md5 hash for chunk name

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -305,7 +305,8 @@ class File extends Node implements IFile, IFileNode {
 	private function getPartFileBasePath($path) {
 		$partFileInStorage = \OC::$server->getConfig()->getSystemValue('part_file_in_storage', true);
 		if ($partFileInStorage) {
-			return $path;
+			$pathParts = \pathinfo($path);
+			return Filesystem::normalizePath($pathParts['dirname'].'/'.\md5($pathParts['basename']));
 		} else {
 			return \md5($path); // will place it in the root of the view with a unique name
 		}

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -305,8 +305,7 @@ class File extends Node implements IFile, IFileNode {
 	private function getPartFileBasePath($path) {
 		$partFileInStorage = \OC::$server->getConfig()->getSystemValue('part_file_in_storage', true);
 		if ($partFileInStorage) {
-			$pathParts = \pathinfo($path);
-			return Filesystem::normalizePath($pathParts['dirname'].'/'.\md5($pathParts['basename']));
+			return Filesystem::hashFileName($path);
 		} else {
 			return \md5($path); // will place it in the root of the view with a unique name
 		}

--- a/changelog/unreleased/39088
+++ b/changelog/unreleased/39088
@@ -1,0 +1,10 @@
+Bugfix: Hash chunk(v2) filename
+
+Before this PR, while uploading a file, chunks(v2) were created with filename
+consist of original filename plus chunk suffix.
+This could lead to a too long filename error.
+With this PR the chunk filenames consist of md5 hash and chunk suffix, which
+decreases the filename and prevents a too long filename error.
+
+https://github.com/owncloud/core/pull/39088
+https://github.com/owncloud/enterprise/issues/4692

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -1091,7 +1091,14 @@ class Filesystem {
 	}
 
 	/**
-	 * Hash the file name in a given path while preserving the rest of it
+	 * Hash the file name in a given path while preserving the rest of it.
+	 * This method is used in combination with file chunking to prevent the
+	 * file name from exceeding its limit.
+	 *
+	 * Examples:
+	 * /files/test.txt -> /files/dd18bf3a8e0a2a3e53e2661c7fb53534
+	 * files/test.txt -> files/dd18bf3a8e0a2a3e53e2661c7fb53534
+	 * /test.txt -> /dd18bf3a8e0a2a3e53e2661c7fb53534
 	 *
 	 * @param string $path
 	 * @return string

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -1089,4 +1089,22 @@ class Filesystem {
 	public static function getETag($path) {
 		return self::$defaultInstance->getETag($path);
 	}
+
+	/**
+	 * Hash the file name in a given path while preserving the rest of it
+	 *
+	 * @param string $path
+	 * @return string
+	 */
+	public static function hashFileName($path) {
+		$pathParts = \pathinfo($path);
+		$hashedFileName = \md5($pathParts['basename']);
+
+		if (isset($pathParts['dirname']) && $pathParts['dirname'] !== '.') {
+			$dirname = \rtrim($pathParts['dirname'], '/');
+			$hashedFileName = $dirname . '/' . $hashedFileName;
+		}
+
+		return $hashedFileName;
+	}
 }

--- a/lib/private/Files/Stream/Checksum.php
+++ b/lib/private/Files/Stream/Checksum.php
@@ -213,6 +213,18 @@ class Checksum extends Wrapper {
 			return self::$checksums[$path];
 		}
 
+		// check the md5 in case only the filename was hashed
+		// this was introduced in 10.9
+		$pathParts = \pathinfo($path);
+
+		$hashedNameToCheck = \md5($pathParts['basename']);
+		if (isset($pathParts['dirname']) && $pathParts['dirname'] !== '.') {
+			$hashedNameToCheck = $pathParts['dirname'] . '/' . $hashedNameToCheck;
+		}
+		if (isset(self::$checksums[$hashedNameToCheck])) {
+			return self::$checksums[$hashedNameToCheck];
+		}
+
 		// check the md5($path) in case "part_file_in_storage" is set to false
 		// see apps/dav/lib/Connector/Sabre/File.php getPartFileBasePath  (around line 305)
 		// strip initial dir, usually "files" from "files/dir1/dir2"

--- a/lib/private/Files/Stream/Checksum.php
+++ b/lib/private/Files/Stream/Checksum.php
@@ -24,6 +24,7 @@ namespace OC\Files\Stream;
 
 use Icewind\Streams\Wrapper;
 use OC\Cache\CappedMemoryCache;
+use OC\Files\Filesystem;
 
 /**
  * Computes the checksum of the wrapped stream. The checksum can be retrieved with
@@ -213,14 +214,9 @@ class Checksum extends Wrapper {
 			return self::$checksums[$path];
 		}
 
-		// check the md5 in case only the filename was hashed
+		// check the hash in case only the filename was hashed
 		// this was introduced in 10.9
-		$pathParts = \pathinfo($path);
-
-		$hashedNameToCheck = \md5($pathParts['basename']);
-		if (isset($pathParts['dirname']) && $pathParts['dirname'] !== '.') {
-			$hashedNameToCheck = $pathParts['dirname'] . '/' . $hashedNameToCheck;
-		}
+		$hashedNameToCheck = Filesystem::hashFileName($path);
 		if (isset(self::$checksums[$hashedNameToCheck])) {
 			return self::$checksums[$hashedNameToCheck];
 		}

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -562,4 +562,23 @@ class FilesystemTest extends TestCase {
 		\OC::$server->getMountProviderCollection()->registerProvider($mountProvider);
 		$this->assertEquals('/foo/bar/', Filesystem::getMountPoint('/foo/bar'));
 	}
+
+	public function getHashedFileNamePaths() {
+		return [
+			['/test/test.txt', '/test/dd18bf3a8e0a2a3e53e2661c7fb53534'],
+			['test/test.txt', 'test/dd18bf3a8e0a2a3e53e2661c7fb53534'],
+			['/test.txt', '/dd18bf3a8e0a2a3e53e2661c7fb53534'],
+			['test.txt', 'dd18bf3a8e0a2a3e53e2661c7fb53534'],
+		];
+	}
+
+	/**
+	 * @dataProvider getHashedFileNamePaths
+	 *
+	 * @param string $path
+	 * @param string $expected
+	 */
+	public function testHashFileName($path, $expected) {
+		$this->assertEquals($expected, Filesystem::hashFileName($path));
+	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Before this PR, while uploading a file, chunks were created with filename
consist of original filename plus chunk suffix.
This could lead to a too long filename error.
With this PR the chunk filenames consist of md5 hash and chunk suffix, which
decreases the filename and prevents a too long filename error.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4692
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
