### PR TITLE
config_apps_sample changes for WND 2.1.0

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -428,11 +428,11 @@ $CONFIG = [
  *
  * Possible keys: `wnd.groupmembership.checkUserFirst` BOOL
  *
- * *Note* With WND 2.1.0, key `wnd.storage.testForHiddenMount` is obsolete and has been removed completely
+ * *Note* With WND 2.1.0, key `wnd.storage.testForHiddenMount` is obsolete and has been removed completely.
  */
 
 /**
- * Mandatory listener reconnect to the database
+ * Mandatory Listener Reconnect to the Database
  * The listener will reconnect to the DB after given seconds. This will
  * prevent the listener to crash if the connection to the DB is closed after
  * being idle for a long time.
@@ -440,23 +440,23 @@ $CONFIG = [
 'wnd.listen.reconnectAfterTime' => 28800,
 
 /**
- * Enable additional debug logging for the WND app
+ * Enable Additional Debug Logging for the WND App
  */
 'wnd.logging.enable' => false,
 
 /**
- * The way file attributes for folders and files will be handled
+ * The Way File Attributes for Folders and Files will be Handled
  * There are 3 possible values: "none", "stat" and "getxattr":
  *
- * - "stat". This is the default if the option is missing or has an invalid value
- *   This means that the file attributes will be evaluated only for files, NOT for folders
- *   Folders will be shown even if the "hidden" file attribute * is set.
+ * - "stat". This is the default if the option is missing or has an invalid value.
+ *   This means that the file attributes will be evaluated only for files, NOT for folders.
+ *   Folders will be shown even if the "hidden" file attribute is set.
  *
  * - "none". This means that the file attributes won't be evaluated in any case. Both
  *   hidden files and folders will be shown, and you can write on read-only files
  *   (the action is available in ownCloud, but it will fail in the SMB server).
  *
- * - "getxattr". This means that file attributes will be evaluated always. However, due to
+ * - "getxattr". This means that file attributes will always be evaluated. However, due to
  *   problems in recent libsmbclient versions (4.11+, it might be earlier) it will cause
  *   malfunctions in ownCloud; permissions are wrongly evaluated. So far, this mode works
  *   with libsmbclient 4.7 but not with 4.11+ (not tested with any version in between).
@@ -466,7 +466,7 @@ $CONFIG = [
 'wnd.fileInfo.parseAttrs.mode' => stat,
 
 /**
- * Enable or disable the WND in-memory notifier for password changes
+ * Enable or Disable the WND In-Memory Notifier for Password Changes
  * Having this feature enabled implies that whenever a WND process detects a
  * wrong password in the storage - maybe the password has changed in the
  * backend - all WND storages that are in-memory will be notified in order to reset
@@ -480,7 +480,7 @@ $CONFIG = [
 'wnd.in_memory_notifier.enable' => true,
 
 /**
- * Maximum number of items for the cache used by the WND permission managers
+ * Maximum Number of Items for the Cache Used by the WND Permission Managers
  * A higher number implies that more items are allowed, increasing the memory usage.
  * Real memory usage per item varies because it depends on the path being cached.
  * Note that this is an in-memory cache used per request.
@@ -490,7 +490,7 @@ $CONFIG = [
 'wnd.permissionmanager.cache.size' => 512,
 
 /**
- * TTL for the WND2 caching wrapper
+ * TTL for the WND2 Caching Wrapper
  * Time to Live (TTL) in seconds to be used to cache information for the WND2 (collaborative)
  * cache wrapper implementation. The value will be used by all WND2 storages. Although the
  * cache isn't exactly per user but per storage id, consider the cache to be per user, because
@@ -502,7 +502,7 @@ $CONFIG = [
 'wnd2.cachewrapper.ttl' => 1800,  // 30 minutes
 
 /**
- * Enable to push WND events to the activity app
+ * Enable to Push WND Events to the Activity App
  * Register WND as extension into the Activity app in order to send information about what
  * the `wnd:process-queue` command is doing. The activity sent will be based on what
  * the `wnd:process-queue` detects, and the activity will be sent to each affected user. There
@@ -514,7 +514,7 @@ $CONFIG = [
 'wnd.activity.registerExtension' => false,
 
 /**
- * Enable to send WND activity notifications to sharees
+ * Enable to Send WND Activity Notifications to Sharees
  * The `wnd:process-queue` command will also send activity notifications to the sharees
  * if a WND file or folder is shared (or accessible via a share). It's REQUIRED that the
  * `wnd.activity.registerExtension` flag is set to true (see above), otherwise this flag will
@@ -523,7 +523,7 @@ $CONFIG = [
 'wnd.activity.sendToSharees' => false,
 
 /**
- * Make the group membership component assume that the ACL contains a user
+ * Make the Group Membership Component Assume that the ACL Contains a User
  * The WND app doesn't know about the users or groups associated with ACLs. This
  * means that an ACL containing "admin" might refer to a user called "admin" or a
  * group called "admin". By default, the group membership component considers the ACLs to
@@ -548,7 +548,7 @@ $CONFIG = [
  */
 
 /**
- * Provide advanced management of file tagging
+ * Provide Advanced Management of File Tagging
  * Enables admins to specify rules and conditions (file size, file mimetype, group membership and more)
  * to automatically assign tags to uploaded files. Values: `tagbased` (default) or `userbased`.
  */

--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -414,7 +414,7 @@ $CONFIG = [
  *
  * Possible keys: `wnd.logging.enable` BOOL
  *
- * Possible keys: `wnd.storage.testForHiddenMount` BOOL
+ * Possible keys: `wnd.fileInfo.parseAttrs.mode` STRING
  *
  * Possible keys: `wnd.in_memory_notifier.enable` BOOL
  *
@@ -427,6 +427,8 @@ $CONFIG = [
  * Possible keys: `wnd.activity.sendToSharees` BOOL
  *
  * Possible keys: `wnd.groupmembership.checkUserFirst` BOOL
+ *
+ * *Note* With WND 2.1.0, key `wnd.storage.testForHiddenMount` is obsolete and has been removed completely
  */
 
 /**
@@ -443,14 +445,25 @@ $CONFIG = [
 'wnd.logging.enable' => false,
 
 /**
- * Check for visible target mount folders when connecting
- * Ensure that the connectivity check verifies the mount point is visible.
- * This means the target folder is NOT hidden.
- * Setting this option to false can speed up the connectivity check by skipping
- * this step. It will be the admin's responsibility to ensure the mount
- * point is visible. This setting will affect all the WND mount points.
+ * The way file attributes for folders and files will be handled
+ * There are 3 possible values: "none", "stat" and "getxattr":
+ *
+ * - "stat". This is the default if the option is missing or has an invalid value
+ *   This means that the file attributes will be evaluated only for files, NOT for folders
+ *   Folders will be shown even if the "hidden" file attribute * is set.
+ *
+ * - "none". This means that the file attributes won't be evaluated in any case. Both
+ *   hidden files and folders will be shown, and you can write on read-only files
+ *   (the action is available in ownCloud, but it will fail in the SMB server).
+ *
+ * - "getxattr". This means that file attributes will be evaluated always. However, due to
+ *   problems in recent libsmbclient versions (4.11+, it might be earlier) it will cause
+ *   malfunctions in ownCloud; permissions are wrongly evaluated. So far, this mode works
+ *   with libsmbclient 4.7 but not with 4.11+ (not tested with any version in between).
+ *
+ * Note that the ACLs (if active) will be evaluated and applied on top of this mechanism.
  */
-'wnd.storage.testForHiddenMount' => true,
+'wnd.fileInfo.parseAttrs.mode' => stat,
 
 /**
  * Enable or disable the WND in-memory notifier for password changes


### PR DESCRIPTION
## Description
config_apps_sample changes for WND 2.1.0

## Related Issue
As part of https://github.com/owncloud/windows_network_drive/pull/366 (Additional check for detecting directories with libsmbclient 4.11+)

## Motivation and Context
Update config

## How Has This Been Tested?
no tests necessary

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

config-to-docs run will be part of a PR in docs, PR will be linked when ready 