### PR TITLE
[tests-only] [full-ci] skip accept-share and other test scenarios on old oC10

### DIFF
--- a/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature
+++ b/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: favorite
 
   Background:
@@ -62,7 +62,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiFederationToShares1/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares1/federated.feature
@@ -66,6 +66,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+
   Scenario Outline: Federated sharee can see the pending share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -89,6 +90,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: Federated sharee requests information of only one share
     Given using server "REMOTE"
@@ -142,6 +144,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+
   Scenario Outline: sending a GET request to a pending federated share is not valid
     Given using OCS API version "<ocs-api-version>"
     When user "Brian" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/pending/12"
@@ -152,6 +155,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+
   Scenario Outline: sending a GET request to a nonexistent federated share
     Given using OCS API version "<ocs-api-version>"
     When user "Brian" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/9999999999"
@@ -161,6 +165,7 @@ Feature: federated
       | ocs-api-version | ocs-status | http-status |
       | 1               | 404        | 200         |
       | 2               | 404        | 404         |
+
 
   Scenario Outline: accept a pending federated share
     Given using server "REMOTE"
@@ -174,6 +179,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: Reshare a federated shared file
     Given using server "REMOTE"
@@ -210,6 +216,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+
   Scenario Outline: Overwrite a federated shared file as recipient - local server shares - remote server receives
     Given user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Brian" from server "LOCAL" has shared "/textfile0.txt" with user "Alice" from server "REMOTE"
@@ -223,6 +230,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: Overwrite a federated shared file as recipient - remote server shares - local server receives
     Given using server "REMOTE"
@@ -239,6 +247,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
     Given user "Brian" has created folder "PARENT"
     And user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
@@ -252,6 +261,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
     Given using server "REMOTE"
@@ -267,6 +277,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: Overwrite a federated shared file as recipient using old chunking
     Given using server "REMOTE"
@@ -288,6 +299,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+
   Scenario Outline: Overwrite a file in a federated shared folder as recipient using old chunking
     Given using server "REMOTE"
     And user "Alice" has created folder "PARENT"
@@ -307,6 +319,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: Federated sharee deletes an accepted federated share
     Given using server "REMOTE"
@@ -362,6 +375,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: Federated sharee deletes a pending federated share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -412,6 +426,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
     Given using server "LOCAL"
     And using OCS API version "<ocs-api-version>"
@@ -456,6 +471,7 @@ Feature: federated
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/Shares/PARENT/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
 
+
   Scenario Outline: share of a folder to a federated user who already has a folder with the same name
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
@@ -484,6 +500,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: share of a file to the federated user who already has a file with the same name
     Given using server "REMOTE"
@@ -515,7 +532,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @issue-35154
+  @issue-35154 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: receive a local share that has the same name as a previously received federated share
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
@@ -540,6 +557,7 @@ Feature: federated
     And the content of file "/Shares/randomfile.txt" for user "Carol" on server "LOCAL" should be "remote content"
     And the content of file "/Shares/randomfile (2).txt" for user "Carol" on server "LOCAL" should be "local content"
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: receive a federated share that has the same name as a previously received local share
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"

--- a/tests/acceptance/features/apiFederationToShares2/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares2/federated.feature
@@ -627,7 +627,7 @@ Feature: federated
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: User modifies expiration date for federated reshare of a file with another server with default expiration date
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -650,7 +650,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: User modifies expiration date more than the default for federated reshare of a file
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
+++ b/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS
+@api @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: checksums
 
   Background:

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -115,7 +115,7 @@ Feature: checksums
     Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
 
   @files_sharing-app-required
-  @issue-ocis-reva-196
+  @issue-ocis-reva-196 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: Sharing a file with checksum should return the checksum in the propfind using new DAV path
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -220,7 +220,7 @@ Feature: quota
     Then the HTTP status code should be "201"
     And as "Alice" folder "testQuota" should exist
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: user cannot create file on shared folder by a user with zero quota
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -235,7 +235,7 @@ Feature: quota
     And the DAV exception should be "Sabre\DAV\Exception\InsufficientStorage"
     And as "Brian" file "/shareFolder/newTextFile.txt" should not exist
 
