### PR TITLE
[tests-only]Refactor tests related to file_target issue

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-reva-34
+@api @files_sharing-app-required
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:
@@ -8,6 +8,7 @@ Feature: share resources where the sharee receives the share in multiple ways
       | username |
       | Alice    |
       | Brian    |
+
 
   Scenario Outline: Creating a new share with user who already received a share through their group
     Given using OCS API version "<ocs_api_version>"
@@ -23,21 +24,28 @@ Feature: share resources where the sharee receives the share in multiple ways
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "Brian" should include
-      | share_with             | %username%              |
-      | share_with_displayname | %displayname%           |
-      | file_target            | /Shares/textfile0 (2).txt |
+      | share_with             | %username%                |
+      | share_with_displayname | %displayname%             |
+      | file_target            | <file_target>             |
       | path                   | /Shares/textfile0 (2).txt |
-      | permissions            | share,read,update       |
-      | uid_owner              | %username%              |
-      | displayname_owner      | %displayname%           |
-      | item_type              | file                    |
-      | mimetype               | text/plain              |
-      | storage_id             | ANY_VALUE               |
-      | share_type             | user                    |
+      | permissions            | share,read,update         |
+      | uid_owner              | %username%                |
+      | displayname_owner      | %displayname%             |
+      | item_type              | file                      |
+      | mimetype               | text/plain                |
+      | storage_id             | ANY_VALUE                 |
+      | share_type             | user                      |
+    @skipOnOcis
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | file_target               |
+      | 1               | 100             | /Shares/textfile0 (2).txt |
+      | 2               | 200             | /Shares/textfile0 (2).txt |
+
+    @skipOnOcV10 @issue-2131
+    Examples:
+      | ocs_api_version | ocs_status_code | file_target        |
+      | 1               | 100             | /textfile0 (2).txt |
+      | 2               | 200             | /textfile0 (2).txt |
 
   @issue-ocis-1289
   Scenario Outline: Share of folder and sub-folder to same user
@@ -107,7 +115,7 @@ Feature: share resources where the sharee receives the share in multiple ways
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-2133
+
   Scenario Outline: multiple users share a file with the same name but different permissions to a user
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -117,28 +125,35 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Alice" accepts share "/randomfile.txt" offered by user "Brian" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response about user "Brian" sharing with user "Alice" should include
-      | uid_owner   | %username%             |
-      | share_with  | %username%             |
-      | file_target | /Shares/randomfile.txt |
-      | item_type   | file                   |
-      | permissions | read                   |
+      | uid_owner   | %username%      |
+      | share_with  | %username%      |
+      | file_target | <file_target_1> |
+      | item_type   | file            |
+      | permissions | read            |
     When user "Carol" shares file "randomfile.txt" with user "Alice" with permissions "read,update" using the sharing API
     And user "Alice" accepts share "/randomfile.txt" offered by user "Carol" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response about user "Carol" sharing with user "Alice" should include
-      | uid_owner   | %username%                 |
-      | share_with  | %username%                 |
-      | file_target | /Shares/randomfile (2).txt |
-      | item_type   | file                       |
-      | permissions | read,update                |
+      | uid_owner   | %username%      |
+      | share_with  | %username%      |
+      | file_target | <file_target_2> |
+      | item_type   | file            |
+      | permissions | read,update     |
     And the content of file "/Shares/randomfile.txt" for user "Alice" should be "First data"
     And the content of file "/Shares/randomfile (2).txt" for user "Alice" should be "Second data"
+    @skipOnOcis
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | file_target_1          | file_target_2              |
+      | 1               | /Shares/randomfile.txt | /Shares/randomfile (2).txt |
+      | 2               | /Shares/randomfile.txt | /Shares/randomfile (2).txt |
 
-  @issue-ocis-2133
+    @skipOnOcV10 @issue-ocis-2131
+    Examples:
+      | ocs_api_version | file_target_1   | file_target_2       |
+      | 1               | /randomfile.txt | /randomfile (2).txt |
+      | 2               | /randomfile.txt | /randomfile (2).txt |
+
+
   Scenario Outline: multiple users share a folder with the same name to a user
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -150,26 +165,33 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Alice" accepts share "/zzzfolder" offered by user "Brian" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response about user "Brian" sharing with user "Alice" should include
-      | uid_owner   | %username%        |
-      | share_with  | %username%        |
-      | file_target | /Shares/zzzfolder |
-      | item_type   | folder            |
-      | permissions | read,delete       |
+      | uid_owner   | %username%      |
+      | share_with  | %username%      |
+      | file_target | <file_target_1> |
+      | item_type   | folder          |
+      | permissions | read,delete     |
     When user "Carol" shares folder "zzzfolder" with user "Alice" with permissions "read,share" using the sharing API
     And user "Alice" accepts share "/zzzfolder" offered by user "Carol" using the sharing API
     And user "Alice" gets the info of the last share using the sharing API
     Then the fields of the last response about user "Carol" sharing with user "Alice" should include
