### PR TITLE
Fix file conflict dialog when dragging a file into a folder

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -822,8 +822,9 @@ OC.Uploader.prototype = _.extend({
 		// only keep non-conflicting uploads
 		selection.uploads = _.filter(selection.uploads, function(upload) {
 			var file = upload.getFile();
-			if (file.relativePath || upload.getTargetFolder() !== '/') {
-				// can't check in subfolder contents
+			var targetUploadFolder = upload.getTargetFolder();
+			if (file.relativePath || (targetUploadFolder && targetUploadFolder !== '/')) {
+				// can't check in subfolder contents, let backend handle this
 				return true;
 			}
 			if (!fileList) {
@@ -997,6 +998,7 @@ OC.Uploader.prototype = _.extend({
 				 */
 				add: function(e, data) {
 					self.log('add', e, data);
+					console.log(data.targetDir);
 					var that = $(this), freeSpace;
 
 					var upload = new OC.FileUpload(self, data);

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -818,10 +818,11 @@ OC.Uploader.prototype = _.extend({
 	checkExistingFiles: function (selection, callbacks) {
 		var fileList = this.fileList;
 		var conflicts = [];
+
 		// only keep non-conflicting uploads
 		selection.uploads = _.filter(selection.uploads, function(upload) {
 			var file = upload.getFile();
-			if (file.relativePath) {
+			if (file.relativePath || upload.getTargetFolder() !== '/') {
 				// can't check in subfolder contents
 				return true;
 			}

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -818,7 +818,6 @@ OC.Uploader.prototype = _.extend({
 	checkExistingFiles: function (selection, callbacks) {
 		var fileList = this.fileList;
 		var conflicts = [];
-
 		// only keep non-conflicting uploads
 		selection.uploads = _.filter(selection.uploads, function(upload) {
 			var file = upload.getFile();
@@ -998,7 +997,6 @@ OC.Uploader.prototype = _.extend({
 				 */
 				add: function(e, data) {
 					self.log('add', e, data);
-					console.log(data.targetDir);
 					var that = $(this), freeSpace;
 
 					var upload = new OC.FileUpload(self, data);

--- a/changelog/unreleased/39162
+++ b/changelog/unreleased/39162
@@ -1,0 +1,8 @@
+Bugfix: File conflict dialog when dragging a file into a folder
+
+When dragging a file into a folder, while another file with an identical 
+name exists in the parent directory, the UI falsely showed a conflict 
+dialog alert.  This has been fixed.
+
+https://github.com/owncloud/core/pull/39162
+https://github.com/owncloud/core/issues/39133


### PR DESCRIPTION
## Description
When dragging a file into a folder, while another file with an identical name exists in the parent directory, the UI falsely showed a conflict dialog alert.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39133

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Upload file "test.txt" to your root dir
- Create an empty folder "folder" in your root dir
- Drag-and-drop "test.txt" from your computer's explorer/finder onto "folder", resulting in a new upload
- -> The file should be uploaded without any issues.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
