### PR TITLE
Ignore non-user folders in command occ:user report

### DIFF
--- a/changelog/unreleased/39223
+++ b/changelog/unreleased/39223
@@ -1,0 +1,8 @@
+Bugfix: don't count non-user folder in occ user:report command
+
+Before this PR several folders, for example 'avatars', have been counted as user
+folders via the occ user:report command.
+With this PR a list of folders has been added which should not be counted as user folders.
+The user directory count is now correct.
+
+https://github.com/owncloud/core/pull/39223

--- a/core/Command/User/Report.php
+++ b/core/Command/User/Report.php
@@ -25,8 +25,10 @@
 
 namespace OC\Core\Command\User;
 
+use OC\Files\FileInfo;
 use OC\Helper\UserTypeHelper;
 use OCP\IUser;
+use OCP\User;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -99,7 +101,13 @@ class Report extends Command {
 
 	private function countUserDirectories() {
 		$dataview = new \OC\Files\View('/');
-		$userDirectories = $dataview->getDirectoryContent('/', 'httpd/unix-directory');
+		$directories = $dataview->getDirectoryContent('/', 'httpd/unix-directory');
+
+		// don't count in invalid directories for example 'avatars'.
+		$userDirectories = \array_filter($directories, function (FileInfo $directory) {
+			return !\in_array($directory->getName(), User::DIRECTORIES_THAT_ARE_NOT_USERS);
+		});
+
 		return \count($userDirectories);
 	}
 }

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -367,17 +367,10 @@ class Manager extends PublicEmitter implements IUserManager {
 				throw new \Exception($l->t('The username can not be longer than 64 characters'));
 			}
 
-			$invalidUids = [
-				'avatars',
-				'meta',
-				'files_external',
-				'files_encryption',
-				'.htaccess',
-				'.ocdata',
-				'owncloud.db',
-				'owncloud.log',
-				'index.html'
-			];
+			$invalidUids = \array_merge(
+				\OCP\User::FILES_THAT_ARE_NOT_USERS,
+				\OCP\User::DIRECTORIES_THAT_ARE_NOT_USERS
+			);
 
 			if (\in_array(\strtolower($uid), $invalidUids)) {
 				throw new \Exception($l->t("The special username %s is not allowed", $uid));

--- a/lib/public/User/Constants.php
+++ b/lib/public/User/Constants.php
@@ -36,4 +36,27 @@ class Constants {
 		self::USER_TYPE_USER => 'user',
 		self::USER_TYPE_GUEST => 'guest',
 	];
+
+	/**
+	 * @var array
+	 * These directories can exist in the data directory along with user folders, and are not valid usernames
+	 **/
+	public const DIRECTORIES_THAT_ARE_NOT_USERS = [
+		'avatars',
+		'meta',
+		'files_external',
+		'files_encryption',
+	];
+
+	/**
+	 * @var array
+	 * These files can exist in the data directory along with user folders, and are not valid usernames
+	 **/
+	public const FILES_THAT_ARE_NOT_USERS = [
+		'.htaccess',
+		'.ocdata',
+		'owncloud.db',
+		'owncloud.log',
+		'index.html'
+	];
 }

--- a/tests/Core/Command/User/ReportTest.php
+++ b/tests/Core/Command/User/ReportTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @author Jan Ackermann <jackermann@owncloud.com>
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\User;
+
+use OC\Core\Command\User\Report;
+use OC\Files\Storage\Storage;
+use OC\Files\View;
+use OC\Helper\UserTypeHelper;
+use OCP\IUserManager;
+use OCP\User;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+/**
+ * Class ReportTest
+ *
+ * @group DB
+ */
+class ReportTest extends TestCase {
+	use UserTrait;
+
+	/** @var CommandTester */
+	private $commandTester;
+
+	/** @var IUserManager | MockObject */
+	private $userManager;
+
+	/** @var UserTypeHelper | MockObject */
+	private $userTypeHelper;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$userTypeHelper = $this->getMockBuilder('OC\Helper\UserTypeHelper')->disableOriginalConstructor()->getMock();
+		$this->userTypeHelper = $userTypeHelper;
+
+		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
+		$this->userManager = $userManager;
+
+		$command = new Report($userManager, $userTypeHelper);
+		$command->setApplication(new Application());
+		$this->commandTester = new CommandTester($command);
+
+		$view = new View('');
+		list($storage) = $view->resolvePath('');
+		/** @var $storage Storage */
+
+		foreach (User\Constants::DIRECTORIES_THAT_ARE_NOT_USERS as $nonUserFolder) {
+			$storage->mkdir($nonUserFolder);
+		}
+		$storage->mkdir('user1');
+	}
+
+	public function testCommandInput() {
+		$this->userManager->expects($this->once())->method('countUsers')->willReturn([
+			\OC\User\Database::class => 5,
+		]);
+
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+
+		$expectedOutput = <<<EOS
++------------------+---+
+| User Report      |   |
++------------------+---+
+| OC\User\Database | 5 |
+|                  |   |
+| guest users      | 0 |
+|                  |   |
+| total users      | 5 |
+|                  |   |
+| user directories | 1 |
++------------------+---+
+
+EOS;
+
+		$this->assertEquals($expectedOutput, $output);
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Bugfix: don't count non-user folder in occ user:report command

Before this PR several folders, for example 'avatars', have been counted as user
folders via the occ user:report command.
With this PR a list of folders has been added which should not be counted as user folders.
The user directory count is now correct.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
