### PR TITLE
Fix issues when setting 0 as user display name

### DIFF
--- a/changelog/unreleased/39272
+++ b/changelog/unreleased/39272
@@ -1,0 +1,7 @@
+Bugfix: Setting 0 as user display name
+
+Setting the display name of a user to 0 was allowed before,
+but the UI showed the UID instead. This has been fixed.
+
+https://github.com/owncloud/core/pull/39272
+https://github.com/owncloud/core/issues/30657

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -168,7 +168,11 @@ class Database extends Backend implements IUserBackend, IProvidesHomeBackend, IP
 	 */
 	public function getDisplayName($uid) {
 		$this->loadUser($uid);
-		return empty($this->cache[$uid]['displayname']) ? $uid : $this->cache[$uid]['displayname'];
+		if (\strlen($this->cache[$uid]['displayname']) === 0) {
+			return $uid;
+		}
+
+		return $this->cache[$uid]['displayname'];
 	}
 
 	/**

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -166,7 +166,7 @@ class User implements IUser {
 	 */
 	public function getDisplayName() {
 		$displayName = $this->account->getDisplayName();
-		if (empty($displayName)) {
+		if (\strlen($displayName) === 0) {
 			$displayName = $this->getUID();
 		}
 		return $displayName;


### PR DESCRIPTION
## Description
Setting the display name of a user to 0 was allowed before, but the UI showed the UID instead. This has been fixed.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/30657

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
