### PR TITLE
Add timeout for public link quick action notification

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -381,13 +381,13 @@
 						OC.Notification.show(t(
 							'files_sharing',
 							'A new public link with download & view permissions has been created and copied to the clipboard.'
-						));
+						), { timeout: 7 });
 					},
 					error: function () {
 						OC.Notification.show(t(
 							'files_sharing',
 							'The public link could not be created. Please contact the administrator for help.'),
-							{ type: 'error' }
+							{ type: 'error', timeout: 7 }
 						);
 					}
 				});

--- a/changelog/unreleased/39130
+++ b/changelog/unreleased/39130
@@ -6,3 +6,4 @@ in the config.php.
 
 https://github.com/owncloud/enterprise/issues/4718
 https://github.com/owncloud/core/pull/39130
+https://github.com/owncloud/core/pull/39163


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related to https://github.com/owncloud/enterprise/issues/4729

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
