### PR TITLE
Command occ 'user:report -> count user dirs system wide

### DIFF
--- a/changelog/unreleased/39254
+++ b/changelog/unreleased/39254
@@ -1,0 +1,12 @@
+Bugfix: Command occ 'user:report' might not count 'user directories' correctly
+
+Before this PR the underlying function of 'user:report' just looked up in the
+'datadirectory' set in 'config.php'.
+This implies that user directories which are symlinks or even not in the
+'datadirectory', have not been taken into account.
+With this PR we check if the user's home path exists and increase the
+'user directories' count.
+
+https://github.com/owncloud/core/pull/39254
+https://github.com/owncloud/enterprise/issues/4742
+

--- a/core/Command/User/Report.php
+++ b/core/Command/User/Report.php
@@ -26,6 +26,7 @@
 namespace OC\Core\Command\User;
 
 use OC\Files\FileInfo;
+use OC\Files\View;
 use OC\Helper\UserTypeHelper;
 use OCP\IUser;
 use OCP\User;
@@ -100,14 +101,16 @@ class Report extends Command {
 	}
 
 	private function countUserDirectories() {
-		$dataview = new \OC\Files\View('/');
-		$directories = $dataview->getDirectoryContent('/', 'httpd/unix-directory');
+		$userDirCount = 0;
 
-		// don't count in invalid directories for example 'avatars'.
-		$userDirectories = \array_filter($directories, function (FileInfo $directory) {
-			return !\in_array($directory->getName(), User::DIRECTORIES_THAT_ARE_NOT_USERS);
+		$this->userManager->callForSeenUsers(function (IUser $user) use (&$userDirCount) {
+			$homePath = $user->getHome();
+
+			if (\is_dir($homePath)) {
+				$userDirCount++;
+			}
 		});
 
-		return \count($userDirectories);
+		return $userDirCount;
 	}
 }

--- a/tests/Core/Command/User/ReportTest.php
+++ b/tests/Core/Command/User/ReportTest.php
@@ -23,16 +23,13 @@
 namespace Tests\Core\Command\User;
 
 use OC\Core\Command\User\Report;
-use OC\Files\Storage\Storage;
 use OC\Files\View;
 use OC\Helper\UserTypeHelper;
 use OCP\IUserManager;
-use OCP\User;
-use PHPUnit\Framework\MockObject\MockObject;
+use OCP\User\Constants;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
-use Test\Traits\UserTrait;
 
 /**
  * Class ReportTest
@@ -40,23 +37,17 @@ use Test\Traits\UserTrait;
  * @group DB
  */
 class ReportTest extends TestCase {
-	use UserTrait;
-
 	/** @var CommandTester */
 	private $commandTester;
 
-	/** @var IUserManager | MockObject */
+	/** @var IUserManager */
 	private $userManager;
-
-	/** @var UserTypeHelper | MockObject */
-	private $userTypeHelper;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$userTypeHelper = $this->getMockBuilder('OC\Helper\UserTypeHelper')->disableOriginalConstructor()->getMock();
-		$this->userTypeHelper = $userTypeHelper;
+		$userTypeHelper = new UserTypeHelper();
 
-		$userManager = $this->getMockBuilder('OCP\IUserManager')->disableOriginalConstructor()->getMock();
+		$userManager = \OC::$server->getUserManager();
 		$this->userManager = $userManager;
 
 		$command = new Report($userManager, $userTypeHelper);
@@ -67,17 +58,19 @@ class ReportTest extends TestCase {
 		list($storage) = $view->resolvePath('');
 		/** @var $storage Storage */
 
-		foreach (User\Constants::DIRECTORIES_THAT_ARE_NOT_USERS as $nonUserFolder) {
+		/**
+		 * Create some folders in the 'datadirectory'
+		 * which should not be counted as user directories
+		 */
+		foreach (Constants::DIRECTORIES_THAT_ARE_NOT_USERS as $nonUserFolder) {
 			$storage->mkdir($nonUserFolder);
 		}
-		$storage->mkdir('user1');
+
+		// Login to create user directory
+		$this->loginAsUser('admin');
 	}
 
 	public function testCommandInput() {
-		$this->userManager->expects($this->once())->method('countUsers')->willReturn([
-			\OC\User\Database::class => 5,
-		]);
-
 		$this->commandTester->execute([]);
 		$output = $this->commandTester->getDisplay();
 
@@ -85,11 +78,11 @@ class ReportTest extends TestCase {
 +------------------+---+
 | User Report      |   |
 +------------------+---+
-| OC\User\Database | 5 |
+| OC\User\Database | 1 |
 |                  |   |
 | guest users      | 0 |
 |                  |   |
-| total users      | 5 |
+| total users      | 1 |
 |                  |   |
 | user directories | 1 |
 +------------------+---+

--- a/tests/Core/Command/User/ReportTest.php
+++ b/tests/Core/Command/User/ReportTest.php
@@ -74,7 +74,12 @@ class ReportTest extends TestCase {
 		$this->commandTester->execute([]);
 		$output = $this->commandTester->getDisplay();
 
-		$expectedOutput = <<<EOS
+		$view = new View('');
+		$storage = $view->getMount('/')->getStorage();
+		$isLocalStorage = $storage->isLocal();
+
+		if ($isLocalStorage) {
+			$expectedOutput = <<<EOS
 +------------------+---+
 | User Report      |   |
 +------------------+---+
@@ -88,6 +93,22 @@ class ReportTest extends TestCase {
 +------------------+---+
 
 EOS;
+		} else {
+			$expectedOutput = <<<EOS
++------------------+---+
+| User Report      |   |
++------------------+---+
+| OC\User\Database | 1 |
+|                  |   |
+| guest users      | 0 |
+|                  |   |
+| total users      | 1 |
+|                  |   |
+| user directories | 0 |
++------------------+---+
+
+EOS;
+		}
 
 		$this->assertEquals($expectedOutput, $output);
 	}

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -1898,6 +1898,8 @@ class UsersControllerTest extends \Test\TestCase {
 		} else {
 			$this->assertEquals(new Http\JSONResponse(), $response);
 		}
+
+		\OC::$server->getUserManager()->get($userName)->delete();
 	}
 
 	public function setDataForSendMail() {

--- a/tests/lib/Files/Storage/LockingTests.php
+++ b/tests/lib/Files/Storage/LockingTests.php
@@ -21,6 +21,7 @@ namespace Test\Files\Storage;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OC\User\User;
 use OCP\Files\Storage\IPersistentLockingStorage;
 use Test\TestCase;
 
@@ -61,6 +62,11 @@ class LockingTests extends TestCase {
 				'token' => '123-456-789'
 			]);
 		}
+
+		if (\OC::$server->getUserManager()->get('locking-user') instanceof User) {
+			\OC::$server->getUserManager()->get('locking-user')->delete();
+		}
+
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Bugfix: Command occ 'user:report' might not count 'user directories' correctly

Before this PR the underlying function of 'user:report' just looked up in the
'datadirectory' set in 'config.php'.
This implies that user directories which are symlinks or even not in the '
datadirectory', have not been taken into account.
With this PR we check if the user's home path exist and increase the
'user directories' count.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- May fix https://github.com/owncloud/enterprise/issues/4742

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Create user admin and user2
- Run `occ user:report`
- `| user directories | 2 |` -> **correct**
---
- Run `php occ user:move-home user2 /home/test ` and remove the old home
- Run `occ user:report`
- `| user directories | 1 |` -> **not correct**
---
- Apply this patch
- Run `occ user:report`
- `| user directories | 2 |` -> **correct**


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
