### PR TITLE
[tests-only] Fix default value of parameter to assertLogFileContainsAtLeastOneEntryMatchingTable

### DIFF
--- a/tests/acceptance/features/bootstrap/LoggingContext.php
+++ b/tests/acceptance/features/bootstrap/LoggingContext.php
@@ -277,7 +277,7 @@ class LoggingContext implements Context {
 	private function assertLogFileContainsAtLeastOneEntryMatchingTable(
 		bool      $shouldOrNot,
 		TableNode $expectedLogEntries,
-		bool $regexCompare
+		bool $regexCompare = false
 	):void {
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			// Currently we don't interact with the log file on reva or OCIS


### PR DESCRIPTION
In PR #39304 refactoring the `$regexCompare` lost its default value. That caused test fails in apps like:
https://drone.owncloud.com/owncloud/admin_audit/2141/33/9
```
Type error: Too few arguments to function LoggingContext::assertLogFileContainsAtLeastOneEntryMatchingTable(), 2 passed in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/LoggingContext.php on line 214 and exactly 3 expected (Behat\Testwork\Call\Exception\FatalThrowableError)
```

Put back the default value.