### PR TITLE
Fix preview rendering for sharees

### DIFF
--- a/changelog/unreleased/39202
+++ b/changelog/unreleased/39202
@@ -1,0 +1,9 @@
+Bugfix: Preview rendering for sharees
+
+Previous to this fix, the previews of updated shared files did
+not change for sharees. Those previews now get re-generated if
+the content of the files changed.
+
+https://github.com/owncloud/core/pull/39202
+https://github.com/owncloud/core/issues/39202
+https://github.com/owncloud/core/issues/31855

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -768,22 +768,26 @@ class Preview {
 			if ($this->preview) {
 				$mount = $fileInfo->getMountPoint();
 
-				// Updating a shared file will always re-generate the thumnail for the
+				// Updating a shared file will always re-generate the preview for the
 				// share owner, but not its sharees. Therefore we need to check if the
-				// current cached thumbnail is different from the share owner's one.
+				// current cached preview is different from the share owner's one.
 				if ($mount instanceof SharedMount) {
 					$owner = $fileInfo->getOwner();
 					$ownerView = new View($owner->getUID() . '/' . $cached);
-					$ownerThumbnail = $ownerView->getFileInfo('');
+					$ownerPreview = $ownerView->getFileInfo('');
 
-					if ($ownerThumbnail) {
-						$currentThumbnail = $this->userView->getFileInfo($cached);
+					if ($ownerPreview) {
+						$currentPreview = $this->userView->getFileInfo($cached);
 
 						// Different checksums mean we need to re-generate the thumbnail
 						// to match with the share owner's one.
-						if ($ownerThumbnail->getChecksum() != $currentThumbnail->getChecksum()) {
+						if ($ownerPreview->getChecksum() !== $currentPreview->getChecksum()) {
 							$this->preview = null;
 						}
+					} else {
+						// Owner preview gets deleted when a sharee edits a file.
+						// Re-generate preview for the sharee in this case.
+						$this->preview = null;
 					}
 				}
 			}


### PR DESCRIPTION
## Description
Previous to this fix, the previews of updated shared files did not change for sharees. Those previews now get re-generated if the content of the files changed.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/39202
- Fixes https://github.com/owncloud/core/issues/31855
- Fixes https://github.com/owncloud/gallery/issues/826

## How Has This Been Tested?
See steps in https://github.com/owncloud/core/issues/39202

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