-      | uid_owner   | %username%            |
-      | share_with  | %username%            |
-      | file_target | /Shares/zzzfolder (2) |
-      | item_type   | folder                |
-      | permissions | read,share            |
+      | uid_owner   | %username%      |
+      | share_with  | %username%      |
+      | file_target | <file_target_2> |
+      | item_type   | folder          |
+      | permissions | read,share      |
     And as "Alice" folder "/Shares/zzzfolder/Brian" should exist
     And as "Alice" folder "/Shares/zzzfolder (2)/Carol" should exist
+    @skipOnOcis
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | file_target_1     | file_target_2         |
+      | 1               | /Shares/zzzfolder | /Shares/zzzfolder (2) |
+      | 2               | /Shares/zzzfolder | /Shares/zzzfolder (2) |
+
+    @skipOnOcV10 @issue-ocis-2131
+    Examples:
+      | ocs_api_version | file_target_1 | file_target_2  |
+      | 1               | /zzzfolder    | /zzzfolder (2) |
+      | 2               | /zzzfolder    | /zzzfolder (2) |
 
   @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP
   Scenario Outline: share with a group and then add a user to that group that already has a file with the shared name
@@ -193,7 +215,8 @@ Feature: share resources where the sharee receives the share in multiple ways
       | 1               |
       | 2               |
 
-  Scenario: Sharing parent folder to user with all permissions and its child folder to group with read permission then check create operation
+
+  Scenario Outline: Sharing parent folder to user with all permissions and its child folder to group with read permission then check create operation
     Given group "grp1" has been created
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created the following folders
@@ -206,16 +229,26 @@ Feature: share resources where the sharee receives the share in multiple ways
     When user "Carol" shares folder "/parent" with user "Brian" with permissions "all" using the sharing API
     And user "Carol" shares folder "/parent/child1" with group "grp1" with permissions "read" using the sharing API
     And user "Brian" accepts share "/parent" offered by user "Carol" using the sharing API
-    And user "Brian" accepts share "/parent/child1" offered by user "Carol" using the sharing API
-    And user "Alice" accepts share "/parent/child1" offered by user "Carol" using the sharing API
+    And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
+    And user "Alice" accepts share "<path>" offered by user "Carol" using the sharing API
     Then user "Brian" should be able to create folder "/Shares/parent/fo1"
     And user "Brian" should be able to create folder "/Shares/parent/child1/fo2"
     And as "Brian" folder "/Shares/child1" should exist
     And user "Brian" should not be able to create folder "/Shares/child1/fo3"
     And as "Alice" folder "/Shares/child1" should exist
     And user "Alice" should not be able to create folder "/Shares/child1/fo3"
+    @skipOnOcis
+    Examples:
+      | path           |
+      | /parent/child1 |
 
-  Scenario: Sharing parent folder to user with all permissions and its child folder to group with read permission then check rename operation
+    @skipOnOcV10 @issue-2440
+    Examples:
+      | path    |
+      | /child1 |
+
+
+  Scenario Outline: Sharing parent folder to user with all permissions and its child folder to group with read permission then check rename operation
     Given group "grp1" has been created
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created the following folders
@@ -229,15 +262,25 @@ Feature: share resources where the sharee receives the share in multiple ways
     When user "Carol" shares folder "/parent" with user "Brian" with permissions "all" using the sharing API
     And user "Carol" shares folder "/parent/child1" with group "grp1" with permissions "read" using the sharing API
     And user "Brian" accepts share "/parent" offered by user "Carol" using the sharing API
-    And user "Brian" accepts share "/parent/child1" offered by user "Carol" using the sharing API
-    And user "Alice" accepts share "/parent/child1" offered by user "Carol" using the sharing API
+    And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
+    And user "Alice" accepts share "<path>" offered by user "Carol" using the sharing API
     Then user "Brian" should be able to rename file "/Shares/parent/child1/child2/textfile-2.txt" to "/Shares/parent/child1/child2/rename.txt"
     And as "Brian" file "/Shares/child1/child2/rename.txt" should exist
     And user "Brian" should not be able to rename file "/Shares/child1/child2/rename.txt" to "/Shares/child1/child2/rename2.txt"
     And as "Alice" file "/Shares/child1/child2/rename.txt" should exist
     And user "Alice" should not be able to rename file "/Shares/child1/child2/rename.txt" to "/Shares/child1/child2/rename2.txt"
