### PR TITLE
[tests-only] skip changed tests on old oC10

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -151,123 +151,123 @@ Feature: admin sharing settings
     When the administrator disables add server automatically once a federation share was created successfully using the webUI
     Then the config key "autoAddServers" of app "federation" should have value "0"
 
-  @skipOnOcV10.3
+
   Scenario: enable default expiration date for user shares
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for user shares using the webUI
     Then the config key "shareapi_default_expire_date_user_share" of app "core" should have value "yes"
 
-  @skipOnOcV10.3
+
   Scenario: enable default expiration date for group shares
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for group shares using the webUI
     Then the config key "shareapi_default_expire_date_group_share" of app "core" should have value "yes"
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: enable default expiration date for federated shares
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for federated shares using the webUI
     Then the config key "shareapi_default_expire_date_remote_share" of app "core" should have value "yes"
 
-  @skipOnOcV10.3
+
   Scenario: set a different default expiration days for user shares
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for user shares using the webUI
     And the administrator updates the user share expiration date to "4" days using the webUI
     Then the config key "shareapi_expire_after_n_days_user_share" of app "core" should have value "4"
 
-  @skipOnOcV10.3
+
   Scenario: set a different default expiration days for group shares
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for group shares using the webUI
     And the administrator updates the group share expiration date to "11" days using the webUI
     Then the config key "shareapi_expire_after_n_days_group_share" of app "core" should have value "11"
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: set a different default expiration days for federated shares
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for federated shares using the webUI
     And the administrator updates the federated share expiration date to "18" days using the webUI
     Then the config key "shareapi_expire_after_n_days_remote_share" of app "core" should have value "18"
 
-  @skipOnOcV10.3
+
   Scenario: set default expiration days for user shares and enforce as maximum expiration days
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for user shares using the webUI
     And the administrator enforces maximum expiration date for user shares using the webUI
     Then the config key "shareapi_enforce_expire_date_user_share" of app "core" should have value "yes"
 
-  @skipOnOcV10.3
+
   Scenario: set default expiration days for group shares and enforce as maximum expiration days
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for group shares using the webUI
     And the administrator enforces maximum expiration date for group shares using the webUI
     Then the config key "shareapi_enforce_expire_date_group_share" of app "core" should have value "yes"
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: set default expiration days for federated shares and enforce as maximum expiration days
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for federated shares using the webUI
     And the administrator enforces maximum expiration date for federated shares using the webUI
     Then the config key "shareapi_enforce_expire_date_remote_share" of app "core" should have value "yes"
 
-  @skipOnOcV10.3
+
   Scenario: check previously set default expiration days for user shares
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     When the administrator browses to the admin sharing settings page
     Then the default expiration date checkbox for user shares should be enabled on the webUI
     And the expiration date for user shares should set to "7" days on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: check previously set default expiration days for group shares
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     When the administrator browses to the admin sharing settings page
     Then the default expiration date checkbox for group shares should be enabled on the webUI
     And the expiration date for group shares should set to "7" days on the webUI
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: check previously set default expiration days for federated shares
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     When the administrator browses to the admin sharing settings page
     Then the default expiration date checkbox for federated shares should be enabled on the webUI
     And the expiration date for federated shares should set to "7" days on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: check previously enforced maximum expiration days for user shares
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     When the administrator browses to the admin sharing settings page
     Then the enforce maximum expiration date checkbox for user shares should be enabled on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: check previously enforced maximum expiration days for group shares
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     When the administrator browses to the admin sharing settings page
     Then the enforce maximum expiration date checkbox for group shares should be enabled on the webUI
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: check previously enforced maximum expiration days for federated shares
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
     When the administrator browses to the admin sharing settings page
     Then the enforce maximum expiration date checkbox for federated shares should be enabled on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: check previously set expiration days for user shares
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "5"
     When the administrator browses to the admin sharing settings page
     Then the expiration date for user shares should set to "5" days on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: check previously set expiration days for group shares
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "5"
     When the administrator browses to the admin sharing settings page
     Then the expiration date for group shares should set to "5" days on the webUI
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: check previously set expiration days for federated shares
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "5"

--- a/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
@@ -19,6 +19,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
+
   Scenario: test the single steps of sharing a folder to a remote server
     Given user "Alice" has logged in using the webUI
     When the user shares folder "simple-folder" with federated user "Alice" with displayname "%username%@%remote_server_without_scheme%" using the webUI
