### PR TITLE
[Tests-Only] Accept all shares matching the path when accepting shares

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2913,7 +2913,7 @@ trait Sharing {
 			$shareIds,
 			__METHOD__ . " could not find share $share, offered by $offeredBy to $user"
 		);
-		foreach($shareIds as $shareId) {
+		foreach ($shareIds as $shareId) {
 			$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}" .
 				"/shares/pending/$shareId";
 			if (\substr($action, 0, 7) === "decline") {

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2872,7 +2872,7 @@ trait Sharing {
 		$offeredBy = $this->getActualUsername($offeredBy);
 
 		$dataResponded = $this->getAllSharesSharedWithUser($user);
-		$shareId = null;
+		$shareIds = [];
 		foreach ($dataResponded as $shareElement) {
 			$shareFolder = \trim(
 				SetupHelper::getSystemConfigValue('share_folder', $this->getStepLineRef())
@@ -2906,28 +2906,29 @@ trait Sharing {
 				&& (string) $shareElement['uid_owner'] === $offeredBy
 				&& (string) $shareElement['path'] === $share
 			) {
-				$shareId = (string) $shareElement['id'];
-				break;
+				array_push($shareIds, (string) $shareElement['id']);
 			}
 		}
-		Assert::assertNotNull(
-			$shareId,
+		Assert::assertNotEmpty(
+			$shareIds,
 			__METHOD__ . " could not find share $share, offered by $offeredBy to $user"
 		);
-		$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}" .
-			"/shares/pending/$shareId";
-		if (\substr($action, 0, 7) === "decline") {
-			$httpRequestMethod = "DELETE";
-		} elseif (\substr($action, 0, 6) === "accept") {
-			$httpRequestMethod = "POST";
-		}
+		foreach($shareIds as $shareId) {
+			$url = "/apps/files_sharing/api/v{$this->sharingApiVersion}" .
+				"/shares/pending/$shareId";
+			if (\substr($action, 0, 7) === "decline") {
+				$httpRequestMethod = "DELETE";
+			} elseif (\substr($action, 0, 6) === "accept") {
+				$httpRequestMethod = "POST";
+			}
 
-		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
-			$user,
-			$httpRequestMethod,
-			$url,
-			null
-		);
+			$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
+				$user,
+				$httpRequestMethod,
+				$url,
+				null
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This pr changes the `When /^user "([^"]*)" (declines|accepts) share "([^"]*)" offered by user "([^"]*)" using the sharing API` testing step to accept all shares matching the path instead of just the first one.
This is required for test cases like [this one](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature#L24) where both a group and a user share for the same resource need to be considered.

## Motivation and Context

It allows for properly test the existing test cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
