### PR TITLE
Fix image orientation method

### DIFF
--- a/changelog/unreleased/39140
+++ b/changelog/unreleased/39140
@@ -1,0 +1,8 @@
+Bugfix: Image orientation
+
+Fix the retrieval an image's exif information to ensure it's rotated
+correctly in thumbnails and preview.
+
+https://github.com/owncloud/core/pull/39140
+https://github.com/owncloud/core/issues/39114
+https://github.com/owncloud/enterprise/issues/4666

--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -217,14 +217,6 @@ class AvatarController extends Controller {
 			$image->load($handle);
 			$image->fixOrientation();
 
-			if (\is_resource($handle)) {
-				\fclose($handle);
-			}
-
-			if ($tmpImage) {
-				\unlink($tmpImage);
-			}
-
 			if ($image->valid()) {
 				$mimeType = $image->mimeType();
 				if ($mimeType !== 'image/jpeg' && $mimeType !== 'image/png') {
@@ -249,14 +241,15 @@ class AvatarController extends Controller {
 				);
 			}
 		} catch (\Exception $e) {
+			$this->logger->logException($e, ['app' => 'core']);
+			return new DataResponse(['data' => ['message' => $this->l->t('An error occurred. Please contact your admin.')]], Http::STATUS_OK, $headers);
+		} finally {
 			if (\is_resource($handle)) {
 				\fclose($handle);
 			}
 			if ($tmpImage) {
 				\unlink($tmpImage);
 			}
-			$this->logger->logException($e, ['app' => 'core']);
-			return new DataResponse(['data' => ['message' => $this->l->t('An error occurred. Please contact your admin.')]], Http::STATUS_OK, $headers);
 		}
 	}
 

--- a/lib/private/Preview/Image.php
+++ b/lib/private/Preview/Image.php
@@ -44,10 +44,13 @@ abstract class Image implements IProvider2 {
 		}
 
 		$image = new \OC_Image();
-
-		$fileContent = $file->getContent();
-		$image->load($fileContent);
+		$handle = $file->fopen('r');
+		$image->load($handle);
 		$image->fixOrientation();