@@ -30,6 +31,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And as "Alice" file "/simple-folder (2)/lorem.txt" should exist
     And as "Alice" folder "/simple-empty-folder (2)" should exist
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: test the single steps of receiving a federation share
     Given using server "REMOTE"
     And these users have been created with default attributes and without skeleton files:
@@ -57,7 +59,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And folder "simple-folder (2)" should be listed in the shared-with-you page on the webUI
     And folder "simple-empty-folder (2)" should be listed in the shared-with-you page on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator inside folder shared using federated sharing
     Given user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" from server "LOCAL" has shared "/simple-folder" with user "Alice" from server "REMOTE"
@@ -67,7 +69,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | lorem.txt  |
       | sub-folder |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator for file uploaded inside folder shared using federated sharing
     Given user "Alice" from server "LOCAL" has shared "/simple-folder" with user "Alice" from server "REMOTE"
     And user "Alice" has logged in using the webUI
@@ -76,7 +78,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then the following resources should have share indicators on the webUI
       | new-lorem.txt |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator for folder created inside folder shared using federated sharing
     Given user "Alice" from server "LOCAL" has shared "/simple-folder" with user "Alice" from server "REMOTE"
     And user "Alice" has logged in using the webUI
@@ -85,7 +87,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then the following resources should have share indicators on the webUI
       | sub-folder |
 
-  @skipOnOcV10.3
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: sharing details inside folder shared using federated sharing
     Given user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
@@ -97,7 +99,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user opens the share dialog for file "textfile.txt"
     Then federated user "Alice" with displayname "%username%@%remote_server% (Federated share)" should be listed as share receiver via "simple-folder" on the webUI
 
-  @skipOnOcV10.3
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: sharing details of items inside a shared folder shared with local user and federated user
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/simple-folder/sub-folder"
@@ -110,7 +112,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then federated user "Alice" with displayname "%username%@%remote_server% (Federated share)" should be listed as share receiver via "simple-folder" on the webUI
     And user "Brian" with displayname "%displayname%" should be listed as share receiver via "sub-folder" on the webUI
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario: expiration date is disabled for federation sharing, sharer checks the expiration date of a federation share
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "no"
     And user "Alice" from server "LOCAL" has shared "lorem.txt" with user "Alice" from server "REMOTE"
@@ -124,7 +126,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | expiration |            |
       | uid_owner  | Alice      |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario: expiration date is enabled for federation sharing, sharer checks the expiration date of a federation share
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
@@ -139,7 +141,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | expiration | +7 days    |
       | uid_owner  | Alice      |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: expiration date is enforced for federation sharing, user shares file
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
@@ -159,7 +161,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | 3        | +3 days |
       | 0        | today   |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario: expiration date is enforced for federation sharing, user shares and tries to change expiration date more than allowed
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
@@ -176,7 +178,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | expiration | +3 days    |
       | uid_owner  | Alice      |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario: expiration date is enforced for federated sharing, user receives a share with expiration date and reshares with expiration date less than the original with a local user
     Given user "Brian" has been created with default attributes and without skeleton files
     And using server "REMOTE"
@@ -197,7 +199,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | expiration | +10 days       |
       | uid_owner  | Alice          |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario: expiration date is enforced for federated sharing, user receives a share with expiration date and reshares with expiration date less than the original with another federated user
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -217,7 +219,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | expiration | +4 days        |
       | uid_owner  | Alice          |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario: expiration date is enforced for federated sharer, local receiver reshares received file with another local user
     Given user "Brian" has been created with default attributes and without skeleton files
     And using server "REMOTE"
@@ -237,7 +239,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
       | expiration |                |
       | uid_owner  | Alice          |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario: expiration date is enforced for federated sharer, local receiver reshares received file with another federated user
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/webUITags/deleteTags.feature
+++ b/tests/acceptance/features/webUITags/deleteTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
+@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: Deletion of existing tags from files and folders
   As a user
   I want to delete tags from files and folders
@@ -95,4 +95,3 @@ Feature: Deletion of existing tags from files and folders
     And file "/randomfile.txt" should have the following tags for user "Alice"
       | name     | type   |
       | some-tag | normal |
-

--- a/tests/acceptance/features/webUITags/editTags.feature
+++ b/tests/acceptance/features/webUITags/editTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
+@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: Edit tags for files and folders
   As a user
   I want to edit tags for files/folders


### PR DESCRIPTION
## Description
PR #38877 changed some words on the UI of fedreated sharing. The changed tests need to be skipped on old oC10.

There were other changes to the way that the tagging UI happens. The changed tests for that also need to be skipped on old oC10.

I removed other very old tags that are no longer relevant to any test combinations that we run.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
