### PR TITLE
Set expire end of day in UI

### DIFF
--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -93,7 +93,7 @@
 			if (this._linksOnly) {
 				var expirationTimestamp = 0;
 				if(fileData.shares && fileData.shares[0].expiration !== null) {
-					expirationTimestamp = moment(fileData.shares[0].expiration).valueOf();
+					expirationTimestamp = moment(fileData.shares[0].expiration).endOf('day').valueOf();
 				}
 				$tr.attr('data-expiration', expirationTimestamp);
 

--- a/apps/files_sharing/tests/js/sharedfilelistSpec.js
+++ b/apps/files_sharing/tests/js/sharedfilelistSpec.js
@@ -614,7 +614,9 @@ describe('OCA.Sharing.FileList tests', function() {
 			fileList.reload();
 
 			var expirationDateInADay = moment()
-				.add(1, 'days').format('YYYY-MM-DD HH:mm:ss');
+				.set({"hour": 0, "minute": 0, "second": 0})
+				.add(1, 'days')
+				.format('YYYY-MM-DD HH:mm:ss');
 
 			/* jshint camelcase: false */
 			ocsResponse = {

--- a/changelog/unreleased/39238
+++ b/changelog/unreleased/39238
@@ -1,0 +1,8 @@
+Bugfix: Show the correct expiring date in 'Shared by link' files list
+
+Before this PR the "Expiration date" column did not respect that shares
+expiration is set to the end of date and showing wrong values.
+This has been fixed with this PR
+
+https://github.com/owncloud/core/pull/39238
+https://github.com/owncloud/core/issues/39234


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Bugix: Show the correct expiring date in Shared by link files list

Before this PR the "Expiration date" column did not respect that shares 
expiration will be end of date and showing wrong values.
This has been fixed with this PR

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39234

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
