### PR TITLE
Include a flag to mark if the loginName2userName has been processed

### DIFF
--- a/apps/federatedfilesharing/lib/Address.php
+++ b/apps/federatedfilesharing/lib/Address.php
@@ -155,10 +155,11 @@ class Address {
 	protected function translateUid($uid) {
 		// FIXME this should be a method in the user management instead
 		// Move to a helper instead of C&P meanwhile?
+		$handled = false;
 		\OCP\Util::emitHook(
 			'\OCA\Files_Sharing\API\Server2Server',
 			'preLoginNameUsedAsUserName',
-			['uid' => &$uid]
+			['uid' => &$uid, 'hasBeenHandled' => &$handled]
 		);
 		return $uid;
 	}

--- a/apps/federatedfilesharing/lib/Address.php
+++ b/apps/federatedfilesharing/lib/Address.php
@@ -156,6 +156,8 @@ class Address {
 		// FIXME this should be a method in the user management instead
 		// Move to a helper instead of C&P meanwhile?
 		$handled = false;
+		// the $handled var will be sent as reference so the listeners can use it as a flag
+		// in order to know if the event has been processed already or not.
 		\OCP\Util::emitHook(
 			'\OCA\Files_Sharing\API\Server2Server',
 			'preLoginNameUsedAsUserName',

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -128,10 +128,11 @@ class RequestHandlerController extends OCSController {
 			}
 			// FIXME this should be a method in the user management instead
 			\OCP\Util::writeLog('federatedfilesharing', 'shareWith before, ' . $shareWith, \OCP\Util::DEBUG);
+			$handled = false;
 			\OCP\Util::emitHook(
 				'\OCA\Files_Sharing\API\Server2Server',
 				'preLoginNameUsedAsUserName',
-				['uid' => &$shareWith]
+				['uid' => &$shareWith, 'hasBeenHandled' => &$handled]
 			);
 			\OCP\Util::writeLog('federatedfilesharing', 'shareWith after, ' . $shareWith, \OCP\Util::DEBUG);
 			if (!$this->userManager->userExists($shareWith)) {

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -129,6 +129,8 @@ class RequestHandlerController extends OCSController {
 			// FIXME this should be a method in the user management instead
 			\OCP\Util::writeLog('federatedfilesharing', 'shareWith before, ' . $shareWith, \OCP\Util::DEBUG);
 			$handled = false;
+			// the $handled var will be sent as reference so the listeners can use it as a flag
+			// in order to know if the event has been processed already or not.
 			\OCP\Util::emitHook(
 				'\OCA\Files_Sharing\API\Server2Server',
 				'preLoginNameUsedAsUserName',

--- a/changelog/unreleased/39105
+++ b/changelog/unreleased/39105
@@ -1,0 +1,10 @@
+Bugfix: Prevent unneeded call to LDAP during login with local users
+
+Previously, when the user_ldap app was enabled, any login with a local user
+would check the LDAP server for that user even though it shouldn't be needed.
+
+Now, such call won't happen if it has been handled by a different component.
+In particular, login with a local user won't trigger that request to LDAP.
+
+https://github.com/owncloud/core/pull/39105
+https://github.com/owncloud/user_ldap/pull/675

--- a/lib/private/Share/Helper.php
+++ b/lib/private/Share/Helper.php
@@ -302,15 +302,17 @@ class Helper extends \OC\Share\Constants {
 
 		if (\rtrim($normalizedServer1, '/') === \rtrim($normalizedServer2, '/')) {
 			// FIXME this should be a method in the user management instead
+			$user1Handled = false;
+			$user2Handled = false;
 			\OCP\Util::emitHook(
 				'\OCA\Files_Sharing\API\Server2Server',
 				'preLoginNameUsedAsUserName',
-				['uid' => &$user1]
+				['uid' => &$user1, 'hasBeenHandled' => &$user1Handled]
 			);
 			\OCP\Util::emitHook(
 				'\OCA\Files_Sharing\API\Server2Server',
 				'preLoginNameUsedAsUserName',
-				['uid' => &$user2]
+				['uid' => &$user2, 'hasBeenHandled' => &$user2Handled]
 			);
 
 			if ($user1 === $user2) {

--- a/lib/private/Share/Helper.php
+++ b/lib/private/Share/Helper.php
@@ -304,6 +304,8 @@ class Helper extends \OC\Share\Constants {
 			// FIXME this should be a method in the user management instead
 			$user1Handled = false;
 			$user2Handled = false;
+			// the $user1Handled and $user2Handled vars will be sent as reference so the listeners
+			// can use it as a flag in order to know if the event has been processed already or not.
 			\OCP\Util::emitHook(
 				'\OCA\Files_Sharing\API\Server2Server',
 				'preLoginNameUsedAsUserName',

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -354,6 +354,10 @@ class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IP
 			throw new \Exception('key uid is expected to be set in $param');
 		}
 
+		if (isset($param['hasBeenHandled']) && $param['hasBeenHandled']) {
+			return;
+		}
+
 		$backends = \OC::$server->getUserManager()->getBackends();
 		foreach ($backends as $backend) {
 			if ($backend instanceof Database) {
@@ -361,6 +365,7 @@ class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IP
 				$uid = $backend->loginName2UserName($param['uid']);
 				if ($uid !== false) {
 					$param['uid'] = $uid;
+					$param['hasBeenHandled'] = true;
 					return;
 				}
 			}

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -355,6 +355,7 @@ class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IP
 		}
 
 		if (isset($param['hasBeenHandled']) && $param['hasBeenHandled']) {
+			// if the event has been handled already, ignore it
 			return;
 		}
 
@@ -365,7 +366,7 @@ class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IP
 				$uid = $backend->loginName2UserName($param['uid']);
 				if ($uid !== false) {
 					$param['uid'] = $uid;
-					$param['hasBeenHandled'] = true;
+					$param['hasBeenHandled'] = true;  // mark the event as handled
 					return;
 				}
 			}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -401,10 +401,11 @@ class Session implements IUserSession, Emitter {
 	}
 
 	protected function isTwoFactorEnforced($username) {
+		$handled = false;
 		Util::emitHook(
 			'\OCA\Files_Sharing\API\Server2Server',
 			'preLoginNameUsedAsUserName',
-			['uid' => &$username]
+			['uid' => &$username, 'hasBeenHandled' => &$handled]
 		);
 		$user = $this->manager->get($username);
 		if ($user === null) {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -402,6 +402,8 @@ class Session implements IUserSession, Emitter {
 
 	protected function isTwoFactorEnforced($username) {
 		$handled = false;
+		// the $handled var will be sent as reference so the listeners can use it as a flag
+		// in order to know if the event has been processed already or not.
 		Util::emitHook(
 			'\OCA\Files_Sharing\API\Server2Server',
 			'preLoginNameUsedAsUserName',


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Add a flag when asking for the username to indicate that someone has already processed the request and there is no need for others to check further.

Requires:
* https://github.com/owncloud/user_ldap/pull/675

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
When the user_ldap app is enabled, logging in with the admin user triggered an LDAP request. This shouldn't happen when the admin's account is empty and there is no relation with any ldap user.
If the LDAP server is busy, it will slow down the login process even for non-ldap users.

## How Has This Been Tested?
Having the user_ldap app enabled (and patched), log in with the admin user. With both patches, there is no bind request send to the LDAP server when logged in with the admin user.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
