### PR TITLE
Change wording for enable file locking checkbox

### DIFF
--- a/changelog/unreleased/39106
+++ b/changelog/unreleased/39106
@@ -1,0 +1,7 @@
+Bugfix: Clarify the description of the manual file locking option
+
+The administrator can enable manual file locking in the admin settings.
+That enables manual file locking on the web interface, not on all clients.
+The text has been changed to describe this correctly.
+
+https://github.com/owncloud/core/pull/39106

--- a/settings/templates/panels/admin/persistentlocking.php
+++ b/settings/templates/panels/admin/persistentlocking.php
@@ -21,6 +21,6 @@ script('settings', 'panels/persistentlocking');
 		   value="1" <?php if ($_['manualFileLockOnClientsEnabled'] === 'yes') {
 	print_unescaped('checked="checked"');
 } ?> />
-	<label for="manualFileLockOnClientsEnabled"><?php p($l->t('Enable manual file locking on clients'));?></label>
+	<label for="manualFileLockOnClientsEnabled"><?php p($l->t('Enable manual file locking in the web interface'));?></label>
 	<br/>
 </div>


### PR DESCRIPTION
Current wording is confusing because the checkbox is only controlling the feature on the web UI. It will not affect the API and consequently not the other clients.