### PR TITLE
Sanitize data that  gets sent to server on user create via webUI

### DIFF
--- a/changelog/unreleased/39306
+++ b/changelog/unreleased/39306
@@ -1,0 +1,11 @@
+Bugfix: Sanitize data send to the server while creating users via webUI
+
+Before this change toggle between 'Set password for new users' option,
+may preserve and send unwanted password or email information.
+This has been fixed, the webUI will not send email data to the server
+if the option 'Set password for new users' is active,
+vice versa password won't be sent if the option is disabled.
+
+
+https://github.com/owncloud/core/pull/39306
+https://github.com/owncloud/core/issues/32619

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -289,6 +289,10 @@ span.usersLastLoginTooltip { white-space: nowrap; }
 	display: inline;
 }
 
+#newuser .groups li.creator {
+	cursor: pointer;
+}
+
 #newuser .groupsListContainer.hidden,
 #userlist .groupsListContainer.hidden {
 	display: none;

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -959,13 +959,15 @@ $(document).ready(function () {
 		var username = $('#newusername').val();
 		var password = $('#newuserpassword').val();
 		var email = $('#newemail').val();
+		var setPassword = $('#CheckBoxPasswordOnUserCreate').is(':checked');
+
 		if ($.trim(username) === '') {
 			OC.Notification.showTemporary(t('settings', 'Error creating user: {message}', {
 				message: t('settings', 'A valid username must be provided')
 			}));
 			return false;
 		}
-		if ($('#CheckBoxPasswordOnUserCreate').is(':checked')) {
+		if (setPassword === true) {
 			if ($.trim(password) === '') {
 				OC.Notification.showTemporary(t('settings', 'Error creating user: {message}', {
 					message: t('settings', 'A valid password must be provided')
@@ -974,65 +976,70 @@ $(document).ready(function () {
 			}
 		} else {
 			if ($.trim(email) === '') {
-				OC.Notification.showTemporary( t('settings', 'Error creating user: {message}', {
+				OC.Notification.showTemporary(t('settings', 'Error creating user: {message}', {
 					message: t('settings', 'A valid email must be provided')
 				}));
 				return false;
 			}
 		}
 
-		var promise = $.Deferred().resolve().promise();
+		var groups = $('#newuser .groups').data('groups') || [];
 
-		promise.then(function() {
-			var groups = $('#newuser .groups').data('groups') || [];
-			$.post(
-				OC.generateUrl('/settings/users/users'),
-				{
-					username: username,
-					password: password,
-					groups: groups,
-					email: email
-				},
-				function (result) {
-					if (result.groups) {
-						for (var i in result.groups) {
-							var gid = result.groups[i];
-							if(UserList.availableGroups.indexOf(gid) === -1) {
-								UserList.availableGroups.push(gid);
-							}
-							$li = GroupList.getGroupLI(gid);
-							userCount = GroupList.getUserCount($li);
-							GroupList.setUserCount($li, userCount + 1);
+		var data = {
+			username: username,
+			groups: groups,
+		};
+
+		if (setPassword === true) {
+			data.password = password;
+			data.email = '';
+		} else {
+			data.password = '';
+			data.email = email;
+		}
+
+		$.post(
+			OC.generateUrl('/settings/users/users'),
+			data,
+			function (result) {
+				if (result.groups) {
+					for (var i in result.groups) {
+						var gid = result.groups[i];
+						if (UserList.availableGroups.indexOf(gid) === -1) {
+							UserList.availableGroups.push(gid);
 						}
+						$li = GroupList.getGroupLI(gid);
+						userCount = GroupList.getUserCount($li);
+						GroupList.setUserCount($li, userCount + 1);
 					}
-					if(!UserList.has(username)) {
-						UserList.add(result, true);
-					}
-					$('#newusername').focus();
-					GroupList.incEveryoneCount();
-				}).fail(function(result) {
-					OC.Notification.showTemporary(t('settings', 'Error creating user: {message}', {
-						message: result.responseJSON.message
-					}, undefined, {escape: false}));
-				}).success(function(){
-					$('#newuser').get(0).reset();
-				});
+				}
+				if (!UserList.has(username)) {
+					UserList.add(result, true);
+				}
+				$('#newusername').focus();
+				GroupList.incEveryoneCount();
+			}).fail(function (result) {
+			OC.Notification.showTemporary(t('settings', 'Error creating user: {message}', {
+				message: result.responseJSON.message
+			}, undefined, {escape: false}));
+		}).success(function () {
+			$('#newuser').get(0).reset();
 		});
 	});
 
-        if ($('#CheckboxIsEnabled').is(':checked')) {
-                $("#userlist .enabled").show();
-        }
-        // Option to display/hide the "Enabled" column
-        $('#CheckboxIsEnabled').click(function() {
-                if ($('#CheckboxIsEnabled').is(':checked')) {
-                        $("#userlist .enabled").show();
-                        OC.AppConfig.setValue('core', 'umgmt_show_is_enabled', 'true');
-                } else {
-                        $("#userlist .enabled").hide();
-                        OC.AppConfig.setValue('core', 'umgmt_show_is_enabled', 'false');
-                }
-        });
+	if ($('#CheckboxIsEnabled').is(':checked')) {
+		$("#userlist .enabled").show();
+	}
+	// Option to display/hide the "Enabled" column
+	$('#CheckboxIsEnabled').click(function () {
+		if ($('#CheckboxIsEnabled').is(':checked')) {
+			$("#userlist .enabled").show();
+			OC.AppConfig.setValue('core', 'umgmt_show_is_enabled', 'true');
+		} else {
+			$("#userlist .enabled").hide();
+			OC.AppConfig.setValue('core', 'umgmt_show_is_enabled', 'false');
+		}
+	});
 
 
 	if ($('#CheckboxStorageLocation').is(':checked')) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Bugfix: Sanitize data send to the server while creating users via webUI

Before this change toggle between 'Set password for new users' option,
may preserve and send unwanted password or email information.
This has been fixed, the webUI will not send email data to the server
if the option 'Set password for new users' is active,
vice versa password won't be sent if the option is disabled.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/32619

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
