### PR TITLE
Update appinfo cache only if the app version is newer

### DIFF
--- a/changelog/unreleased/39108
+++ b/changelog/unreleased/39108
@@ -1,0 +1,15 @@
+Bugfix: Update appinfo cache only if the app version is newer
+
+Previously, in case there were multiple copies of the same app with different
+versions, the information being cached was the latest one found based on the
+locations defined in the config.php file, which might not be the one from the
+latest app version. This might be a problem in some scenarios specially checking
+the version of the app. Note that the code used was the one from the latest app
+version found.
+
+Now, the information cached is always from the latest version found. In the
+weird case that both versions are the same, the information from the first one
+will be kept. This shouldn't be a problem because the information is expected
+to be the same.
+
+https://github.com/owncloud/core/pull/39108

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -511,7 +511,11 @@ class AppManager implements IAppManager {
 		];
 
 		// cache results for a day
-		$this->appInfo->set($appId, $data, 86400);
+		$appIdData = $this->appInfo->get($appId);
+		if ($appIdData === null || version_compare($appIdData['info']['version'], $info['version']) === -1) {
+			// if no data is cached for the appId or the new one has a higher version, update cache
+			$this->appInfo->set($appId, $data, 86400);
+		}
 		$this->appInfo->set($file, $data, 86400);
 
 		return $info;

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -512,7 +512,7 @@ class AppManager implements IAppManager {
 
 		// cache results for a day
 		$appIdData = $this->appInfo->get($appId);
-		if ($appIdData === null || version_compare($appIdData['info']['version'], $info['version']) === -1) {
+		if ($appIdData === null || \version_compare($appIdData['info']['version'], $info['version']) === -1) {
 			// if no data is cached for the appId or the new one has a higher version, update cache
 			$this->appInfo->set($appId, $data, 86400);
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Cache app info for the appid only if the version is newer.

## Related Issue
https://github.com/owncloud/core/issues/38549

## Motivation and Context
If there are multiple versions of the same app in different locations, we're expected to use the one with the latest version.
Note that the problem happens having a local cache active.

## How Has This Been Tested?
1. Having at least 2 different app locations, install the same app (not the latest version) in all of them
2. In the config.php file, set the first app location as writable
3. Update the app via `occ market:upgrade <app>`

There is no problem with the upgrade. The installed version in the DB is the latest one (downloaded from the market). Reloading the page doesn't trigger the "update needed" page.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
