### PR TITLE
[Tests-Only] Adjust implementation for asserting the value of error message to accept range of  values

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -235,18 +235,20 @@ Feature: get file properties
 
   Scenario Outline: Do a PROPFIND to a non-existing URL
     When user "Alice" requests "<url>" with "PROPFIND" using basic auth
-    Then the value of the item "/d:error/s:message" in the response about user "Alice" should be "<message>"
+    Then the value of the item "/d:error/s:message" in the response about user "Alice" should be "<message1>" or "<message2>"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
-    @skipOnOcis
-    Examples:
-      | url                                  | message                                      |
-      | /remote.php/dav/files/does-not-exist | Principal with name does-not-exist not found |
-      | /remote.php/dav/does-not-exist       | File not found: does-not-exist in 'root'     |
+
     @skipOnOcV10
     Examples:
-      | url                                  | message                                  |
-      | /remote.php/dav/files/does-not-exist | Resource /users/does-not-exist not found |
-      | /remote.php/dav/does-not-exist       | File not found in root                   |
+      | url                                  | message1                                 | message2                              |
+      | /remote.php/dav/files/does-not-exist | Resource /users/does-not-exist not found | Resource /oc/does-not-exist not found |
+      | /remote.php/dav/does-not-exist       | File not found in root                   |                                       |
+
+    @skipOnOcis
+    Examples:
+      | url                                  | message1                                     | message2 |
+      | /remote.php/dav/files/does-not-exist | Principal with name does-not-exist not found |          |
+      | /remote.php/dav/does-not-exist       | File not found: does-not-exist in 'root'     |          |
 
   @issue-ocis-reva-217
   Scenario: add, receive multiple custom meta properties to a file

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -682,6 +682,54 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
+	 * @Then the value of the item :xpath in the response about user :user should be :value1 or :value2
+	 *
+	 * @param string $xpath
+	 * @param string|null $user
+	 * @param string $expectedValue1
+	 * @param string $expectedValue2
+	 *
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public function assertValueOfItemInResponseAboutUserIsEitherOr($xpath, $user, $expectedValue1, $expectedValue2) {
+		if (!$expectedValue2) {
+			$expectedValue2 = $expectedValue1;
+		}
+		$resXml = $this->featureContext->getResponseXmlObject();
+		if ($resXml === null) {
+			$resXml = HttpRequestHelper::getResponseXml(
+				$this->featureContext->getResponse(),
+				__METHOD__
+			);
+		}
+		$xmlPart = $resXml->xpath($xpath);
+		Assert::assertTrue(
+			isset($xmlPart[0]),
+			"Cannot find item with xpath \"$xpath\""
+		);
+		$value = $xmlPart[0]->__toString();
+		$user = $this->featureContext->getActualUsername($user);
+		$expectedValue1 = $this->featureContext->substituteInLineCodes(
+			$expectedValue1,
+			$user
+		);
+
+		$expectedValue2 = $this->featureContext->substituteInLineCodes(
+			$expectedValue2,
+			$user
+		);
+
+		// The expected value can contain /%base_path%/ which can be empty some time
+		// This will result in urls such as //remote.php, so replace that
+		$expectedValue1 = preg_replace("/\/\/remote\.php/i", "/remote.php", $expectedValue1);
+		$expectedValue2 = preg_replace("/\/\/remote\.php/i", "/remote.php", $expectedValue2);
+		$expectedValues = [$expectedValue1, $expectedValue2];
+		$isExpectedValueInMessage = \in_array($value, $expectedValues);
+		Assert::assertTrue($isExpectedValueInMessage, "The actual value \"$value\" is not one of the expected values: \"$expectedValue1\" or \"$expectedValue2\"");
+	}
+
+	/**
 	 * @Then the value of the item :xpath in the response should match :value
 	 *
 	 * @param string $xpath


### PR DESCRIPTION
## Description
This PR adjusts the implementation for asserting the value of the error message is any one of the values to make the tests pass in oc10, ocis and reva.

## Motivation and Context
- The value of the error message returned turned out to be slightly different in local setup and CI for reva. The value returned in reva CI is different to that of the value returned in ocis and oc10 as well. Hence, the function which asserts the strict equal of the value is adjusted.

## How Has This Been Tested?
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
