### PR TITLE
[tests-only] [full-ci] skip recently changed tests when running on older oC10

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -189,7 +189,7 @@ Feature: disable user
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     Then the HTTP status code should be "401"
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: getting shares shared by disabled user (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -210,7 +210,7 @@ Feature: disable user
     Then as "Brian" file "/textfile0.txt" should exist
     And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: getting shares shared by disabled user in a group (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -186,7 +186,7 @@ Feature: disable user
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     Then the HTTP status code should be "401"
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: getting shares shared by disabled user (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -207,7 +207,7 @@ Feature: disable user
     Then as "Brian" file "/textfile0.txt" should exist
     And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: getting shares shared by disabled user in a group (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required
+@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: sharing works when a username and group name are the same
 
   Background:
@@ -6,7 +6,7 @@ Feature: sharing works when a username and group name are the same
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnLDAP @skipOnOcV10.3.0 @skipOnOcV10.3.1
+  @skipOnLDAP
   Scenario: creating a new share with user and a group having same name
     Given these users have been created without skeleton files:
       | username |
@@ -30,7 +30,7 @@ Feature: sharing works when a username and group name are the same
     And the content of file "/Shares/randomfile.txt" for user "Brian" should be "Random data"
     And the content of file "/Shares/randomfile.txt" for user "Carol" should be "Random data"
 
-  @skipOnLDAP @skipOnOcV10.3.0 @skipOnOcV10.3.1
+  @skipOnLDAP
   Scenario: creating a new share with group and a user having same name
     Given these users have been created without skeleton files:
       | username |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: share with groups, group names are case-sensitive
 
   Background:
@@ -53,7 +53,7 @@ Feature: share with groups, group names are case-sensitive
       | 2               | Case-Sensitive-Group | CASE-SENSITIVE-GROUP | case-sensitive-group | 200             |
       | 2               | CASE-SENSITIVE-GROUP | case-sensitive-group | Case-Sensitive-Group | 200             |
 
-  @skipOnLDAP @issue-ldap-250 @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+  @skipOnLDAP @issue-ldap-250
   Scenario Outline: group names are case-sensitive, sharing with nonexistent groups with different upper and lower case names
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -388,7 +388,7 @@ Feature: sharing
      | /Shares/randomfile.txt |
     And the content of file "Shares/randomfile.txt" for user "brian" should be "Random data"
 
-  @skipOnLDAP
+  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: creating a new share with user of a group when username contains capital letters
     Given these users have been created without skeleton files:
       | username |
@@ -438,7 +438,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP
+  @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: share with a group and then add a user to that group
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -493,7 +493,7 @@ Feature: sharing
     And file "/textfile0.txt" should not be included as path in the response
     And as "Brian" file "/Shares/textfile0.txt" should not exist
     And as "Carol" file "/Shares/textfile0.txt" should not exist
-    @skipOnOcis
+    @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | path                  |
       | 1               | 100             | /Shares/textfile0.txt |

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: updating shares to users and groups that have the same name
 
   Background:

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -204,7 +204,7 @@ Feature: previews of files downloaded through the webdav API
     When user "Alice" uploads file with content "this is a file to upload" to "/parent.txt" using the WebDAV API
     Then as user "Brian" the preview of "/Shares/parent.txt" with width "32" and height "32" should have been changed
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: it should update the preview content if the file content is updated (content with UTF chars)
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     When user "Alice" uploads file with content "सिमसिमे पानी" to "/lorem.txt" using the WebDAV API
@@ -213,42 +213,42 @@ Feature: previews of files downloaded through the webdav API
     And the downloaded image should be "32" pixels wide and "32" pixels high
     And the downloaded preview content should match with "सिमसिमे-पानी.png" fixtures preview content
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario: updates to a file should change the preview for both sharees and sharers
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has uploaded file with content "file to upload" to "/FOLDER/lorem.txt"
+    And user "Alice" has shared folder "FOLDER" with user "Brian"
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    And user "Alice" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
+    And user "Brian" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
+    When user "Alice" uploads file "filesForUpload/lorem.txt" to "/FOLDER/lorem.txt" using the WebDAV API
+    Then as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    When user "Brian" uploads file with content "new uploaded content" to "/FOLDER/lorem.txt" using the WebDAV API
+    Then as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
 
-    Scenario: updates to a file should change the preview for both sharees and sharers
-      Given user "Brian" has been created with default attributes and without skeleton files
-      And user "Alice" has created folder "FOLDER"
-      And user "Alice" has uploaded file with content "file to upload" to "/FOLDER/lorem.txt"
-      And user "Alice" has shared folder "FOLDER" with user "Brian"
-      And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
-      And user "Alice" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
-      And user "Brian" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
-      When user "Alice" uploads file "filesForUpload/lorem.txt" to "/FOLDER/lorem.txt" using the WebDAV API
-      Then as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-      And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-      When user "Brian" uploads file with content "new uploaded content" to "/FOLDER/lorem.txt" using the WebDAV API
-      Then as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-      And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-
-
-    Scenario: updates to a group shared file should change the preview for both sharees and sharers
-      Given group "grp1" has been created
-      And user "Brian" has been created with default attributes and without skeleton files
-      And user "Carol" has been created with default attributes and without skeleton files
-      And user "Brian" has been added to group "grp1"
-      And user "Carol" has been added to group "grp1"
-      And user "Alice" has created folder "FOLDER"
-      And user "Alice" has uploaded file with content "file to upload" to "/FOLDER/lorem.txt"
-      And user "Alice" has shared folder "/FOLDER" with group "grp1"
-      And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
-      And user "Carol" has accepted share "/FOLDER" offered by user "Alice"
-      And user "Alice" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
-      And user "Brian" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
-      And user "Carol" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
-      When user "Alice" uploads file "filesForUpload/lorem.txt" to "/FOLDER/lorem.txt" using the WebDAV API
-      Then as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-      And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-      And as user "Carol" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-      When user "Brian" uploads file with content "new uploaded content" to "/FOLDER/lorem.txt" using the WebDAV API
-      Then as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-      And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
-      And as user "Carol" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario: updates to a group shared file should change the preview for both sharees and sharers
+    Given group "grp1" has been created
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Brian" has been added to group "grp1"
+    And user "Carol" has been added to group "grp1"
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has uploaded file with content "file to upload" to "/FOLDER/lorem.txt"
+    And user "Alice" has shared folder "/FOLDER" with group "grp1"
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    And user "Carol" has accepted share "/FOLDER" offered by user "Alice"
+    And user "Alice" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
+    And user "Brian" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
+    And user "Carol" has downloaded the preview of "/FOLDER/lorem.txt" with width "32" and height "32"
+    When user "Alice" uploads file "filesForUpload/lorem.txt" to "/FOLDER/lorem.txt" using the WebDAV API
+    Then as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Carol" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    When user "Brian" uploads file with content "new uploaded content" to "/FOLDER/lorem.txt" using the WebDAV API
+    Then as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+    And as user "Carol" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -60,7 +60,7 @@ Feature: Add group
       | "⛷"       |
       | "⛹"       |
 
-  @skipOnLDAP
+  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: adding multiple users to a group
     Given these users have been created without skeleton files:
       | username |

--- a/tests/acceptance/features/webUIPersonalSettings/accessToChangeEmailAddressThroughConfig.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/accessToChangeEmailAddressThroughConfig.feature
@@ -16,6 +16,7 @@ Feature: Control access to edit email address of user through config file
     Then the attributes of user "Alice" returned by the API should include
       | email | new-address@owncloud.com |
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: Admin does not give access to users to change their email address
     When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
     And the user browses to the personal general settings page

--- a/tests/acceptance/features/webUIRenameFiles/renameFile.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFile.feature
@@ -75,6 +75,7 @@ Feature: rename files
     And the user reloads the current page of the webUI
     Then file "aaaaaa.txt" should be listed on the webUI
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: Rename a file using spaces at front and/or back of file name and type
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -48,6 +48,7 @@ Feature: rename folders
     And the user reloads the current page of the webUI
     Then folder "hash#And&QuestionMark?At@FolderName" should be listed on the webUI
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: Rename a folder using spaces at front and/or back of the name
     Given user "Alice" has created folder "a-folder"
     And user "Alice" has logged in using the webUI


### PR DESCRIPTION
## Description
Various core PRs have been merged in the last few days that add/change core behavior... The effected tests are not expected to pass any more against previous oC10 releases, so skip in that case.

Nightly CI https://drone.owncloud.com/owncloud/files_primary_s3/2525 has the examples of what fails.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
