### PR TITLE
fix logo sizing

### DIFF
--- a/changelog/unreleased/39129
+++ b/changelog/unreleased/39129
@@ -1,0 +1,6 @@
+Bugfix: Fix logo size on login screen
+
+The previous fixed logo size resulted in a cut off logo in some cases. This
+was fixed by using a dynamically logo resize css rule.
+
+https://github.com/owncloud/core/pull/39129

--- a/core/css/header.css
+++ b/core/css/header.css
@@ -81,10 +81,10 @@
 #header .logo {
 	background-image: url('../img/logo.svg');
 	background-repeat: no-repeat;
-	background-size: 220px;
+	background-size: contain;
 	background-position: center center;
 	width: 252px;
-	height: 120px;
+	height: 142px;
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
## Description
In some cases the previously fixed logo size resulted in a cut off logo. This PR sets the logo size dynamically.

## Screenshots (if appropriate):
Before
<img width="457" alt="grafik" src="https://user-images.githubusercontent.com/16665512/130416123-eb170bad-df19-4cac-bc4d-a73f4184097c.png">


After
<img width="458" alt="grafik" src="https://user-images.githubusercontent.com/16665512/130416281-eac3874c-dcf7-416b-9fc3-251a2e58e2bb.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