-  @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: share receiver with 0 quota should not be able to move file from shared folder to home folder
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -249,7 +249,7 @@ Feature: quota
     Then the HTTP status code should be "507"
     And the DAV exception should be "Sabre\DAV\Exception\InsufficientStorage"
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: sharer should be able to upload to a folder shared with user having zero quota
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -265,7 +265,7 @@ Feature: quota
     And the content of file "/testquota.txt" for user "Alice" should be "test"
     And as "Brian" file "/Shares/testquota" should not exist
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: share receiver with 0 quota should be able to upload on shared folder
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328 @issue-ocis-1250
+@api @files_sharing-app-required @issue-ocis-1328 @issue-ocis-1250 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: Sharing resources with different case names with the sharee and checking the coexistence of resources on sharee/receivers side
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: resources shared with the same name are received with unique names
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
@@ -6,7 +6,7 @@ Feature: shares are received in the default folder for received shares
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Do not allow sharing of the entire share_folder
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -6,6 +6,7 @@ Feature: cannot share resources outside the group when share with membership gro
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
 
+
   Scenario Outline: sharer should not be able to share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -26,6 +27,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: sharer should be able to share a folder to a user who is not member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -46,6 +48,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: sharer should be able to share a folder to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -67,6 +70,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
+
   Scenario Outline: sharer should not be able to share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -87,6 +91,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: sharer should be able to share a file to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -108,6 +113,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: sharer should be able to share a file to a user who is not a member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
@@ -39,7 +39,7 @@ Feature: local-storage
       | 1               | 100             | /filetoshare.txt    |
       | 2               | 200             | /filetoshare.txt    |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | pending_share_path             |
       | 1               | 100             | /local_storage/filetoshare.txt |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -6,7 +6,7 @@ Feature: sharing
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   @skipOnEncryptionType:user-keys @issue-32322
   Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
@@ -36,7 +36,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   @skipOnEncryptionType:user-keys @issue-32322 @issue-ocis-2133
   Scenario Outline: Creating a share of a file containing commas in the filename, with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
@@ -206,7 +206,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Share of folder to a group
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -238,7 +238,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: sharing again an own file while belonging to a group
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -290,7 +290,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: user shares a file with file name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -308,7 +308,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: user shares a file with file name longer than 64 chars to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -328,7 +328,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: user shares a folder with folder name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -347,7 +347,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: user shares a folder with folder name longer than 64 chars to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -406,7 +406,7 @@ Feature: sharing
       | /Shares/randomfile.txt |
     And the content of file "/Shares/randomfile.txt" for user "Brian" should be "Random data"
 
-  @issue-ocis-reva-34
+  @issue-ocis-reva-34 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Share of folder to a group with emoji in the name
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -505,7 +505,7 @@ Feature: sharing
       | 2               | 200             | /textfile0.txt |
 
 
-  @skipOnFilesClassifier @issue-files-classifier-291 @issue-ocis-2146
+  @skipOnFilesClassifier @issue-files-classifier-291 @issue-ocis-2146 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: Share a file by multiple channels and download from sub-folder and direct file share
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -555,7 +555,7 @@ Feature: sharing
       | pending_share_path |
       | /userOneFolder     |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path            |
       | /userZeroFolder/userOneFolder |
@@ -582,7 +582,7 @@ Feature: sharing
       | pending_share_path |
       | /userOneFolder     |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path            |
       | /userZeroFolder/userOneFolder |
@@ -612,12 +612,12 @@ Feature: sharing
       | pending_share_path |
       | /userOneFolder     |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path            |
       | /userZeroFolder/userOneFolder |
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Creating a share of a renamed file
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -647,6 +647,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: shares to a deleted user should not be listed as shares for the sharer
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -669,7 +670,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-719
+  @issue-ocis-719 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Creating a share of a renamed file when another share exists
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -717,7 +718,7 @@ Feature: sharing
       | 1               | 200         |
       | 2               | 403         |
 
-  @issue-ocis-2215
+  @issue-ocis-2215 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Sharing the shares folder to users is not possible
     Given using OCS API version "<ocs-api-version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -734,7 +735,7 @@ Feature: sharing
       | 1               | 200         |
       | 2               | 403         |
 
