### PR TITLE
[Tests-Only] Add acceptance test case for uploading files with maximum file name length possible

### DIFF
--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -168,3 +168,21 @@ Feature: upload file using new chunking
       | file-name |
       | &#?       |
       | TIÄFÜ     |
+
+
+  Scenario: Upload chunked file with new chunking with lengthy filenames
+    Given the owncloud log level has been set to debug
+    And the owncloud log has been cleared
+    When user "Alice" uploads the following chunks to "हजार नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-012345.txt" with new chunking and using the WebDAV API
+      | number | content                   |
+      | 1      | AAAAAAAAAAAAAAAAAAAAAAAAA |
+      | 2      | BBBBBBBBBBBBBBBBBBBBBBBBB |
+      | 3      | CCCCCCCCCCCCCCCCCCCCCCCCC |
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Alice"
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And as "Alice" file "हजार नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-012345.txt" should exist
+    And the content of file "हजार नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-012345.txt" for user "Alice" should be "AAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCCCCCC"
+    And the log file should not contain any log-entries containing these attributes:
+      | app |
+      | dav |

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
@@ -99,3 +99,20 @@ Feature: upload file using old chunking
       | 0           |
       | @a#8a=b?c=d |
       | ?abc=oc #   |
+
+  Scenario: Upload chunked file with old chunking with lengthy filenames
+    Given the owncloud log level has been set to debug
+    And the owncloud log has been cleared
+    When user "Alice" uploads the following chunks to "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" with old chunking and using the WebDAV API
+      | number | content                   |
+      | 1      | AAAAAAAAAAAAAAAAAAAAAAAAA |
+      | 2      | BBBBBBBBBBBBBBBBBBBBBBBBB |
+      | 3      | CCCCCCCCCCCCCCCCCCCCCCCCC |
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Alice"
+      | ETag | /^[a-f0-9:\.]{1,32}$/ |
+    And as "Alice" file "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" should exist
+    And the content of file "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" for user "Alice" should be "AAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCCCCCC"
+    And the log file should not contain any log-entries containing these attributes:
+      | app |
+      | dav |


### PR DESCRIPTION
## Description
This PR adds acceptance tests for syncing files with UTF-8 names, where files with maximum possible filename length are uploaded using chunking.

## Related Issue
- https://github.com/owncloud/core/issues/39095

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