+    @skipOnOcis
+    Examples:
+      | path           |
+      | /parent/child1 |
 
-  Scenario: Sharing parent folder to user with all permissions and its child folder to group with read permission then check delete operation
+    @skipOnOcV10 @issue-2440
+    Examples:
+      | path    |
+      | /child1 |
+
+
+  Scenario Outline: Sharing parent folder to user with all permissions and its child folder to group with read permission then check delete operation
     Given group "grp1" has been created
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created the following folders
@@ -251,15 +294,25 @@ Feature: share resources where the sharee receives the share in multiple ways
     When user "Carol" shares folder "/parent" with user "Brian" with permissions "all" using the sharing API
     And user "Carol" shares folder "/parent/child1" with group "grp1" with permissions "read" using the sharing API
     And user "Brian" accepts share "/parent" offered by user "Carol" using the sharing API
-    And user "Brian" accepts share "/parent/child1" offered by user "Carol" using the sharing API
-    And user "Alice" accepts share "/parent/child1" offered by user "Carol" using the sharing API
+    And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
+    And user "Alice" accepts share "<path>" offered by user "Carol" using the sharing API
     Then user "Brian" should be able to delete file "/Shares/parent/child1/child2/textfile-2.txt"
     And as "Brian" folder "/Shares/child1" should exist
     And user "Brian" should not be able to delete folder "/Shares/child1/child2"
     And as "Alice" folder "/Shares/child1" should exist
     And user "Alice" should not be able to delete folder "/Shares/child1/child2"
+    @skipOnOcis
+    Examples:
+      | path           |
+      | /parent/child1 |
 
-  Scenario: Sharing parent folder to user with all permissions and its child folder to group with read permission then check reshare operation
+    @skipOnOcV10 @issue-2440
+    Examples:
+      | path    |
+      | /child1 |
+
+
+  Scenario Outline: Sharing parent folder to user with all permissions and its child folder to group with read permission then check reshare operation
     Given group "grp1" has been created
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created the following folders
@@ -272,15 +325,25 @@ Feature: share resources where the sharee receives the share in multiple ways
     When user "Carol" shares folder "/parent" with user "Brian" with permissions "all" using the sharing API
     And user "Carol" shares folder "/parent/child1" with group "grp1" with permissions "read" using the sharing API
     And user "Brian" accepts share "/parent" offered by user "Carol" using the sharing API
-    And user "Brian" accepts share "/parent/child1" offered by user "Carol" using the sharing API
-    And user "Alice" accepts share "/parent/child1" offered by user "Carol" using the sharing API
+    And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
+    And user "Alice" accepts share "<path>" offered by user "Carol" using the sharing API
     Then user "Brian" should be able to share folder "/Shares/parent" with user "Alice" with permissions "read" using the sharing API
     And user "Alice" accepts share "/parent" offered by user "Brian" using the sharing API
     And as "Brian" folder "/Shares/child1" should exist
     And as "Alice" folder "/Shares/child1" should exist
     And as "Alice" folder "/Shares/parent" should exist
+    @skipOnOcis
+    Examples:
+      | path           |
+      | /parent/child1 |
 
-  Scenario: Sharing parent folder to group with read permission and its child folder to user with all permissions then check create operation
+    @skipOnOcV10
+    Examples:
+      | path    |
+      | /child1 |
+
+
+  Scenario Outline: Sharing parent folder to group with read permission and its child folder to user with all permissions then check create operation
     Given group "grp1" has been created
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created the following folders
@@ -292,7 +355,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" has been added to group "grp1"
     When user "Carol" shares folder "/parent" with group "grp1" with permissions "read" using the sharing API
     And user "Carol" shares folder "/parent/child1" with user "Brian" with permissions "all" using the sharing API
-    And user "Brian" accepts share "/parent/child1" offered by user "Carol" using the sharing API
+    And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
     And user "Brian" accepts share "/parent" offered by user "Carol" using the sharing API
     And user "Alice" accepts share "/parent" offered by user "Carol" using the sharing API
     Then user "Brian" should be able to create folder "/Shares/child1/fo1"
@@ -301,8 +364,18 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should not be able to create folder "/Shares/parent/fo3"
     And as "Alice" folder "/Shares/parent" should exist
     And user "Alice" should not be able to create folder "/Shares/parent/fo3"
+    @skipOnOcis
+    Examples:
+      | path           |
+      | /parent/child1 |
 
