### PR TITLE
Add eventlistener to detect a click on an iFrame and close open menus

### DIFF
--- a/changelog/unreleased/39094
+++ b/changelog/unreleased/39094
@@ -1,0 +1,9 @@
+Bugfix: Close open menus if click is on an iFrame
+
+Before this PR click events was caught by iFrames due to this circumstances
+for example the settings menu was never closed while clicking inside the
+files_pdfviewer viewer. With this PR a new event has been added and closes the
+menu.
+
+https://github.com/owncloud/core/issues/39093
+https://github.com/owncloud/core/pull/39094

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1552,6 +1552,15 @@ function initCore() {
 
 	OC.registerMenu($('#expand'), $('#expanddiv'));
 
+	/**
+	 * This event gets fired, if your focused element is for example the navbar
+	 * and you click on an iframe.
+	 * So we can close the open menus, for example the #settings menu
+	 */
+	$(window).on('blur.closemenus',function(){
+		OC.hideMenus();
+	});
+
 	// toggle for menus
 	$(document).on('mouseup.closemenus', function (event) {
 		var $el = $(event.target);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Before this PR click events was caught by iFrames due to this circumstances
for example the settings menu was never closed while clicking inside the
files_pdfviewer viewer. With this PR a new event has been added and closes the
menu.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39093

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Open a pdf with files_pdfviewer 
- Click on the settings menu (top right)
- Click inside the pdf
- Settings menu closes :+1: 
Same applies to Collabora

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
