### PR TITLE
[full-ci] add percent to usernames

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -29,6 +29,11 @@ Feature: edit users
       | a@-+_.b  | a.b@example.com     |
       | a space  | a.space@example.com |
 
+    @skipOnOcV10
+    Examples:
+      | username | email           |
+      | a%b      | a.b@example.com |
+
   @smokeTest
   Scenario: the administrator can edit a user display (the API allows editing the "display name" by using the key word "display")
     Given user "brand-new-user" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -31,7 +31,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     Examples:
       | username | displayname  | email               |
-      | a@-+_.b  | A weird b    | a.b@example.com     |
+      | a%b@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
 
   Scenario: admin gets an existing user, providing uppercase username in the URL

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -31,8 +31,13 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     Examples:
       | username | displayname  | email               |
-      | a%b@-+_.b  | A weird b    | a.b@example.com     |
+      | a@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
+
+    @skipOnOcV10
+    Examples:
+      | username | displayname  | email           |
+      | a%b      | A percent b  | a.b@example.com |
 
   Scenario: admin gets an existing user, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -26,7 +26,7 @@ Feature: edit users
     And the email address of user "<username>" should be "a-different-email@example.com"
     Examples:
       | username | email               |
-      | a@-+_.b  | a.b@example.com     |
+      | a%b@-+_.b  | a.b@example.com     |
       | a space  | a.space@example.com |
 
   @smokeTest

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -26,8 +26,13 @@ Feature: edit users
     And the email address of user "<username>" should be "a-different-email@example.com"
     Examples:
       | username | email               |
-      | a%b@-+_.b  | a.b@example.com     |
+      | a@-+_.b  | a.b@example.com     |
       | a space  | a.space@example.com |
+
+    @skipOnOcV10
+    Examples:
+      | username | email           |
+      | a%b      | a.b@example.com |
 
   @smokeTest
   Scenario: the administrator can edit a user display (the API allows editing the "display name" by using the key word "display")

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -20,7 +20,7 @@ Feature: enable user
   Scenario: admin enables an user with special characters in the username
     Given these users have been created without skeleton files:
       | username | email               |
-      | a@-+_.b  | a.b@example.com     |
+      | a%b@-+_.b  | a.b@example.com     |
       | a space  | a.space@example.com |
     And the following users have been disabled
       | username |

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -20,7 +20,7 @@ Feature: enable user
   Scenario: admin enables an user with special characters in the username
     Given these users have been created without skeleton files:
       | username | email               |
-      | a%b@-+_.b  | a.b@example.com     |
+      | a@-+_.b  | a.b@example.com     |
       | a space  | a.space@example.com |
     And the following users have been disabled
       | username |

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -31,7 +31,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     Examples:
       | username | displayname  | email               |
-      | a@-+_.b  | A weird b    | a.b@example.com     |
+      | a%b@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
 
   Scenario: admin gets an existing user, providing uppercase username in the URL

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -31,8 +31,13 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     Examples:
       | username | displayname  | email               |
-      | a%b@-+_.b  | A weird b    | a.b@example.com     |
+      | a@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
+
+    @skipOnOcV10
+    Examples:
+      | username | displayname  | email           |
+      | a%b      | A percent b  | a.b@example.com |
 
   Scenario: admin gets an existing user, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:


### PR DESCRIPTION
we ran into this when trying a user that had an email as the username. ocis-web would encode the `@` as `%40` and the chi router would not match the route. See https://github.com/go-chi/chi/pull/659