### PR TITLE
Restore old view with -m option

### DIFF
--- a/changelog/unreleased/39326
+++ b/changelog/unreleased/39326
@@ -1,0 +1,3 @@
+Enhancement: Bring back minimalistic view to occ app:list with '-m' option
+
+https://github.com/owncloud/core/pull/39326

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -73,11 +73,18 @@ class ListApps extends Base {
 				InputOption::VALUE_REQUIRED,
 				'true - limit to shipped apps only, false - limit to non-shipped apps only.'
 			)
+			->addOption(
+				'minimal',
+				'm',
+				InputOption::VALUE_NONE,
+				'Minimal view - only display apps with version',
+			)
 		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$appNameSubString = $input->getArgument('search-pattern');
+		$minimalView = $input->getOption('minimal');
 
 		if ($input->getOption('shipped') === 'true' || $input->getOption('shipped') === 'false') {
 			$shippedFilter = $input->getOption('shipped') === 'true';
@@ -114,6 +121,11 @@ class ListApps extends Base {
 			foreach ($enabledApps as $app) {
 				$appDetailRecord = [];
 
+				if ($minimalView) {
+					$apps['enabled'][] = sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
+					continue;
+				}
+
 				if (isset($versions[$app])) {
 					$appDetailRecord['Version'] = $versions[$app];
 				}
@@ -127,6 +139,12 @@ class ListApps extends Base {
 			\sort($disabledApps);
 			foreach ($disabledApps as $app) {
 				$appDetailRecord = [];
+
+				if ($minimalView) {
+					$apps['disabled'][] = sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
+					continue;
+				}
+
 				if (($input->getOption('disabled') && isset($versions[$app]))) {
 					$appDetailRecord['Version'] = $versions[$app];
 				}

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -249,6 +249,18 @@ class AppManagementContext implements Context {
 	}
 
 	/**
+	 * @When the administrator lists the apps in minimal format using the occ command
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function adminListsTheAppsInMinimalFormat():void {
+		$this->featureContext->runOcc(
+			['app:list', '--minimal --no-ansi']
+		);
+	}
+
+	/**
 	 * @Then app :appId with version :appVersion and path :appPath should have been listed in the enabled apps section
 	 *
 	 * @param string $appId
@@ -311,6 +323,32 @@ class AppManagementContext implements Context {
 	}
 
 	/**
+	 * @Then app :appId should have been listed in the enabled apps section
+	 *
+	 * @param string $appId
+	 *
+	 * @return void
+	 */
+	public function appShouldHaveBeenListedInTheEnabledAppsSection(string $appId):void {
+		$commandOutput = $this->featureContext->getStdOutOfOccCommand();
+		$expectedStartOfOutput = "Enabled:";
+		Assert::assertEquals(
+			$expectedStartOfOutput,
+			\substr($commandOutput, 0, 8),
+			"app:list command output did not start with '$expectedStartOfOutput'"
+		);
+		$startOfDisabledSection = \strpos($commandOutput, "Disabled:");
+		if ($startOfDisabledSection) {
+			$commandOutput = \substr($commandOutput, 0, $startOfDisabledSection);
+		}
+		$expectedString = "- $appId";
+		Assert::assertNotFalse(
+			\strpos($commandOutput, $expectedString),
+			"app:list output did not contain '$expectedString' in the enabled section"
+		);
+	}
+
+	/**
 	 * @Then app :appId should have been listed in the disabled apps section
 	 *
 	 * @param string $appId
@@ -329,6 +367,23 @@ class AppManagementContext implements Context {
 		Assert::assertNotFalse(
 			\strpos($commandOutput, $expectedString),
 			"app:list output did not contain '$expectedString' in the disabled section"
+		);
+	}
+
+	/**
+	 * @Then app version and path lines should not exist in the list app output
+	 *
+	 * @return void
+	 */
+	public function appVersionAndPathLinesShouldNotExist():void {
+		$commandOutput = $this->featureContext->getStdOutOfOccCommand();
+		Assert::assertStringNotContainsString(
+			"Version:",
+			$commandOutput
+		);
+		Assert::assertStringNotContainsString(
+			"Path:",
+			$commandOutput
 		);
 	}
 

--- a/tests/acceptance/features/cliAppManagement/listApps.feature
+++ b/tests/acceptance/features/cliAppManagement/listApps.feature
@@ -57,3 +57,15 @@ Feature: list apps
     Then the command should have been successful
     And app "testapp1" with version "2.3.4" and path "apps/testapp1" should have been listed in the disabled apps section
     And the enabled apps section should not exist
+
+  Scenario: list all the apps in minimal format
+    Given app "testapp1" with version "2.3.4" has been put in dir "apps"
+    And app "testapp1" has been enabled
+    And app "testapp2" with version "5.6.7" has been put in dir "apps"
+    And app "testapp2" has been disabled
+    When the administrator lists the apps in minimal format using the occ command
+    Then the command should have been successful
+    And app "testapp1" should have been listed in the enabled apps section
+    And app "testapp2" should have been listed in the disabled apps section
+    And app version and path lines should not exist in the list app output
+


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Enhancement: Bring back minimalistic view to occ app:list with '-m' option


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

### Without -m flag
![image](https://user-images.githubusercontent.com/26169327/136168713-24441416-340f-41de-b473-e0bb640c2f8d.png)

### With -m flag
![image](https://user-images.githubusercontent.com/26169327/136168805-ea3f1553-c4b2-431a-a3ee-59364951363d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4117
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
