### PR TITLE
Add confirmation dialog while removing a tag

### DIFF
--- a/changelog/unreleased/39158
+++ b/changelog/unreleased/39158
@@ -1,0 +1,7 @@
+Enhancement: Confirmation dialog for deleting tags
+
+This feature introduces confirmation dialog while deleting a tag
+to prevent unwanted data-loss
+
+https://github.com/owncloud/core/issues/39157
+https://github.com/owncloud/core/pull/39158

--- a/core/js/systemtags/systemtagsinputfield.js
+++ b/core/js/systemtags/systemtagsinputfield.js
@@ -15,7 +15,7 @@
 		'<input class="systemTagsInputField" type="hidden" name="tags" value=""/>';
 
 	var RESULT_TEMPLATE =
-		'<div class="systemtags-item{{#if isNew}} new-item{{/if}}" data-id="{{id}}">' +
+		'<div class="systemtags-item{{#if isNew}} new-item{{/if}}" data-id="{{id}}" data-name="{{name}}">' +
 		'    <span class="checkmark icon icon-checkmark"></span>' +
 		'{{#if isAdmin}}' +
 		'    <span class="label">{{{tagMarkup}}}</span>' +
@@ -176,13 +176,34 @@
 		 *
 		 * @param {Object} ev event
 		 */
-		_onClickDeleteTag: function(ev) {
+		_onClickDeleteTag: function (ev) {
+			var self = this;
 			var $item = $(ev.target).closest('.systemtags-item');
 			var tagId = $item.attr('data-id');
-			this.collection.get(tagId).destroy();
-			$item.closest('.select2-result').remove();
-			// TODO: spinner
-			return false;
+			var tagName = $item.attr('data-name');
+
+			ev.stopPropagation();
+			OC.dialogs.confirm(
+				t(
+					'core',
+					'Do you really want to remove the tag "{tagName}" and unassign it from all files and folders ?',
+					{tagName: tagName}
+				),
+				t('core', 'Remove tag'),
+				function (result) {
+					if (result === true) {
+						self.collection.get(tagId).destroy();
+						$item.closest('.select2-result').remove();
+					}
+
+					self.$tagsField.select2('open');
+				},
+				true
+			).then(function () {
+				// We need to do close the dropdown temporary otherwise select2 will overlay the dialog
+				self.$tagsField.select2('close');
+
+			});
 		},
 
 		_addToSelect2Selection: function(selection) {

--- a/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
+++ b/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
@@ -238,9 +238,9 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 		});
 		describe('tag actions', function() {
 			var opts;
+			var confirmDialogStub;
 
 			beforeEach(function() {
-
 				opts = select2Stub.getCall(0).args[0];
 
 				view.collection.add([
@@ -248,7 +248,14 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 				]);
 
 				$dropdown.append(opts.formatResult(view.collection.get('1').toJSON()));
+				confirmDialogStub = sinon.stub(OC.dialogs, 'confirm');
 
+				var deferred = $.Deferred();
+				confirmDialogStub.returns(deferred.promise());
+				deferred.resolve();
+			});
+			afterEach(function() {
+				confirmDialogStub.restore();
 			});
 			it('displays rename form when clicking rename', function() {
 				$dropdown.find('.rename').mouseup();
@@ -274,6 +281,9 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 				// delete button appears in tag actions
 				expect($dropdown.find('.delete').length).toEqual(1);
 				$dropdown.find('.delete').mouseup();
+
+				confirmDialogStub.yield(true);
+				expect(confirmDialogStub.calledOnce).toEqual(true);
 
 				expect(destroyStub.calledOnce).toEqual(true);
 				expect(destroyStub.calledOn(view.collection.get('1')));

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -66,6 +66,8 @@ class DetailsDialog extends OwncloudPage {
 	"//ul[@class='select2-results']" .
 	"//span[@class='label']";
 	private $tagEditInputXpath = "//input[@id='view12-rename-input']";
+	protected $tagDeleteConfirmButtonXpath
+		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style, 'display: none')])]//button[text()='Yes']";
 
 	private $commentXpath = "//ul[@class='comments']//div[@class='message' and contains(., '%s')]";
 	private $commentInputXpath = "//form[@class='newCommentForm']//textarea[@class='message']";
@@ -518,6 +520,16 @@ class DetailsDialog extends OwncloudPage {
 				);
 				$deleteBtn->focus();
 				$deleteBtn->click();
+
+				$deleteConfirmBtn = $this->find("xpath", $this->tagDeleteConfirmButtonXpath);
+				$this->assertElementNotNull(
+					$deleteConfirmBtn,
+					__METHOD__ .
+					" xpath: $this->tagDeleteConfirmButtonXpath" .
+					" could not find confirmation button"
+				);
+				$deleteConfirmBtn->focus();
+				$deleteConfirmBtn->click();
 			}
 		}
 	}


### PR DESCRIPTION
## Description
Enhancement: Confirmation dialog for deleting tags

This feature introduces a confirmation dialog while deleting a tag
to prevent unwanted data-loss

## Related Issue
- Fixes #39157 

## Screenshots
![image](https://user-images.githubusercontent.com/26169327/131522866-71949b71-6e81-4055-aa62-02e8ce5a52ee.png)



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
