### PR TITLE
[tests-only] Skip editUsers test that was changed in PR 39262 on old oC10

### DIFF
--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -112,6 +112,7 @@ Feature: edit users
       | new-group | NEW-GROUP | New-Group |
       | NEW-GROUP | New-Group | new-group |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: removing multiple users from a group
     Given these users have been created without skeleton files:
       | username |


### PR DESCRIPTION
## Description
This test scenario was changed in PR #39262 
It is not expected to pass on "old" oC10 release. Skip it in that case.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
