### PR TITLE
[Tests-Only]Adjust tests according to the expected behavior in OCIS

### DIFF
--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -11,7 +11,7 @@ Feature: sharing
       | Brian    |
       | Carol    |
 
-  @issue-ocis-2141
+  @issue-ocis-2141 @notToImplementOnOCIS
   Scenario: Keep usergroup shares (#22143)
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -26,7 +26,21 @@ Feature: sharing
     Then user "Brian" should see the following elements
       | /myFOLDER/myTMP/ |
 
-  @issue-ocis-2141
+
+  Scenario: Keep usergroup shares when the user renames the share within the Shares folder(#22143)
+    Given group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/TMP"
+    When user "Alice" shares folder "TMP" with group "grp1" using the sharing API
+    And user "Brian" accepts share "/TMP" offered by user "Alice" using the sharing API
+    And user "Carol" accepts share "/TMP" offered by user "Alice" using the sharing API
+    And user "Brian" moves folder "/Shares/TMP" to "/Shares/new" using the WebDAV API
+    And the administrator deletes user "Carol" using the provisioning API
+    Then user "Brian" should see the following elements
+      | /Shares/new/|
+
+  @issue-ocis-2141 @notToImplementOnOCIS
   Scenario: keep user shared file name same after one of recipient has renamed the file
     Given user "Alice" has uploaded file with content "foo" to "/sharefile.txt"
     And user "Alice" has shared file "/sharefile.txt" with user "Brian"
@@ -38,7 +52,19 @@ Feature: sharing
     And as "Alice" file "/sharefile.txt" should exist
     And as "Brian" file "/Shares/sharefile.txt" should exist
 
-  @issue-ocis-2141
+
+  Scenario: keep user shared file name same after one of recipient has renamed the file inside the Shares folder
+    Given user "Alice" has uploaded file with content "foo" to "/sharefile.txt"
+    And user "Alice" has shared file "/sharefile.txt" with user "Brian"
+    And user "Alice" has shared file "/sharefile.txt" with user "Carol"
+    And user "Brian" has accepted share "/sharefile.txt" offered by user "Alice"
+    And user "Carol" has accepted share "/sharefile.txt" offered by user "Alice"
+    When user "Carol" moves file "/Shares/sharefile.txt" to "/Shares/renamedsharefile.txt" using the WebDAV API
+    Then as "Carol" file "/Shares/renamedsharefile.txt" should exist
+    And as "Alice" file "/sharefile.txt" should exist
+    And as "Brian" file "/Shares/sharefile.txt" should exist
+
+  @issue-ocis-2141 @notToImplementOnOCIS
   Scenario: keep user shared file directory same in respect to respective user if one of the recipient has moved the file
     Given user "Alice" has uploaded file with content "foo" to "/sharefile.txt"
     And user "Alice" has shared file "/sharefile.txt" with user "Brian"
@@ -51,7 +77,7 @@ Feature: sharing
     And as "Alice" file "/sharefile.txt" should exist
     And as "Brian" file "/Shares/sharefile.txt" should exist
 
-  @issue-ocis-2146
+  @issue-ocis-2146 @notToImplementOnOCIS
   Scenario Outline: move folder inside received folder with special characters
     Given group "grp1" has been created
     And user "Carol" has been added to group "grp1"
@@ -74,7 +100,7 @@ Feature: sharing
       | ?abc=oc #     | ?abc=oc g%rp#   | # oc?test=oc&a  |
       | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d    |
 
-  @issue-ocis-2141
+  @issue-ocis-2141 @notToImplementOnOCIS
   Scenario: receiver renames a received share with share, read, change permissions
     Given user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
@@ -90,7 +116,23 @@ Feature: sharing
     And as "Alice" file "/folderToShare/renamedFile" should exist
     But as "Alice" file "/folderToShare/fileInside" should not exist
 
-  @issue-ocis-2141
+
+  Scenario: receiver renames a received share with share, read, change permissions inside the Shares folder
+    Given user "Alice" has created folder "folderToShare"
+    And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
+    And user "Alice" has shared folder "folderToShare" with user "Brian" with permissions "share,read,change"
+    And user "Brian" has accepted share "/folderToShare" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/folderToShare" to "/Shares/myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "/Shares/myFolder" should exist
+    But as "Alice" folder "/Shares/myFolder" should not exist
+    When user "Brian" moves file "/Shares/myFolder/fileInside" to "/Shares/myFolder/renamedFile" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/Shares/myFolder/renamedFile" should exist
+    And as "Alice" file "/folderToShare/renamedFile" should exist
+    But as "Alice" file "/folderToShare/fileInside" should not exist
+
+  @issue-ocis-2141 @notToImplementOnOCIS
   Scenario: receiver tries to rename a received share with share, read permissions
     Given user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
@@ -105,7 +147,22 @@ Feature: sharing
     And as "Brian" file "/myFolder/renamedFile" should not exist
     But as "Brian" file "/myFolder/fileInside" should exist
 
-  @issue-ocis-2141
+
+  Scenario: receiver tries to rename a received share with share, read permissions inside the Shares folder
+    Given user "Alice" has created folder "folderToShare"
+    And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
+    And user "Alice" has shared folder "folderToShare" with user "Brian" with permissions "share,read"
+    And user "Brian" has accepted share "/folderToShare" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/folderToShare" to "/Shares/myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "/Shares/myFolder" should exist
+    But as "Alice" folder "/Shares/myFolder" should not exist
+    When user "Brian" moves file "/Shares/myFolder/fileInside" to "/Shares/myFolder/renamedFile" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Brian" file "/Shares/myFolder/renamedFile" should not exist
+    But as "Brian" file "Shares/myFolder/fileInside" should exist
+
+
   Scenario: receiver renames a received folder share to a different name on the same folder
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has shared folder "PARENT" with user "Brian"
@@ -115,7 +172,7 @@ Feature: sharing
     And as "Brian" folder "/Shares/myFolder" should exist
     But as "Alice" folder "myFolder" should not exist
 
-  @issue-ocis-2141
+
   Scenario: receiver renames a received file share to different name on the same folder
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     And user "Alice" has shared file "fileToShare.txt" with user "Brian"
@@ -125,7 +182,7 @@ Feature: sharing
     And as "Brian" file "/Shares/newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
 
-  @issue-ocis-2141
+
   Scenario: receiver renames a received file share to different name on the same folder for group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -137,7 +194,7 @@ Feature: sharing
     And as "Brian" file "/Shares/newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
 
-  @issue-ocis-2146
+
   Scenario: receiver renames a received folder share to different name on the same folder for group sharing
     Given group "grp1" has been created
     And user "Alice" has created folder "PARENT"
@@ -149,7 +206,7 @@ Feature: sharing
     And as "Brian" folder "/Shares/myFolder" should exist
     But as "Alice" folder "myFolder" should not exist
 
-  @issue-ocis-2141
+  @issue-ocis-2141 @notToImplementOnOCIS
   Scenario: receiver renames a received file share with read,update,share permissions in group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -161,7 +218,19 @@ Feature: sharing
     And as "Brian" file "newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
 
-  @issue-ocis-2141
+
+  Scenario: receiver renames a received file share with read,update,share permissions inside the Shares folder in group sharing
+    Given group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has shared file "fileToShare.txt" with group "grp1" with permissions "read,update,share"
+    And user "Brian" has accepted share "/fileToShare.txt" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/fileToShare.txt" to "/Shares/newFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/Shares/newFile.txt" should exist
+    But as "Alice" file "/Shares/newFile.txt" should not exist
+
+  @issue-ocis-2141 @notToImplementOnOCIS
   Scenario: receiver renames a received folder share with share, read, change permissions in group sharing
     Given group "grp1" has been created
     And user "Alice" has created folder "PARENT"
@@ -173,8 +242,20 @@ Feature: sharing
     And as "Brian" folder "myFolder" should exist
     But as "Alice" folder "myFolder" should not exist
 
-  @issue-ocis-2141
-  Scenario: receiver tries to rename a received file share with share, read permissions in group sharing
+
+  Scenario: receiver renames a received folder share with share, read, change permissions inside the Shares folder in group sharing
+    Given group "grp1" has been created
+    And user "Alice" has created folder "PARENT"
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared folder "PARENT" with group "grp1" with permissions "share,read,change"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "/Shares/myFolder" should exist
+    But as "Alice" folder "/Shares/myFolder" should not exist
+
+  @issue-ocis-2141 @notToImplementOnOCIS
+  Scenario: receiver renames a received file share with share, read permissions in group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
@@ -185,8 +266,20 @@ Feature: sharing
     And as "Brian" file "newFile.txt" should exist
     But as "Alice" file "newFile.txt" should not exist
 
-  @issue-ocis-2141
-  Scenario: receiver tries to rename a received folder share with share, read permissions in group sharing
+
+  Scenario: receiver renames a received file share with share, read permissions inside the Shares folder in group sharing)
+    Given group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
+    And user "Alice" has shared file "fileToShare.txt" with group "grp1" with permissions "share,read"
+    And user "Brian" has accepted share "/fileToShare.txt" offered by user "Alice"
+    When user "Brian" moves file "/Shares/fileToShare.txt" to "/Shares/newFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/Shares/newFile.txt" should exist
+    But as "Alice" file "/Shares/newFile.txt" should not exist
+
+  @issue-ocis-2141 @notToImplementOnOCIS
+  Scenario: receiver renames a received folder share with share, read permissions in group sharing
     Given group "grp1" has been created
     And user "Alice" has created folder "PARENT"
     And user "Brian" has been added to group "grp1"
@@ -197,8 +290,20 @@ Feature: sharing
     And as "Brian" folder "myFolder" should exist
     But as "Alice" folder "myFolder" should not exist
 
+
+  Scenario: receiver renames a received folder share with share, read permissions inside the Shares folder in group sharing
+    Given group "grp1" has been created
+    And user "Alice" has created folder "PARENT"
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has shared folder "PARENT" with group "grp1" with permissions "share,read"
+    And user "Brian" has accepted share "/PARENT" offered by user "Alice"
+    When user "Brian" moves folder "/Shares/PARENT" to "/Shares/myFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "/Shares/myFolder" should exist
+    But as "Alice" folder "/Shares/myFolder" should not exist
+
   @issue-ocis-2141
-  Scenario Outline: receiver tries to rename a received folder share to name with special characters in group sharing
+  Scenario Outline: receiver renames a received folder share to name with special characters in group sharing
     Given group "grp1" has been created
     And user "Carol" has been added to group "grp1"
     And user "Alice" has created folder "<sharer_folder>"
@@ -221,7 +326,7 @@ Feature: sharing
       | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d    |
 
   @issue-ocis-2141
-  Scenario Outline: receiver tries to rename a received file share to name with special characters with share, read, change permissions in group sharing
+  Scenario Outline: receiver renames a received file share to name with special characters with share, read, change permissions in group sharing
     Given group "grp1" has been created
     And user "Carol" has been added to group "grp1"
     And user "Alice" has created folder "<sharer_folder>"
@@ -245,7 +350,7 @@ Feature: sharing
       | ?abc=oc #     | ?abc=oc g%rp#   | # oc?test=oc&a |
       | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d   |
 
-  @issue-ocis-2141
+  @issue-ocis-2141 @notToImplementOnOCIS
   Scenario: receiver moves file within a received folder to new folder
     Given user "Alice" has created folder "folderToShare"
     And user "Brian" has created folder "FOLDER"

--- a/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
@@ -24,7 +24,7 @@ Feature: sharing
       | old              |
       | new              |
 
-  @smokeTest @files_trashbin-app-required
+  @smokeTest @files_trashbin-app-required @notToImplementOnOCIS
   Scenario Outline: moving a file out of a share as recipient creates a backup for the owner
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/shared"
@@ -42,7 +42,7 @@ Feature: sharing
       | old              |
       | new              |
 
-  @files_trashbin-app-required
+  @files_trashbin-app-required @notToImplementOnOCIS
   Scenario Outline: moving a folder out of a share as recipient creates a backup for the owner
     Given using <dav-path-version> DAV path
     And user "Alice" has created folder "/shared"

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
@@ -8,11 +8,12 @@ Feature: resharing can be done on a reshared resource
       | username |
       | Alice    |
       | Brian    |
+      | Carol    |
+      | David    |
 
+  @notToImplementOnOCIS
   Scenario: Reshared files can be still accessed if a user in the middle removes it.
-    Given user "Carol" has been created with default attributes and without skeleton files
-    And user "David" has been created with default attributes and without skeleton files
-    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
     And user "Brian" has moved file "/Shares/textfile0.txt" to "/textfile0_shared.txt"
@@ -23,3 +24,16 @@ Feature: resharing can be done on a reshared resource
     When user "Brian" deletes file "/textfile0_shared.txt" using the WebDAV API
     Then the content of file "/Shares/textfile0_shared.txt" for user "Carol" should be "ownCloud test text file 0"
     And the content of file "/Shares/textfile0_shared.txt" for user "David" should be "ownCloud test text file 0"
+
+  @skipOnOcV10
+  Scenario: Reshared files can be still accessed if a user in the middle removes it.
+    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    And user "Brian" has shared file "/Shares/textfile0.txt" with user "Carol"
+    And user "Carol" has accepted share "/textfile0.txt" offered by user "Brian"
+    And user "Carol" has shared file "/Shares/textfile0.txt" with user "David"
+    And user "David" has accepted share "/textfile0.txt" offered by user "Carol"
+    When user "Brian" deletes file "/Shares/textfile0.txt" using the WebDAV API
+    Then the content of file "/Shares/textfile0.txt" for user "Carol" should be "ownCloud test text file 0"
+    And the content of file "/Shares/textfile0.txt" for user "David" should be "ownCloud test text file 0"

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -29,8 +29,8 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-1289
-  Scenario Outline: keep group permissions in sync
+  @issue-ocis-1289 @notToImplementOnOCIS
+  Scenario Outline: keep group permissions in sync when the share is moved to another folder by the receiver and then the sharer updates the permissions
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And group "grp1" has been created
@@ -62,6 +62,41 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
+
+  @issue-ocis-1289
+  Scenario Outline: keep group permissions in sync when the share is renamed by the receiver and then the permissions are updated by sharer
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    And user "Brian" has moved file "/Shares/textfile0.txt" to "/Shares/textfile_new.txt"
+    When user "Alice" updates the last share using the sharing API with
+      | permissions | read |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the fields of the last response to user "Alice" sharing with group "grp1" should include
+      | id                | A_STRING              |
+      | item_type         | file                  |
+      | item_source       | A_STRING              |
+      | share_type        | group                 |
+      | file_source       | A_STRING              |
+      | file_target       | /Shares/textfile0.txt |
+      | permissions       | read                  |
+      | stime             | A_NUMBER              |
+      | storage           | A_STRING              |
+      | mail_send         | 0                     |
+      | uid_owner         | %username%            |
+      | displayname_owner | %displayname%         |
+      | mimetype          | text/plain            |
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
 
   Scenario Outline: Cannot set permissions to zero
     Given using OCS API version "<ocs_api_version>"
@@ -233,6 +268,7 @@ Feature: sharing
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
       | 2               | 200             |
+
 
   Scenario Outline: Increasing permissions is allowed for owner
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
@@ -129,7 +129,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required
+  @files_sharing-app-required @notToImplementOnOCIS
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -144,7 +144,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/received/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required
+  @files_sharing-app-required @notToImplementOnOCIS
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "old content" to "/sharefile.txt"
@@ -158,7 +158,7 @@ Feature: dav-versions
     And the content of file "/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/received/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @issue-38027 @skipOnOcV10
+  @files_sharing-app-required @issue-38027 @skipOnOcV10 @notToImplementOnOCIS
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -173,8 +173,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/received/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required
-  @issue-ocis-reva-34
+  @files_sharing-app-required @issue-ocis-reva-34
   Scenario: sharer can restore a file inside a group shared folder modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
@@ -194,8 +193,7 @@ Feature: dav-versions
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Carol" should be "First content"
 
-  @files_sharing-app-required
-  @issue-ocis-reva-386
+  @files_sharing-app-required @issue-ocis-reva-386
   Scenario Outline: Moving a file (with versions) into a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -223,8 +221,7 @@ Feature: dav-versions
       | old         | Brian | /testshare        |
       | new         | Brian | /testshare        |
 
-  @files_sharing-app-required
-  @issue-ocis-reva-386
+  @files_sharing-app-required @issue-ocis-reva-386
   Scenario Outline: Moving a file (with versions) out of a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -244,12 +241,18 @@ Feature: dav-versions
     And as "Alice" file "/Shares/testshare/testfile.txt" should not exist
     And as "Brian" file "/testshare/testfile.txt" should not exist
     And the version folder of file "/testfile.txt" for user "<mover>" should contain "2" elements
+
+    @notToImplementOnOCIS
     Examples:
       | dav_version | mover | src-folder        |
       | old         | Alice | /Shares/testshare |
       | new         | Alice | /Shares/testshare |
-      | old         | Brian | /testshare        |
-      | new         | Brian | /testshare        |
+
+
+    Examples:
+      | dav_version | mover | src-folder |
+      | old         | Brian | /testshare |
+      | new         | Brian | /testshare |
 
   @skipOnOcV10.3.0 @files_sharing-app-required
   Scenario: Receiver tries to get file versions of unshared file from the sharer
@@ -274,6 +277,7 @@ Feature: dav-versions
     When user "Brian" tries to get versions of file "textfile0.txt" from "Alice"
     Then the HTTP status code should be "207"
     And the number of versions should be "3"
+
 
   Scenario: Receiver tries get file versions of shared file before receiving it
     Given user "Brian" has been created with default attributes and without skeleton files


### PR DESCRIPTION
## Description
This PR adds `notToImplementOnOCIS` tag for the test scenarios in which the folders are to be moved/renamed from the shares folder,  which are never to be implemented on ocis. For some scenarios where some changes might reproduce the expected behavior of that in ocis, required adjustments are made. Few scenarios are added for the behavior only in ocis.

## Related Issue
- https://github.com/owncloud/ocis/issues/2141

## How Has This Been Tested?
- CI 
- https://github.com/owncloud/ocis/pull/2395

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
