### PR TITLE
Add option to hide the upload estimation in WebUI

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1338,12 +1338,16 @@ OC.Uploader.prototype = _.extend({
 							filledBufferSize++;
 						}
 					}
-					var smoothRemainingSeconds = (bufferTotal / filledBufferSize);
-					var h = moment.duration(smoothRemainingSeconds, "seconds").humanize();
+
+					if (!oc_appconfig.files.hide_upload_estimation) {
+						var smoothRemainingSeconds = (bufferTotal / filledBufferSize);
+						var h = moment.duration(smoothRemainingSeconds, "seconds").humanize();
+						self.$uploadprogressbar.find('.label .mobile').text(h);
+						self.$uploadprogressbar.find('.label .desktop').text(h);
+					}
+
 					self.$uploadprogressbar.attr('data-loaded', data.loaded);
 					self.$uploadprogressbar.attr('data-total', data.total);
-					self.$uploadprogressbar.find('.label .mobile').text(h);
-					self.$uploadprogressbar.find('.label .desktop').text(h);
 					self.$uploadprogressbar.attr('original-title',
 						t('files', '{loadedSize} of {totalSize} ({bitrate})' , {
 							loadedSize: humanFileSize(data.loaded),

--- a/apps/files/lib/App.php
+++ b/apps/files/lib/App.php
@@ -49,12 +49,14 @@ class App {
 		$uploadStallTimeout = (int)($config->getAppValue('files', 'upload_stall_timeout', 60)); // in seconds
 		$uploadStallRetries = (int)($config->getAppValue('files', 'upload_stall_retries', 100));
 		$enableLockFileAction = (boolean)($config->getAppValue('files', 'enable_lock_file_action', 'no') === 'yes');
+		$hideUploadEstimation = (boolean)($config->getAppValue('files', 'hide_upload_estimation', 'no') === 'yes');
 
 		$array['array']['oc_appconfig']['files'] = [
 			'max_chunk_size' => $maxChunkSize,
 			'upload_stall_timeout' => $uploadStallTimeout,
 			'upload_stall_retries' => $uploadStallRetries,
-			'enable_lock_file_action' => $enableLockFileAction
+			'enable_lock_file_action' => $enableLockFileAction,
+			'hide_upload_estimation' => $hideUploadEstimation
 		];
 	}
 }

--- a/apps/files/tests/js/fileUploadSpec.js
+++ b/apps/files/tests/js/fileUploadSpec.js
@@ -28,6 +28,10 @@ describe('OC.Upload tests', function() {
 	var getFolderContentsStub;
 
 	beforeEach(function() {
+		oc_appconfig = oc_appconfig || {};
+		oc_appconfig.files = oc_appconfig.files || {};
+		oc_appconfig.files.hide_upload_estimation = false;
+
 		testFile = {
 			name: 'test.txt',
 			size: 5000, // 5 KB

--- a/changelog/unreleased/39228
+++ b/changelog/unreleased/39228
@@ -1,7 +1,8 @@
 Enhancement: Add option to hide the upload estimation in WebUI
 
 The upload estimation can now be hidden when setting
-`hide_upload_estimation` to "yes" via occ command.
+`hide_upload_estimation` to "yes" via occ command:
+occ config:app:set files hide_upload_estimation --value="yes"
 
 https://github.com/owncloud/core/pull/39228
 https://github.com/owncloud/enterprise/issues/4743

--- a/changelog/unreleased/39228
+++ b/changelog/unreleased/39228
@@ -1,0 +1,7 @@
+Enhancement: Add option to hide the upload estimation in WebUI
+
+The upload estimation can now be hidden when setting
+`hide_upload_estimation` to "yes" via occ command.
+
+https://github.com/owncloud/core/pull/39228
+https://github.com/owncloud/enterprise/issues/4743


### PR DESCRIPTION
## Description
The upload estimation can now be hidden when setting `hide_upload_estimation` to "yes" via occ command.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4743

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/50302941/133242227-b109f9b7-785a-4ba9-b7b5-ada17679bba0.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
