### PR TITLE
Allow skeletondirectory to be an empty string

### DIFF
--- a/changelog/unreleased/39230
+++ b/changelog/unreleased/39230
@@ -1,0 +1,6 @@
+Enhancement: Allow skeletondirectory to be an empty string
+
+skeletondirectory can now be set to an empty string in config.php to indicate
+that no skeleton is required.
+
+https://github.com/owncloud/core/pull/39230

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -276,7 +276,7 @@ $CONFIG = [
 /**
  * Define the directory where the skeleton files are located
  * These files will be copied to the data directory of new users.
- * Leave this directory empty if you do not want to copy any skeleton files.
+ * Set this to the empty string if you do not want to copy any skeleton files.
  * A valid path must be given for this key otherwise errors will be generated in owncloud.log.
  */
 'skeletondirectory' => '/path/to/owncloud/core/skeleton',

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -382,6 +382,11 @@ class OC_Util {
 	public static function copySkeleton($userId, \OCP\Files\Folder $userDirectory) {
 		$skeletonDirectory = \OC::$server->getConfig()->getSystemValue('skeletondirectory', \OC::$SERVERROOT . '/core/skeleton');
 
+		// An empty setting for skeletondirectory means that no skeleton is required.
+		if ($skeletonDirectory === '') {
+			return;
+		}
+
 		if (!\is_dir($skeletonDirectory)) {
 			throw new \OC\HintException('The skeleton folder '.$skeletonDirectory.' is not accessible');
 		}


### PR DESCRIPTION
## Description
https://github.com/owncloud/core/blob/master/config/config.sample.php says:
```
/**
 * Define the directory where the skeleton files are located
 * These files will be copied to the data directory of new users.
 * Leave this directory empty if you do not want to copy any skeleton files.
 * A valid path must be given for this key otherwise errors will be generated in owncloud.log.
 */
'skeletondirectory' => '/path/to/owncloud/core/skeleton',
```

But it seems unnecessary to require pointing this to some empty directory. That can be a hassle, and is a nuisance in CI.

This PR allows setting:
```
'skeletondirectory' => '',
```

And that makes it work just the same as if `skeletondirectory` is a path to and empty directory.

## How Has This Been Tested?
Prior to this PR, setting `'skeletondirectory' => '',` resulted in a log entry:
```
{"reqId":"klZAwAcwlfjWOuKTqlEw","level":3,"time":"2021-09-15T04:41:31+00:00","remoteAddr":"192.168.1.64","user":"z123","app":"no app in context","method":"POST","url":"\/index.php\/login","message":"The skeleton folder  is not accessible"}
```

After this PR, no log is generated and a new user gets no skeleton files.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4036
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
