### PR TITLE
Allow the occ command to list users and groups matching a single character

### DIFF
--- a/changelog/unreleased/39258
+++ b/changelog/unreleased/39258
@@ -1,0 +1,7 @@
+Bugfix: Allow user:list and group:list to filter on short strings
+
+The occ user:list and group:list commands can now be used to list users and
+groups that match a short string, regardless of the setting of user.search_min_length
+
+https://github.com/owncloud/core/pull/39258
+https://github.com/owncloud/core/issues/31117

--- a/core/Command/Group/ListGroups.php
+++ b/core/Command/Group/ListGroups.php
@@ -56,7 +56,7 @@ class ListGroups extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$groupNameSubString = $input->getArgument('search-pattern');
-		$groups = $this->groupManager->search($groupNameSubString, null, null, 'management');
+		$groups = $this->groupManager->search($groupNameSubString, null, null, 'management', true);
 		$groups = \array_map(function ($group) {
 			/** @var IGroup $group */
 			return $group->getGID();

--- a/core/Command/User/ListUsers.php
+++ b/core/Command/User/ListUsers.php
@@ -91,7 +91,7 @@ class ListUsers extends Base {
 		$attributes = \array_map('mb_strtolower', $input->getOption('attributes'));
 		$useKey = \count($attributes) > 1
 			|| $input->getOption('output') !== self::OUTPUT_FORMAT_PLAIN;
-		$users = $this->userManager->search($userNameSubString);
+		$users = $this->userManager->search($userNameSubString, null, null, true);
 		$users = \array_map(function (IUser $user) use ($output, $attributes, $useKey) {
 			if ($output->isVerbose()) {
 				// include all attributes

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -151,7 +151,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 		$this->backends = [];
 		$this->clearCaches();
 	}
-	
+
 	protected function clearCaches() {
 		$this->cachedGroups = [];
 		$this->cachedUserGroups = [];
@@ -236,11 +236,12 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @param int|null $limit limit
 	 * @param int|null $offset offset
 	 * @param string|null $scope scope string
+	 * @param bool $alwaysReturnAllMatches
 	 * @return \OC\Group\Group[] groups
 	 */
-	public function search($search, $limit = null, $offset = null, $scope = null) {
+	public function search($search, $limit = null, $offset = null, $scope = null, $alwaysReturnAllMatches = false) {
 		$groups = [];
-		if ($this->userSearch->isSearchable($search)) {
+		if ($alwaysReturnAllMatches || $this->userSearch->isSearchable($search)) {
 			foreach ($this->backends as $backend) {
 				if (!$backend->isVisibleForScope($scope)) {
 					// skip backend

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -279,12 +279,13 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @param string $pattern
 	 * @param int $limit
 	 * @param int $offset
+	 * @param bool $alwaysReturnAllMatches
 	 * @return \OC\User\User[]
 	 */
-	public function search($pattern, $limit = null, $offset = null) {
+	public function search($pattern, $limit = null, $offset = null, $alwaysReturnAllMatches = false) {
 		$accounts = $this->accountMapper->search('user_id', $pattern, $limit, $offset);
 		$users = [];
-		if ($this->userSearch->isSearchable($pattern)) {
+		if ($alwaysReturnAllMatches || $this->userSearch->isSearchable($pattern)) {
 			foreach ($accounts as $account) {
 				$user = $this->getUserObject($account);
 				$users[$user->getUID()] = $user;

--- a/tests/Core/Command/Group/ListGroupsTest.php
+++ b/tests/Core/Command/Group/ListGroupsTest.php
@@ -57,6 +57,8 @@ class ListGroupsTest extends TestCase {
 	public function inputProvider() {
 		return [
 			[['search-pattern' => 'group'], 'group1'],
+			[['search-pattern' => 'g'], 'group1'],
+			[['search-pattern' => 'up'], 'group1'],
 		];
 	}
 }

--- a/tests/Core/Command/User/ListUsersTest.php
+++ b/tests/Core/Command/User/ListUsersTest.php
@@ -64,6 +64,8 @@ class ListUsersTest extends TestCase {
 		return [
 			[[], ['testlistuser']],
 			[['search-pattern' => 'testlist'], ['testlistuser']],
+			[['search-pattern' => 't'], ['testlistuser']],
+			[['search-pattern' => 'li'], ['testlistuser']],
 			[['--attributes' => [
 				'uid', 'displayname', 'email', 'quota', 'enabled', 'lastlogin',
 				'home', 'backend', 'cloudid', 'searchterms'

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -501,6 +501,20 @@ class OccUsersGroupsContext implements Context {
 	}
 
 	/**
+	 * @When the administrator gets the groups containing :substring in the group name in JSON format using the occ command
+	 *
+	 * @param string $subString
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorGetsTheGroupsContainingInJsonUsingTheOccCommand(string $subString) {
+		$this->occContext->invokingTheCommand(
+			"group:list $subString --output=json"
+		);
+	}
+
+	/**
 	 * @When the administrator removes user :username from group :group using the occ command
 	 *
 	 * @param string $username
@@ -578,7 +592,7 @@ class OccUsersGroupsContext implements Context {
 	 * @throws Exception
 	 */
 	public function theUsersReturnedByTheOccCommandShouldBe(TableNode $useridTable) {
-		$this->featureContext->verifyTableNodeColumns($useridTable, ['uid', 'display name']);
+		$this->featureContext->verifyTableNodeColumns($useridTable, ['uid']);
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputUsers = \json_decode($lastOutput, true);
 		$result = [];
@@ -688,16 +702,28 @@ class OccUsersGroupsContext implements Context {
 	}
 
 	/**
-	 * @Then the display name returned by the occ command should be :displayName
+	 * @Then /^the (first|second|third) display name returned by the occ command should be "([^"]*)"$/
 	 *
+	 * @param string $place
 	 * @param string $displayName
 	 *
 	 * @return void
 	 */
-	public function theDisplayNameReturnedByTheOccCommandShouldBe($displayName) {
+	public function theDisplayNameReturnedByTheOccCommandShouldBe($place, $displayName) {
+		switch ($place) {
+			case "first":
+				$index = 0;
+				break;
+			case "second":
+				$index = 1;
+				break;
+			case "third":
+				$index = 2;
+				break;
+		}
 		$lastOutput = $this->featureContext->getStdOutOfOccCommand();
 		$lastOutputUser = \json_decode($lastOutput, true);
-		$lastOutputDisplayName = \array_column($lastOutputUser, 'displayName')[0];
+		$lastOutputDisplayName = \array_column($lastOutputUser, 'displayName')[$index];
 		Assert::assertEquals(
 			$displayName,
 			$lastOutputDisplayName,

--- a/tests/acceptance/features/cliProvisioning/getGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroup.feature
@@ -17,9 +17,9 @@ Feature: get group
     When the administrator gets the users in group "brand-new-group" in JSON format using the occ command
     Then the command should have been successful
     And the users returned by the occ command should be
-      | uid            | display name |
-      | brand-new-user | Anne Brown   |
-      | 123            | 123          |
+      | uid            |
+      | brand-new-user |
+      | 123            |
 
   Scenario: admin gets user in the group who is disabled
     Given user "brand-new-user" has been created with default attributes and small skeleton files
@@ -30,8 +30,8 @@ Feature: get group
     When the administrator gets the users in group "brand-new-group" in JSON format using the occ command
     Then the command should have been successful
     And the users returned by the occ command should be
-      | uid            | display name |
-      | brand-new-user | Anne Brown   |
+      | uid            |
+      | brand-new-user |
 
   Scenario: admin tries to get users in a nonexistent group
     Given group "brand-new-group" has been created

--- a/tests/acceptance/features/cliProvisioning/getGroups.feature
+++ b/tests/acceptance/features/cliProvisioning/getGroups.feature
@@ -31,3 +31,22 @@ Feature: get groups
       | case-sensitive-group |
       | Case-Sensitive-Group |
       | CASE-SENSITIVE-GROUP |
+
+  Scenario Outline: admin gets all the groups containing some sub-string
+    Given group "brand-new" has been created
+    And group "brand-new-group" has been created
+    And group "brand-new-thing" has been created
+    And group "some-other-name" has been created
+    When the administrator gets the groups containing "<group-to-list>" in the group name in JSON format using the occ command
+    Then the command should have been successful
+    And the groups returned by the occ command should be
+      | group           |
+      | brand-new       |
+      | brand-new-group |
+      | brand-new-thing |
+    Examples:
+      | group-to-list |
+      | brand-new     |
+      | brand         |
+      | b             |
+      | new           |

--- a/tests/acceptance/features/cliProvisioning/getUser.feature
+++ b/tests/acceptance/features/cliProvisioning/getUser.feature
@@ -9,7 +9,7 @@ Feature: get user
     And the administrator has changed the display name of user "brand-new-user" to "Anne Brown"
     When the administrator retrieves the information of user "brand-new-user" in JSON format using the occ command
     Then the command should have been successful
-    And the display name returned by the occ command should be "Anne Brown"
+    And the first display name returned by the occ command should be "Anne Brown"
 
   Scenario: admin tries to get a nonexistent user
     Given user "nonexistentuser" has been deleted

--- a/tests/acceptance/features/cliProvisioning/getUsers.feature
+++ b/tests/acceptance/features/cliProvisioning/getUsers.feature
@@ -11,8 +11,8 @@ Feature: get users
     When the administrator retrieves all the users in JSON format using the occ command
     Then the command should have been successful
     And the users returned by the occ command should be
-      | uid            | display name |
-      | brand-new-user | Just A User  |
+      | uid            |
+      | brand-new-user |
 
   Scenario: admin gets the list of all inactive users
     Given these users have been created with default attributes and without skeleton files:
@@ -28,3 +28,29 @@ Feature: get users
       | uid   | display name | inactive days |
       | Alice | Alice Hansen | 7             |
       | Brian | Brian Murphy | 400           |
+
+  Scenario Outline: admin gets a short username that has multiple matches of longer usernames
+    Given user "brand-new" has been created with default attributes and without skeleton files
+    And user "brand-new-user" has been created with default attributes and without skeleton files
+    And user "brand-new-test" has been created with default attributes and without skeleton files
+    And user "some-other-name" has been created with default attributes and without skeleton files
+    And the administrator has changed the display name of user "brand-new" to "Alice Adams"
+    And the administrator has changed the display name of user "brand-new-user" to "Brian Brown"
+    And the administrator has changed the display name of user "brand-new-test" to "Carol Coffee"
+    When the administrator retrieves the information of user "<user-to-list>" in JSON format using the occ command
+    Then the command should have been successful
+    And the users returned by the occ command should be
+      | uid            |
+      | brand-new      |
+      | brand-new-user |
+      | brand-new-test |
+    # the users come back in order of the username, not the display name
+    And the first display name returned by the occ command should be "Alice Adams"
+    And the second display name returned by the occ command should be "Carol Coffee"
+    And the third display name returned by the occ command should be "Brian Brown"
+    Examples:
+      | user-to-list |
+      | brand-new    |
+      | brand        |
+      | b            |
+      | new          |


### PR DESCRIPTION
## Description
The `occ user:list` and `occ group:list` commands were being limited by the value of `user.search_min_length`. A command like `php occ user:list a` would return an empty list, even though there were usernames with the letter "a".

If `user.search_min_length` is set to a higher value (e.g. 4) then `php occ user:list abc` would return and empty list, instead of the users with "abc" in the username.

This behavior can be annoying at the command line. It is not obvious to the command-line user why no users are found.

There is no particular reason to limit the command-line matching of users. The command-line user can execute `php occ user:list` without parameters and get a full list of users anyway. The behavior was an "accident"  from the implementation of `user.search_min_length`.

This PR stops `user:list` and `group:list` from being limites by the setting of `user.search_min_length`

## Related Issue
- Fixes #31117 

## How Has This Been Tested?
CI - see new test cases

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
