### PR TITLE
Keep pagination active with empty search queries

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2896,7 +2896,10 @@
 			var $trs = this.$fileList.find('tr');
 			do {
 				_.each($trs, filterRows);
-				if (visibleCount < total) {
+
+				// prerender the file list until all items are found.
+				// skip this with an empty filter to keep the pagination.
+				if (visibleCount < total && filter !== '') {
 					$trs = this._nextPage(false);
 				}
 			} while (visibleCount < total && $trs.length > 0);

--- a/changelog/unreleased/39155
+++ b/changelog/unreleased/39155
@@ -1,0 +1,8 @@
+Bugfix: Keep pagination active with empty search queries
+
+Before this fix, an empty search string would pre-render all rows in
+the file list, ignoring the pagination. This fix ensures that the 
+file list is paginated correctly in combination with an empty search query.
+
+https://github.com/owncloud/core/pull/39155
+https://github.com/owncloud/enterprise/issues/4615


### PR DESCRIPTION
## Description
Before this fix, an empty search string would pre-render all rows in the file list, ignoring the pagination. This fix ensures that the file list is paginated correctly in combination with an empty search query.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4615

## How Has This Been Tested?
- Upload a folder with 1000 files
- Enter a string in the search box
- Wait until results are loaded (doesn't matter if there are any) and remove the string again
- Pagination should now still work

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
