### PR TITLE
Fix versions for files named '0'

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -416,7 +416,7 @@ class Storage {
 	 */
 	public static function getVersions($uid, $filename) {
 		$versions = [];
-		if (empty($filename)) {
+		if ($filename === null || $filename === '') {
 			return $versions;
 		}
 		// fetch for old versions

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -564,37 +564,52 @@ class VersioningTest extends TestCase {
 		$this->assertTrue($this->rootView->file_exists($v2Copied));
 	}
 
+	public function getVersionsProvider() {
+		return [
+			['/test.txt'],
+			['/subfolder/test.txt'],
+			['/subfolder/0'],
+			['/0'],
+		];
+	}
+
 	/**
 	 * test if we find all versions and if the versions array contain
 	 * the correct 'path' and 'name'
+	 *
+	 * @dataProvider getVersionsProvider
+	 * @param string $filepath
 	 */
-	public function testGetVersions() {
+	public function testGetVersions($filepath) {
 		$t1 = \time();
 		// second version is two weeks older, this way we make sure that no
 		// version will be expired
 		$t2 = $t1 - 60 * 60 * 24 * 14;
 
-		// create some versions
-		$v1 = $this->versionsRootOfUser1 . '/subfolder/test.txt.v' . $t1;
-		$v2 = $this->versionsRootOfUser1 . '/subfolder/test.txt.v' . $t2;
+		$fileName = \basename($filepath);
+		$parent = \dirname($filepath);
 
-		$this->rootView->mkdir($this->versionsRootOfUser1 . '/subfolder/');
+		// create some versions
+		$v1 = $this->versionsRootOfUser1 . $filepath . '.v' . $t1;
+		$v2 = $this->versionsRootOfUser1 . $filepath . '.v' . $t2;
+
+		$this->rootView->mkdir($this->versionsRootOfUser1 . $parent);
 
 		$this->rootView->file_put_contents($v1, 'version1');
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		// execute copy hook of versions app
-		$versions = \OCA\Files_Versions\Storage::getVersions($this->user1, '/subfolder/test.txt');
+		$versions = \OCA\Files_Versions\Storage::getVersions($this->user1, $filepath);
 
 		$this->assertCount(2, $versions);
 
 		foreach ($versions as $version) {
-			$this->assertSame('/subfolder/test.txt', $version['path']);
-			$this->assertSame('test.txt', $version['name']);
+			$this->assertSame($filepath, $version['path']);
+			$this->assertSame($fileName, $version['name']);
 		}
 
 		//cleanup
-		$this->rootView->deleteAll($this->versionsRootOfUser1 . '/subfolder');
+		$this->rootView->deleteAll($this->versionsRootOfUser1 . $parent);
 	}
 
 	/**

--- a/changelog/unreleased/39300
+++ b/changelog/unreleased/39300
@@ -1,0 +1,7 @@
+Bugfix: Versions for files named "0"
+
+This fixes an issue where files named "0" were missing their
+versions in the WebUI.
+
+https://github.com/owncloud/core/pull/39300
+https://github.com/owncloud/core/issues/36000


### PR DESCRIPTION
## Description
This fixes an issue where files named "0" were missing their versions in the WebUI.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/36000

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
