### PR TITLE
[tests-only] added scenarios for public quick links uniqueness for a resource

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -3379,6 +3379,62 @@ trait Sharing {
 	}
 
 	/**
+	 * @param string $user
+	 * @param string $path
+	 * @param string $type
+	 * @param int $permissions
+	 *
+	 * @return array
+	 */
+	public function preparePublicQuickLinkPayload(string $user, string $path, string $type, int $permissions = 1): array {
+		return [
+			"permissions" => $permissions,
+			"expireDate" => "",
+			"shareType" => 3,
+			"itemType" => $type,
+			"itemSource" => $this->getFileIdForPath($user, $path),
+			"name" => "Public quick link",
+			"attributes" =>  [
+				[
+					"scope" => "files_sharing",
+					"key" => "isQuickLink",
+					"value" => true
+				]
+			],
+			"path" => $path
+		];
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has created a read only public link for (file|folder) "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $type
+	 * @param string $path
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theUserHasCreatedAReadOnlyPublicLinkForFileFolder(string $user, string $type, string $path):void {
+		$user = $this->getActualUsername($user);
+		$userPassword = $this->getPasswordForUser($user);
+
+		$requestPayload = $this->preparePublicQuickLinkPayload($user, $path, $type);
+		$url = $this->getBaseUrl() . "/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json";
+
+		$response = HttpRequestHelper::post(
+			$url,
+			$this->getStepLineRef(),
+			$user,
+			$userPassword,
+			null,
+			$requestPayload
+		);
+		$this->setResponse($response);
+		$this->theHTTPStatusCodeShouldBe(200);
+	}
+
+	/**
 	 * @When /^user "([^"]*)" adds the public share created from server "([^"]*)" using the sharing API$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -769,6 +769,23 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Given the user has created a read only public link for file/folder :name
+	 *
+	 * @param string $name
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theUserHasCreatedAReadOnlyPublicLinkForFolder(string $name):void {
+		$this->createReadOnlyPublicShareLinkUsingQuickAction($name);
+		$this->theUserOpensTheShareDialogForFileFolder($name);
+		$linkTab = $this->sharingDialog->openPublicShareTab($this->getSession());
+		$linkName = $linkTab->getNameOfFirstPublicLink($this->getSession());
+		$linkUrl = $linkTab->getLinkUrl($linkName);
+		$this->featureContext->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+	}
+
+	/**
 	 * @When the user creates a new public link for file/folder :name using the webUI with
 	 * @Given the user has created a new public link for file/folder :name using the webUI with
 	 *

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -753,6 +753,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 
 	/**
 	 * @When the user creates a read only public link for file/folder :name using the quick action button
+	 * @Given the user has created a read only public link for file/folder :name using the webUI
 	 *
 	 * @param string $name
 	 *
@@ -760,23 +761,6 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @throws Exception
 	 */
 	public function theUserCreatesAReadOnlyPublicLinkForFolderUsingTheQuickActionButton(string $name):void {
-		$this->createReadOnlyPublicShareLinkUsingQuickAction($name);
-		$this->theUserOpensTheShareDialogForFileFolder($name);
-		$linkTab = $this->sharingDialog->openPublicShareTab($this->getSession());
-		$linkName = $linkTab->getNameOfFirstPublicLink($this->getSession());
-		$linkUrl = $linkTab->getLinkUrl($linkName);
-		$this->featureContext->addToListOfCreatedPublicLinks($linkName, $linkUrl);
-	}
-
-	/**
-	 * @Given the user has created a read only public link for file/folder :name
-	 *
-	 * @param string $name
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theUserHasCreatedAReadOnlyPublicLinkForFolder(string $name):void {
 		$this->createReadOnlyPublicShareLinkUsingQuickAction($name);
 		$this->theUserOpensTheShareDialogForFileFolder($name);
 		$linkTab = $this->sharingDialog->openPublicShareTab($this->getSession());

--- a/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
+++ b/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
@@ -326,7 +326,6 @@ Feature: Share by public link
     When the user browses to the files page
     Then the public link quick action button should not be displayed for folder "simple-folder" on the webUI
 
-
   @skipOnOcV10.8.0
   Scenario: no new public quick link is created for a resource with already a public quick link
     Given the administrator has "enabled" public link quick action
@@ -334,19 +333,16 @@ Feature: Share by public link
     And user "Alice" has uploaded file with content "test" to "/simple-folder/lorem.txt"
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
-    And the user has created a read only public link for folder "simple-folder"
+    And the user has created a read only public link for folder "simple-folder" using the webUI
     When the user creates a read only public link for folder "simple-folder" using the quick action button
-    And the number of public links should be 1
+    Then the number of public links should be 1
 
   @skipOnOcV10.8.0
   Scenario: no new public quick link is created for a resource with already a public quick link (after a login)
     Given the administrator has "enabled" public link quick action
     And user "Alice" has created folder "/simple-folder"
-    And user "Alice" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "Alice" has created a read only public link for folder "simple-folder"
     And user "Alice" has logged in using the webUI
-    And the user has browsed to the files page
-    And the user has created a read only public link for folder "simple-folder"
-    When the user re-logs in as "Alice" using the webUI
     And the user browses to the files page
     When the user creates a read only public link for folder "simple-folder" using the quick action button
-    And the number of public links should be 1
+    Then the number of public links should be 1

--- a/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
+++ b/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
@@ -325,3 +325,28 @@ Feature: Share by public link
     And user "Alice" has logged in using the webUI
     When the user browses to the files page
     Then the public link quick action button should not be displayed for folder "simple-folder" on the webUI
+
+
+  @skipOnOcV10.8.0
+  Scenario: no new public quick link is created for a resource with already a public quick link
+    Given the administrator has "enabled" public link quick action
+    And user "Alice" has created folder "/simple-folder"
+    And user "Alice" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+    And the user has created a read only public link for folder "simple-folder"
+    When the user creates a read only public link for folder "simple-folder" using the quick action button
+    And the number of public links should be 1
+
+  @skipOnOcV10.8.0
+  Scenario: no new public quick link is created for a resource with already a public quick link (after a login)
+    Given the administrator has "enabled" public link quick action
+    And user "Alice" has created folder "/simple-folder"
+    And user "Alice" has uploaded file with content "test" to "/simple-folder/lorem.txt"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the files page
+    And the user has created a read only public link for folder "simple-folder"
+    When the user re-logs in as "Alice" using the webUI
+    And the user browses to the files page
+    When the user creates a read only public link for folder "simple-folder" using the quick action button
+    And the number of public links should be 1


### PR DESCRIPTION
## Description
- added acceptance tests scenarios for public quick links uniqueness for a resource

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39132


## How this has been tested?
- 🤖 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
