### PR TITLE
Simplify 'set password' UI text

### DIFF
--- a/changelog/unreleased/39257
+++ b/changelog/unreleased/39257
@@ -1,0 +1,3 @@
+Bugfix: Simplify set password text for new passwords
+
+https://github.com/owncloud/core/pull/39257

--- a/settings/templates/setpassword.php
+++ b/settings/templates/setpassword.php
@@ -44,7 +44,7 @@ script('settings', 'setpassword');
 		<span id="message"></span>
 		<label id="error-message" class="warning" style="display:none"></label>
 		<button type="submit" id="submit">
-			<span><?php p($l->t('Please set your password')); ?></span>
+			<span><?php p($l->t('Set password')); ?></span>
 			<div class="loading-spinner"><div></div><div></div><div></div><div></div></div>
 		</button>
 	</div>

--- a/settings/tests/js/setpasswordSpec.js
+++ b/settings/tests/js/setpasswordSpec.js
@@ -26,7 +26,7 @@ describe('OCA.UserManagement.SetPassword tests', function () {
 			' />' +
 			'<span id="message"></span>' +
 			'</p>' +
-			'<input type="submit" id="submit" value="Please set your password"' +
+			'<input type="submit" id="submit" value="Set password"' +
 			'</fieldset>' +
 			'</form>'
 		);


### PR DESCRIPTION
## Description
Simplify the words. Instead of the button saying "Please set your password", just say "Set password"

## Related Issue
- Fixes #33455 

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
