### PR TITLE
[tests-only] Use nodejs docker image for JS steps in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -402,6 +402,7 @@ def dependencies(ctx):
 
     default = {
         "phpVersions": ["7.2"],
+        "nodeJsVersion": "14",
     }
 
     if "defaults" in config:
@@ -446,7 +447,7 @@ def dependencies(ctx):
                          vendorbinPhan(phpVersion) +
                          vendorbinPhpstan(phpVersion) +
                          vendorbinBehat() +
-                         yarnInstall(phpVersion) +
+                         yarnInstall(params["nodeJsVersion"]) +
                          cacheRebuildOnEventPush() +
                          cacheFlushOnEventPush(),
                 "depends_on": [],
@@ -513,7 +514,6 @@ def codestyle():
                          composerInstall(phpVersion) +
                          vendorbinCodestyle(phpVersion) +
                          vendorbinCodesniffer(phpVersion) +
-                         yarnInstall(phpVersion) +
                          [
                              {
                                  "name": "php-style",
@@ -737,7 +737,6 @@ def phpstan():
                 "steps": cacheRestore() +
                          composerInstall(phpVersion) +
                          vendorbinPhpstan(phpVersion) +
-                         yarnInstall(phpVersion) +
                          installServer(phpVersion, "sqlite", params["logLevel"]) +
                          [
                              {
@@ -810,7 +809,6 @@ def phan():
                 "steps": cacheRestore() +
                          composerInstall(phpVersion) +
                          vendorbinPhan(phpVersion) +
-                         yarnInstall(phpVersion) +
                          installServer(phpVersion, "sqlite", params["logLevel"]) +
                          [
                              {
@@ -891,7 +889,6 @@ def litmus():
                 },
                 "steps": cacheRestore() +
                          composerInstall(phpVersion) +
-                         yarnInstall(phpVersion) +
                          installServer(phpVersion, db, params["logLevel"], params["useHttps"]) +
                          setupLocalStorage(phpVersion) +
                          fixPermissions(phpVersion, False) +
@@ -1056,7 +1053,6 @@ def dav():
                     },
                     "steps": cacheRestore() +
                              composerInstall(phpVersion) +
-                             yarnInstall(phpVersion) +
                              installServer(phpVersion, db, params["logLevel"]) +
                              davInstall(phpVersion, scriptPath) +
                              fixPermissions(phpVersion, False) +
@@ -1092,9 +1088,9 @@ def javascript(ctx, withCoverage):
         return pipelines
 
     default = {
+        "nodeJsVersion": "14",
         "coverage": True,
         "logLevel": "2",
-        "phpVersion": "7.2",
         "skip": False,
     }
 
@@ -1136,12 +1132,11 @@ def javascript(ctx, withCoverage):
             "path": "src",
         },
         "steps": cacheRestore() +
-                 composerInstall(params["phpVersion"]) +
-                 yarnInstall(params["phpVersion"]) +
+                 yarnInstall(params["nodeJsVersion"]) +
                  [
                      {
                          "name": "test-js",
-                         "image": "owncloudci/php:%s" % params["phpVersion"],
+                         "image": "owncloudci/php:7.4",
                          "pull": "always",
                          "commands": [
                              "make test-js",
@@ -1326,7 +1321,6 @@ def phpTests(ctx, testType, withCoverage):
                         },
                         "steps": cacheRestore() +
                                  composerInstall(phpVersion) +
-                                 yarnInstall(phpVersion) +
                                  installServer(phpVersion, db, params["logLevel"]) +
                                  installExtraApps(phpVersion, extraAppsDict, dir["server"]) +
                                  setupScality(phpVersion, needScality) +
@@ -1446,6 +1440,7 @@ def acceptance(ctx):
         "federatedServerVersions": [""],
         "browsers": ["chrome"],
         "phpVersions": ["7.4"],
+        "nodeJsVersion": "14",
         "databases": ["mariadb:10.2"],
         "federatedPhpVersion": "7.2",
         "federatedServerNeeded": False,
@@ -1643,7 +1638,7 @@ def acceptance(ctx):
                                     "steps": cacheRestore() +
                                              composerInstall(phpVersion) +
                                              vendorbinBehat() +
-                                             yarnInstall(phpVersion) +
+                                             yarnInstall(params["nodeJsVersion"]) +
                                              ((
                                                  installCoreFromTarball(params["coreTarball"], db, params["logLevel"], params["useHttps"], params["federatedServerNeeded"], params["proxyNeeded"], pathOfServerUnderTest)
                                              ) if params["testAgainstCoreTarball"] else (
@@ -1702,7 +1697,7 @@ def acceptance(ctx):
 
     return pipelines
 
-def sonarAnalysis(ctx, phpVersion = "7.4"):
+def sonarAnalysis(ctx, phpVersion = "7.4", nodeJsVersion = "14"):
     sonar_env = {
         "SONAR_TOKEN": {
             "from_secret": "sonar_token",
@@ -1742,7 +1737,7 @@ def sonarAnalysis(ctx, phpVersion = "7.4"):
                  ] +
                  cacheRestore() +
                  composerInstall(phpVersion) +
-                 yarnInstall(phpVersion) +
+                 yarnInstall(nodeJsVersion) +
                  installServer(phpVersion, "sqlite") +
                  [
                      {
@@ -2382,10 +2377,10 @@ def vendorbinBehat():
         ],
     }]
 
-def yarnInstall(phpVersion):
+def yarnInstall(nodeJsVersion):
     return [{
         "name": "yarn-install",
-        "image": "owncloudci/php:%s" % phpVersion,
+        "image": "owncloudci/nodejs:%s" % nodeJsVersion,
         "pull": "always",
         "environment": {
             "NPM_CONFIG_CACHE": "%s/.cache/npm" % dir["server"],

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,6 @@ KARMA=$(NODE_PREFIX)/node_modules/.bin/karma
 JSDOC=$(NODE_PREFIX)/node_modules/.bin/jsdoc
 PHPUNIT="$(shell pwd)/lib/composer/phpunit/phpunit/phpunit"
 COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
-ifndef COMPOSER_BIN
-    $(error composer is not available on your system, please install composer)
-endif
 
 # bin file definitions
 PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer
@@ -269,7 +266,7 @@ clean-docs:
 	rm -Rf build/jsdocs
 
 .PHONY: test-doc-links
-test-doc-links: 
+test-doc-links:
 	php tests/docs/DocLinksTest.php $(DOC_LINK_VERSION)
 
 #


### PR DESCRIPTION
## Description
This PR makes as many changes as I currently can towards using `owncloudci/nodejs:14` for all the pipeline steps that do "JavaScript stuff".

- excess yarn-install steps are removed from PHP code analysis and unit test pipelines (those were always not needed)
- yarn-install now uses nodejs:14
- the step that does `make test-js` still uses `owncloudci/php:7.4` (I didn't get the JS unit tests to pass yet inside `owncloudci/nodejs:14` - I can work on that next)
- the check and message in `Makefile` about "error composer is not available on your system" is removed. That causes trouble if any `make` command is done from inside a docker image that does not have PHP and composer available. It was just information for developers, who hopefully can work out for themselves that composer is needed when developing with PHP.

Note: I tried bumping nodejs to 14 in `build/package.json` but that caused problems in steps that use `owncloudci/core`, so I have not done that here yet.

## Related Issue
https://github.com/owncloud-ci/php/issues/137

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