+
+		if (\is_resource($handle)) {
+			\fclose($handle);
+		}
 
 		if ($image->valid()) {
 			$image->scaleDownToFit($maxX, $maxY);

--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -56,6 +56,8 @@ class OC_Image implements \OCP\IImage {
 	private $fileInfo;
 	/** @var \OCP\ILogger */
 	private $logger;
+	/** @var array|false */
+	private $exifData;
 
 	/**
 	 * Get mime type for an image file.
@@ -347,33 +349,30 @@ class OC_Image implements \OCP\IImage {
 	 * (I'm open for suggestions on better method name ;)
 	 * Get the orientation based on EXIF data.
 	 *
-	 * @return int The orientation or -1 if no EXIF data is available.
+	 * @return int The orientation or -1 if no EXIF orientation data is available.
 	 */
 	public function getOrientation() {
-		if ($this->imageType !== IMAGETYPE_JPEG) {
-			$this->logger->debug('OC_Image->fixOrientation() Image is not a JPEG.', ['app' => 'core']);
-			return -1;
-		}
+		return $this->exifData['Orientation'] ?? -1;
+	}
+
+	/**
+	 * Loads EXIF data of a given image.
+	 * Only supported when the image is loaded via path or handle.
+	 *
+	 * @param resource|string $file
+	 */
+	private function loadExifData($file) {
 		if (!\is_callable('exif_read_data')) {
-			$this->logger->debug('OC_Image->fixOrientation() Exif module not enabled.', ['app' => 'core']);
-			return -1;
+			$this->logger->debug('OC_Image->loadExifData() Exif module not enabled.', ['app' => 'core']);
+			return;
 		}
-		if (!$this->valid()) {
-			$this->logger->debug('OC_Image->fixOrientation() No image loaded.', ['app' => 'core']);
-			return -1;
+
+		if (!\is_resource($file) && !\is_readable($this->file)) {
+			$this->logger->debug('OC_Image->loadExifData() No readable file or path set.', ['app' => 'core']);
+			return;
 		}
-		if ($this->filePath === null || !\is_readable($this->filePath)) {
-			$this->logger->debug('OC_Image->fixOrientation() No readable file path set.', ['app' => 'core']);
-			return -1;
-		}
-		$exif = @\exif_read_data($this->filePath, 'IFD0');
-		if (!$exif) {
-			return -1;
-		}
-		if (!isset($exif['Orientation'])) {
-			return -1;
-		}
-		return $exif['Orientation'];
+
+		$this->exifData = @\exif_read_data($file, 'IFD0');
 	}
 
 	/**
@@ -481,6 +480,7 @@ class OC_Image implements \OCP\IImage {
 	public function loadFromFileHandle($handle) {
 		$contents = \stream_get_contents($handle);
 		if ($this->loadFromData($contents)) {
+			$this->loadExifData($handle);
 			return $this->resource;
 		}
 		return false;
@@ -576,6 +576,7 @@ class OC_Image implements \OCP\IImage {
 				break;
 		}
 		if ($this->valid()) {
+			$this->loadExifData($imagePath);
 			$this->imageType = $iType;
 			$this->mimeType = \image_type_to_mime_type($iType);
 			$this->filePath = $imagePath;

--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -367,7 +367,7 @@ class OC_Image implements \OCP\IImage {
 			return;
 		}
 
-		if (!\is_resource($file) && !\is_readable($this->file)) {
+		if (!\is_resource($file) && !\is_readable($file)) {
 			$this->logger->debug('OC_Image->loadExifData() No readable file or path set.', ['app' => 'core']);
 			return;
 		}

--- a/tests/Core/Controller/AvatarControllerTest.php
+++ b/tests/Core/Controller/AvatarControllerTest.php
@@ -280,9 +280,6 @@ class AvatarControllerTest extends TestCase {
 		$copyRes = \copy(\OC::$SERVERROOT.'/tests/data/testimage.jpg', $fileName);
 		$this->assertTrue($copyRes);
 
-		//Create file in cache
-		$this->cache->expects($this->once())->method('get')->willReturn(\file_get_contents(\OC::$SERVERROOT.'/tests/data/testimage.jpg'));
-
 		//Create request return
 		$reqRet = ['error' => [0], 'tmp_name' => [$fileName], 'size' => [\filesize(\OC::$SERVERROOT.'/tests/data/testimage.jpg')]];
 		$this->request->expects($this->once())->method('getUploadedFile')->willReturn($reqRet);
@@ -318,9 +315,6 @@ class AvatarControllerTest extends TestCase {
 		$copyRes = \copy(\OC::$SERVERROOT.'/tests/data/testimage.gif', $fileName);
 		$this->assertTrue($copyRes);
 
-		//Create file in cache
-		$this->cache->expects($this->once())->method('get')->willReturn(\file_get_contents(\OC::$SERVERROOT.'/tests/data/testimage.gif'));
-
 		//Create request return
 		$reqRet = ['error' => [0], 'tmp_name' => [$fileName], 'size' => [\filesize(\OC::$SERVERROOT.'/tests/data/testimage.gif')]];
 		$this->request->expects($this->once())->method('getUploadedFile')->willReturn($reqRet);
@@ -341,7 +335,9 @@ class AvatarControllerTest extends TestCase {
 		$userFolder = $this->createMock(Folder::class);
 		$file = $this->getMockBuilder('OCP\Files\File')
 			->disableOriginalConstructor()->getMock();
-		$file->expects($this->any())->method('getContent')->willReturn(\file_get_contents(\OC::$SERVERROOT.'/tests/data/testimage.jpg'));
+		$filePath = \OC::$SERVERROOT.'/tests/data/testimage.jpg';
+		$handle = \fopen($filePath, 'r');
+		$file->expects($this->any())->method('fopen')->willReturn($handle);
 		$userFolder->expects($this->once())->method('get')->willReturn($file);
 
 		$this->rootFolder->expects($this->once())->method('getUserFolder')->willReturn($userFolder);
@@ -383,7 +379,9 @@ class AvatarControllerTest extends TestCase {
 		$userFolder = $this->createMock(Folder::class);
 		$file = $this->getMockBuilder('OCP\Files\File')
 			->disableOriginalConstructor()->getMock();
-		$file->expects($this->any())->method('getContent')->willReturn(\file_get_contents(\OC::$SERVERROOT.'/tests/data/testimage.jpg'));
+		$filePath = \OC::$SERVERROOT.'/tests/data/testimage.jpg';
+		$handle = \fopen($filePath, 'r');
+		$file->expects($this->any())->method('fopen')->willReturn($handle);
 		$userFolder->expects($this->once())->method('get')->willReturn($file);
 		$this->rootFolder->expects($this->once())->method('getUserFolder')->willReturn($userFolder);
 


### PR DESCRIPTION
## Description
Fixes an issue where exif information of images was not processed properly on file- and avatar-uploads. This only works when loading files via path or handle. Before we mostly loaded images via content.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/39114
- Possible fix for https://github.com/owncloud/enterprise/issues/4666

## How Has This Been Tested?
- Upload an image with exif information including orientation. Example: https://github.com/ianare/exif-samples/blob/master/jpg/orientation/landscape_3.jpg
- Open file in media viewer -> the file should have a correct orientation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
