### PR TITLE
[tests-only] skip intermittent test - issue 39213

### DIFF
--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -26,7 +26,7 @@ Feature: Add, delete and edit comments in files and folders
       | 😀 🤖       |
       | नेपालि      |
 
-  @skipOnFIREFOX @files_sharing-app-required
+  @skipOnFIREFOX @files_sharing-app-required @skipOnOcV10 @issue-39213
   Scenario Outline: Add comment on a shared file and check it is shown in other user's UI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"


### PR DESCRIPTION
## Description
The comments webUI test scenario in the related issue has become "very" intermittent in core today.
I  can run the test locally OK. The browser looks OK. We need to investigate what happens sometimes when we get:
```
element click intercepted: Element <a class="action action-share permanent" href="#" data-action="Share" data-original-title="" title="">...</a> is not clickable at point (767, 165). Other element would receive the click: <a href="#">...</a>
```

But for now, skip the test scenario.

## Related Issue
#39213 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
