### PR TITLE
MariaDb changes for MariaDb 10.6

### DIFF
--- a/changelog/unreleased/39286
+++ b/changelog/unreleased/39286
@@ -1,0 +1,10 @@
+Enhancement: Add support for MariaDB 10.6
+
+With this change support for MariaDB 10.6 has been added.
+If it is a fresh ownCloud installation, MariaDB 10.6 can be used right away.
+For upgrading from an older version the command 'occ db:restore-default-row-format'
+has been introduced to remove the deprecated row_format 'compressed' from the
+ownCloud database tables and set it to the default value.
+
+https://github.com/owncloud/core/pull/39286
+https://github.com/owncloud/core/issues/39283

--- a/core/Command/Db/RestoreDefaultRowFormat.php
+++ b/core/Command/Db/RestoreDefaultRowFormat.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @author Jan Ackermann <jackermann@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\Db;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RestoreDefaultRowFormat extends Command {
+	/** @var IConfig */
+	private $config;
+
+	/** @var IDBConnection */
+	private $connection;
+
+	/**
+	 * @param IConfig $config
+	 * @param IDBConnection $connection
+	 */
+	public function __construct(IConfig $config, IDBConnection $connection) {
+		$this->config = $config;
+		$this->connection = $connection;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('db:restore-default-row-format')
+			->setDescription('Restore default row format of MySQL/MariaDB tables.');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		if (!$this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
+			$output->writeln("<error>This command is only valid for MySQL/MariaDB databases.</error>");
+			return 1;
+		}
+
+		$dbPrefix = $this->config->getSystemValue("dbtableprefix");
+		$dbName = $this->config->getSystemValue("dbname");
+
+		$defaultRowFormatStatement = $this->connection->executeQuery("SELECT @@GLOBAL.innodb_default_row_format as 'default'");
+		$defaultFormat = $defaultRowFormatStatement->fetchColumn();
+
+		/**
+		 * Fetch tables with the row_format not matching default.
+		 */
+		$tableSelectStatement = $this->connection->executeQuery(
+			"SELECT DISTINCT(TABLE_NAME) AS `name`, LOWER(ROW_FORMAT) as `format`" .
+			"	FROM INFORMATION_SCHEMA . TABLES" .
+			"	WHERE TABLE_SCHEMA = ?" .
+			"	AND TABLE_NAME LIKE ?" .
+			"	AND ROW_FORMAT != ?",
+			[$dbName, $dbPrefix.'%', $defaultFormat]
+		);
+		$tables = $tableSelectStatement->fetchAll();
+		$tablesCount = \count($tables);
+
+		$output->writeln("<info>Found $tablesCount tables to convert</info>");
+
+		// Update row_format to DEFAULT
+		foreach ($tables as $table) {
+			$tableName = $table["name"];
+			$tableRowFormat = $table["format"];
+			$output->writeln("<info>Converting table '$tableName' with row format '$tableRowFormat' to default value '$defaultFormat'</info>");
+
+			$alterTableQuery = $this->connection->prepare('ALTER TABLE `' . $tableName . '` ROW_FORMAT=DEFAULT;');
+			$alterTableQuery->execute();
+		}
+
+		$output->writeln("<info>Conversion done</info>");
+		return 0;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -98,6 +98,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 		)
 	);
 	$application->add(new OC\Core\Command\Db\ConvertMysqlToMB4(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection(), \OC::$server->getURLGenerator()));
