### PR TITLE
[tests-only] added api acceptance tests for previews update feature after change in file content

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -218,6 +218,11 @@ class FeatureContext extends BehatVariablesContext {
 	private $response = null;
 
 	/**
+	 * @var string
+	 */
+	private $responseBodyContents = null;
+
+	/**
 	 * @var CookieJar
 	 */
 	private $cookieJar;

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -4270,11 +4270,52 @@ trait WebDav {
 	 * @return void
 	 */
 	public function imageDimensionsShouldBe($width, $height) {
-		$size = \getimagesizefromstring($this->response->getBody()->getContents());
+		if ($this->responseBodyContents === null) {
+			$this->responseBodyContents = $this->response->getBody()->getContents();
+		}
+		$size = \getimagesizefromstring($this->responseBodyContents);
 		Assert::assertNotFalse($size, "could not get size of image");
 		Assert::assertEquals($width, $size[0], "width not as expected");
 		Assert::assertEquals($height, $size[1], "height not as expected");
 	}
+
+	/**
+	 * @Given user :user has downloaded the preview of :path with width :width and height :height
+	 *
+	 * @param $user
+	 * @param $path
+	 * @param $width
+	 * @param $height
+	 *
+	 * @return void
+	 */
+	public function userDownloadsThePreviewOfWithWidthAndHeight($user, $path, $width, $height):void {
+		$this->downloadPreviewOfFiles($user, $path, $width, $height);
+		$this->theHTTPStatusCodeShouldBe(200);
+		$this->imageDimensionsShouldBe($width, $height);
+	}
+
+	/**
+	 * @Then as user :user the preview of :path with width :width and height :height should have been changed
+	 *
+	 * @param $user
+	 * @param $path
+	 * @param $width
+	 * @param $height
+	 *
+	 * @return void
+	 */
+	public function asUserThePreviewOfPathWithHeightAndWidthShouldHaveBeenChanged($user, $path, $width, $height):void {
+		$this->downloadPreviewOfFiles($user, $path, $width, $height);
+		$this->theHTTPStatusCodeShouldBe(200);
+		$newResponseBodyContents = $this->response->getBody()->getContents();
+		Assert::assertNotEquals(
+			$newResponseBodyContents,
+			$this->responseBodyContents,
+			__METHOD__ . " previous and current previews content is same but expected to be different",
+		);
+	}
+
 	/**
 	 * @param string $user
 	 * @param string $path


### PR DESCRIPTION
## Description
- added API acceptance tests for preview update feature after a change in file content

## Related Issue
- Part of https://github.com/owncloud/core/issues/39211

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