-  @issue-ocis-2215
+  @issue-ocis-2215 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Sharing the shares folder to groups is not possible
     Given using OCS API version "<ocs-api-version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -753,7 +754,7 @@ Feature: sharing
       | 1               | 200         |
       | 2               | 403         |
 
-  @issue-ocis-2215
+  @issue-ocis-2215 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Sharing the shares folder as public link is not possible
     Given using OCS API version "<ocs-api-version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328 @issue-ocis-1289
+@api @files_sharing-app-required @issue-ocis-1328 @issue-ocis-1289 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: Exclude groups from receiving shares
   As an admin
   I want to exclude groups from receiving shares

--- a/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
@@ -62,6 +62,7 @@ Feature: accept/decline shares coming from internal users
       | change      |
       | all         |
 
+
   Scenario Outline: share a file & folder with another internal user when auto accept is enabled and there is a default folder for received shares
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
     And the administrator has set the default folder for received shares to "<share_folder>"
@@ -87,6 +88,7 @@ Feature: accept/decline shares coming from internal users
       | /ReceivedShares     | /ReceivedShares     | PARENT               | textfile0.txt          |
       | ReceivedShares      | /ReceivedShares     | PARENT               | textfile0.txt          |
       | /My/Received/Shares | /My/Received/Shares | PARENT               | textfile0.txt          |
+
 
   Scenario Outline: share a file & folder with internal group with different permissions when auto accept is enabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -403,6 +405,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT/       |
       | /textfile0.txt |
 
+
   Scenario: share a file & folder with another internal user when auto accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
@@ -463,6 +466,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT (2)/       |
       | /textfile0 (2).txt |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: accept a pending share when there is a default folder for received shares
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And the administrator has set the default folder for received shares to "<share_folder>"
@@ -510,6 +514,7 @@ Feature: accept/decline shares coming from internal users
       | /ReceivedShares     | /ReceivedShares     | PARENT               | textfile0.txt          |
       | ReceivedShares      | /ReceivedShares     | PARENT               | textfile0.txt          |
       | /My/Received/Shares | /My/Received/Shares | PARENT               | textfile0.txt          |
+
 
   Scenario: accept an accepted share
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
@@ -585,6 +590,7 @@ Feature: accept/decline shares coming from internal users
     And user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the sharing API should report that no shares are shared with user "Brian"
 
+
   Scenario: only one user in a group accepts a share
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "Alice" has shared folder "/PARENT" with group "grp1"
@@ -610,6 +616,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT (2)/       |
       | /textfile0 (2).txt |
 
+
   Scenario: receive two shares with identical names from different users, accept one by one
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "Alice" has created folder "/shared"
@@ -630,6 +637,7 @@ Feature: accept/decline shares coming from internal users
       | /shared/     |
       | /shared (2)/ |
 
+
   Scenario: share with a group that you are part of yourself
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -639,6 +647,7 @@ Feature: accept/decline shares coming from internal users
       | path     |
       | /PARENT/ |
     And the sharing API should report that no shares are shared with user "Alice"
+
 
   Scenario Outline: user accepts file that was initially accepted from another user and then declined
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
@@ -721,6 +730,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/PARENT (2)/abc.txt" for user "Brian" should be "uploaded content"
     And the content of file "/FOLDER (2)/abc.txt" for user "Brian" should be "uploaded content"
 
+
   Scenario: user shares folder in a group with matching folder-name for every users involved
     Given user "Alice" has uploaded file with content "uploaded content" to "/PARENT/abc.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/FOLDER/abc.txt"
@@ -753,6 +763,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/PARENT (2)/abc.txt" for user "Carol" should be "uploaded content"
     And the content of file "/FOLDER (2)/abc.txt" for user "Carol" should be "uploaded content"
 
+
   Scenario: user shares files in a group with matching file-names for every users involved in sharing
     Given user "Alice" has uploaded file with content "ownCloud text file 1" to "/textfile1.txt"
     And user "Brian" has uploaded file with content "ownCloud text file 1" to "/textfile1.txt"
@@ -771,6 +782,7 @@ Feature: accept/decline shares coming from internal users
       | /textfile1.txt       |
       | /textfile0 (2).txt |
       | /textfile1 (2).txt |
