### PR TITLE
Clarify days parameter of the occ dav:cleanup-chunks command

### DIFF
--- a/apps/dav/lib/Command/CleanupChunks.php
+++ b/apps/dav/lib/Command/CleanupChunks.php
@@ -48,15 +48,15 @@ class CleanupChunks extends Command {
 			->setName('dav:cleanup-chunks')
 			->setDescription('Cleanup outdated chunks')
 			->addArgument(
-				'age-in-days',
+				'minimum-age-in-days',
 				InputArgument::OPTIONAL,
-				'age of uploads in days - minimum 2 days - maximum 100',
+				'minimum age of uploads to cleanup (in days - minimum 2 days - maximum 100)',
 				2
 			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$d = $input->getArgument('age-in-days');
+		$d = $input->getArgument('minimum-age-in-days');
 		$d = \max(2, \min($d, 100));
 		$cutOffTime = new \DateTime("$d days ago");
 		$output->writeln("Cleaning chunks older than $d days({$cutOffTime->format('c')})");

--- a/apps/dav/tests/unit/Command/CleanupChunksTest.php
+++ b/apps/dav/tests/unit/Command/CleanupChunksTest.php
@@ -56,7 +56,7 @@ class CleanupChunksTest extends TestCase {
 	 */
 	public function testCommandInput($inputDays, $expectedDays) {
 		$this->commandTester->execute([
-			'age-in-days' => $inputDays
+			'minimum-age-in-days' => $inputDays
 		]);
 		$output = $this->commandTester->getDisplay();
 		$this->assertStringContainsString(

--- a/changelog/unreleased/39090
+++ b/changelog/unreleased/39090
@@ -1,0 +1,6 @@
+Change: Clarify days parameter of the occ dav:cleanup-chunks command
+
+The days parameter is the minimum age of uploads to cleanup. This has been
+clarified in the command help.
+
+https://github.com/owncloud/core/pull/39090


### PR DESCRIPTION
## Description
The days parameter of the occ dav:cleanup-chunks command is actually the minimum number of days old for cleaning up chunks. This was not 100% clear from the command help. The text and parameter name have been adjusted to say it is the minimum days.

I noticed when thinking about https://github.com/owncloud/core/pull/39068#issuecomment-888147103 and how to test this command.

```
$ php occ dav:cleanup-chunks --help
Description:
  Cleanup outdated chunks

Usage:
  dav:cleanup-chunks [<minimum-age-in-days>]

Arguments:
  minimum-age-in-days   minimum age of uploads to cleanup (in days - minimum 2 days - maximum 100) [default: 2]

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
      --no-warnings     Skip global warnings, show command output only
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

## How Has This Been Tested?
CI and local command use.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: I checked in docs and the command is described OK there
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
