### PR TITLE
Display clickable links in upgrade process 

### DIFF
--- a/changelog/unreleased/39184
+++ b/changelog/unreleased/39184
@@ -1,0 +1,7 @@
+Enhancement: Display clickable links during web UI upgrade process
+
+Before this PR, error messages can contain links that have not been clickable.
+With this PR, links are clickable and open them in a new tab.
+
+https://github.com/owncloud/core/pull/39184
+https://github.com/owncloud/core/issues/39178

--- a/core/js/update.js
+++ b/core/js/update.js
@@ -110,33 +110,43 @@
 		},
 
 		setMessage: function(message) {
-			$('#update-progress-message').html(message);
+			var parsedMessage = this.parseMessage(message);
+			$('#update-progress-message').html(parsedMessage);
 			$('#update-progress-detailed')
 				.append($('<span>'))
-				.append(message)
+				.append(parsedMessage)
 				.append($('<br>'));
 		},
 
 		setPermanentMessage: function(message) {
-			$('#update-progress-message').html(message);
+			var parsedMessage = this.parseMessage(message);
+			$('#update-progress-message').html(parsedMessage);
 			$('#update-progress-message-warnings')
 				.show()
-				.append($('<ul>').append(message));
+				.append($('<ul>').append(parsedMessage));
 			$('#update-progress-detailed')
 				.append($('<span>'))
-				.append(message)
+				.append(parsedMessage)
 				.append($('<br>'));
 		},
-		
+
 		setErrorMessage: function (message) {
+			var parsedMessage = this.parseMessage(message);
 			$('#update-progress-message-error')
 				.show()
-				.html(message);
+				.html(parsedMessage);
 			$('#update-progress-detailed')
 				.append($('<span>'))
-				.append(message)
+				.append(parsedMessage)
 				.append($('<br>'));
-		}
+		},
+
+		parseMessage: function (message) {
+			// generate a tags from urls
+			var urlRegex = /(https?:\/\/[^\s]+)/g;
+			return message.replace(urlRegex, '<a href="$1" target="_blank">$1</a>');
+		},
+
 	};
 
 })();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Enhancement: Display clickable links during web UI upgrade process

Before this PR, error messages can contain links that have not been clickable.
With this PR, links are clickable and open them in a new tab.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39178

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):#
### Before
![image](https://user-images.githubusercontent.com/26169327/132487379-cf63750d-5545-45c5-b7a0-e3c3273bff35.png)


### After 
![image](https://user-images.githubusercontent.com/26169327/132487121-ee8f0f16-d56c-49ab-b9ff-5068661c9cf5.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