+
 
   Scenario: user shares resource with matching resource-name with another user when auto accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
@@ -791,6 +803,7 @@ Feature: accept/decline shares coming from internal users
       | /textfile0.txt       |
       | /PARENT (2)/       |
       | /textfile0 (2).txt |
+
 
   Scenario: user shares file in a group with matching filename when auto accept is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
@@ -982,4 +995,3 @@ Feature: accept/decline shares coming from internal users
       | /PaRent/     |
       | /PaRent (2)/ |
     And the content of file "/PaRent (2)/message.txt" for user "Carol" should be "from alice"
-    

--- a/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
@@ -97,7 +97,7 @@ Feature: accept/decline shares coming from internal users
       | pending_share_path_1 | pending_share_path_2 |
       | /PARENT/             | /textfile0.txt       |
 
-  @smokeTest @issue-ocis-2131
+  @smokeTest @issue-ocis-2131 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: accept a pending share
     Given user "Alice" has shared folder "/PARENT" with user "Brian"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian"
@@ -139,7 +139,7 @@ Feature: accept/decline shares coming from internal users
       | /Shares/PARENT        |
       | /Shares/textfile0.txt |
 
-  @notToImplementOnOCIS
+  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: accept a pending share when there is a default folder for received shares
     Given the administrator has set the default folder for received shares to "<share_folder>"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -189,6 +189,7 @@ Feature: accept/decline shares coming from internal users
       | ReceivedShares      | /ReceivedShares     | PARENT               | textfile0.txt          |
       | /My/Received/Shares | /My/Received/Shares | PARENT               | textfile0.txt          |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: accept an accepted share
     Given user "Alice" has created folder "/shared"
     And user "Alice" has shared folder "/shared" with user "Brian"
@@ -226,11 +227,10 @@ Feature: accept/decline shares coming from internal users
       | declined_share_path_1 | declined_share_path_2 |
       | /Shares/PARENT/       | /Shares/textfile0.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT/              | /textfile0.txt        |
-
 
   @smokeTest @issue-ocis-2128
   Scenario Outline: decline an accepted share
@@ -257,7 +257,7 @@ Feature: accept/decline shares coming from internal users
       | declined_share_path_1 | declined_share_path_2 |
       | /Shares/PARENT/       | /Shares/textfile0.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT/              | /textfile0.txt        |
@@ -269,6 +269,7 @@ Feature: accept/decline shares coming from internal users
     When user "Alice" deletes folder "/PARENT" using the WebDAV API
     And user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the sharing API should report that no shares are shared with user "Brian"
+
 
   Scenario Outline: only one user in a group accepts a share
     Given user "Alice" has shared folder "/PARENT" with group "grp1"
@@ -300,13 +301,13 @@ Feature: accept/decline shares coming from internal users
       | pending_share_path_1 | pending_share_path_2  |
       | /Shares/PARENT/      | /Shares/textfile0.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path_1 | pending_share_path_2 |
       | /PARENT/             | /textfile0.txt       |
 
 
-  @issue-ocis-2131
+  @issue-ocis-2131 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: receive two shares with identical names from different users, accept one by one
     Given user "Alice" has created folder "/shared"
     And user "Alice" has created folder "/shared/Alice"
@@ -327,6 +328,7 @@ Feature: accept/decline shares coming from internal users
       | path                |
       | /Shares/shared/     |
       | /Shares/shared (2)/ |
+
 
   Scenario Outline: share with a group that you are part of yourself
     When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
@@ -370,7 +372,7 @@ Feature: accept/decline shares coming from internal users
       | accepted_share_path |
       | /testfile (2).txt   |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | accepted_share_path |
       | /testfile.txt       |
@@ -404,7 +406,7 @@ Feature: accept/decline shares coming from internal users
       | accepted_share_path_1 | accepted_share_path_2 |
       | /PARENT (2)           | /PARENT (2) (2)       |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | accepted_share_path_1 | accepted_share_path_2 |
       | /PARENT               | /PARENT               |
@@ -432,6 +434,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/Shares/PARENT/abc.txt" for user "Brian" should be "uploaded content"
     And the content of file "/Shares/FOLDER/abc.txt" for user "Brian" should be "uploaded content"
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: user shares folder in a group with matching folder-name for every users involved
     Given user "Alice" has uploaded file with content "uploaded content" to "/PARENT/abc.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/FOLDER/abc.txt"
