### PR TITLE
Use original UID when setting the share receiver

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -436,12 +436,17 @@ class Share20OcsController extends OCSController {
 			if ($globalAutoAccept) {
 				$userAutoAccept = $this->config->getUserValue($shareWith, 'files_sharing', 'auto_accept_share', 'yes') === 'yes';
 			}
-			// Valid user is required to share
-			if (!\is_string($shareWith) || !$this->userManager->userExists($shareWith)) {
+
+			// Valid user is required to share. Fetch the user to retrieve
+			// the username later for setSharedWith().
+			$user = $this->userManager->get($shareWith);
+			if (!$user) {
 				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);
 				return new Result(null, 404, $this->l->t('Please specify a valid user'));
 			}
-			$share->setSharedWith($shareWith);
+
+			// Fetch the UID to match exactly with the user (case sensitive).
+			$share->setSharedWith($user->getUID());
 			$share->setPermissions($permissions);
 			if ($userAutoAccept) {
 				$share->setState(Share::STATE_ACCEPTED);

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -103,6 +103,8 @@ class Share20OcsControllerTest extends TestCase {
 	private $sharingAllowlist;
 	/** @var IConfig */
 	private $config;
+	/** @var IUser */
+	private $sharee;
 
 	protected function setUp(): void {
 		$this->shareManager = $this->getMockBuilder(IManager::class)
@@ -126,7 +128,8 @@ class Share20OcsControllerTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->userSession->method('getUser')->willReturn($this->currentUser);
 
-		$this->userManager->method('userExists')->willReturn(true);
+		$this->sharee = $this->createMock(IUser::class);
+		$this->sharee->method('getUID')->willReturn('validUser');
 
 		$this->l = $this->createMock('\OCP\IL10N');
 		$this->l->method('t')
@@ -773,6 +776,8 @@ class Share20OcsControllerTest extends TestCase {
 			->method('lock')
 			->with(ILockingProvider::LOCK_SHARED);
 
+		$this->userManager->method('get')->willReturn(null);
+
 		$expected = new Result(null, 404, 'Please specify a valid user');
 
 		$result = $this->ocs->createShare();
@@ -869,7 +874,7 @@ class Share20OcsControllerTest extends TestCase {
 				->with('valid-path')
 				->willReturn($path);
 
-		$this->userManager->method('userExists')->with('validUser')->willReturn(true);
+		$this->userManager->method('get')->willReturn($this->sharee);
 
 		$path->expects($this->once())
 			->method('lock')
@@ -1637,7 +1642,7 @@ class Share20OcsControllerTest extends TestCase {
 			->with('valid-path')
 			->willReturn($path);
 
-		$this->userManager->method('userExists')->with('validUser')->willReturn(true);
+		$this->userManager->method('get')->willReturn($this->sharee);
 
 		$this->shareManager
 			->expects($this->once())
@@ -3719,7 +3724,7 @@ class Share20OcsControllerTest extends TestCase {
 			->with('valid-path')
 			->willReturn($path);
 
-		$this->userManager->method('userExists')->with('validUser')->willReturn(true);
+		$this->userManager->method('get')->willReturn($this->sharee);
 
 		$path->expects($this->once())
 			->method('lock')
@@ -3829,7 +3834,7 @@ class Share20OcsControllerTest extends TestCase {
 			->with('valid-path')
 			->willReturn($path);
 
-		$this->userManager->method('userExists')->with('validUser')->willReturn(true);
+		$this->userManager->method('get')->willReturn($this->sharee);
 
 		$path->expects($this->once())
 			->method('lock')

--- a/changelog/unreleased/39293
+++ b/changelog/unreleased/39293
@@ -1,0 +1,8 @@
+Bugfix: Use original UID when setting the share receiver
+
+This fixes an issue where a share reciever was not set properly
+when passing the username with an incorrect casing. As usernames
+are case insensitive in general, this is more consistent now.
+
+https://github.com/owncloud/core/pull/39293
+https://github.com/owncloud/core/issues/26273

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
@@ -325,7 +325,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-35484
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: share with user when username contains capital letters
     Given these users have been created without skeleton files:
       | username |
@@ -335,16 +335,14 @@ Feature: sharing
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "BRIAN" should include
-      | share_with  | %username%        |
+      | share_with  | brian             |
       | file_target | /randomfile.txt   |
       | path        | /randomfile.txt   |
       | permissions | share,read,update |
       | uid_owner   | %username%        |
-    #And user "brian" should see the following elements
-    #  | /randomfile.txt |
-    #And the content of file "randomfile.txt" for user "brian" should be "Random data"
-    And user "brian" should not see the following elements if the upper and lower case username are different
-      | /randomfile.txt |
+    And user "brian" should see the following elements
+     | /randomfile.txt |
+    And the content of file "randomfile.txt" for user "brian" should be "Random data"
 
   @skipOnLDAP
   Scenario: creating a new share with user of a group when username contains capital letters

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -368,8 +368,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-35484
-  @issue-ocis-reva-11
+  @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: share with user when username contains capital letters
     Given these users have been created without skeleton files:
       | username |
@@ -379,20 +378,15 @@ Feature: sharing
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" sharing with user "BRIAN" should include
-      | share_with  | %username%             |
+      | share_with  | brian                  |
       | file_target | /Shares/randomfile.txt |
       | path        | /randomfile.txt        |
       | permissions | share,read,update      |
       | uid_owner   | %username%             |
-    # Because of issue-35484 the share is not seen to be pending, so it cannot
-    # even be accepted, and so the file does not exist for Brian
-    #
-    #When user "brian" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
-    #Then user "brian" should see the following elements
-    #  | /Shares/randomfile.txt |
-    #And the content of file "randomfile.txt" for user "brian" should be "Random data"
-    And user "brian" should not see the following elements
-      | /Shares/randomfile.txt |
+    When user "brian" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
+    Then user "brian" should see the following elements
+     | /Shares/randomfile.txt |
+    And the content of file "Shares/randomfile.txt" for user "brian" should be "Random data"
 
   @skipOnLDAP
   Scenario: creating a new share with user of a group when username contains capital letters


### PR DESCRIPTION
## Description
This fixes an issue where a share receiver was not set properly when passing the username with an incorrect casing. As usernames are case insensitive in general, this is more consistent now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/26273
- Fixes https://github.com/owncloud/core/issues/35484

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
