### PR TITLE
Use buttons and icons for file list actions without text in mobile view

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -696,11 +696,9 @@ a.action > img {
 	padding-right: 15px;
 }
 
-.selectedActions a.delete-selected.mobile {
-	display: none;
-	padding-right: 5px;
-}
-
+.selectedActions a.delete-selected.mobile.button,
+.selectedActions a.download.mobile.button,
+.selectedActions a.undelete.mobile.button,
 .selectedActions a.hidden {
 	display: none;
 }

--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -84,8 +84,26 @@ table #headerSize, #headerDate, .filesize, .modified, .date {
 	display: none !important;
 }
 
-.selectedActions a.delete-selected.mobile {
-	display: inline;
+/* hide common selected file actions mobile */
+.selectedActions a.download,
+.selectedActions a.delete-selected,
+.selectedActions a.undelete {
+	display: none;
 }
+
+/* show mobile selected file actions mobile */
+.selectedActions a.delete-selected.mobile.button,
+.selectedActions a.undelete.mobile.button,
+.selectedActions a.download.mobile.button {
+	display: inline;
+	padding: 5px;
+	font-size: 13px;
+	margin-left: 5px;
+}
+
+.selectedActions a:last-child {
+	margin-right: 5px;
+}
+
 }
 

--- a/apps/files/templates/list.php
+++ b/apps/files/templates/list.php
@@ -52,9 +52,11 @@
 							<span class="icon icon-download"></span>
 							<span><?php p($l->t('Download'))?></span>
 						</a>
-						<a href="" class="delete-selected mobile">
+						<a href="" class="download mobile button">
+							<span class="icon icon-download "></span>
+						</a>
+						<a href="" class="delete-selected mobile button">
 							<span class="icon icon-delete"></span>
-							<span><?php p($l->t('Delete'))?></span>
 						</a>
 					</span>
 				</div>

--- a/apps/files_trashbin/templates/index.php
+++ b/apps/files_trashbin/templates/index.php
@@ -33,9 +33,11 @@
 							<span class="icon icon-history"></span>
 							<span><?php p($l->t('Restore'))?></span>
 						</a>
-							<a href="" class="delete-selected mobile">
+						<a href="" class="undelete mobile button">
+							<span class="icon icon-history"></span>
+						</a>
+						<a href="" class="delete-selected mobile button">
 							<span class="icon icon-delete"></span>
-							<span><?php p($l->t('Delete'))?></span>
 						</a>
 					</span>
 				</div>

--- a/changelog/unreleased/39233
+++ b/changelog/unreleased/39233
@@ -1,0 +1,8 @@
+Enhancement: Use icons + buttons instead of text for file actions in mobile view
+
+Before this PR, as files were selected in the files list, actions was shown with
+icon and text, for example: 'Download' and 'Delete'.
+This uses much space and UI glitches are possible due to limited screen size.
+With this PR we now show buttons with the associated icons without any text.
+
+https://github.com/owncloud/core/pull/39233


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Enhancement: Use icons + buttons instead of text for file actions in mobile view

Before this PR, as files were selected in the files list, actions was shown with
icon and text, for example: 'Download' and 'Delete'.
This uses much space and UI glitches are possible due to limited screen size.
With this PR we now show buttons with the associated icons without any text.

## Screenshots (if appropriate):

### Files - Before
![image](https://user-images.githubusercontent.com/26169327/133395491-4b759da0-8733-4a55-ae53-bde84979fb72.png)

### Files - After 
![image](https://user-images.githubusercontent.com/26169327/133394322-5c53f300-0dbf-45e5-80a8-50e5182e3329.png)


### Deleted files - Before
![image](https://user-images.githubusercontent.com/26169327/133395653-27ab28a6-a620-47cb-96d7-2ea52a921ce9.png)

### Deleted files - After
![image](https://user-images.githubusercontent.com/26169327/133396017-4a327950-915f-4364-9069-d76f0551a195.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
