### PR TITLE
[tests-only] [full-ci] Add trashbin API tests for deleting files shared with a group

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -268,9 +268,9 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/new-folder/new-file.txt"
-    When user "Alice" deletes folder "/new-folder/" using the WebDAV API
+    When user "Alice" deletes folder "/new-folder" using the WebDAV API
     Then as "Alice" the file with original path "/new-folder/new-file.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/new-folder/" should exist in the trashbin
+    And as "Alice" the folder with original path "/new-folder" should exist in the trashbin
     And as "Alice" file "/new-folder/new-file.txt" should exist in the trashbin
     But as "Alice" file "/new-folder/new-file.txt" should not exist
     Examples:

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -21,7 +21,7 @@ Feature: using trashbin together with sharing
       | new      |
 
 
-  Scenario Outline: deleting a file in a received folder moves it to trashbin
+  Scenario Outline: deleting a file in a received folder moves it to the trashbin of both users
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
@@ -30,6 +30,89 @@ Feature: using trashbin together with sharing
     And user "Brian" has moved file "/shared" to "/renamed_shared"
     When user "Brian" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
     Then as "Brian" the file with original path "/renamed_shared/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: sharee deleting a file in a group-shared folder moves it to the trashbin of sharee and sharer only
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with group "grp1"
+    When user "Brian" deletes file "/shared/shared_file.txt" using the WebDAV API
+    Then as "Brian" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    And as "Carol" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: sharer deleting a file in a group-shared folder moves it to the trashbin of sharer only
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with group "grp1"
+    When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
+    Then as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
+    And as "Carol" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: sharee deleting a folder in a group-shared folder moves it to the trashbin of sharee and sharer only
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has created folder "/shared/sub"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with group "grp1"
+    When user "Brian" deletes folder "/shared/sub" using the WebDAV API
+    Then as "Brian" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Carol" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: sharer deleting a folder in a group-shared folder moves it to the trashbin of sharer only
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has created folder "/shared/sub"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with group "grp1"
+    When user "Alice" deletes folder "/shared/sub" using the WebDAV API
+    Then as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
+    And as "Carol" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -24,7 +24,7 @@ Feature: using trashbin together with sharing
       | new      |
 
 
-  Scenario Outline: deleting a file in a received folder moves it to trashbin
+  Scenario Outline: deleting a file in a received folder moves it to trashbin of both users
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/shared"
@@ -34,6 +34,97 @@ Feature: using trashbin together with sharing
     And user "Brian" has moved file "/Shares/shared" to "/Shares/renamed_shared"
     When user "Brian" deletes file "/Shares/renamed_shared/shared_file.txt" using the WebDAV API
     Then as "Brian" the file with original path "/Shares/renamed_shared/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: sharee deleting a file in a group-shared folder moves it to the trashbin of sharee and sharer only
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with group "grp1"
+    And user "Brian" has accepted share "/Shares/shared" offered by user "Alice"
+    And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
+    When user "Brian" deletes file "/Shares/shared/shared_file.txt" using the WebDAV API
+    Then as "Brian" the file with original path "/Shares/shared/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: sharer deleting a file in a group-shared folder moves it to the trashbin of sharer only
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with group "grp1"
+    And user "Brian" has accepted share "/Shares/shared" offered by user "Alice"
+    And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
+    When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
+    Then as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
+    And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: sharee deleting a folder in a group-shared folder moves it to the trashbin of sharee and sharer only
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has created folder "/shared/sub"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with group "grp1"
+    And user "Brian" has accepted share "/Shares/shared" offered by user "Alice"
+    And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
+    When user "Brian" deletes file "/Shares/shared/sub/shared_file.txt" using the WebDAV API
+    Then as "Brian" the file with original path "/Shares/shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Carol" the file with original path "/Shares/sub/shared/shared_file.txt" should not exist in the trashbin
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+
+
+  Scenario Outline: sharer deleting a folder in a group-shared folder moves it to the trashbin of sharer only
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And group "grp1" has been created
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "/shared"
+    And user "Alice" has created folder "/shared/sub"
+    And user "Alice" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
+    And user "Alice" has shared folder "/shared" with group "grp1"
+    And user "Brian" has accepted share "/Shares/shared" offered by user "Alice"
+    And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
+    When user "Alice" deletes file "/shared/sub/shared_file.txt" using the WebDAV API
+    Then as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "/Shares/shared/sub/shared_file.txt" should not exist in the trashbin
+    And as "Carol" the file with original path "/Shares/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -293,17 +293,17 @@ Feature: Restore deleted files/folders
   Scenario Outline: A subfolder from a deleted multi level folder can be restored including the content
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/new-folder"
-    And user "Alice" has created folder "/new-folder/folder1/"
-    And user "Alice" has created folder "/new-folder/folder1/folder2/"
+    And user "Alice" has created folder "/new-folder/folder1"
+    And user "Alice" has created folder "/new-folder/folder1/folder2"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/folder1/folder2/new-file.txt"
-    And user "Alice" has deleted folder "/new-folder/"
+    And user "Alice" has deleted folder "/new-folder"
     When user "Alice" restores the folder with original path "/new-folder/folder1" to "/folder1" using the trashbin API
     Then the HTTP status code should be "201"
     And as "Alice" the file with original path "/new-folder/folder1/folder2/new-file.txt" should not exist in the trashbin
