### PR TITLE
add --destination-use-user-folder option to files:transfer-ownership command

### DIFF
--- a/changelog/unreleased/39118
+++ b/changelog/unreleased/39118
@@ -1,0 +1,8 @@
+Enhancement: Extend transfer ownership cmd with option to transfer entire user
+
+Command occ files:transfer-ownership now includes flag --destination-use-user-folder <user-id>
+that allows to transfer all user files and shares to destination user that has never logged in. 
+This is helpful in situation when users need to be migrated to new accounts.
+
+https://github.com/owncloud/core/pull/39118
+https://github.com/owncloud/enterprise/issues/4686


### PR DESCRIPTION
Special purpose command for https://github.com/owncloud/enterprise/issues/4686

- [x] validate tests
- [x] docs

Perform transfer of files and shares from `/files/source-user-id` to `/files/dest-user-id`
```
occ files:transfer-ownership --destination-use-user-folder source-user-id dest-user-id
```