### PR TITLE
[tests-only] [full-ci] Refactor previews tests so they can run on oC10 or OCIS

### DIFF
--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -4,21 +4,6 @@ Feature: previews of files downloaded through the webdav API
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcis @issue-ocis-2069
-  Scenario Outline: download different sizes of previews of file
-    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
-    When user "Alice" downloads the preview of "/parent.txt" with width <width> and height <height> using the WebDAV API
-    Then the HTTP status code should be "200"
-    And the downloaded image should be <width> pixels wide and <height> pixels high
-    Examples:
-      | width | height |
-      | 1     | 1      |
-      | 32    | 32     |
-      | 1024  | 1024   |
-      | 1     | 1024   |
-      | 1024  | 1      |
-
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-188
   Scenario Outline: download previews with invalid width
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "Alice" downloads the preview of "/parent.txt" with width "<width>" and height "32" using the WebDAV API
@@ -35,7 +20,7 @@ Feature: previews of files downloaded through the webdav API
       | A     |
       | %2F   |
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-188
+
   Scenario Outline: download previews with invalid height
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "Alice" downloads the preview of "/parent.txt" with width "32" and height "<height>" using the WebDAV API
@@ -112,7 +97,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
-  @issue-ocis-2071 @skipOnOcis
+
   Scenario: download previews of other users files
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -121,7 +106,7 @@ Feature: previews of files downloaded through the webdav API
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "File not found: parent.txt in '%username%'"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-2064
+
   Scenario: download previews of folders
     Given user "Alice" has created folder "subfolder"
     When user "Alice" downloads the preview of "/subfolder/" with width "32" and height "32" using the WebDAV API
@@ -136,7 +121,7 @@ Feature: previews of files downloaded through the webdav API
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "File with name parent.txt could not be located"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @issue-ocis-192 @issue-ocis-2070 @skipOnOcis
+
   Scenario: Download file previews when it is disabled by the administrator
     Given the administrator has updated system config key "enable_previews" with value "false" and type "boolean"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -144,7 +129,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @issue-ocis-2070 @skipOnOcis
+
   Scenario: unset maximum size of previews
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And the administrator has updated system config key "preview_max_x" with value "null"
@@ -153,7 +138,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @issue-ocis-2070 @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcis
+
   Scenario: set maximum size of previews
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When the administrator updates system config key "preview_max_x" with value "null" using the occ command
@@ -163,7 +148,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "400"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\BadRequest"
 
-  @issue-ocis-2070 @skipOnOcis
+
   Scenario Outline: download previews of different size smaller than the maximum size set
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And the administrator has updated system config key "preview_max_x" with value "32"
@@ -178,7 +163,7 @@ Feature: previews of files downloaded through the webdav API
       | 32    | 12     | 200       |
       | 12    | 32     | 200       |
 
-  @issue-ocis-2070 @skipOnOcis
+
   Scenario Outline: download previews of different size larger than the maximum size set
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     And the administrator has updated system config key "preview_max_x" with value "32"

--- a/tests/acceptance/features/apiWebdavPreviews/previewsAutoAdustedSizing.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previewsAutoAdustedSizing.feature
@@ -1,0 +1,25 @@
+@api @preview-extension-required
+Feature: sizing of previews of files downloaded through the webdav API
+  As a user
+  I want the aspect-ratio of previews to be preserved even when I ask for an unusual preview size
+  So that the previews always have a similar look-and-feel to the original file
+
+  This is optional behavior of an implementation. OCIS happens like this,
+  but oC10 does not do this auto-fix of the aspect ratio.
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  @skipOnOcV10
+  Scenario Outline: download different sizes of previews of file
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    When user "Alice" downloads the preview of "/parent.txt" with width <request_width> and height <request_height> using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded image should be <return_width> pixels wide and <return_height> pixels high
+    Examples:
+      | request_width | request_height | return_width | return_height |
+      | 1             | 1              | 16           | 16            |
+      | 32            | 32             | 32           | 32            |
+      | 1024          | 1024           | 640          | 480           |
+      | 1             | 1024           | 16           | 16            |
+      | 1024          | 1              | 640          | 480           |

--- a/tests/acceptance/features/apiWebdavPreviews/previewsExactSizing.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previewsExactSizing.feature
@@ -1,0 +1,25 @@
+@api @preview-extension-required
+Feature: sizing of previews of files downloaded through the webdav API
+  As a user
+  I want previews to be the exact requested size even when I ask for an unusual preview size combination
+  So that the previews always have the exact size that I want as a user/client.
+
+  This is optional behavior of an implementation. oC10 happens like this,
+  but OCIS does an auto-fix of the aspect ratio.
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  @skipOnOcis
+  Scenario Outline: download different sizes of previews of file
+    Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
+    When user "Alice" downloads the preview of "/parent.txt" with width <width> and height <height> using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the downloaded image should be <width> pixels wide and <height> pixels high
+    Examples:
+      | width | height |
+      | 1     | 1      |
+      | 32    | 32     |
+      | 1024  | 1024   |
+      | 1     | 1024   |
+      | 1024  | 1      |


### PR DESCRIPTION
## Description
There are various `previews.feature` tests that are not being skipped on OCIS. And in the OCIS  repo there are versions of some of these tests that are "bug demos". These days we have the expected-failures files. So we can run the "real" tests from core in OCIS CI  and add them to expected-failures if they do not pass.

This PR:

1) Removes the skip tags from all the previews tests, so that they will all run in all CI
2) Provides two different test scenarios for sizing of previews of files downloaded through the webdav API - the behavior of oC10 is that the exact requested size is returned (even if the request is something "weird" like 1 pixel by 32 pixels). OCIS behaves differently (and more reasonably, depending on how you define "reasonable" - it always returns a width-height that preserves the aspect-ratio of the original file). That is discussed in https://github.com/owncloud/ocis/issues/2069 - and we are accepting that the 2 implementations can have this difference in behavior.

## Related Issue
https://github.com/owncloud/ocis/issues/2313

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
