### PR TITLE
Avoid duplication of public quick links on the same resource

### DIFF
--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -329,6 +329,14 @@
 				shareType: OC.Share.SHARE_TYPE_LINK,
 				itemType: fileInfoModel.isDirectory() ? 'folder' : 'file',
 				itemSource: fileInfoModel.get('id'),
+				name: t('files_sharing', 'Public quick link'),
+				attributes: [
+					{
+						key: 'isQuickLink',
+						scope: 'files_sharing',
+						value: true,
+					}
+				],
 			};
 
 			var shareModel = new OC.Share.ShareModel(attributes);
@@ -356,15 +364,44 @@
 					}
 				}
 
+				var linkCollection = shareItemModel.getLinkSharesCollection();
+
 				if (initNewShareLinkView) {
-					var linkCollection = shareItemModel.getLinkSharesCollection();
 					linkShareView = new OC.Share.ShareDialogLinkListView({
 						collection: linkCollection,
 						itemModel: shareItemModel
 					});
 				}
 
-				attributes.name = linkShareView._generateName();
+				// check for existing public quick link
+				var quickLink = false;
+				for (var index = 0; index < linkCollection.length; index++) {
+					var share = linkCollection.at(index);
+					var shareAttrs = share.get('attributes');
+					if (!shareAttrs) {
+						continue;
+					}
+					for (var ii = 0; ii < shareAttrs.length; ii++) {
+						if (shareAttrs[ii].key === 'isQuickLink') {
+							quickLink = share;
+							break;
+						}
+					}
+					if (quickLink) {
+						break;
+					}
+				}
+
+				if (quickLink) {
+					self._copyToClipboard(quickLink.getLink());
+
+					OC.Notification.show(t(
+						'files_sharing',
+						'Public link has been copied to the clipboard.'
+					), { timeout: 7 });
+					return;
+				}
+
 				attributes.path = fileInfoModel.get('path') + '/' + fileInfoModel.get('name');
 
 				shareModel.save(attributes, {

--- a/apps/files_sharing/js/share.js
+++ b/apps/files_sharing/js/share.js
@@ -332,8 +332,8 @@
 				name: t('files_sharing', 'Public quick link'),
 				attributes: [
 					{
-						key: 'isQuickLink',
 						scope: 'files_sharing',
+						key: 'isQuickLink',
 						value: true,
 					}
 				],

--- a/changelog/unreleased/39130
+++ b/changelog/unreleased/39130
@@ -7,3 +7,4 @@ in the config.php.
 https://github.com/owncloud/enterprise/issues/4718
 https://github.com/owncloud/core/pull/39130
 https://github.com/owncloud/core/pull/39163
+https://github.com/owncloud/core/pull/39167

--- a/core/js/sharemodel.js
+++ b/core/js/sharemodel.js
@@ -76,7 +76,6 @@
 			delete data.storage_id;
 			delete data.mimetype;
 			delete data.parent;
-
 			return data;
 		},
 

--- a/core/js/sharemodel.js
+++ b/core/js/sharemodel.js
@@ -76,6 +76,7 @@
 			delete data.storage_id;
 			delete data.mimetype;
 			delete data.parent;
+
 			return data;
 		},
 


### PR DESCRIPTION
## Description
Enhancement: Extend public quick link feature 

With this PR, public quick links created via the quick links icon in the file list will be created only once. We do this by adding `isQuickLink` to the share's attributes. See https://github.com/owncloud/enterprise/issues/4730#issuecomment-911610309 for the expected behavior.

Extends https://github.com/owncloud/core/pull/39130

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4730

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