@@ -470,6 +473,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/Shares/PARENT/abc.txt" for user "Carol" should be "uploaded content"
     And the content of file "/Shares/FOLDER/abc.txt" for user "Carol" should be "uploaded content"
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: user shares files in a group with matching file-names for every users involved in sharing
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
     And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
@@ -494,6 +498,7 @@ Feature: accept/decline shares coming from internal users
       | /Shares/textfile0.txt |
       | /Shares/textfile1.txt |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: user shares resource with matching resource-name with another user when auto accept is disabled
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     And user "Alice" shares file "/textfile0.txt" with user "Brian" using the sharing API
@@ -513,6 +518,7 @@ Feature: accept/decline shares coming from internal users
       | /Shares/PARENT/       |
       | /Shares/textfile0.txt |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: user shares file in a group with matching filename when auto accept is disabled
     Given user "Carol" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
@@ -535,7 +541,7 @@ Feature: accept/decline shares coming from internal users
       | /textfile0.txt        |
       | /Shares/textfile0.txt |
 
-  @skipOnLDAP
+  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: user shares folder with matching folder name a user before that user has logged in
     Given these users have been created with small skeleton files but not initialized:
       | username |
@@ -570,14 +576,14 @@ Feature: accept/decline shares coming from internal users
       | 1               | 100             | /Shares/PARENT      |
       | 2               | 200             | /Shares/PARENT      |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | declined_share_path |
       | 1               | 100             | /PARENT             |
       | 2               | 200             | /PARENT             |
 
 
-  @issue-ocis-765
+  @issue-ocis-765 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: shares exist after restoring already shared file to a previous version
     And user "Alice" has uploaded file with content "Test Content." to "/toShareFile.txt"
     And user "Alice" has uploaded file with content "Content Test Updated." to "/toShareFile.txt"
@@ -587,7 +593,7 @@ Feature: accept/decline shares coming from internal users
     Then the content of file "/toShareFile.txt" for user "Alice" should be "Test Content."
     And the content of file "/Shares/toShareFile.txt" for user "Brian" should be "Test Content."
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a user receives multiple group shares for matching file and folder name
     Given group "grp2" has been created
     And user "Alice" has been added to group "grp2"
@@ -648,7 +654,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/Shares/PARENT (2).txt" for user "Brian" should be "from carol to grp1"
     And the content of file "/Shares/parent.txt" for user "Brian" should be "from carol to grp1"
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a group receives multiple shares from non-member for matching file and folder name
     Given user "Brian" has been removed from group "grp1"
     And user "Alice" has created folder "/PaRent"

--- a/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: accept/decline shares coming from internal users to the Shares folder
   As a user
   I want to have control of which received shares I accept

--- a/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-reva-1328 @issues-ocis-1289
+@api @files_sharing-app-required @issue-ocis-reva-1328 @issues-ocis-1289 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
@@ -27,7 +27,7 @@ Feature: local-storage
       | 1               | /filetoshare.txt   |
       | 2               | /filetoshare.txt   |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | pending_share_path             |
       | 1               | /local_storage/filetoshare.txt |
@@ -51,7 +51,7 @@ Feature: local-storage
       | 1               | /foo               |
       | 2               | /foo               |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | pending_share_path |
       | 1               | /local_storage/foo |
@@ -84,7 +84,7 @@ Feature: local-storage
       | 1               | /foo               |
       | 2               | /foo               |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | pending_share_path |
       | 1               | /local_storage/foo |
@@ -112,7 +112,7 @@ Feature: local-storage
       | 1               | /filetoshare.txt   |
       | 2               | /filetoshare.txt   |
 
-   @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+   @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | pending_share_path             |
       | 1               | /local_storage/filetoshare.txt |

--- a/tests/acceptance/features/apiShareOperationsToShares1/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/accessToShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToShares1/accessToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/accessToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: write directly into the folder for received shares
   On ownCloud10 with the folder for received shares set, for example, to "Shares"
   A user should see a "Shares" folder when they have received a share.

