### PR TITLE
fix: use correct controller name in dav routes.php

### DIFF
--- a/apps/dav/appinfo/routes.php
+++ b/apps/dav/appinfo/routes.php
@@ -1,6 +1,6 @@
 <?php
 return [
 	'routes' => [
-		['name' => 'msofba#success', 'url' => '/msofba-success', 'verb' => 'GET'],
+		['name' => 'MSOFBA#success', 'url' => '/msofba-success', 'verb' => 'GET'],
 	]
 ];

--- a/changelog/unreleased/38838
+++ b/changelog/unreleased/38838
@@ -4,3 +4,4 @@ WebDAV endpoint now supports Microsoft Office Form Based Authentication (MSOFBA)
 
 https://docs.microsoft.com/en-us/openspecs/sharepoint_protocols/ms-ofba/30c7bbe9-b284-421f-b866-4e7ed4866027
 https://github.com/owncloud/core/pull/38838
+https://github.com/owncloud/core/pull/39204


### PR DESCRIPTION
## Description
endpoint index.php/apps/dav/msofba-success responded with 500 due to unknown controller

## Related Issue
- refs #38838 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
