### PR TITLE
Fix doc placeholder URL in general-settings

### DIFF
--- a/changelog/unreleased/39267
+++ b/changelog/unreleased/39267
@@ -1,0 +1,4 @@
+Bugfix: Fix doc placeholder URL in "general"-settings
+
+https://github.com/owncloud/core/pull/39267
+https://github.com/owncloud/core/issues/27666

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -272,8 +272,10 @@
 			var messages = [];
 
 			if (xhr.status === 200) {
-				var oc_defaults = oc_defaults || {};
-				var docPlaceholderUrl = oc_defaults.docPlaceholderUrl || '';
+				var docPlaceholderUrl = '';
+				if (oc_defaults && oc_defaults.docPlaceholderUrl) {
+					docPlaceholderUrl = oc_defaults.docPlaceholderUrl;
+				}
 
 				if(OC.getProtocol() === 'https') {
 					// Extract the value of 'Strict-Transport-Security'


### PR DESCRIPTION
## Description
`oc_defaults` was always empty before, therefore no doc URL.

## Related Issue
Related to https://github.com/owncloud/core/issues/27666

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4058
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
