### PR TITLE
Fix Makefile for qa-master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,7 @@ clean-dist:
 # Build qa distribution
 #
 $(dist_dir)/qa/owncloud: $(composer_dev_deps) $(core_vendor) $(core_all_src) $(core_test_dirs)
+	cd $(NODE_PREFIX) && $(YARN) run clean-modules
 	rm -Rf $@; mkdir -p $@/config
 	cp -RL $(core_all_src) $@
 	cp -Rf $(core_test_dirs) $@


### PR DESCRIPTION
The Makefile target `$(dist_dir)/qa/owncloud`
differs from target `$(dist_dir)/owncloud`
where it should not. 

Only the latter runs yarn clean-modules. This seems needed in both cases -- at least it helps me to avoid a 'too many levels of symbolic link' error
caused by a cyclic symlink core/vendor/moment/meteor/moment.js when building the daily qa master tar.

Not sure if that only covers symptoms of something else, please review.
