### PR TITLE
[tests-only] Accept both the user and the group share offered by Alice

### DIFF
--- a/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
@@ -25,7 +25,8 @@ Feature: sharing
     Given user "Alice" has created folder "/merge-test-outside-perms"
     When user "Alice" shares folder "/merge-test-outside-perms" with group "grp1" with permissions "read" using the sharing API
     And user "Alice" shares folder "/merge-test-outside-perms" with user "Brian" with permissions "all" using the sharing API
-    And user "Brian" accepts share "/merge-test-outside-perms" offered by user "Alice" using the sharing API
+    And user "Brian" has accepted the first pending share "/merge-test-outside-perms" offered by user "Alice"
+    And user "Brian" has accepted the next pending share "/merge-test-outside-perms" offered by user "Alice"
     Then as user "Brian" folder "/Shares/merge-test-outside-perms" should contain a property "oc:permissions" with value "SRDNVCK"
     And as "Brian" folder "/Shares/merge-test-outside-perms (2)" should not exist
 
@@ -45,7 +46,8 @@ Feature: sharing
     And user "Alice" has created folder "/merge-test-outside-twogroups-perms"
     When user "Alice" shares folder "/merge-test-outside-twogroups-perms" with group "grp1" with permissions "read" using the sharing API
     And user "Alice" shares folder "/merge-test-outside-twogroups-perms" with group "grp2" with permissions "all" using the sharing API
-    And user "Brian" accepts share "/merge-test-outside-twogroups-perms" offered by user "Alice" using the sharing API
+    And user "Brian" has accepted the first pending share "/merge-test-outside-twogroups-perms" offered by user "Alice"
+    And user "Brian" has accepted the next pending share "/merge-test-outside-twogroups-perms" offered by user "Alice"
     Then as user "Brian" folder "/Shares/merge-test-outside-twogroups-perms" should contain a property "oc:permissions" with value "SRDNVCK"
     And as "Brian" folder "/Shares/merge-test-outside-twogroups-perms (2)" should not exist
 
@@ -56,7 +58,8 @@ Feature: sharing
     When user "Alice" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp1" with permissions "read" using the sharing API
     And user "Alice" shares folder "/merge-test-outside-twogroups-member-perms" with group "grp2" with permissions "all" using the sharing API
     And user "Alice" shares folder "/merge-test-outside-twogroups-member-perms" with user "Brian" with permissions "read" using the sharing API
-    And user "Brian" accepts share "/merge-test-outside-twogroups-member-perms" offered by user "Alice" using the sharing API
+    And user "Brian" has accepted the first pending share "/merge-test-outside-twogroups-member-perms" offered by user "Alice"
+    And user "Brian" has accepted the next pending share "/merge-test-outside-twogroups-member-perms" offered by user "Alice"
     Then as user "Brian" folder "/Shares/merge-test-outside-twogroups-member-perms" should contain a property "oc:permissions" with value "SRDNVCK"
     And as "Brian" folder "/Shares/merge-test-outside-twogroups-member-perms (2)" should not exist
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR changes a few tests to explicitly accept all shares for the same resource. That is required for the tests to pass in the sharesstorageprovider branch.


## Types of changes
- [X] Tests only (no source changes)