--- a/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesPendingFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesPendingFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: get the pending shares filtered by type (user, group etc)
   As a user
   I want to be able to know the pending shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesSharedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/getWebDAVSharePermissions.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToShares2/shareAccessByID.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/shareAccessByID.feature
@@ -9,7 +9,7 @@ Feature: share access by ID
       | Alice    |
       | Brian    |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Get a share with a valid share ID
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
@@ -124,7 +124,7 @@ Feature: share access by ID
       | 1               | 100             | /Shares/textfile0.txt |
       | 2               | 200             | /Shares/textfile0.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | declined_share_path |
       | 1               | 100             | /textfile0.txt      |

--- a/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required
+@api @files_sharing-app-required @public_link_share-feature-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: reshare as public link
   As a user
   I want to create public link shares from files/folders shared with me

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS @issue-ocis-2079
+@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: reshare as public link
   As a user
   I want to create public link shares from files/folders shared with me

--- a/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature
@@ -320,13 +320,13 @@ Feature: update a public link share
     And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the <webdav_api_version> public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | http_status_code | webdav_api_version |
       | 1               | 200              | old                |
       | 2               | 404              | old                |
 
-    @issue-ocis-reva-11
+    @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | http_status_code | webdav_api_version |
       | 1               | 200              | new                |
@@ -350,13 +350,13 @@ Feature: update a public link share
     And the HTTP status code should be "200"
     And uploading a file should work using the <webdav_api_version> public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | webdav_api_version |
       | 1               | 100             | old                |
       | 2               | 200             | old                |
 
-    @issue-ocis-reva-11
+    @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | webdav_api_version |
       | 1               | 100             | new                |
@@ -380,13 +380,13 @@ Feature: update a public link share
     And the HTTP status code should be "<http_status_code>"
     And uploading a file should not work using the <webdav_api_version> public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | http_status_code | webdav_api_version |
       | 1               | 200              | old                |
       | 2               | 404              | old                |
 
-    @issue-ocis-reva-11
+    @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | http_status_code | webdav_api_version |
       | 1               | 200              | new                |
@@ -410,13 +410,13 @@ Feature: update a public link share
     And the HTTP status code should be "200"
     And uploading a file should work using the <webdav_api_version> public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | webdav_api_version |
       | 1               | 100             | old                |
       | 2               | 200             | old                |
 
-    @issue-ocis-reva-11
+    @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | webdav_api_version |
       | 1               | 100             | new                |

--- a/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
@@ -30,7 +30,7 @@ Feature: resharing can be done on a reshared resource
       | /textfile0_shared.txt |
       | /textfile0_shared.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path |
       | /textfile0.txt     |

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: resharing can be disabled
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: a subfolder of a received share can be reshared
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-reva-194 @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-reva-194 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1250 @notToImplementOnOCIS
+@api @files_sharing-app-required @issue-ocis-1250 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
@@ -1,4 +1,4 @@
-@api @files_versions-app-required @issue-ocis-reva-275
+@api @files_versions-app-required @issue-ocis-reva-275 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 
 Feature: dav-versions
 

--- a/tests/acceptance/features/apiVersions/fileVersionsSharingToSharesIssue36228.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsSharingToSharesIssue36228.feature
@@ -1,4 +1,4 @@
-@api @files_versions-app-required @issue-36228 @notToImplementOnOCIS
+@api @files_versions-app-required @issue-36228 @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 
 Feature: dav-versions
 

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -65,7 +65,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -95,7 +95,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -125,7 +125,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -157,7 +157,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
@@ -118,7 +118,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -146,7 +146,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -174,7 +174,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -209,7 +209,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -244,7 +244,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -279,7 +279,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -119,7 +119,7 @@ Feature: propagation of etags when copying files or folders
       | old         |
       | new         |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -157,7 +157,7 @@ Feature: propagation of etags when copying files or folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
@@ -41,7 +41,7 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -66,7 +66,7 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
@@ -42,7 +42,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver uploading a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -66,7 +66,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer uploading a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -90,7 +90,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver overwriting a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -115,7 +115,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer overwriting a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11
+@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: lock should propagate correctly if a share is reshared
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: set timeouts of LOCKS on shares
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-172
+@api @issue-ocis-reva-172 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: independent locks
   Make sure all locks are independent and don't interact with other items that have the same name
 
