### PR TITLE
fix: no sensitive data shall be displayed on the exception page - eve…

### DIFF
--- a/changelog/unreleased/39334
+++ b/changelog/unreleased/39334
@@ -1,0 +1,7 @@
+Bugfix: No sensitive data on exception page
+
+In debug mode any exception stack trace is rendered to the browser which can
+hold sensitive data like passwords as method arguments.
+They are now filtered and no longer exposed to the user.
+
+https://github.com/owncloud/core/pull/39334

--- a/lib/private/legacy/template.php
+++ b/lib/private/legacy/template.php
@@ -36,8 +36,8 @@
  *
  */
 
+use OC\Log;
 use OC\TemplateLayout;
-use OCP\IL10N;
 use OCP\Theme\ITheme;
 
 require_once __DIR__.'/template/functions.php';
@@ -367,6 +367,8 @@ class OC_Template extends \OC\Template\Base {
 	 */
 	public static function printExceptionErrorPage($exception, $fetchPage = false) {
 		try {
+			$trace = Log::replaceSensitiveData($exception->getTraceAsString());
+
 			$request = \OC::$server->getRequest();
 			$content = new \OC_Template('', 'exception', 'error', false);
 			$content->assign('errorClass', \get_class($exception));
@@ -374,7 +376,7 @@ class OC_Template extends \OC\Template\Base {
 			$content->assign('errorCode', $exception->getCode());
 			$content->assign('file', $exception->getFile());
 			$content->assign('line', $exception->getLine());
-			$content->assign('trace', $exception->getTraceAsString());
+			$content->assign('trace', $trace);
 			$content->assign('debugMode', \OC::$server->getSystemConfig()->getValue('debug', false));
 			$content->assign('remoteAddr', $request->getRemoteAddress());
 			$content->assign('requestID', $request->getId());


### PR DESCRIPTION
…n in debug mode

## Description

## Related Issue
fixes https://github.com/owncloud/enterprise/issues/4783

## How Has This Been Tested?
- set debug => true in config.php
- add a throw new Exception() in LoginController::tryLogin()
- login
- see the exception page
- user name and password are not displayed in the stack trace

## Screenshots (if appropriate):
![Screenshot from 2021-10-08 10-34-14](https://user-images.githubusercontent.com/1005065/136525525-5f9be489-ffec-45f9-b19d-dceccc827582.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
