### PR TITLE
Implement meta data for part files

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -170,7 +170,7 @@ class File extends Node implements IFile, IFileNode {
 
 		if ($usePartFile) {
 			// mark file as partial while uploading (ignored by the scanner)
-			$partFilePath = $this->getPartFileBasePath($this->path) . '.ocTransferId' . \rand() . '.part';
+			$partFilePath = Filesystem::createPartFilePath($this->path);
 		} else {
 			// upload file directly as the final path
 			$partFilePath = $this->path;
@@ -300,15 +300,6 @@ class File extends Node implements IFile, IFileNode {
 			\OC::$server->getEventDispatcher()->dispatch('file.afterupdate', $afterEvent);
 		}
 		return '"' . $this->info->getEtag() . '"';
-	}
-
-	private function getPartFileBasePath($path) {
-		$partFileInStorage = \OC::$server->getConfig()->getSystemValue('part_file_in_storage', true);
-		if ($partFileInStorage) {
-			return Filesystem::hashFileName($path);
-		} else {
-			return \md5($path); // will place it in the root of the view with a unique name
-		}
 	}
 
 	/**
@@ -530,7 +521,7 @@ class File extends Node implements IFile, IFileNode {
 
 				if ($usePartFile) {
 					// we first assembly the target file as a part file
-					$partFile = $this->getPartFileBasePath($path . '/' . $info['name']) . '.ocTransferId' . $info['transferid'] . '.part';
+					$partFile = Filesystem::createPartFilePath($path . '/' . $info['name'], $info['transferid']);
 					/** @var \OC\Files\Storage\Storage $targetStorage */
 					list($partStorage, $partInternalPath) = $this->fileView->resolvePath($partFile);
 

--- a/changelog/unreleased/39088
+++ b/changelog/unreleased/39088
@@ -6,5 +6,9 @@ This could lead to a too long filename error.
 With this PR the chunk filenames consist of md5 hash and chunk suffix, which
 decreases the filename and prevents a too long filename error.
 
+The implementation also provides a way to retrieve meta data of a
+part file. This way, the original file path or name can be fetched.
+
 https://github.com/owncloud/core/pull/39088
+https://github.com/owncloud/core/pull/39131
 https://github.com/owncloud/enterprise/issues/4692

--- a/lib/private/Files/Stream/Checksum.php
+++ b/lib/private/Files/Stream/Checksum.php
@@ -222,7 +222,6 @@ class Checksum extends Wrapper {
 		}
 
 		// check the md5($path) in case "part_file_in_storage" is set to false
-		// see apps/dav/lib/Connector/Sabre/File.php getPartFileBasePath  (around line 305)
 		// strip initial dir, usually "files" from "files/dir1/dir2"
 		$pathPieces = \explode('/', $path, 2);
 		if (\count($pathPieces) !== 2) {

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -581,4 +581,26 @@ class FilesystemTest extends TestCase {
 	public function testHashFileName($path, $expected) {
 		$this->assertEquals($expected, Filesystem::hashFileName($path));
 	}
+
+	public function testCreatePartFilePath() {
+		$path = '/test/test.txt';
+		$transferId = \rand();
+		$expectedPartFilePath = "/test/dd18bf3a8e0a2a3e53e2661c7fb53534.ocTransferId$transferId.part";
+		$this->assertEquals($expectedPartFilePath, Filesystem::createPartFilePath($path, $transferId));
+	}
+
+	public function testgetPartFileMetaData() {
+		$path = '/test/test.txt';
+		$partFilePath = Filesystem::createPartFilePath($path);
+
+		$partFileName = \basename($partFilePath);
+		$partFileMetaData = Filesystem::getPartFileMetaData($partFileName);
+
+		$this->assertEquals([
+			'path' => $partFilePath,
+			'originalRoot' => Filesystem::getRoot(),
+			'originalPath' => $path,
+			'originalName' => \basename($path),
+		], $partFileMetaData);
+	}
 }


### PR DESCRIPTION
## Description
https://github.com/owncloud/core/pull/39088 introduced the hashing of file names on chunked uploads. However, we experienced that some apps need the file path including the "real" (unhashed) file name. The `files_classifier` e.g. determines the file extension during a chunked upload based on the name.

Therefore this PR implements a way to retrieve meta data for part files. This way, the real path or file name can be retrieved.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
