### PR TITLE
feat: encryption keys location can be specified by the storage implementation

### DIFF
--- a/changelog/unreleased/39091
+++ b/changelog/unreleased/39091
@@ -1,0 +1,7 @@
+Change: Allow storage implementations to have their own encryption key storage
+
+The default encryption key storage location is not suitable for all storage
+implementations because e.g. the storage is not linked to a user.
+This is required for files_spaces.
+
+https://github.com/owncloud/core/pull/39091

--- a/lib/private/Encryption/File.php
+++ b/lib/private/Encryption/File.php
@@ -51,7 +51,11 @@ class File implements \OCP\Encryption\IFile {
 	public function getAccessList($path) {
 
 		// Make sure that a share key is generated for the owner too
-		list($owner, $ownerPath) = $this->util->getUidAndFilename($path);
+		try {
+			list($owner, $ownerPath) = $this->util->getUidAndFilename($path);
+		} catch (\BadMethodCallException $e) {
+			return ['users' => [], 'public' => false];
+		}
 
 		// always add owner to the list of users with access to the file
 		$userIds = [$owner];

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -348,6 +348,13 @@ class Storage implements IStorage {
 	 * @return string
 	 */
 	protected function getPathToKeys($path) {
+		# ask the storage implementation for the key storage
+		$mount = $this->mountManager->find($path);
+		$keyPath = $mount ? $mount->getStorage()->getEncryptionFileKeyDirectory('', $mount->getInternalPath($path)) : null;
+		if ($keyPath) {
+			return $keyPath;
+		}
+
 		list($owner, $relativePath) = $this->util->getUidAndFilename($path);
 		$systemWideMountPoint = $this->util->isSystemWideMountPoint($relativePath, $owner);
 

--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -73,6 +73,9 @@ class Util {
 	/** @var array paths excluded from encryption */
 	protected $excludedPaths;
 
+	/** @var array paths excluded full paths from encryption */
+	protected $excludedFullPaths;
+
 	/** @var \OC\Group\Manager $manager */
 	protected $groupManager;
 
@@ -104,6 +107,9 @@ class Util {
 		$this->excludedPaths[] = 'avatars';
 		$this->excludedPaths[] = 'avatar.png';
 		$this->excludedPaths[] = 'avatar.jpg';
+
+		// TODO: find a sophisticated solution
+		$this->excludedFullPaths[] = '/files_spaces/*/encryption*';
 	}
 
 	/**
@@ -353,6 +359,12 @@ class Util {
 				return true;
 			}
 
+			foreach ($this->excludedFullPaths as $excludedFullPathPath) {
+				if (fnmatch($excludedFullPathPath, $path)
+				) {
+					return true;
+				}
+			}
 			//detect system wide folders
 			if (\in_array($root[1], $this->excludedPaths)) {
 				return true;

--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -360,8 +360,7 @@ class Util {
 			}
 
 			foreach ($this->excludedFullPaths as $excludedFullPathPath) {
-				if (fnmatch($excludedFullPathPath, $path)
-				) {
+				if (\fnmatch($excludedFullPathPath, $normalizedPath)) {
 					return true;
 				}
 			}

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -797,4 +797,8 @@ abstract class Common implements Storage, ILockingStorage, IVersionedStorage, IP
 			return $lock;
 		}, $locks);
 	}
+
+	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string {
+		return null;
+	}
 }

--- a/lib/private/Files/Storage/Storage.php
+++ b/lib/private/Files/Storage/Storage.php
@@ -115,4 +115,6 @@ interface Storage extends \OCP\Files\Storage {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function changeLock($path, $type, ILockingProvider $provider);
+
+	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string;
 }

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -1084,6 +1084,13 @@ class Encryption extends Wrapper {
 	 */
 	protected function isVersion($path) {
 		$normalized = Filesystem::normalizePath($path);
+
+		// handle versions for spaces
+		$parts = \explode('/', $normalized);
+		if ($parts[1] === 'files_spaces' && $parts[3] === 'versions') {
+			return true;
+		}
+
 		return \substr($normalized, 0, \strlen('/files_versions/')) === '/files_versions/';
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -651,4 +651,8 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IPersistent
 
 		return [];
 	}
+
+	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string {
+		return $this->getWrapperStorage()->getEncryptionFileKeyDirectory($encryptionModuleId, $path);
+	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -216,7 +216,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			return new Encryption\Keys\Storage(
 				$view,
 				$util,
-				$c->getUserSession()
+				$c->getUserSession(),
+				$c->getMountManager()
 			);
 		});
 		$this->registerService('TagMapper', function (Server $c) {

--- a/tests/lib/Encryption/Keys/StorageTest.php
+++ b/tests/lib/Encryption/Keys/StorageTest.php
@@ -25,11 +25,16 @@ namespace Test\Encryption\Keys;
 
 use OC\Encryption\Keys\Storage;
 use OC\Encryption\Util;
+use OC\Files\Filesystem;
 use OC\Files\View;
+use OCP\Files\Mount\IMountManager;
+use OCP\Files\Mount\IMountPoint;
 use OCP\IUser;
 use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 use Test\Traits\UserTrait;
+use OCP\IConfig;
 
 /**
  * Class StorageTest
@@ -44,56 +49,66 @@ class StorageTest extends TestCase {
 	/** @var Storage */
 	protected $storage;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | Util */
+	/** @var MockObject | Util */
 	protected $util;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | View */
+	/** @var MockObject | View */
 	protected $view;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject */
+	/** @var MockObject */
 	protected $config;
+	/**
+	 * @var string[]
+	 */
+	private $mkdirStack;
+	/**
+	 * @var IMountManager|MockObject
+	 */
+	private $mountManager;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->util = $this->getMockBuilder('OC\Encryption\Util')
+		$this->util = $this->getMockBuilder(Util::class)
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->util->method('getKeyStorageRoot')->willReturn('');
 
-		$this->view = $this->getMockBuilder('OC\Files\View')
+		$this->view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->mountManager = $this->createMock(IMountManager::class);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user1');
-		/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
+		/** @var IUserSession | MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession->method('getUser')->willReturn($user);
 
 		$this->createUser('user1', '123456');
 		$this->createUser('user2', '123456');
-		$this->storage = new Storage($this->view, $this->util, $userSession);
+		$this->storage = new Storage($this->view, $this->util, $userSession, $this->mountManager);
 	}
 
 	public function tearDown(): void {
-		\OC\Files\Filesystem::tearDown();
+		Filesystem::tearDown();
 		parent::tearDown();
 	}
 
-	public function testSetFileKey() {
-		$this->util->expects($this->any())
+	public function testSetFileKey(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(false);
 		$this->view->expects($this->once())
@@ -109,7 +124,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function dataTestGetFileKey() {
+	public function dataTestGetFileKey(): array {
 		return [
 			['/files/foo.txt', '/files/foo.txt', true, 'key'],
 			['/files/foo.txt.ocTransferId2111130212.part', '/files/foo.txt', true, 'key'],
@@ -125,8 +140,8 @@ class StorageTest extends TestCase {
 	 * @param bool $originalKeyExists
 	 * @param string $expectedKeyContent
 	 */
-	public function testGetFileKey($path, $strippedPartialName, $originalKeyExists, $expectedKeyContent) {
-		$this->util->expects($this->any())
+	public function testGetFileKey($path, $strippedPartialName, $originalKeyExists, $expectedKeyContent): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturnMap([
 				['user1/files/foo.txt', ['user1', '/files/foo.txt']],
@@ -137,7 +152,7 @@ class StorageTest extends TestCase {
 		$this->util->expects($this->once())
 			->method('stripPartialFileExtension')
 			->willReturn('user1' . $strippedPartialName);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(false);
 
@@ -169,14 +184,14 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testSetFileKeySystemWide() {
-		$this->util->expects($this->any())
+	public function testSetFileKeySystemWide(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(true);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
 		$this->view->expects($this->once())
@@ -192,14 +207,14 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testGetFileKeySystemWide() {
-		$this->util->expects($this->any())
+	public function testGetFileKeySystemWide(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(true);
 		$this->view->expects($this->once())
@@ -217,7 +232,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testSetSystemUserKey() {
+	public function testSetSystemUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_put_contents')
 			->with(
@@ -231,7 +246,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testSetUserKey() {
+	public function testSetUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_put_contents')
 			->with(
@@ -245,7 +260,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testGetSystemUserKey() {
+	public function testGetSystemUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_get_contents')
 			->with($this->equalTo('/files_encryption/encModule/shareKey_56884'))
@@ -261,7 +276,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testGetUserKey() {
+	public function testGetUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_get_contents')
 			->with($this->equalTo('/user1/files_encryption/encModule/user1.publicKey'))
@@ -277,7 +292,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testGetUserKeyShared() {
+	public function testGetUserKeyShared(): void {
 		$this->view->expects($this->once())
 			->method('file_get_contents')
 			->with($this->equalTo('/user2/files_encryption/encModule/user2.publicKey'))
@@ -297,7 +312,7 @@ class StorageTest extends TestCase {
 		$this->assertTrue($this->isUserHomeMounted('user2'));
 	}
 
-	public function testGetUserKeyWhenKeyStorageIsOutsideHome() {
+	public function testGetUserKeyWhenKeyStorageIsOutsideHome(): void {
 		$this->view->expects($this->once())
 			->method('file_get_contents')
 			->with($this->equalTo('/enckeys/user2/files_encryption/encModule/user2.publicKey'))
@@ -311,9 +326,9 @@ class StorageTest extends TestCase {
 		$user->method('getUID')->willReturn('user1');
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession->method('getUser')->willReturn($user);
-		$util = $this->createMock(\OC\Encryption\Util::class);
+		$util = $this->createMock(Util::class);
 		$util->method('getKeyStorageRoot')->willReturn('enckeys');
-		$storage = new Storage($this->view, $util, $userSession);
+		$storage = new Storage($this->view, $util, $userSession, $this->mountManager);
 
 		$this->assertFalse($this->isUserHomeMounted('user2'));
 
@@ -331,7 +346,7 @@ class StorageTest extends TestCase {
 	 * @param string $userId
 	 * @return boolean true if mounted, false otherwise
 	 */
-	private function isUserHomeMounted($userId) {
+	private function isUserHomeMounted($userId): bool {
 		// verify that user2's FS got mounted when retrieving the key
 		$mountManager = \OC::$server->getMountManager();
 		$mounts = $mountManager->getAll();
@@ -342,7 +357,7 @@ class StorageTest extends TestCase {
 		return !empty($mounts);
 	}
 
-	public function testDeleteUserKey() {
+	public function testDeleteUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_exists')
 			->with($this->equalTo('/user1/files_encryption/encModule/user1.publicKey'))
@@ -357,7 +372,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testDeleteSystemUserKey() {
+	public function testDeleteSystemUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_exists')
 			->with($this->equalTo('/files_encryption/encModule/shareKey_56884'))
@@ -372,14 +387,14 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testDeleteFileKeySystemWide() {
-		$this->util->expects($this->any())
+	public function testDeleteFileKeySystemWide(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(true);
 		$this->view->expects($this->once())
@@ -396,14 +411,14 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testDeleteFileKey() {
-		$this->util->expects($this->any())
+	public function testDeleteFileKey(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(false);
 		$this->view->expects($this->once())
@@ -423,11 +438,11 @@ class StorageTest extends TestCase {
 	/**
 	 * @dataProvider dataProviderCopyRename
 	 */
-	public function testRenameKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget) {
-		$this->view->expects($this->any())
+	public function testRenameKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget): void {
+		$this->view
 			->method('file_exists')
 			->willReturn(true);
-		$this->view->expects($this->any())
+		$this->view
 			->method('is_dir')
 			->willReturn(true);
 		$this->view->expects($this->once())
@@ -437,12 +452,12 @@ class StorageTest extends TestCase {
 				$this->equalTo($expectedTarget)
 			)
 			->willReturn(true);
-		$this->util->expects($this->any())
+		$this->util
 			->method('getUidAndFilename')
-			->will($this->returnCallback([$this, 'getUidAndFilenameCallback']));
-		$this->util->expects($this->any())
+			->willReturnCallback([$this, 'getUidAndFilenameCallback']);
+		$this->util
 			->method('isSystemWideMountPoint')
-			->willReturnCallback(function ($path, $owner) use ($systemWideMountSource, $systemWideMountTarget) {
+			->willReturnCallback(function ($path) use ($systemWideMountSource, $systemWideMountTarget) {
 				if (\strpos($path, 'source.txt') !== false) {
 					return $systemWideMountSource;
 				}
@@ -455,11 +470,11 @@ class StorageTest extends TestCase {
 	/**
 	 * @dataProvider dataProviderCopyRename
 	 */
-	public function testCopyKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget) {
-		$this->view->expects($this->any())
+	public function testCopyKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget): void {
+		$this->view
 			->method('file_exists')
 			->willReturn(true);
-		$this->view->expects($this->any())
+		$this->view
 			->method('is_dir')
 			->willReturn(true);
 		$this->view->expects($this->once())
@@ -469,12 +484,12 @@ class StorageTest extends TestCase {
 				$this->equalTo($expectedTarget)
 			)
 			->willReturn(true);
-		$this->util->expects($this->any())
+		$this->util
 			->method('getUidAndFilename')
-			->will($this->returnCallback([$this, 'getUidAndFilenameCallback']));
-		$this->util->expects($this->any())
+			->willReturnCallback([$this, 'getUidAndFilenameCallback']);
+		$this->util
 			->method('isSystemWideMountPoint')
-			->willReturnCallback(function ($path, $owner) use ($systemWideMountSource, $systemWideMountTarget) {
+			->willReturnCallback(function ($path) use ($systemWideMountSource, $systemWideMountTarget) {
 				if (\strpos($path, 'source.txt') !== false) {
 					return $systemWideMountSource;
 				}
@@ -484,7 +499,7 @@ class StorageTest extends TestCase {
 		$this->storage->copyKeys($source, $target);
 	}
 
-	public function getUidAndFilenameCallback() {
+	public function getUidAndFilenameCallback(): array {
 		$args = \func_get_args();
 
 		$path = $args[0];
@@ -493,7 +508,7 @@ class StorageTest extends TestCase {
 		return [$parts[1], '/' . \implode('/', \array_slice($parts, 2))];
 	}
 
-	public function dataProviderCopyRename() {
+	public function dataProviderCopyRename(): array {
 		return [
 			['/user1/files/source.txt', '/user1/files/target.txt', false, false,
 				'/user1/files_encryption/keys/files/source.txt/', '/user1/files_encryption/keys/files/target.txt/'],
@@ -531,13 +546,13 @@ class StorageTest extends TestCase {
 	 * @param string $storageRoot
 	 * @param string $expected
 	 */
-	public function testGetPathToKeys($path, $systemWideMountPoint, $storageRoot, $expected) {
-		$this->invokePrivate($this->storage, 'root_dir', [$storageRoot]);
+	public function testGetPathToKeys($path, $systemWideMountPoint, $storageRoot, $expected): void {
+		self::invokePrivate($this->storage, 'root_dir', [$storageRoot]);
 
-		$this->util->expects($this->any())
+		$this->util
 			->method('getUidAndFilename')
-			->will($this->returnCallback([$this, 'getUidAndFilenameCallback']));
-		$this->util->expects($this->any())
+			->willReturnCallback([$this, 'getUidAndFilenameCallback']);
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn($systemWideMountPoint);
 
@@ -547,7 +562,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function dataTestGetPathToKeys() {
+	public function dataTestGetPathToKeys(): array {
 		return [
 			['/user1/files/source.txt', false, '', '/user1/files_encryption/keys/files/source.txt/'],
 			['/user1/files/source.txt', true, '', '/files_encryption/keys/files/source.txt/'],
@@ -556,16 +571,16 @@ class StorageTest extends TestCase {
 		];
 	}
 
-	public function testKeySetPreparation() {
-		$this->view->expects($this->any())
+	public function testKeySetPreparation(): void {
+		$this->view
 			->method('file_exists')
 			->willReturn(false);
-		$this->view->expects($this->any())
+		$this->view
 			->method('is_dir')
 			->willReturn(false);
-		$this->view->expects($this->any())
+		$this->view
 			->method('mkdir')
-			->will($this->returnCallback([$this, 'mkdirCallback']));
+			->willReturnCallback([$this, 'mkdirCallback']);
 
 		$this->mkdirStack = [
 			'/user1/files_encryption/keys/foo',
@@ -576,7 +591,7 @@ class StorageTest extends TestCase {
 		self::invokePrivate($this->storage, 'keySetPreparation', ['/user1/files_encryption/keys/foo']);
 	}
 
-	public function mkdirCallback() {
+	public function mkdirCallback(): void {
 		$args = \func_get_args();
 		$expected = \array_pop($this->mkdirStack);
 		$this->assertSame($expected, $args[0]);
@@ -584,35 +599,44 @@ class StorageTest extends TestCase {
 
 	/**
 	 * @dataProvider dataTestGetFileKeyDir
-	 *
-	 * @param bool $isSystemWideMountPoint
-	 * @param string $storageRoot
-	 * @param string $expected
 	 */
-	public function testGetFileKeyDir($isSystemWideMountPoint, $storageRoot, $expected) {
+	public function testGetFileKeyDir($isSystemWideMountPoint, $storageRoot, $expected, $hasMountPoint = false, $storagePath = null, $expectDefaultImpl = true): void {
 		$path = '/user1/files/foo/bar.txt';
 		$owner = 'user1';
 		$relativePath = '/foo/bar.txt';
 
-		$this->invokePrivate($this->storage, 'root_dir', [$storageRoot]);
+		if ($hasMountPoint) {
+			$storage = $this->createMock(\OC\Files\Storage\Storage::class);
+			$storage->method('getEncryptionFileKeyDirectory')
+				->with('OC_DEFAULT_MODULE', $relativePath)
+				->willReturn($storagePath);
+			$mount = $this->createMock(IMountPoint::class);
+			$mount->method('getStorage')->willReturn($storage);
+			$mount->method('getInternalPath')->willReturn($relativePath);
+			$this->mountManager->method('find')->willReturn($mount);
+		}
 
-		$this->util->expects($this->once())->method('isSystemWideMountPoint')
+		self::invokePrivate($this->storage, 'root_dir', [$storageRoot]);
+
+		$this->util->expects($expectDefaultImpl ? $this->once(): $this->never())->method('isSystemWideMountPoint')
 			->willReturn($isSystemWideMountPoint);
-		$this->util->expects($this->once())->method('getUidAndFilename')
+		$this->util->expects($expectDefaultImpl ? $this->once(): $this->never())->method('getUidAndFilename')
 			->with($path)->willReturn([$owner, $relativePath]);
 
 		$this->assertSame(
 			$expected,
-			$this->invokePrivate($this->storage, 'getFileKeyDir', ['OC_DEFAULT_MODULE', $path])
+			self::invokePrivate($this->storage, 'getFileKeyDir', ['OC_DEFAULT_MODULE', $path])
 		);
 	}
 
-	public function dataTestGetFileKeyDir() {
+	public function dataTestGetFileKeyDir(): array {
 		return [
 			[false, '', '/user1/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/'],
 			[true, '', '/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/'],
 			[false, 'newStorageRoot', '/newStorageRoot/user1/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/'],
 			[true, 'newStorageRoot', '/newStorageRoot/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/'],
+			[false, '', '/user1/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/', true, null],
+			[false, '', '/foo/bar/keys/foo/bar.txt/OC_DEFAULT_MODULE/', true, '/foo/bar/keys/foo/bar.txt/OC_DEFAULT_MODULE/', false],
 		];
 	}
 }


### PR DESCRIPTION

## Description
This allows storage implementations to specify the location for encryption keys
https://github.com/owncloud/files_spaces needs this because the space does not belong to a user.


## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4687


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
