### PR TITLE
Added wait before click on share quick action button and removed skip…

### DIFF
--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -203,6 +203,7 @@ class FileRow extends OwncloudPage {
 	 * @throws ElementNotFoundException
 	 */
 	public function openSharingDialog(Session $session) {
+		$this->waitForAjaxCallsToStartAndFinish($session);
 		$this->findSharingButton()->click();
 		$this->waitTillElementIsNull($this->loadingIndicatorXpath);
 		/**

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -21,7 +21,7 @@ Feature: restrict Sharing
     And user "Brian" has created folder "simple-folder"
     And user "Brian" has logged in using the webUI
 
-  @smokeTest @skip @issue-38908
+  @smokeTest
   Scenario: Restrict users to only share with users in their groups
     Given the setting "Restrict users to only share with users in their groups" in the section "Sharing" has been enabled
     When the user browses to the files page
@@ -30,7 +30,7 @@ Feature: restrict Sharing
     And the user re-logs in as "Alice" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
-  @smokeTest @skip @issue-38908
+  @smokeTest
   Scenario: Restrict users to only share with groups they are member of
     Given the setting "Restrict users to only share with groups they are member of" in the section "Sharing" has been enabled
     When the user browses to the files page
@@ -49,7 +49,7 @@ Feature: restrict Sharing
     And the user re-logs in as "David" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
-  @smokeTest @skip @issue-38908
+  @smokeTest
   Scenario: Forbid sharing with groups
     Given the setting "Allow sharing with groups" in the section "Sharing" has been disabled
     When the user browses to the files page


### PR DESCRIPTION
## Description
- removed issue and skip tags from restrict sharing feature
- added wait before clicking share quick action button

## Related Issue
- Fixes #38908 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- https://github.com/owncloud/core/pull/39269

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