-  Scenario: Sharing parent folder to group with read permission and its child folder to user with all permissions then check rename operation
+    @skipOnOcV10
+    Examples:
+      | path    |
+      | /child1 |
+
+
+  Scenario Outline: Sharing parent folder to group with read permission and its child folder to user with all permissions then check rename operation
     Given group "grp1" has been created
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created the following folders
@@ -315,7 +388,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Carol" has uploaded file with content "some data" to "/parent/child1/child2/textfile-2.txt"
     When user "Carol" shares folder "/parent" with group "grp1" with permissions "read" using the sharing API
     And user "Carol" shares folder "/parent/child1" with user "Brian" with permissions "all" using the sharing API
-    And user "Brian" accepts share "/parent/child1" offered by user "Carol" using the sharing API
+    And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
     And user "Brian" accepts share "/parent" offered by user "Carol" using the sharing API
     And user "Alice" accepts share "/parent" offered by user "Carol" using the sharing API
     Then user "Brian" should be able to rename file "/Shares/child1/child2/textfile-2.txt" to "/Shares/child1/child2/rename.txt"
@@ -323,8 +396,18 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should not be able to rename file "/Shares/parent/child1/child2/rename.txt" to "/Shares/parent/child1/child2/rename2.txt"
     And as "Alice" file "/Shares/parent/child1/child2/rename.txt" should exist
     And user "Alice" should not be able to rename file "/Shares/parent/child1/child2/rename.txt" to "/Shares/parent/child1/child2/rename2.txt"
+    @skipOnOcis
+    Examples:
+      | path           |
+      | /parent/child1 |
 
-  Scenario: Sharing parent folder to group with read permission and its child folder to user with all permissions then check delete operation
+    @skipOnOcV10 @issue-ocis-2440
+    Examples:
+      | path    |
+      | /child1 |
+
+
+  Scenario Outline: Sharing parent folder to group with read permission and its child folder to user with all permissions then check delete operation
     Given group "grp1" has been created
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created the following folders
@@ -337,7 +420,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Carol" has uploaded file with content "some data" to "/parent/child1/child2/textfile-2.txt"
     When user "Carol" shares folder "/parent" with group "grp1" with permissions "read" using the sharing API
     And user "Carol" shares folder "/parent/child1" with user "Brian" with permissions "all" using the sharing API
-    And user "Brian" accepts share "/parent/child1" offered by user "Carol" using the sharing API
+    And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
     And user "Brian" accepts share "/parent" offered by user "Carol" using the sharing API
     And user "Alice" accepts share "/parent" offered by user "Carol" using the sharing API
     Then user "Brian" should be able to delete file "/Shares/child1/child2/textfile-2.txt"
@@ -345,8 +428,18 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should not be able to delete folder "/Shares/parent/child1"
     And as "Alice" folder "/Shares/parent" should exist
     And user "Alice" should not be able to delete folder "/Shares/parent/child1"
+    @skipOnOcis
+    Examples:
+      | path           |
+      | /parent/child1 |
 
-  Scenario: Sharing parent folder to group with read permission and its child folder to user with all permissions then check reshare operation
+    @skipOnOcV10 @issue-ocis-2440
+    Examples:
+      | path    |
+      | /child1 |
+
+
+  Scenario Outline: Sharing parent folder to group with read permission and its child folder to user with all permissions then check reshare operation
     Given group "grp1" has been created
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Carol" has created the following folders
@@ -358,16 +451,26 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" has been added to group "grp1"
     When user "Carol" shares folder "/parent" with group "grp1" with permissions "read" using the sharing API
     And user "Carol" shares folder "/parent/child1" with user "Brian" with permissions "all" using the sharing API
-    And user "Brian" accepts share "/parent/child1" offered by user "Carol" using the sharing API
+    And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
     And user "Brian" accepts share "/parent" offered by user "Carol" using the sharing API
     And user "Alice" accepts share "/parent" offered by user "Carol" using the sharing API
     Then user "Brian" should be able to share folder "/Shares/child1" with user "Alice" with permissions "read" using the sharing API
-    And user "Alice" accepts share "/parent/child1" offered by user "Brian" using the sharing API
+    And user "Alice" accepts share "<path>" offered by user "Brian" using the sharing API
     And as "Brian" folder "/Shares/parent" should exist
     And as "Alice" folder "/Shares/parent" should exist
     And as "Alice" folder "/Shares/child1" should exist
+    @skipOnOcis
+    Examples:
+      | path           |
+      | /parent/child1 |
 
