### PR TITLE
Allow upload of empty folders via drag & drop in WebUI

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -214,11 +214,10 @@ OC.FileUpload.prototype = {
 		var file = this.getFile();
 
 		/**
-		 * isDirectory indicates an empty directory, so we just check if it
-		 * already exists and create one if not.
-		 * Afterward, we exit the function, since no data needs to be uploaded.
+		 * If the variable file is a directory, we just create it and return.
+		 * Files being handled separately
 		 */
-		if(file.isDirectory){
+		if (file.isDirectory){
 			return this.uploader.ensureFolderExists(OC.joinPaths(this._targetFolder, file.fullPath));
 		}
 

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -213,6 +213,15 @@ OC.FileUpload.prototype = {
 		var data = this.data;
 		var file = this.getFile();
 
+		/**
+		 * isDirectory indicates an empty directory, so we just check if it
+		 * already exists and create one if not.
+		 * Afterward, we exit the function, since no data needs to be uploaded.
+		 */
+		if(file.isDirectory){
+			return this.uploader.ensureFolderExists(OC.joinPaths(this._targetFolder, file.fullPath));
+		}
+
 		// it was a folder upload, so make sure the parent directory exists already
 		var folderPromise;
 		if (file.relativePath) {

--- a/apps/files/js/jquery.fileupload.js
+++ b/apps/files/js/jquery.fileupload.js
@@ -1079,7 +1079,14 @@
             } else {
                 paramNameSet = paramName;
             }
-            data.originalFiles = files;
+
+            data.originalFiles = [];
+            $.each(files, function (file){
+                if(!file.isDirectory){
+                    data.originalFiles.push(file);
+                }
+            });
+
             $.each(fileSet || files, function (index, element) {
                 var newData = $.extend({}, data);
                 newData.files = fileSet ? element : [element];
@@ -1150,7 +1157,12 @@
                         entries,
                         path + entry.name + '/'
                     ).done(function (files) {
-                        dfd.resolve(files);
+                        // Create a record for an empty folder
+                        if(!files.length && entry.isDirectory){
+                            dfd.resolve(entry);
+                        }else{
+                            dfd.resolve(files);
+                        }
                     }).fail(errorHandler);
                 },
                 readEntries = function () {

--- a/changelog/unreleased/39285
+++ b/changelog/unreleased/39285
@@ -1,0 +1,12 @@
+Enhancement: Allow empty folder uploads via webUI
+
+Before this change, drag and drop of an empty folder did not work, there was no
+response in the webUI.
+While uploading a folder with a text file and an empty folder,
+the folder with the text file was created but the empty folder wasn't.
+
+These empty folder upload scenarios work now.
+
+https://github.com/owncloud/core/pull/39285
+https://github.com/owncloud/core/issues/32235
+https://github.com/owncloud/enterprise/issues/3117


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Enhancement: Allow empty folder uploads via webUI

Before this PR, drag and drop an empty folder did not work, there was no
response in the webUI anyways.
While uploading a folder with a text file and an empty folder,
the folder with the text file was created but the empty folder wasn't.

With this PR the upper scenarios work now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32235
- Fixes https://github.com/owncloud/enterprise/issues/3117

## Motivation and Context
- I have my music collection on my computer with dirs from interprets a-z
- I want to upload my music collection to ownCloud
- Some folders have not been uploaded as they are empty
- Bad :( 

## How Has This Been Tested?
Tested on browsers 
- [x] IE 11 -> Dropping folders does not work, even with content or not -> this issue was prexisting  **Does not work**
- [x] Chrome/Chromium -> **Works**
- [x] Edge -> **Works**
- [x] Firefox -> **Works**
- [x] Safari -> **Works**

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
