### PR TITLE
fix display of tags selection box

### DIFF
--- a/changelog/unreleased/39146
+++ b/changelog/unreleased/39146
@@ -1,0 +1,8 @@
+Bugfix: Fix display of tag selection in sidebar
+
+This PR add small CSS fixes to the Tags selection dialogue:
+- Fixed grey tag space if clear icon (x) is not displayed
+- Align checkmark in selection list vertically
+- Use correct HTML elements (div instead of span)
+
+https://github.com/owncloud/core/pull/39146

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -303,5 +303,5 @@ a.toggleShareDetails:hover {
 }
 
 .select2-container-multi .select2-choices .select2-search-choice {
-	padding: 3px 18px 3px 5px;
+	padding: .2em 0.6em;
 }

--- a/core/css/systemtags.css
+++ b/core/css/systemtags.css
@@ -37,7 +37,7 @@
 .systemtags-select2-dropdown .select2-result-label .icon {
 	display: inline-block;
 	opacity: .5;
-	padding: 4px;
+	padding: 0 4px;
 }
 
 .systemtags-select2-dropdown .select2-result-label .icon:hover {
@@ -45,9 +45,7 @@
 }
 
 .systemtags-select2-dropdown .systemtags-actions {
-	position: absolute;
-	right: 0;
-	top: 3px;
+	display: flex;
 }
 
 .systemtags-select2-dropdown .systemtags-rename-form {
@@ -78,12 +76,21 @@
 	text-transform: none;
 }
 
+.systemtags-select2-container .select2-choices .select2-search-choice-close {
+	position: static;
+}
+
+.systemtags-select2-container .select2-choices .select2-search-choice > div {
+	display: inline-block;
+}
+
 .systemtags-select2-container .select2-choices .select2-search-choice.select2-locked .label {
 	opacity: 0.5;
 }
 
 .systemtags-select2-container .select2-choices .select2-search-choice-close {
 	display: none;
+	margin-left: 6px;
 }
 .systemtags-select2-container .select2-choices .select2-search-field input {
 	line-height: 20px;
@@ -100,7 +107,14 @@
 	display: none;
 }
 
-.systemtags-item .label{
+.systemtags-item {
+	display: flex;
+	padding: 4px;
+	flex-direction: row;
+}
+
+.systemtags-item, 
+.systemtags-item * {
 	cursor: pointer;
 }
 
@@ -109,7 +123,10 @@
 	border-color: rgba(240,240,240,.9);
 	box-shadow: none;
 	background-image: none;
+	display: flex;
+	align-items: center;
 }
+
 .select2-results .select2-highlighted {
 	background-color: rgba(240,240,240,.9);
 	color: #000;

--- a/core/js/systemtags/systemtagsinputfield.js
+++ b/core/js/systemtags/systemtagsinputfield.js
@@ -15,7 +15,7 @@
 		'<input class="systemTagsInputField" type="hidden" name="tags" value=""/>';
 
 	var RESULT_TEMPLATE =
-		'<span class="systemtags-item{{#if isNew}} new-item{{/if}}" data-id="{{id}}">' +
+		'<div class="systemtags-item{{#if isNew}} new-item{{/if}}" data-id="{{id}}">' +
 		'    <span class="checkmark icon icon-checkmark"></span>' +
 		'{{#if isAdmin}}' +
 		'    <span class="label">{{{tagMarkup}}}</span>' +
@@ -23,12 +23,12 @@
 		'    <span class="label">{{name}}</span>' +
 		'{{/if}}' +
 		'{{#allowActions}}' +
-		'    <span class="systemtags-actions">' +
+		'    <div class="systemtags-actions">' +
 		'        <a href="#" class="rename icon icon-rename" title="{{renameTooltip}}"></a>' +
 		'        <a href="#" class="delete icon icon-delete" title="{{deleteTooltip}}"></a>' +
-		'    </span>' +
+		'    </div>' +
 		'{{/allowActions}}' +
-		'</span>';
+		'</div>';
 
 	var SELECTION_TEMPLATE =
 		'{{#if isAdmin}}' +

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -60,8 +60,8 @@ class DetailsDialog extends OwncloudPage {
 	private $tagsSuggestDropDownXpath = "//div[contains(@class, 'systemtags-select2-dropdown') and contains(@id, 'select2-drop')]";
 
 	private $tagsResultFromDropdownXpath = "//li[contains(@class, 'select2-result')]";
-	private $tagEditButtonInTagXpath = "//span[@class='systemtags-actions']//a[contains(@class, 'rename')]";
-	private $tagDeleteButtonInTagXpath = "//span[@class='systemtags-actions']//a[contains(@class, 'delete')]";
+	private $tagEditButtonInTagXpath = "//div[@class='systemtags-actions']//a[contains(@class, 'rename')]";
+	private $tagDeleteButtonInTagXpath = "//div[@class='systemtags-actions']//a[contains(@class, 'delete')]";
 	private $tagsDropDownResultXpath = "//div[contains(@class, 'systemtags-select2-dropdown')]" .
 	"//ul[@class='select2-results']" .
 	"//span[@class='label']";


### PR DESCRIPTION
## Description
This PR add small CSS fixes to the Tags selection dialogue:
- Fixed grey tag space if clear icon (x) is not displayed
- Align checkmark in selection list vertically
- Use correct HTML elements (`div` instead of `span`)

Before:
![grafik](https://user-images.githubusercontent.com/16665512/131361087-4072cc46-23e0-4e82-92d6-79e8bb3ebfca.png)

After:
![grafik](https://user-images.githubusercontent.com/16665512/131364360-dfeed497-e278-4672-861a-98d02f536f7c.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Major browsers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
