### PR TITLE
Hide the 'Remove Password' button on public links

### DIFF
--- a/changelog/unreleased/39302
+++ b/changelog/unreleased/39302
@@ -1,0 +1,7 @@
+Enhancement: Hide the "Remove Password" button on public links
+
+This change hides the "Remove Password" button when editing a
+public link if a password in mandatory.
+
+https://github.com/owncloud/core/pull/39302
+https://github.com/owncloud/core/issues/35684

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -366,7 +366,7 @@
 				})
 			}
 
-			if (this.model.get('encryptedPassword')) {
+			if (this.model.get('encryptedPassword') && !this.linkPasswordRequired()) {
 				buttons.push({
 					classes: 'removePassword',
 					text: t('core', 'Remove password'),
@@ -391,6 +391,24 @@
 				self.$dialog.html(self.$el);
 				self.$el.find('input:first').focus();
 			});
+		},
+
+		linkPasswordRequired: function() {
+			if (this.model.get('permissions') === OC.PERMISSION_CREATE) {
+				return oc_appconfig.core.enforceLinkPasswordWriteOnly;
+			}
+
+			if (this.model.get('permissions') === OC.PERMISSION_READ) {
+				return oc_appconfig.core.enforceLinkPasswordReadOnly;
+			}
+
+			if (this.model.get('permissions') === (OC.PERMISSION_READ | OC.PERMISSION_CREATE)) {
+				return oc_appconfig.core.enforceLinkPasswordReadWrite;
+			}
+
+			if (this.model.get('permissions') >= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE)) {
+				return oc_appconfig.core.enforceLinkPasswordReadWriteDelete;
+			}
 		}
 
 });


### PR DESCRIPTION
## Description
This change hides the "Remove Password" button when editing a public link if a password in mandatory.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/35684

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
