### PR TITLE
Upgrading symfony/translation (v4.4.30 => v4.4.32)

### DIFF
--- a/changelog/unreleased/PHPdependencies20210727onwardSymfony
+++ b/changelog/unreleased/PHPdependencies20210727onwardSymfony
@@ -5,7 +5,7 @@ The following Symfony components have been updated to:
 - event-dispatcher 4.4.30
 - process 4.4.30
 - routing 4.4.30
-- translation 4.4.30
+- translation 4.4.32
 
 The following Symfony polyfill components have been updated to:
 - symfony/polyfill-mbstring v1.23.1
@@ -17,3 +17,6 @@ https://symfony.com/blog/symfony-4-4-29-released
 https://github.com/owncloud/core/pull/39079
 https://symfony.com/blog/symfony-4-4-30-released
 https://github.com/owncloud/core/pull/39153
+https://symfony.com/blog/symfony-4-4-31-released
+https://symfony.com/blog/symfony-4-4-32-released
+https://github.com/owncloud/core/pull/39298

--- a/composer.lock
+++ b/composer.lock
@@ -4236,7 +4236,7 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v4.4.30",
+            "version": "v4.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
@@ -4305,7 +4305,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v4.4.30"
+                "source": "https://github.com/symfony/translation/tree/v4.4.32"
             },
             "funding": [
                 {


### PR DESCRIPTION
## Description
```
$ composer update
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading symfony/translation (v4.4.30 => v4.4.32)
Writing lock file
```

https://symfony.com/blog/symfony-4-4-31-released
https://symfony.com/blog/symfony-4-4-32-released

Note: Symfony had a problem with the 4.4.31 release and quickly released 4.4.32 an hour later. It will be good to do this version bump and get past 4.4.31

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
