### PR TITLE
default pollinterval 30000 msec

### DIFF
--- a/changelog/unreleased/39143
+++ b/changelog/unreleased/39143
@@ -1,0 +1,6 @@
+Change: Update the default poll-interval in capabilities
+
+The default pollinterval advertised in capabilities has been set to
+30000 milliseconds. Previously it was 60 milliseconds.
+
+https://github.com/owncloud/core/pull/39143

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1492,6 +1492,16 @@ $CONFIG = [
 'minimum.supported.desktop.version' => '2.3.3',
 
 /**
+ * Define the suggested poll interval for clients
+ * Specifies how often clients should poll the server for changes.
+ * The value is in milliseconds. The value is not enforced.
+ * Clients may use this value to decide how frequently to check the server for
+ * changes.
+ *
+ */
+'pollinterval' => 30000,
+
+/**
  * Define whether to include external storage in quota calculation
  * EXPERIMENTAL: option whether to include external storage in quota
  * calculation, defaults to false.

--- a/lib/private/OCS/CoreCapabilities.php
+++ b/lib/private/OCS/CoreCapabilities.php
@@ -51,7 +51,8 @@ class CoreCapabilities implements ICapability {
 	public function getCapabilities() {
 		return [
 			'core' => [
-				'pollinterval' => $this->config->getSystemValue('pollinterval', 60),
+				// pollinterval is an integer number of milliseconds
+				'pollinterval' => $this->config->getSystemValue('pollinterval', 30000),
 				'webdav-root' => $this->config->getSystemValue('webdav-root', 'remote.php/webdav'),
 				'status' => Util::getStatusInfo(true),
 				'support-url-signing' => true,

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -41,7 +41,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                           | value             |
-      | core          | pollinterval                              | 60                |
+      | core          | pollinterval                              | 30000             |
       | core          | webdav-root                               | remote.php/webdav |
       | core          | status@@@edition                          | %edition%         |
       | core          | status@@@productname                      | %productname%     |
@@ -304,7 +304,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -329,7 +329,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element       | value             |
-      | core          | pollinterval          | 60                |
+      | core          | pollinterval          | 30000             |
       | core          | webdav-root           | remote.php/webdav |
       | files_sharing | api_enabled           | EMPTY             |
       | files_sharing | can_share             | EMPTY             |
@@ -348,7 +348,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -371,7 +371,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -395,7 +395,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -419,7 +419,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -443,7 +443,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                                | value             |
-      | core          | pollinterval                                   | 60                |
+      | core          | pollinterval                                   | 30000             |
       | core          | webdav-root                                    | remote.php/webdav |
       | files_sharing | api_enabled                                    | 1                 |
       | files_sharing | can_share                                      | 1                 |
@@ -470,7 +470,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                                | value             |
-      | core          | pollinterval                                   | 60                |
+      | core          | pollinterval                                   | 30000             |
       | core          | webdav-root                                    | remote.php/webdav |
       | files_sharing | api_enabled                                    | 1                 |
       | files_sharing | can_share                                      | 1                 |
@@ -497,7 +497,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                                | value             |
-      | core          | pollinterval                                   | 60                |
+      | core          | pollinterval                                   | 30000             |
       | core          | webdav-root                                    | remote.php/webdav |
       | files_sharing | api_enabled                                    | 1                 |
       | files_sharing | can_share                                      | 1                 |
@@ -524,7 +524,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -548,7 +548,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -572,7 +572,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -598,7 +598,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -624,7 +624,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -648,7 +648,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -672,7 +672,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -697,7 +697,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -723,7 +723,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element               | value             |
-      | core          | pollinterval                  | 60                |
+      | core          | pollinterval                  | 30000             |
       | core          | webdav-root                   | remote.php/webdav |
       | files_sharing | api_enabled                   | 1                 |
       | files_sharing | can_share                     | 1                 |
@@ -746,7 +746,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -770,7 +770,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -799,7 +799,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -830,7 +830,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | EMPTY             |
@@ -861,7 +861,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | 1                 |
@@ -893,7 +893,7 @@ Feature: capabilities
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                       | value             |
-      | core          | pollinterval                          | 60                |
+      | core          | pollinterval                          | 30000             |
       | core          | webdav-root                           | remote.php/webdav |
       | files_sharing | api_enabled                           | 1                 |
       | files_sharing | can_share                             | EMPTY             |

--- a/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
@@ -14,7 +14,7 @@ Feature: default capabilities for normal user
     And the HTTP status code should be "200"
     And the capabilities should contain
       | capability    | path_to_element                           | value             |
-      | core          | pollinterval                              | 60                |
+      | core          | pollinterval                              | 30000             |
       | core          | webdav-root                               | remote.php/webdav |
       | core          | status@@@edition                          | %edition%         |
       | core          | status@@@productname                      | %productname%     |


### PR DESCRIPTION
The desktop client uses a default poll interval of 30000 msec whenever the capabilities announce something less than 5000.
To get in sync with this behaviour, I suggest to also change the value here to 30000.

A value of 60 also leads to confusion, as users assume the unit is seconds, which it is not.

Suggestion for future: Hardcode the unit in the name of the variable, like. e.g. `pollinterval_msec`

Related doc issue: https://github.com/owncloud/docs/issues/3970

Doc issue transferred to https://github.com/owncloud/docs-server/issues/109