@@ -29,7 +29,7 @@ Feature: independent locks
       | new      | shared     |
       | new      | exclusive  |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from the same user)
     Given using <dav-path> DAV path
     And user "Alice" has created folder "locked/"

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-172 @files_sharing-app-required
+@api @issue-ocis-reva-172 @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: UNLOCK locked items (sharing)
 
   Background:
@@ -30,7 +30,7 @@ Feature: UNLOCK locked items (sharing)
       | new      | shared     | /parent.txt        |
       | new      | exclusive  | /parent.txt        |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis  
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
     Examples:
       | dav-path | lock-scope | pending_share_path |
       | old      | shared     | /PARENT/parent.txt |
@@ -99,7 +99,7 @@ Feature: UNLOCK locked items (sharing)
       | new      | shared     | /parent.txt        |
       | new      | exclusive  | /parent.txt        |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis  
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
     Examples:
       | dav-path | lock-scope | pending_share_path |
       | old      | shared     | /PARENT/parent.txt |
@@ -126,7 +126,7 @@ Feature: UNLOCK locked items (sharing)
       | new      | shared     | /parent.txt        |
       | new      | exclusive  | /parent.txt        |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis  
+    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
     Examples:
       | dav-path | lock-scope | pending_share_path |
       | old      | shared     | /PARENT/parent.txt |

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -76,7 +76,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: download previews of shared files (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -183,7 +183,7 @@ Feature: previews of files downloaded through the webdav API
     When user "Alice" uploads file with content "this is a file to upload" to "/parent.txt" using the WebDAV API
     Then as user "Alice" the preview of "/parent.txt" with width "32" and height "32" should have been changed
 
-  @notToImplementOnOCIS
+  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: when owner updates a shared file, previews for sharee are also updated
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -192,7 +192,7 @@ Feature: previews of files downloaded through the webdav API
     When user "Alice" uploads file with content "this is a file to upload" to "/parent.txt" using the WebDAV API
     Then as user "Brian" the preview of "/parent.txt" with width "32" and height "32" should have been changed
 
-  @issue-ocis-2538
+  @issue-ocis-2538 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: when owner updates a shared file, previews for sharee are also updated (to shared folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -48,7 +48,7 @@ Feature: copy file
       | new         |
 
   @files_sharing-app-required
-  @issue-ocis-reva-11
+  @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Copying a file to a folder with no permissions
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -69,7 +69,7 @@ Feature: copy file
       | new         |
 
   @files_sharing-app-required
-  @issue-ocis-reva-11
+  @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -207,7 +207,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file over the top of an existing folder received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -226,7 +226,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder over the top of an existing file received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -244,7 +244,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into another folder at different level which is received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -267,7 +267,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a folder at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -292,7 +292,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a file at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -316,7 +316,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into a file at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -340,7 +340,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file over the top of an existing folder received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -362,7 +362,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder over the top of an existing file received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -383,7 +383,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into another folder at different level which is received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -409,7 +409,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a folder at different level received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -437,7 +437,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a file at different level received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -464,7 +464,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239
+  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into a file at different level received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -8,7 +8,7 @@ Feature: admin general settings
     Given the administrator has changed their own email address to "admin@owncloud.com"
     And the administrator has browsed to the admin general settings page
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: administrator sets email server settings
     When the administrator sets the following email server settings using the webUI
       | setting                 | value          |


### PR DESCRIPTION
## Description
https://drone.owncloud.com/owncloud/user_ldap/3494/68/12 has many test failures against oC10 `latest` 10.8.0. `encryption` and `files_primary_s3` have similar test failures.

The exact way that shares are offered and accepted changed, and the sharing acceptance tests that use the offer-a-share then accept-a-share sequence no longer work against core `latest` (10.8.0) and earlier oC10 releases.

Skip those test scenarios on old oC10 releases.

This will help nightly CI to pass for `encryption`, `files_primary_s3` and `user_ldap`

(Note: there are also some issues related to the recent changes for groups on the user-group management page. I will look at those separately tomorrow, when I get a cleaner run of nightly CI tonight)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
