### PR TITLE
Feature/version metadata

### DIFF
--- a/apps/dav/lib/Meta/MetaFile.php
+++ b/apps/dav/lib/Meta/MetaFile.php
@@ -131,7 +131,7 @@ class MetaFile extends File implements ICopySource, IFileNode, IProvidesAddition
 	/**
 	 * @return string
 	 */
-	public function getVersionAuthor() {
+	public function getVersionAuthor() : string {
 		if ($this->file instanceof IProvidesVersionAuthor) {
 			return $this->file->getCreatedBy() ?: $this->file->getEditedBy();
 		}
@@ -141,12 +141,12 @@ class MetaFile extends File implements ICopySource, IFileNode, IProvidesAddition
 	/**
 	 * @return string
 	 */
-	public function getVersionAuthorName() {
+	public function getVersionAuthorName() : string {
 		if ($this->file instanceof IProvidesVersionAuthor) {
 			$uid =  $this->file->getCreatedBy() ?: $this->file->getEditedBy();
 			$manager = \OC::$server->getUserManager();
 			$user = $manager->get($uid);
-			return $user !== null ? $user->getDisplayName() : "";
+			return $user !== null ? $user->getDisplayName() : '';
 		}
 		return '';
 	}

--- a/apps/dav/lib/Meta/MetaFile.php
+++ b/apps/dav/lib/Meta/MetaFile.php
@@ -133,7 +133,7 @@ class MetaFile extends File implements ICopySource, IFileNode, IProvidesAddition
 	 */
 	public function getVersionAuthor() : string {
 		if ($this->file instanceof IProvidesVersionAuthor) {
-			return $this->file->getCreatedBy() ?: $this->file->getEditedBy();
+			return $this->file->getEditedBy();
 		}
 		return '';
 	}
@@ -143,7 +143,7 @@ class MetaFile extends File implements ICopySource, IFileNode, IProvidesAddition
 	 */
 	public function getVersionAuthorName() : string {
 		if ($this->file instanceof IProvidesVersionAuthor) {
-			$uid =  $this->file->getCreatedBy() ?: $this->file->getEditedBy();
+			$uid =  $this->file->getEditedBy();
 			$manager = \OC::$server->getUserManager();
 			$user = $manager->get($uid);
 			return $user !== null ? $user->getDisplayName() : '';

--- a/apps/dav/lib/Meta/MetaFile.php
+++ b/apps/dav/lib/Meta/MetaFile.php
@@ -25,6 +25,7 @@ use OC\Files\Meta\MetaFileVersionNode;
 use OCA\DAV\Files\ICopySource;
 use OCA\DAV\Files\IProvidesAdditionalHeaders;
 use OCA\DAV\Files\IFileNode;
+use OCP\Files\IProvidesVersionAuthor;
 use OCP\Files\Node;
 use Sabre\DAV\File;
 
@@ -125,5 +126,28 @@ class MetaFile extends File implements ICopySource, IFileNode, IProvidesAddition
 	 */
 	public function getNode() {
 		return $this->file;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getVersionAuthor() {
+		if ($this->file instanceof IProvidesVersionAuthor) {
+			return $this->file->getCreatedBy() ?: $this->file->getEditedBy();
+		}
+		return '';
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getVersionAuthorName() {
+		if ($this->file instanceof IProvidesVersionAuthor) {
+			$uid =  $this->file->getCreatedBy() ?: $this->file->getEditedBy();
+			$manager = \OC::$server->getUserManager();
+			$user = $manager->get($uid);
+			return $user !== null ? $user->getDisplayName() : "";
+		}
+		return '';
 	}
 }

--- a/apps/dav/lib/Meta/MetaPlugin.php
+++ b/apps/dav/lib/Meta/MetaPlugin.php
@@ -32,6 +32,7 @@ class MetaPlugin extends ServerPlugin {
 	// namespace
 	public const NS_OWNCLOUD = 'http://owncloud.org/ns';
 	public const PATH_FOR_FILEID_PROPERTYNAME = '{http://owncloud.org/ns}meta-path-for-user';
+	const VERSION_EDITED_BY_PROPERTYNAME = '{http://owncloud.org/ns}metaversioneditedby';
 
 	/**
 	 * Reference to main server object
@@ -96,6 +97,11 @@ class MetaPlugin extends ServerPlugin {
 				}
 				$file = \current($files);
 				return $baseFolder->getRelativePath($file->getPath());
+			});
+		} elseif ($node instanceof MetaFile){
+			$propFind->handle(self::VERSION_EDITED_BY_PROPERTYNAME, function () use ($node) {
+				// FIXME: get from storage of the $node required data
+				return "test1@owncloud.com";
 			});
 		}
 	}

--- a/apps/dav/lib/Meta/MetaPlugin.php
+++ b/apps/dav/lib/Meta/MetaPlugin.php
@@ -32,8 +32,9 @@ class MetaPlugin extends ServerPlugin {
 	// namespace
 	public const NS_OWNCLOUD = 'http://owncloud.org/ns';
 	public const PATH_FOR_FILEID_PROPERTYNAME = '{http://owncloud.org/ns}meta-path-for-user';
-	const VERSION_EDITED_BY_PROPERTYNAME = '{http://owncloud.org/ns}metaversioneditedby';
 
+	public const VERSION_EDITED_BY_PROPERTYNAME = '{http://owncloud.org/ns}meta-version-edited-by';
+	public const VERSION_EDITED_BY_PROPERTYNAME_NAME = '{http://owncloud.org/ns}meta-version-edited-by-name';
 	/**
 	 * Reference to main server object
 	 *
@@ -98,10 +99,12 @@ class MetaPlugin extends ServerPlugin {
 				$file = \current($files);
 				return $baseFolder->getRelativePath($file->getPath());
 			});
-		} elseif ($node instanceof MetaFile){
+		} elseif ($node instanceof MetaFile) {
 			$propFind->handle(self::VERSION_EDITED_BY_PROPERTYNAME, function () use ($node) {
-				// FIXME: get from storage of the $node required data
-				return "test1@owncloud.com";
+				return $node->getVersionAuthor();
+			});
+			$propFind->handle(self::VERSION_EDITED_BY_PROPERTYNAME_NAME, function () use ($node) {
+				return $node->getVersionAuthorName();
 			});
 		}
 	}

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -400,19 +400,35 @@ class Trashbin {
 			$rootView = new View('/');
 
 			if ($rootView->is_dir($owner . '/files_versions/' . $ownerPath)) {
+				$metadataFileExists = $rootView->file_exists($owner . '/files_versions/' . $ownerPath . '.json');
+
 				if ($owner !== $user || $forceCopy) {
 					self::copy_recursive($owner . '/files_versions/' . $ownerPath, $owner . '/files_trashbin/versions/' . \basename($ownerPath) . '.d' . $timestamp, $rootView);
+					if ($metadataFileExists) {
+						self::copy_recursive($owner . '/files_versions/' . $ownerPath . '.json', $owner . '/files_trashbin/versions/' . \basename($ownerPath) . '.json' . '.d' . $timestamp, $rootView);
+					}
 				}
 				if (!$forceCopy) {
 					self::move($rootView, $owner . '/files_versions/' . $ownerPath, $user . '/files_trashbin/versions/' . $filename . '.d' . $timestamp);
+					if ($metadataFileExists) {
+						self::move($rootView, $owner . '/files_versions/' . $ownerPath . '.json', $user . '/files_trashbin/versions/' . $filename . '.json' . '.d' . $timestamp);
+					}
 				}
 			} elseif ($versions = \OCA\Files_Versions\Storage::getVersions($owner, $ownerPath)) {
 				foreach ($versions as $v) {
+					$metaVersionExists = $rootView->file_exists($owner . '/files_versions' . $v['path'] . '.v' . $v['version'] . '.json');
+
 					if ($owner !== $user || $forceCopy) {
 						self::copy($rootView, $owner . '/files_versions' . $v['path'] . '.v' . $v['version'], $owner . '/files_trashbin/versions/' . $v['name'] . '.v' . $v['version'] . '.d' . $timestamp);
+						if ($metaVersionExists) {
+							self::move($rootView, $owner . '/files_versions' . $v['path'] . '.v' . $v['version'] . '.json', $owner . '/files_trashbin/versions/' . $filename . '.v' . $v['version'] . '.json' . '.d' . $timestamp);
+						}
 					}
 					if (!$forceCopy) {
 						self::move($rootView, $owner . '/files_versions' . $v['path'] . '.v' . $v['version'], $user . '/files_trashbin/versions/' . $filename . '.v' . $v['version'] . '.d' . $timestamp);
+						if ($metaVersionExists) {
+							self::move($rootView, $owner . '/files_versions' . $v['path'] . '.v' . $v['version'] . '.json', $user . '/files_trashbin/versions/' . $filename . '.v' . $v['version'] . '.json' . '.d' . $timestamp);
+						}
 					}
 				}
 			}

--- a/apps/files_versions/js/versioncollection.js
+++ b/apps/files_versions/js/versioncollection.js
@@ -11,11 +11,26 @@
 /* global moment */
 
 (function() {
+
+	_.extend(OC.Files.Client, {
+		PROPERTY_FILEID:	'{' + OC.Files.Client.NS_OWNCLOUD + '}id',
+		PROPERTY_VERSION_EDITED_BY:	'{' + OC.Files.Client.NS_OWNCLOUD + '}metaversioneditedby',
+	});
+
 	/**
 	 * @memberof OCA.Versions
 	 */
 	var VersionCollection = OC.Backbone.Collection.extend({
 		sync: OC.Backbone.davSync,
+
+		davProperties: {
+			'metaversioneditedby':	OC.Files.Client.PROPERTY_VERSION_EDITED_BY,
+			'id':	OC.Files.Client.PROPERTY_FILEID,
+			'getlastmodified': OC.Files.Client.PROPERTY_GETLASTMODIFIED,
+			'getcontentlength': OC.Files.Client.PROPERTY_GETCONTENTLENGTH,
+			'resourcetype': OC.Files.Client.PROPERTY_RESOURCETYPE,
+			'getcontenttype': OC.Files.Client.PROPERTY_GETCONTENTTYPE,
+		},
 
 		model: OCA.Versions.VersionModel,
 
@@ -46,9 +61,10 @@
 					id: revision,
 					name: revision,
 					fullPath: fullPath,
-					timestamp: moment(new Date(version['{DAV:}getlastmodified'])).format('X'),
-					size: version['{DAV:}getcontentlength'],
-					mimetype: version['{DAV:}getcontenttype'],
+					timestamp: moment(new Date(version.getlastmodified)).format('X'),
+					size: version.getcontentlength,
+					mimetype: version.getcontenttype,
+					editedBy: version.metaversioneditedby,
 					fileId: fileId
 				};
 			});

--- a/apps/files_versions/js/versioncollection.js
+++ b/apps/files_versions/js/versioncollection.js
@@ -14,7 +14,8 @@
 
 	_.extend(OC.Files.Client, {
 		PROPERTY_FILEID:	'{' + OC.Files.Client.NS_OWNCLOUD + '}id',
-		PROPERTY_VERSION_EDITED_BY:	'{' + OC.Files.Client.NS_OWNCLOUD + '}metaversioneditedby',
+		PROPERTY_VERSION_EDITED_BY:	'{' + OC.Files.Client.NS_OWNCLOUD + '}meta-version-edited-by',
+    	PROPERTY_VERSION_EDITED_BY_NAME:	'{' + OC.Files.Client.NS_OWNCLOUD + '}meta-version-edited-by-name',
 	});
 
 	/**
@@ -24,7 +25,8 @@
 		sync: OC.Backbone.davSync,
 
 		davProperties: {
-			'metaversioneditedby':	OC.Files.Client.PROPERTY_VERSION_EDITED_BY,
+			'meta-version-edited-by':	OC.Files.Client.PROPERTY_VERSION_EDITED_BY,
+      'meta-version-edited-by-name':	OC.Files.Client.PROPERTY_VERSION_EDITED_BY_NAME,
 			'id':	OC.Files.Client.PROPERTY_FILEID,
 			'getlastmodified': OC.Files.Client.PROPERTY_GETLASTMODIFIED,
 			'getcontentlength': OC.Files.Client.PROPERTY_GETCONTENTLENGTH,
@@ -62,9 +64,11 @@
 					name: revision,
 					fullPath: fullPath,
 					timestamp: moment(new Date(version.getlastmodified)).format('X'),
+					relativeTimestamp:  moment(new Date(version.getlastmodified)).fromNow(),
 					size: version.getcontentlength,
 					mimetype: version.getcontenttype,
-					editedBy: version.metaversioneditedby,
+					editedBy: version['meta-version-edited-by'],
+          			editedByName: version['meta-version-edited-by-name'],
 					fileId: fileId
 				};
 			});

--- a/apps/files_versions/js/versioncollection.js
+++ b/apps/files_versions/js/versioncollection.js
@@ -26,7 +26,7 @@
 
 		davProperties: {
 			'meta-version-edited-by':	OC.Files.Client.PROPERTY_VERSION_EDITED_BY,
-      'meta-version-edited-by-name':	OC.Files.Client.PROPERTY_VERSION_EDITED_BY_NAME,
+      		'meta-version-edited-by-name':	OC.Files.Client.PROPERTY_VERSION_EDITED_BY_NAME,
 			'id':	OC.Files.Client.PROPERTY_FILEID,
 			'getlastmodified': OC.Files.Client.PROPERTY_GETLASTMODIFIED,
 			'getcontentlength': OC.Files.Client.PROPERTY_GETCONTENTLENGTH,

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -39,6 +39,7 @@
 		'{{#hasDetails}}' +
 		'<div class="version-details">' +
 		'<span class="size has-tooltip" title="{{altSize}}">{{humanReadableSize}}</span>' +
+		'<span class="size has-tooltip" title="{{editedBy}}">{{editedBy}}</span>' +
 		'</div>' +
 		'{{/hasDetails}}' +
 		'</div>' +
@@ -213,7 +214,8 @@
 				revertIconUrl: OC.imagePath('core', 'actions/history'),
 				previewUrl: getPreviewUrl(version),
 				revertLabel: t('files_versions', 'Restore'),
-				canRevert: (this.collection.getFileInfo().get('permissions') & OC.PERMISSION_UPDATE) !== 0
+				canRevert: (this.collection.getFileInfo().get('permissions') & OC.PERMISSION_UPDATE) !== 0,
+				editedBy: version.has('editedBy'),
 			}, version.attributes);
 		},
 

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -216,7 +216,7 @@
 				revertLabel: t('files_versions', 'Restore'),
 				canRevert: (this.collection.getFileInfo().get('permissions') & OC.PERMISSION_UPDATE) !== 0,
 				editedBy: version.has('editedBy'),
-        editedByName: version.has('editedByName')
+        		editedByName: version.has('editedByName')
 			}, version.attributes);
 		},
 

--- a/apps/files_versions/js/versionstabview.js
+++ b/apps/files_versions/js/versionstabview.js
@@ -39,7 +39,7 @@
 		'{{#hasDetails}}' +
 		'<div class="version-details">' +
 		'<span class="size has-tooltip" title="{{altSize}}">{{humanReadableSize}}</span>' +
-		'<span class="size has-tooltip" title="{{editedBy}}">{{editedBy}}</span>' +
+		'<span title="{{editedBy}}">{{editedByName}}</span>' +
 		'</div>' +
 		'{{/hasDetails}}' +
 		'</div>' +
@@ -216,6 +216,7 @@
 				revertLabel: t('files_versions', 'Restore'),
 				canRevert: (this.collection.getFileInfo().get('permissions') & OC.PERMISSION_UPDATE) !== 0,
 				editedBy: version.has('editedBy'),
+        editedByName: version.has('editedByName')
 			}, version.attributes);
 		},
 

--- a/apps/files_versions/lib/Hooks.php
+++ b/apps/files_versions/lib/Hooks.php
@@ -36,6 +36,7 @@ class Hooks {
 	public static function connectHooks() {
 		// Listen to write signals
 		\OCP\Util::connectHook('OC_Filesystem', 'write', 'OCA\Files_Versions\Hooks', 'write_hook');
+
 		// Listen to delete and rename signals
 		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', 'OCA\Files_Versions\Hooks', 'remove_hook');
 		\OCP\Util::connectHook('OC_Filesystem', 'delete', 'OCA\Files_Versions\Hooks', 'pre_remove_hook');

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -208,8 +208,7 @@ class Storage {
 				if ($config->getSystemValue('file_storage.save_version_author', false) === true) {
 					$user = \OC::$server->getUserSession()->getUser();
 					if ($user !== null && !$users_view->file_exists($versionFileName . '.json')) {
-						$versions = self::getVersions($uid, $filename);
-						$metaDataKey =  \sizeof($versions) === 1 ? Constants::CREATED_BY_USER_METADATA : MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME;
+						$metaDataKey =  MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME;
 						$metadata = [$metaDataKey => $user->getUID()];
 						$metadataJsonObject = \json_encode($metadata);
 						$users_view->file_put_contents($versionFileName . '.json', $metadataJsonObject);
@@ -366,8 +365,7 @@ class Storage {
 
 			if ($metaDataEnabled === true) {
 				$metaTargetPath = $version . '.json';
-				$versions = self::getVersions($uid, $filename);
-				$metaDataKey = \sizeof($versions) == 1 ? Constants::CREATED_BY_USER_METADATA : MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME;
+				$metaDataKey = MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME;
 				$metadataJsonObject = \json_encode([$metaDataKey => $uid]);
 				$users_view->file_put_contents($metaTargetPath, $metadataJsonObject);
 			}
@@ -506,9 +504,7 @@ class Storage {
 						if ($view->file_exists($jsonMetadataFile)) {
 							$metaDataFileContents = $view->file_get_contents($jsonMetadataFile);
 							if ($decoded = \json_decode($metaDataFileContents, true)) {
-								if (isset($decoded[Constants::CREATED_BY_USER_METADATA])) {
-									$versions[$key]['created_by'] = $decoded[Constants::CREATED_BY_USER_METADATA];
-								} elseif ($decoded[MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME] !== null) {
+								if (isset($decoded[MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME])) {
 									$versions[$key]['edited_by'] = $decoded[MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME];
 								}
 							}

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -238,6 +238,10 @@ class Storage {
 	 */
 	protected static function deleteVersion($view, $path) {
 		$view->unlink($path);
+		/**
+		 * @var \OC\Files\Storage\Storage $storage
+		 * @var string $internalPath
+		 */
 		list($storage, $internalPath) = $view->resolvePath($path);
 		$cache = $storage->getCache($internalPath);
 		$cache->remove($internalPath);

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -43,6 +43,8 @@ namespace OCA\Files_Versions;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OC\Share\Constants;
+use OCA\DAV\Meta\MetaPlugin;
 use OCA\Files_Versions\AppInfo\Application;
 use OCA\Files_Versions\Command\Expire;
 use OCP\Files\NotFoundException;
@@ -192,13 +194,27 @@ class Storage {
 			// store a new version of a file
 			$mtime = $users_view->filemtime('files/' . $filename);
 			$sourceFileInfo = $users_view->getFileInfo("files/$filename");
-			if ($users_view->copy("files/$filename", "files_versions/$filename.v$mtime")) {
+
+			$versionFileName = "files_versions/$filename.v$mtime";
+			if ($users_view->copy("files/$filename", $versionFileName)) {
 				// call getFileInfo to enforce a file cache entry for the new version
-				$users_view->getFileInfo("files_versions/$filename.v$mtime");
+				$users_view->getFileInfo($versionFileName);
 				// update checksum of the version
-				$users_view->putFileInfo("files_versions/$filename.v$mtime", [
+				$users_view->putFileInfo($versionFileName, [
 					'checksum' => $sourceFileInfo->getChecksum(),
 				]);
+
+				$config = \OC::$server->getConfig();
+				if ($config->getSystemValue('file_storage.save_version_author', false) === true) {
+					$user = \OC::$server->getUserSession()->getUser();
+					if ($user !== null && !$users_view->file_exists($versionFileName . '.json')) {
+						$versions = self::getVersions($uid, $filename);
+						$metaDataKey =  \sizeof($versions) === 1 ? Constants::CREATED_BY_USER_METADATA : MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME;
+						$metadata = [$metaDataKey => $user->getUID()];
+						$metadataJsonObject = \json_encode($metadata);
+						$users_view->file_put_contents($versionFileName . '.json', $metadataJsonObject);
+					}
+				}
 			}
 		}
 	}
@@ -222,10 +238,6 @@ class Storage {
 	 */
 	protected static function deleteVersion($view, $path) {
 		$view->unlink($path);
-		/**
-		 * @var \OC\Files\Storage\Storage $storage
-		 * @var string $internalPath
-		 */
 		list($storage, $internalPath) = $view->resolvePath($path);
 		$cache = $storage->getCache($internalPath);
 		$cache->remove($internalPath);
@@ -254,6 +266,9 @@ class Storage {
 					];
 					\OC_Hook::emit('\OCP\Versions', 'preDelete', $hookData);
 					self::deleteVersion($view, $filename . '.v' . $v['version']);
+					if ($view->file_exists($path . ".json")) {
+						$view->unlink($path . ".json");
+					}
 					\OC_Hook::emit('\OCP\Versions', 'delete', $hookData);
 				}
 			}
@@ -310,6 +325,14 @@ class Storage {
 					'/' . $sourceOwner . '/files_versions/' . $sourcePath.'.v' . $v['version'],
 					'/' . $targetOwner . '/files_versions/' . $targetPath.'.v'.$v['version']
 				);
+				// move each version json file that holds the name of the user that've made an edit
+				$sourceMetaDataFile = '/' . $sourceOwner . '/files_versions/' . $sourcePath . '.v' . $v['version'] . '.json';
+				if ($rootView->file_exists($sourceMetaDataFile)) {
+					$rootView->$operation(
+						$sourceMetaDataFile,
+						'/' . $targetOwner . '/files_versions/' . $targetPath . '.v' . $v['version'] . '.json'
+					);
+				}
 			}
 		}
 
@@ -328,13 +351,22 @@ class Storage {
 			return false;
 		}
 
+		$metaDataEnabled = \OC::$server->getConfig()->getSystemValue('file_storage.save_version_author', false);
 		$versionCreated = false;
 
-		//first create a new version
+		//first create a new version and metadata if enabled
 		$version = 'files_versions'.$filename.'.v'.$users_view->filemtime('files'.$filename);
 		if (!$users_view->file_exists($version)) {
-			$users_view->copy('files'.$filename, 'files_versions'.$filename.'.v'.$users_view->filemtime('files'.$filename));
+			$users_view->copy('files'.$filename, $version);
 			$versionCreated = true;
+
+			if ($metaDataEnabled === true) {
+				$metaTargetPath = $version . '.json';
+				$versions = self::getVersions($uid, $filename);
+				$metaDataKey = \sizeof($versions) == 1 ? Constants::CREATED_BY_USER_METADATA : MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME;
+				$metadataJsonObject = \json_encode([$metaDataKey => $uid]);
+				$users_view->file_put_contents($metaTargetPath, $metadataJsonObject);
+			}
 		}
 
 		// Restore encrypted version of the old file for the newly restored file
@@ -356,11 +388,20 @@ class Storage {
 		if (self::copyFileContents($users_view, $fileToRestore, 'files' . $filename)) {
 			$users_view->touch("/files$filename", $revision);
 			Storage::scheduleExpire($uid, $filename);
+
+			if ($metaDataEnabled && $users_view->file_exists($fileToRestore . '.json')) {
+				$users_view->unlink($fileToRestore . '.json');
+				list($storage, $internalPath) = $users_view->resolvePath($fileToRestore . '.json');
+				$cache = $storage->getCache($internalPath);
+				$cache->remove($internalPath);
+			}
+
 			\OC_Hook::emit('\OCP\Versions', 'rollback', [
 				'path' => $filename,
 				'user' => $uid,
 				'revision' => $revision,
 			]);
+
 			return true;
 		} elseif ($versionCreated) {
 			self::deleteVersion($users_view, $version);
@@ -456,6 +497,18 @@ class Storage {
 						$versions[$key]['etag'] = $view->getETag($dir . '/' . $entryName);
 						$versions[$key]['storage_location'] = "$dir/$entryName";
 						$versions[$key]['owner'] = $uid;
+
+						$jsonMetadataFile = $dir . '/' . $entryName . '.json';
+						if ($view->file_exists($jsonMetadataFile)) {
+							$metaDataFileContents = $view->file_get_contents($jsonMetadataFile);
+							if ($decoded = \json_decode($metaDataFileContents, true)) {
+								if (isset($decoded[Constants::CREATED_BY_USER_METADATA])) {
+									$versions[$key]['created_by'] = $decoded[Constants::CREATED_BY_USER_METADATA];
+								} elseif ($decoded[MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME] !== null) {
+									$versions[$key]['edited_by'] = $decoded[MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME];
+								}
+							}
+						}
 					}
 				}
 			}
@@ -561,6 +614,7 @@ class Storage {
 
 	/**
 	 * get list of files we want to expire
+	 *
 	 * @param array $versions list of versions
 	 * @param integer $time
 	 * @return array containing the list of to deleted versions and the size of them

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -197,7 +197,7 @@ class VersioningTest extends TestCase {
 			$m1 = $versionsFolder2 . '/test.txt.v' . $t1 . '.json';
 			$m2 = $versionsFolder2 . '/test.txt.v' . $t2 . '.json';
 
-			$this->rootView->file_put_contents($m1, \json_encode([Constants::CREATED_BY_USER_METADATA => $this->user2]));
+			$this->rootView->file_put_contents($m1, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user2]));
 			$this->rootView->file_put_contents($m2, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user2]));
 		}
 
@@ -405,7 +405,7 @@ class VersioningTest extends TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		if ($metaDataEnabled) {
-			$this->rootView->file_put_contents($m1, \json_encode([Constants::CREATED_BY_USER_METADATA => $this->user2]));
+			$this->rootView->file_put_contents($m1, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user2]));
 			$this->rootView->file_put_contents($m2, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user2]));
 		}
 
@@ -460,7 +460,7 @@ class VersioningTest extends TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		if ($metaDataEnabled) {
-			$this->rootView->file_put_contents($m1, \json_encode([Constants::CREATED_BY_USER_METADATA => $this->user1]));
+			$this->rootView->file_put_contents($m1, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 			$this->rootView->file_put_contents($m2, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 		}
 
@@ -532,7 +532,7 @@ class VersioningTest extends TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		if ($metaDataEnabled) {
-			$this->rootView->file_put_contents($m1, \json_encode([Constants::CREATED_BY_USER_METADATA => $this->user1]));
+			$this->rootView->file_put_contents($m1, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 			$this->rootView->file_put_contents($m2, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 		}
 
@@ -593,7 +593,7 @@ class VersioningTest extends TestCase {
 		if ($metaDataEnabled) {
 			$m1 = $v1 . '.json';
 			$m2 = $v2 . '.json';
-			$this->rootView->file_put_contents($m1, \json_encode([Constants::CREATED_BY_USER_METADATA => $this->user2]));
+			$this->rootView->file_put_contents($m1, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user2]));
 			$this->rootView->file_put_contents($m2, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user2]));
 		}
 
@@ -655,7 +655,7 @@ class VersioningTest extends TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		if ($metaDataEnabled) {
-			$this->rootView->file_put_contents($m1, \json_encode([Constants::CREATED_BY_USER_METADATA => $this->user1]));
+			$this->rootView->file_put_contents($m1, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 			$this->rootView->file_put_contents($m2, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 		}
 
@@ -724,7 +724,7 @@ class VersioningTest extends TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		if ($metaDataEnabled) {
-			$this->rootView->file_put_contents($m1, \json_encode([Constants::CREATED_BY_USER_METADATA => $this->user1]));
+			$this->rootView->file_put_contents($m1, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 			$this->rootView->file_put_contents($m2, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 		}
 
@@ -792,7 +792,7 @@ class VersioningTest extends TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		if ($enableMetadata) {
-			$this->rootView->file_put_contents($m1, \json_encode([Constants::CREATED_BY_USER_METADATA => $this->user1]));
+			$this->rootView->file_put_contents($m1, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 			$this->rootView->file_put_contents($m2, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 		}
 
@@ -807,7 +807,7 @@ class VersioningTest extends TestCase {
 		}
 
 		if ($enableMetadata) {
-			$this->assertArrayHasKey('created_by', array_shift($versions));
+			$this->assertArrayHasKey('edited_by', array_shift($versions));
 			$this->assertArrayHasKey('edited_by', array_shift($versions));
 		}
 
@@ -934,7 +934,7 @@ class VersioningTest extends TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		if ($metaDataEnabled) {
-			$this->rootView->file_put_contents($m1, \json_encode([Constants::CREATED_BY_USER_METADATA => $this->user1]));
+			$this->rootView->file_put_contents($m1, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 			$this->rootView->file_put_contents($m2, \json_encode([MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME => $this->user1]));
 		}
 

--- a/changelog/unreleased/39126
+++ b/changelog/unreleased/39126
@@ -1,0 +1,8 @@
+Enhancement: Save and display the author of a file version
+
+The author attribute will be saved and shown in the version list grid for each new file version.
+This will allow the users to see who performed the changes on a specific file and when.
+Also, the author attribute will retain on renaming, copying, and deletion/restoration of the file.
+
+https://github.com/owncloud/enterprise/issues/4518
+https://github.com/owncloud/core/pull/39126

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1266,6 +1266,11 @@ $CONFIG = [
 'sharing.showPublicLinkQuickAction' => false,
 
 /**
+ * Save and display version of uploaded and edited files.
+ */
+'file_storage.save_version_author' => false,
+
+/**
  * All other configuration options
  */
 

--- a/lib/private/Files/Meta/MetaFileVersionNode.php
+++ b/lib/private/Files/Meta/MetaFileVersionNode.php
@@ -28,6 +28,7 @@ use OCP\Files\ForbiddenException;
 use OCP\Files\IProvidesAdditionalHeaders;
 use OC\Preview;
 use OCA\Files_Sharing\SharedStorage;
+use OCP\Files\IProvidesVersionAuthor;
 use OCP\Files\IRootFolder;
 use OCP\Files\IPreviewNode;
 use OCP\Files\Storage\IVersionedStorage;
@@ -40,7 +41,7 @@ use OCP\IImage;
  *
  * @package OC\Files\Meta
  */
-class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvidesAdditionalHeaders {
+class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvidesAdditionalHeaders, IProvidesVersionAuthor {
 
 	/** @var string */
 	private $versionId;
@@ -54,6 +55,16 @@ class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvide
 	private $root;
 	/** @var array */
 	private $versionInfo;
+
+	/**
+	 * @var string
+	 **/
+	private $editedBy = "";
+
+	/**
+	 * @var string
+	 **/
+	private $createdBy = "";
 
 	/**
 	 * MetaFileVersionNode constructor.
@@ -77,8 +88,30 @@ class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvide
 		$this->storage = $storage;
 		$this->internalPath = $internalPath;
 		$this->root = $root;
+
+		if (isset($version['edited_by'])) {
+			$this->editedBy = $version['edited_by'];
+		}
+
+		if (isset($version['created_by'])) {
+			$this->createdBy = $version['created_by'];
+		}
 	}
 
+	/**
+	 * @return string
+	 */
+	public function getEditedBy() {
+		return $this->editedBy;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCreatedBy() {
+		return $this->createdBy;
+	}
+	
 	/**
 	 * @inheritdoc
 	 */

--- a/lib/private/Files/Meta/MetaFileVersionNode.php
+++ b/lib/private/Files/Meta/MetaFileVersionNode.php
@@ -88,13 +88,6 @@ class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvide
 	}
 
 	/**
-	 * @return string
-	 */
-	public function getCreatedBy() : string {
-		return $this->versionInfo['created_by'] ?? '';
-	}
-
-	/**
 	 * @inheritdoc
 	 */
 	public function getName() {

--- a/lib/private/Files/Meta/MetaFileVersionNode.php
+++ b/lib/private/Files/Meta/MetaFileVersionNode.php
@@ -57,16 +57,6 @@ class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvide
 	private $versionInfo;
 
 	/**
-	 * @var string
-	 **/
-	private $editedBy = "";
-
-	/**
-	 * @var string
-	 **/
-	private $createdBy = "";
-
-	/**
 	 * MetaFileVersionNode constructor.
 	 *
 	 * @param MetaVersionCollection $parent
@@ -88,30 +78,22 @@ class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvide
 		$this->storage = $storage;
 		$this->internalPath = $internalPath;
 		$this->root = $root;
-
-		if (isset($version['edited_by'])) {
-			$this->editedBy = $version['edited_by'];
-		}
-
-		if (isset($version['created_by'])) {
-			$this->createdBy = $version['created_by'];
-		}
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getEditedBy() {
-		return $this->editedBy;
+	public function getEditedBy() : string {
+		return $version['edited_by'] ?? '';
 	}
 
 	/**
 	 * @return string
 	 */
-	public function getCreatedBy() {
-		return $this->createdBy;
+	public function getCreatedBy() : string {
+		return $version['created_by'] ?? '';
 	}
-	
+
 	/**
 	 * @inheritdoc
 	 */

--- a/lib/private/Files/Meta/MetaFileVersionNode.php
+++ b/lib/private/Files/Meta/MetaFileVersionNode.php
@@ -84,14 +84,14 @@ class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvide
 	 * @return string
 	 */
 	public function getEditedBy() : string {
-		return $version['edited_by'] ?? '';
+		return $this->versionInfo['edited_by'] ?? '';
 	}
 
 	/**
 	 * @return string
 	 */
 	public function getCreatedBy() : string {
-		return $version['created_by'] ?? '';
+		return $this->versionInfo['created_by'] ?? '';
 	}
 
 	/**

--- a/lib/private/Share/Constants.php
+++ b/lib/private/Share/Constants.php
@@ -61,4 +61,6 @@ class Constants {
 	protected static $backends = [];
 	protected static $backendTypes = [];
 	protected static $isResharingAllowed;
+
+	public const CREATED_BY_USER_METADATA = "{http://owncloud.org/ns}created-by-user";
 }

--- a/lib/private/Share/Constants.php
+++ b/lib/private/Share/Constants.php
@@ -61,6 +61,4 @@ class Constants {
 	protected static $backends = [];
 	protected static $backendTypes = [];
 	protected static $isResharingAllowed;
-
-	public const CREATED_BY_USER_METADATA = "{http://owncloud.org/ns}created-by-user";
 }

--- a/lib/public/Files/IProvidesVersionAuthor.php
+++ b/lib/public/Files/IProvidesVersionAuthor.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Illia Pushnov <illia.pushnov@gmail.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Files;
+
+/**
+ * Interface IProvidesVersionAuthor
+ * This interface provides version author retrieval for file version
+ *
+ * @package OCP\Files
+ * @since 10.9.0
+ */
+interface IProvidesVersionAuthor {
+	/**
+	 * Returns the version author's username
+	 * @return string
+	 * @since 10.9.0
+	 */
+	public function getEditedBy();
+
+	/**
+	 * Returns the file author's username
+	 * @return string
+	 * @since 10.9.0
+	 */
+	public function getCreatedBy();
+}

--- a/lib/public/Files/IProvidesVersionAuthor.php
+++ b/lib/public/Files/IProvidesVersionAuthor.php
@@ -37,13 +37,4 @@ interface IProvidesVersionAuthor {
 	 * @since 10.9.0
 	 */
 	public function getEditedBy() : string;
-
-	/**
-	 * Returns the file author's username if this is the initial version of the file,
-	 * else empty string.
-	 *
-	 * @return string
-	 * @since 10.9.0
-	 */
-	public function getCreatedBy() : string;
 }

--- a/lib/public/Files/IProvidesVersionAuthor.php
+++ b/lib/public/Files/IProvidesVersionAuthor.php
@@ -30,16 +30,20 @@ namespace OCP\Files;
  */
 interface IProvidesVersionAuthor {
 	/**
-	 * Returns the version author's username
+	 * Returns the username of author which made this edit. Returns
+	 * empty string if this is the initial version @see IProvidesVersionAuthor::getCreatedBy()
+	 *
 	 * @return string
 	 * @since 10.9.0
 	 */
-	public function getEditedBy();
+	public function getEditedBy() : string;
 
 	/**
-	 * Returns the file author's username
+	 * Returns the file author's username if this is the initial version of the file,
+	 * else empty string.
+	 *
 	 * @return string
 	 * @since 10.9.0
 	 */
-	public function getCreatedBy();
+	public function getCreatedBy() : string;
 }


### PR DESCRIPTION
The file version author is now being saved in an appropriate timestamp-prefixed JSON file and displayed in the version list on PROPFIND request. Rename, copy and deletion are take into account.

Enable with config-flag: 'file_storage.save_version_author' => true, in config.php