-    And as "Alice" the folder with original path "/new-folder/folder1/" should not exist in the trashbin
+    And as "Alice" the folder with original path "/new-folder/folder1" should not exist in the trashbin
     And as "Alice" file "/folder1/folder2/new-file.txt" should exist
     And the content of file "/folder1/folder2/new-file.txt" for user "Alice" should be "file to delete"
-    But as "Alice" the folder with original path "/new-folder/" should exist in the trashbin
+    But as "Alice" the folder with original path "/new-folder" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -641,10 +641,12 @@ class TrashbinContext implements Context {
 		if ($techPreviewHadToBeEnabled) {
 			$this->occContext->disableDAVTechPreview();
 		}
-		$originalPath = \trim($originalPath, '/');
+
+		// we don't care if the test step writes a leading "/" or not
+		$originalPath = \ltrim($originalPath, '/');
 
 		foreach ($listing as $entry) {
-			if ($entry['original-location'] === $originalPath) {
+			if (\ltrim($entry['original-location'], '/') === $originalPath) {
 				return true;
 			}
 		}
@@ -896,7 +898,7 @@ class TrashbinContext implements Context {
 		$user = $this->featureContext->getActualUsername($user);
 		Assert::assertTrue(
 			$this->isInTrash($user, $originalPath),
-			"File previously located at $originalPath wasn't found in the trashbin"
+			"File previously located at $originalPath wasn't found in the trashbin of user $user"
 		);
 	}
 
@@ -916,7 +918,7 @@ class TrashbinContext implements Context {
 		$user = $this->featureContext->getActualUsername($user);
 		Assert::assertFalse(
 			$this->isInTrash($user, $originalPath),
-			"File previously located at $originalPath was found in the trashbin"
+			"File previously located at $originalPath was found in the trashbin of user $user"
 		);
 	}
 


### PR DESCRIPTION
## Description
Add test scenarios to demonstrate the behavior of the trashbin when files or folders are deleted from a share.

- if the sharee deletes the file or folder then the deleted file(s) go in the trashbin of the sharee and sharer, but not the trashbin of anyone else who received the share (e.g. when the share was to a group)
- if the sharer deletes the file or folder then the deleted file(s) go in the trashbin of the sharer only

The "rule" here is that the sharer always has access to the file(s) in their trashbin. The sharee that deletes something also has it in their trashbin (so that they can restore it if/when they realise that they accidentally deleted it)

I thought that we already had scenarios like this, but I couldn't find any - so I added them.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
