### PR TITLE
Remove tag edit/trash actions from file list

### DIFF
--- a/changelog/unreleased/39148
+++ b/changelog/unreleased/39148
@@ -1,0 +1,9 @@
+Change: Remove misleading tag edit/trash actions
+
+This PR's removes the edit/delete actions from the tag selection list.
+While those actions are only visible to the admin it is still a very misleading 
+way since users think they remove a tag from a file but instead delete it completely. 
+This can have bad consequences, for example breaking retention policies.
+
+https://github.com/owncloud/core/issues/39147
+https://github.com/owncloud/core/pull/39148

--- a/core/js/systemtags/systemtagsinputfield.js
+++ b/core/js/systemtags/systemtagsinputfield.js
@@ -22,12 +22,6 @@
 		'{{else}}' +
 		'    <span class="label">{{name}}</span>' +
 		'{{/if}}' +
-		'{{#allowActions}}' +
-		'    <span class="systemtags-actions">' +
-		'        <a href="#" class="rename icon icon-rename" title="{{renameTooltip}}"></a>' +
-		'        <a href="#" class="delete icon icon-delete" title="{{deleteTooltip}}"></a>' +
-		'    </span>' +
-		'{{/allowActions}}' +
 		'</span>';
 
 	var SELECTION_TEMPLATE =


### PR DESCRIPTION
## Description
This PR's removes the edit/delete actions from the tag selection list. While those actions are only visible to the admin it is still a very misleading way since users think they remove a tag from a file but instead delete it completely. This can have bad consequences, for example breaking retention policies.

## Related Issue
- Fixes #39147 

## Screenshots (if appropriate):
Before:
![grafik](https://user-images.githubusercontent.com/16665512/131367111-7d9aa687-b22d-4394-9ece-faccb81d249c.png)


After:
![grafik](https://user-images.githubusercontent.com/16665512/131367169-1084cbab-9dbd-469a-af03-5397d49f6e18.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
