### PR TITLE
[tests-only] Add bug demonstration scenario for upload chunk test

### DIFF
--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature
@@ -100,6 +100,7 @@ Feature: upload file using old chunking
       | @a#8a=b?c=d |
       | ?abc=oc #   |
 
+  @skipOnOcV10 @issue-36115
   Scenario: Upload chunked file with old chunking with lengthy filenames
     Given the owncloud log level has been set to debug
     And the owncloud log has been cleared
@@ -110,7 +111,7 @@ Feature: upload file using old chunking
       | 3      | CCCCCCCCCCCCCCCCCCCCCCCCC |
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
-      | ETag | /^[a-f0-9:\.]{1,32}$/ |
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     And as "Alice" file "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" should exist
     And the content of file "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" for user "Alice" should be "AAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCCCCCC"
     And the log file should not contain any log-entries containing these attributes:

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunkingOc10Issue36115.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunkingOc10Issue36115.feature
@@ -20,3 +20,24 @@ Feature: upload file using old chunking
 #      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     And as "Alice" file "/myChunkedFile.txt" should exist
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "AAAAABBBBBCCCCC"
+
+
+  Scenario: Upload chunked file with old chunking with lengthy filenames
+    Given using OCS API version "1"
+    And using old DAV path
+    And user "Alice" has been created with default attributes and without skeleton files
+    And the owncloud log level has been set to debug
+    And the owncloud log has been cleared
+    When user "Alice" uploads the following chunks to "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" with old chunking and using the WebDAV API
+      | number | content                   |
+      | 1      | AAAAAAAAAAAAAAAAAAAAAAAAA |
+      | 2      | BBBBBBBBBBBBBBBBBBBBBBBBB |
+      | 3      | CCCCCCCCCCCCCCCCCCCCCCCCC |
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Alice"
+      | ETag | /^[a-f0-9:\.]{1,32}$/ |
+    And as "Alice" file "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" should exist
+    And the content of file "नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-नेपालि-file-नाम-12345678910.txt" for user "Alice" should be "AAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCCCCCCCCCC"
+    And the log file should not contain any log-entries containing these attributes:
+      | app |
+      | dav |


### PR DESCRIPTION
## Description
scenario `apiWebdavUpload2/uploadFileUsingOldChunking.feature:103` falls under issue #36115
added bug demonstration scenario for that test

## How Has This Been Tested?
- test environment: local

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
