### PR TITLE
Implement quick action for creating public links

### DIFF
--- a/apps/files_sharing/js/sharedialogview.js
+++ b/apps/files_sharing/js/sharedialogview.js
@@ -39,10 +39,9 @@
 			});
 
 			var baseLinkShareViewRender = view.linkShareView.render;
-
 			view.render = function () {
 				baseRenderCall.call(view);
-				if (that.isPublicSharingBlockedByAllowlist() && !shareCollectionModel.length) {
+				if (view.configModel.isPublicSharingBlockedByAllowlist() && !shareCollectionModel.length) {
 					view.$el.find('.subtab-publicshare').remove();
 				}
 			};
@@ -50,7 +49,7 @@
 			view.linkShareView.render = function () {
 				baseLinkShareViewRender.call(view.linkShareView);
 
-				if (that.isPublicSharingBlockedByAllowlist()) {
+				if (view.configModel.isPublicSharingBlockedByAllowlist()) {
 					view.linkShareView.$el.find('.addLink').remove();
 					view.$el.find('.empty-message').remove();
 				}
@@ -74,28 +73,6 @@
 
 			};
 		},
-
-		isPublicSharingBlockedByAllowlist: function () {
-			var allowlistEnabled = oc_appconfig.files_sharing.publicShareSharersGroupsAllowlistEnabled;
-			var allowlistGroups = oc_appconfig.files_sharing.publicShareSharersGroupsAllowlist;
-
-
-			if (allowlistEnabled === true &&
-				allowlistGroups.length
-			) {
-				var userGroups = OC.getCurrentUser().groups;
-
-				for (var i = 0; i < userGroups.length; i++) {
-					if (allowlistGroups.indexOf(userGroups[i]) >= 0) {
-						return false;
-					}
-				}
-
-				return true;
-			}
-
-			return false;
-		}
 	};
 })();
 

