### PR TITLE
fix button width

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -391,7 +391,7 @@ a.two-factor-cancel {
 	justify-content: center;
 	flex-direction: column;
 	max-width: 300px;
-	margin: 32px auto 1.2rem;
+	margin: 32px auto;
 }
 
 .loading-spinner {
@@ -653,6 +653,7 @@ a.two-factor-cancel {
 form#alternative-logins {
 	border-top: 1px solid rgba(255,255,255,0.8);
 	padding-top: 16px;
+	max-width: 300px;
 }
 #alternative-logins ul {text-align: center;}
 #alternative-logins legend { margin-bottom:16px; }


### PR DESCRIPTION
## Description
Alt-login buttons were too wide in display.


## Screenshots (if appropriate):
Before
<img width="808" alt="grafik" src="https://user-images.githubusercontent.com/16665512/131834897-e1741c93-0597-435a-b95f-da9d11a54831.png">

After
<img width="760" alt="grafik" src="https://user-images.githubusercontent.com/16665512/131834949-4ddf4a49-1b89-4c22-8e68-d10d7cfee43a.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
