### PR TITLE
[tests-only] skip more sharing scenarios on old oC10

### DIFF
--- a/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
@@ -411,7 +411,7 @@ Feature: accept/decline shares coming from internal users
       | accepted_share_path_1 | accepted_share_path_2 |
       | /PARENT               | /PARENT               |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: user shares folder with matching folder-name for both user involved in sharing
     Given user "Alice" has uploaded file with content "uploaded content" to "/PARENT/abc.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/FOLDER/abc.txt"

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @files_sharing-app-required
+@api @files_trashbin-app-required @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: using trashbin together with sharing
 
   Background:
@@ -63,7 +63,7 @@ Feature: using trashbin together with sharing
       | old      |
       | new      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: restoring a file to a read-only folder
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -82,7 +82,7 @@ Feature: using trashbin together with sharing
       | old      |
       | new      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: restoring a file to a read-only sub-folder
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -859,6 +859,19 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the administrator tries to add user :user to group :group using the webUI
+	 *
+	 * @param string $user
+	 * @param string $group
+	 *
+	 * @return void
+	 */
+	public function adminTriesToAddUserToGroupUsingTheWebui($user, $group) {
+		$user = $this->featureContext->getActualUsername($user);
+		$this->usersPage->addOrRemoveUserToGroup($this->getSession(), $user, $group, true, false);
+	}
+
+	/**
 	 * @When the administrator removes user :user from group :group using the webUI
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
These were missed in PR #39303 yesterday.

In the 2nd commit I have added a step definition that lets us say:
```
    When the administrator tries to add user "db-user" to group "grp1" using the webUI
```

That step looks for the element(s) on the UI to add the user to the group, but does not throw an exception when any of them are not found. This is the sort of thing that we do these days to indicate that a `When` step is "expected" to not really work. The `Then` steps after it should/will check that the thing did not happen:
```
    Then user "Alice" should exist
    But user "Alice" should not belong to group "grp1"
```

This will allow us to refactor the scenarios in user_ldap tests that are failing:
```
runsh: Total unexpected failed scenarios throughout the test run:
webUIProvisioning/groups.feature:70
webUIProvisioning/groups.feature:85
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