-  Scenario: Sharing parent folder to one group with all permissions and its child folder to another group with read permission
+    @skipOnOcV10
+    Examples:
+      | path    |
+      | /child1 |
+
+
+  Scenario Outline: Sharing parent folder to one group with all permissions and its child folder to another group with read permission
     Given these groups have been created:
       | groupname |
       | grp1      |
@@ -385,7 +488,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     When user "Carol" shares folder "/parent" with group "grp1" with permissions "all" using the sharing API
     And user "Carol" shares folder "/parent/child1" with group "grp2" with permissions "read" using the sharing API
     And user "Alice" accepts share "/parent" offered by user "Carol" using the sharing API
-    And user "Brian" accepts share "/parent/child1" offered by user "Carol" using the sharing API
+    And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
     Then user "Alice" should be able to create folder "/Shares/parent/child1/fo1"
     And user "Alice" should be able to create folder "/Shares/parent/child1/child2/fo2"
     And user "Alice" should be able to delete folder "/Shares/parent/child1/fo1"
@@ -397,3 +500,12 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should not be able to create folder "/Shares/child1/child2/fo2"
     And user "Brian" should not be able to rename file "/Shares/child1/child2/rename.txt" to "/Shares/child1/child2/rename2.txt"
     And user "Brian" should not be able to share folder "/Shares/child1" with group "grp3" with permissions "read" using the sharing API
+    @skipOnOcis
+    Examples:
+      | path           |
+      | /parent/child1 |
+
+    @skipOnOcV10
+    Examples:
+      | path    |
+      | /child1 |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -484,10 +484,10 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with group "grp1" should include
-      | share_with  | grp1                  |
-      | file_target | /Shares/textfile0.txt |
-      | path        | /textfile0.txt        |
-      | uid_owner   | %username%            |
+      | share_with  | grp1           |
+      | file_target | <path>         |
+      | path        | /textfile0.txt |
+      | uid_owner   | %username%     |
     When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     And user "Carol" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then as "Brian" file "/Shares/textfile0.txt" should exist
@@ -499,10 +499,17 @@ Feature: sharing
     And file "/textfile0.txt" should not be included as path in the response
     And as "Brian" file "/Shares/textfile0.txt" should not exist
     And as "Carol" file "/Shares/textfile0.txt" should not exist
+    @skipOnOcis
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | path                  |
+      | 1               | 100             | /Shares/textfile0.txt |
+      | 2               | 200             | /Shares/textfile0.txt |
+    @skipOnOcV10 @issue-2441
+    Examples:
+      | ocs_api_version | ocs_status_code | path           |
+      | 1               | 100             | /textfile0.txt |
+      | 2               | 200             | /textfile0.txt |
+
 
   @skipOnFilesClassifier @issue-files-classifier-291 @issue-ocis-2146
   Scenario: Share a file by multiple channels and download from sub-folder and direct file share

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -190,8 +190,8 @@ Feature: sharing
     And as "Alice" folder "/Shares/folder1/folder2" should not exist
     And as "Carol" folder "/Shares/folder2" should exist
 
-  @toFixOnOCIS @issue-ocis-2133
-  Scenario: Share ownership change after moving a shared file to another share
+
+  Scenario Outline: Share ownership change after moving a shared file to another share
     Given these users have been created with default attributes and without skeleton files:
       | username |
       | Brian    |
@@ -211,7 +211,7 @@ Feature: sharing
       | item_source       | A_STRING             |
       | share_type        | user                 |
       | file_source       | A_STRING             |
-      | file_target       | /Shares/Carol-folder |
+      | file_target       | <path>               |
       | permissions       | all                  |
       | stime             | A_NUMBER             |
       | storage           | A_STRING             |
@@ -221,6 +221,15 @@ Feature: sharing
       | mimetype          | httpd/unix-directory |
     And as "Alice" folder "/Alice-folder/folder2" should not exist
     And as "Carol" folder "/Carol-folder/folder2" should exist
+    @skipOnOcis
+    Examples:
+      | path                 |
+      | /Shares/Carol-folder |
+
+    @skipOnOcV10 @issue-2442
+    Examples:
+      | path          |
+      | /Carol-folder |
 
   @skipOnOcV10.3 @skipOnOcV10.4 @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
   #after fixing all the issues merge this scenario with the one below


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
--> 
## Description
This PR adjusts tests related to file_target issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/2133


## Motivation and Context
In OC10 after sharing a file/folder the file target contains the value `Shares/<shared-resource>`
But in OCIS after sharing a file/folder the file target contains the value `/<shared-resource>` only.
This PR splits the tests tagged to `file_target issue` so that they show both `oc10` and `ocis` behavior and tags the correct issue for failing tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
- CI
- https://github.com/owncloud/ocis/pull/2443

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
