### PR TITLE
[tests-only] [full-ci] Fix call to matchNotification in acceptance tests

### DIFF
--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -184,7 +184,7 @@ class NotificationsCoreContext implements Context {
 		$this->matchNotification(
 			$notification,
 			$user,
-			$aboutUser = null,
+			"",
 			false,
 			$formData
 		);


### PR DESCRIPTION
## Description

PR #39309 added type declarations to acceptance test methods like `matchNotification`

Fix one of the calls so that it passes an empty string instead of null.

This will fix failing tests in the notifications app:
https://drone.owncloud.com/owncloud/notifications/1788/26/10
```
Type error: Argument 3 passed to NotificationsCoreContext::matchNotification() must be of the type string, null given, called in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/NotificationsCoreContext.php on line 185 (Behat\Testwork\Call\Exception\FatalThrowableError)
```


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