--- a/apps/files_sharing/lib/Hooks.php
+++ b/apps/files_sharing/lib/Hooks.php
@@ -291,6 +291,7 @@ class Hooks {
 		$array['array']['oc_appconfig']['files_sharing'] = [
 			'publicShareSharersGroupsAllowlist' => $sharingAllowlist->getPublicShareSharersGroupsAllowlist(),
 			'publicShareSharersGroupsAllowlistEnabled' => $sharingAllowlist->isPublicShareSharersGroupsAllowlistEnabled(),
+			'showPublicLinkQuickAction' => \OC::$server->getConfig()->getSystemValue('sharing.showPublicLinkQuickAction', false),
 		];
 
 		return $array;

--- a/apps/files_sharing/tests/HooksTest.php
+++ b/apps/files_sharing/tests/HooksTest.php
@@ -402,6 +402,7 @@ class HooksTest extends \Test\TestCase {
 		$expected['array']['oc_appconfig']['files_sharing'] = [
 			'publicShareSharersGroupsAllowlist' => [],
 			'publicShareSharersGroupsAllowlistEnabled' => false,
+			'showPublicLinkQuickAction' => false,
 		];
 
 		$this->assertEquals($expected, $this->hooks->extendJsConfig([]));

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -9,9 +9,12 @@
  */
 
 describe('OCA.Sharing.FileList tests', function() {
-	var testFiles, alertStub, notificationStub, fileList;
+	var testFiles, alertStub, notificationStub, fileList, oldConfig;
 
 	beforeEach(function() {
+		oldConfig = OC.appConfig.files_sharing;
+		OC.appConfig.files_sharing = _.extend({}, OC.appConfig.files_sharing);
+
 		alertStub = sinon.stub(OC.dialogs, 'alert');
 		notificationStub = sinon.stub(OC.Notification, 'show');
 
@@ -55,6 +58,7 @@ describe('OCA.Sharing.FileList tests', function() {
 		OC.Plugins.register('OCA.Files.FileList', OCA.Files.TagsPlugin);
 	});
 	afterEach(function() {
+		OC.appConfig.files_sharing = oldConfig;
 		testFiles = undefined;
 		fileList.destroy();
 		fileList = undefined;

--- a/changelog/unreleased/39130
+++ b/changelog/unreleased/39130
@@ -1,0 +1,8 @@
+Enhancement: Quick action for creating public links
+
+This feature introduces a quick action in the filelist for creating read-only
+public links. It can be enabled via 'sharing.showPublicLinkQuickAction'
+in the config.php.
+
+https://github.com/owncloud/enterprise/issues/4718
+https://github.com/owncloud/core/pull/39130

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1228,6 +1228,16 @@ $CONFIG = [
 'sharing.federation.allowHttpFallback' => false,
 
 /**
+ * Show a quick action for the public link creation
+ * Set this to true to display a quick action for creating public links
+ * in the filelist. A public link created this way will be read-only per default.
+ *
+ * Note: if enforced password protection for read-only links is enabled, the
+ * quick action will not be displayed!
+ */
+'sharing.showPublicLinkQuickAction' => false,
+
+/**
  * All other configuration options
  */
 

--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -273,6 +273,14 @@ img.icon-loading-small-dark, object.icon-loading-small-dark, video.icon-loading-
 	background-image: url('../img/actions/public-white.svg');
 }
 
+.icon-public-create {
+	background-image: url('../img/actions/public-create.svg');
+}
+
+.icon-public-create-white {
+	background-image: url('../img/actions/public-create-white.svg');
+}
+
 .icon-rename {
 	background-image: url('../img/actions/rename.svg');
 }

--- a/core/img/actions/public-create-white.svg
+++ b/core/img/actions/public-create-white.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="public-create-white.svg"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12">
+    <marker
+       inkscape:stockid="DistanceStart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="DistanceStart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <g
+         id="g2300">
+        <path
+           id="path2306"
+           d="M 0,0 L 2,0"
+           style="fill:none;stroke:context-fill;stroke-width:1.15;stroke-linecap:square" />
+        <path
+           id="path2302"
+           d="M 0,0 L 13,4 L 9,0 13,-4 L 0,0 z "
+           style="fill:context-stroke;fill-rule:evenodd;stroke:none" />
+        <path
+           id="path2304"
+           d="M 0,-4 L 0,40"
+           style="fill:none;stroke:context-stroke;stroke-width:1;stroke-linecap:square" />
+      </g>
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="40"
+     inkscape:cx="9.3875"
+     inkscape:cy="8"
+     inkscape:window-width="1406"
+     inkscape:window-height="857"
+     inkscape:window-x="331"
+     inkscape:window-y="404"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <g
+     transform="matrix(0.61227989,-0.61227989,0.61227989,0.61227989,0.44658442,85.063594)"
+     id="g6"
+     style="fill:#ffffff">
+    <path
+       d="m 69.5,-61.5 c -1.9217,0 -3.5,1.5783 -3.5,3.5 0,0.17425 0.0062,0.33232 0.03125,0.5 h 2.0625 c -0.053,-0.156 -0.094,-0.323 -0.094,-0.5 0,-0.8483 0.6517,-1.5 1.5,-1.5 h 5 c 0.8483,0 1.5,0.6517 1.5,1.5 0,0.8483 -0.6517,1.5 -1.5,1.5 h -1.6875 c -0.28733,0.79501 -0.78612,1.4793 -1.4375,2 h 3.125 c 1.9217,0 3.5,-1.5783 3.5,-3.5 0,-1.9217 -1.5783,-3.5 -3.5,-3.5 h -5 z"
+       id="path2"
+       style="fill:#ffffff" />
+    <path
+       d="m 68.5,-54.5 c 1.9217,0 3.5,-1.5783 3.5,-3.5 0,-0.17425 -0.0062,-0.33232 -0.03125,-0.5 h -2.0625 c 0.053,0.156 0.094,0.323 0.094,0.5 0,0.8483 -0.6517,1.5 -1.5,1.5 h -5 c -0.8483,0 -1.5,-0.6517 -1.5,-1.5 0,-0.8483 0.6517,-1.5 1.5,-1.5 h 1.6875 c 0.28733,-0.79501 0.78612,-1.4793 1.4375,-2 h -3.125 c -1.9217,0 -3.5,1.5783 -3.5,3.5 0,1.9217 1.5783,3.5 3.5,3.5 h 5 z"
+       id="path4"
+       style="fill:#ffffff" />
+  </g>
+  <g
+     transform="matrix(-0.36907198,-0.37644722,0.36907198,-0.37644722,-371.47063,408.12785)"
+     id="g4"
+     style="fill:#ffffff">
+    <rect
+       style="fill:#ffffff;stroke-width:1.79655"
+       id="rect348"
+       width="3.129065"
+       height="13.256586"
+       x="732.617"
+       y="-751.17737"
+       transform="rotate(135)" />
+    <rect
+       style="fill:#ffffff;stroke-width:1.81378;paint-order:stroke fill markers"
+       id="rect348-6"
+       width="3.1268868"
+       height="13.521495"
+       x="-746.12512"
+       y="-740.87329"
+       transform="rotate(-135)" />
+  </g>
+</svg>

--- a/core/img/actions/public-create.svg
+++ b/core/img/actions/public-create.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="public-create.svg"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12">
+    <marker
+       inkscape:stockid="DistanceStart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="DistanceStart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <g
+         id="g2300">
+        <path
+           id="path2306"
+           d="M 0,0 L 2,0"
+           style="fill:none;stroke:context-fill;stroke-width:1.15;stroke-linecap:square" />
+        <path
+           id="path2302"
+           d="M 0,0 L 13,4 L 9,0 13,-4 L 0,0 z "
+           style="fill:context-stroke;fill-rule:evenodd;stroke:none" />
+        <path
+           id="path2304"
+           d="M 0,-4 L 0,40"
+           style="fill:none;stroke:context-stroke;stroke-width:1;stroke-linecap:square" />
+      </g>
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4"
+     inkscape:cx="9.375"
+     inkscape:cy="8"
+     inkscape:window-width="1406"
+     inkscape:window-height="857"
+     inkscape:window-x="331"
+     inkscape:window-y="404"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <g
+     transform="matrix(0.61227989,-0.61227989,0.61227989,0.61227989,0.44658442,85.063594)"
+     id="g6">
+    <path
+       d="m 69.5,-61.5 c -1.9217,0 -3.5,1.5783 -3.5,3.5 0,0.17425 0.0062,0.33232 0.03125,0.5 h 2.0625 c -0.053,-0.156 -0.094,-0.323 -0.094,-0.5 0,-0.8483 0.6517,-1.5 1.5,-1.5 h 5 c 0.8483,0 1.5,0.6517 1.5,1.5 0,0.8483 -0.6517,1.5 -1.5,1.5 h -1.6875 c -0.28733,0.79501 -0.78612,1.4793 -1.4375,2 h 3.125 c 1.9217,0 3.5,-1.5783 3.5,-3.5 0,-1.9217 -1.5783,-3.5 -3.5,-3.5 h -5 z"
+       id="path2" />
+    <path
+       d="m 68.5,-54.5 c 1.9217,0 3.5,-1.5783 3.5,-3.5 0,-0.17425 -0.0062,-0.33232 -0.03125,-0.5 h -2.0625 c 0.053,0.156 0.094,0.323 0.094,0.5 0,0.8483 -0.6517,1.5 -1.5,1.5 h -5 c -0.8483,0 -1.5,-0.6517 -1.5,-1.5 0,-0.8483 0.6517,-1.5 1.5,-1.5 h 1.6875 c 0.28733,-0.79501 0.78612,-1.4793 1.4375,-2 h -3.125 c -1.9217,0 -3.5,1.5783 -3.5,3.5 0,1.9217 1.5783,3.5 3.5,3.5 h 5 z"
+       id="path4" />
+  </g>
+  <g
+     transform="matrix(-0.36907198,-0.37644722,0.36907198,-0.37644722,-371.47063,408.12785)"
+     id="g4">
+    <rect
+       style="fill:#000000;stroke-width:1.79655"
+       id="rect348"
+       width="3.129065"
+       height="13.256586"
+       x="732.617"
+       y="-751.17737"
+       transform="rotate(135)" />
+    <rect
+       style="fill:#000000;stroke-width:1.81378;paint-order:stroke fill markers"
+       id="rect348-6"
+       width="3.1268868"
+       height="13.521495"
+       x="-746.12512"
+       y="-740.87329"
+       transform="rotate(-135)" />
+  </g>
+</svg>

--- a/core/js/shareconfigmodel.js
+++ b/core/js/shareconfigmodel.js
@@ -186,6 +186,25 @@
 
 			return defaultExpireDateRemote;
 		},
+
+		/**
+		 * @returns {boolean}
+		 */
+		isPublicSharingBlockedByAllowlist: function () {
+			var allowlistEnabled = oc_appconfig.files_sharing.publicShareSharersGroupsAllowlistEnabled;
+			var allowlistGroups = oc_appconfig.files_sharing.publicShareSharersGroupsAllowlist;
+
+			if (allowlistEnabled === true && allowlistGroups.length) {
+				var userGroups = OC.getCurrentUser().groups;
+				for (var i = 0; i < userGroups.length; i++) {
+					if (allowlistGroups.indexOf(userGroups[i]) >= 0) {
+						return false;
+					}
+				}
+				return true;
+			}
+			return false;
+		}
 	});
 
 

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -65,7 +65,7 @@ class DetailsDialog extends OwncloudPage {
 	private $tagsDropDownResultXpath = "//div[contains(@class, 'systemtags-select2-dropdown')]" .
 	"//ul[@class='select2-results']" .
 	"//span[@class='label']";
-	private $tagEditInputXpath = "//input[@id='view11-rename-input']";
+	private $tagEditInputXpath = "//input[@id='view12-rename-input']";
 
 	private $commentXpath = "//ul[@class='comments']//div[@class='message' and contains(., '%s')]";
 	private $commentInputXpath = "//form[@class='newCommentForm']//textarea[@class='message']";


### PR DESCRIPTION
## Description
Can be enabled by setting  `'sharing.showPublicLinkQuickAction' => true` in your config.php.

To-Dos:

- [x] Basic implementation
- [x] Hide option when sharing is disabled for certain groups
- [x] Implement synergy with whitelisting
- [x] Ignore when password enforcement policies are active (+ info in config)
- [x] Tests
- [x] Changelog
- [x] Doc ticket
- [x] Create patch with translations

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4718

## Screenshots

![image](https://user-images.githubusercontent.com/50302941/130933317-34c5f6a8-1c5e-41a3-a428-f07c25c17bd2.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/3969
- [x] Changelog item
