### PR TITLE
[tests-only] Fix Guzzle7 exception handling in HttpRequestHelper

### DIFF
--- a/tests/TestHelpers/HttpRequestHelper.php
+++ b/tests/TestHelpers/HttpRequestHelper.php
@@ -25,7 +25,7 @@ namespace TestHelpers;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -109,9 +109,14 @@ class HttpRequestHelper {
 			self::debugRequest($request, $user, $password);
 		}
 
+		// The exceptions that might happen here include:
+		// ConnectException - in that case there is no response. Don't catch the exception.
+		// RequestException - if there is something in the response then pass it back.
+		//                    otherwise re-throw the exception.
+		// GuzzleException - something else unexpected happened. Don't catch the exception.
 		try {
 			$response = $client->send($request);
-		} catch (GuzzleException $ex) {
+		} catch (RequestException $ex) {
 			$response = $ex->getResponse();
 
 			//if the response was null for some reason do not return it but re-throw


### PR DESCRIPTION
## Description
The `getResponse()` method was removed from `GuzzleHttp\Exception\ConnectException` in Guzzle7.

It still exists in `GuzzleHttp\Exception\RequestException`

So not all exceptions have a `getResponse()` method. Be more careful to only try to process a `RequestException` and check for a response. Do not catch other exceptions. They will throw higher up and eventually Behat will catch them and fail the test scenario and report the exception.

## Related Issue
- Fixes #39250 

## How Has This Been Tested?
CI - although the exception handling only happens in unusual circumstances.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