+	$application->add(new OC\Core\Command\Db\RestoreDefaultRowFormat(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\StatusCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\MigrateCommand(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\Db\Migrations\GenerateCommand(\OC::$server->getDatabaseConnection()));

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -218,7 +218,6 @@ class ConnectionFactory {
 			$connectionParams['defaultTableOptions'] = [
 				'collate' => 'utf8mb4_bin',
 				'charset' => 'utf8mb4',
-				'row_format' => 'compressed',
 				'tablePrefix' => $connectionParams['tablePrefix']
 			];
 		}

--- a/lib/private/Repair/Collation.php
+++ b/lib/private/Repair/Collation.php
@@ -66,11 +66,6 @@ class Collation implements IRepairStep {
 		$tables = $this->getAllNonUTF8BinTables($this->connection);
 		foreach ($tables as $table) {
 			$output->info("Change collation for $table ...");
-			if ($characterSet === 'utf8mb4') {
-				// need to set row compression first
-				$query = $this->connection->prepare('ALTER TABLE `' . $table . '` ROW_FORMAT=COMPRESSED;');
-				$query->execute();
-			}
 			$query = $this->connection->prepare('ALTER TABLE `' . $table . '` CONVERT TO CHARACTER SET ' . $characterSet . ' COLLATE ' . $characterSet . '_bin;');
 			$query->execute();
 		}

--- a/tests/Core/Command/Db/RestoreDefaultRowFormatTest.php
+++ b/tests/Core/Command/Db/RestoreDefaultRowFormatTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @author Jan Ackermann <jackermann@owncloud.com>
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\Db;
+
+use Doctrine\DBAL\Driver\Statement;
+use OC\Core\Command\Db\RestoreDefaultRowFormat;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OC\DB\ConnectionFactory;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class RestoreDefaultRowFormatTest
+ */
+class RestoreDefaultRowFormatTest extends TestCase {
+	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
+	private $config;
+	/** @var ConnectionFactory | \PHPUnit\Framework\MockObject\MockObject */
+	private $connectionFactory;
+	/** @var CommandTester */
+	private $commandTester;
+	/** @var \Doctrine\DBAL\Connection | \PHPUnit\Framework\MockObject\MockObject */
+	private $connection;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->connection = $this->getMockBuilder(IDBConnection::class)->getMock();
+		$this->config = $this->getMockBuilder(IConfig::class)
+			->getMock();
+		$this->connectionFactory = $this->getMockBuilder(ConnectionFactory::class)
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testWrongPlatform() {
+		$platform = $this->getMockBuilder(SqlitePlatform::class)->getMock();
+		$this->connection->expects($this->once())->method('getDatabasePlatform')->willReturn($platform);
+
+		$command = new RestoreDefaultRowFormat(
+			$this->config,
+			$this->connection,
+		);
+		$this->commandTester = new CommandTester($command);
+		$this->commandTester->execute([]);
+
+		$output = $this->commandTester->getDisplay();
+		$this->assertStringContainsString('This command is only valid for MySQL/MariaDB databases', $output);
+	}
+
+	public function testConversion() {
+		$platform = $this->getMockBuilder(MySqlPlatform::class)->getMock();
+		$this->connection->expects($this->once())->method('getDatabasePlatform')->willReturn($platform);
+		$this->config->expects($this->exactly(2))->method('getSystemValue')
+			->will($this->returnValueMap([
+				['dbtableprefix', 'oc_'],
+				['dbname', 'oc']
+			]));
+		$statement = $this->getMockBuilder(Statement::class)->getMock();
+		$statement->expects($this->once())->method('fetchColumn')->willReturn('dynamic');
+		$statement->expects($this->once())->method('fetchAll')->willReturn(
+			[
+				['name' => 'oc_users', 'format' => 'compressed'], ['name' => 'oc_accounts', 'format' => 'compressed']
+			]
+		);
+		$this->connection->expects($this->exactly(2))->method('executeQuery')->willReturn($statement);
+		$this->connection->expects($this->exactly(2))->method('prepare')->willReturn($statement);
+
+		$command = new RestoreDefaultRowFormat(
+			$this->config,
+			$this->connection,
+		);
+		$this->commandTester = new CommandTester($command);
+		$this->commandTester->execute([]);
+
+		$output = $this->commandTester->getDisplay();
+		$this->assertStringContainsString('Found 2 tables to convert', $output);
+		$this->assertStringContainsString("Converting table 'oc_users' with row format 'compressed' to default value 'dynamic'", $output);
+		$this->assertStringContainsString("Converting table 'oc_accounts' with row format 'compressed' to default value 'dynamic'", $output);
+		$this->assertStringContainsString('Conversion done', $output);
+	}
+}


### PR DESCRIPTION
## Description
These are the code changes cherry-picked from PR #39282 

They are code changes that make CI pass against MariaDb 10.6

This PR will confirm if these code changes are OK for the oldest supported MariaDb version 10.2.

## Related Issue
- part of #39283 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4115
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
