### PR TITLE
feat: encryption keys location can be specified by the storage implementation

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -216,10 +216,10 @@ class Trashbin {
 	 * @param string $sourcePath
 	 * @param string $owner
 	 * @param string $targetPath
-	 * @param $user
+	 * @param string $user
 	 * @param integer $timestamp
 	 */
-	private static function copyFilesToUser($sourcePath, $owner, $targetPath, $user, $timestamp) {
+	public static function copyFilesToUser($sourcePath, $owner, $targetPath, $user, $timestamp) {
 		self::setUpTrash($owner);
 
 		$targetFilename = \basename($targetPath);
@@ -374,7 +374,16 @@ class Trashbin {
 			}
 			Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', [
 				'filePath' => Filesystem::normalizePath($file_path),
-				'trashPath' => Filesystem::normalizePath($filename . '.d' . $timestamp)
+				'trashPath' => Filesystem::normalizePath($filename . '.d' . $timestamp),
+				'sourceStorage' => $sourceStorage,
+				'sourceInternalPath' => $sourceInternalPath,
+				'trashStorage' => $trashStorage,
+				'trashInternalPath' => $trashInternalPath,
+				'trashVersionStorage' => $trashVersionStorage,
+				'trashVersionInternalPath' => $trashVersionInternalPath,
+				'ownerPath' => $ownerPath,
+				'owner' => $owner,
+				'timestamp' => $timestamp,
 			]);
 
 			if (!$sourceStorage->instanceOfStorage(IVersionedStorage::class)) {

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -47,6 +47,7 @@ use OCA\Files_Versions\MetaStorage;
 use OCP\Encryption\Keys\IStorage;
 use OCP\Files\ForbiddenException;
 use OCP\Files\NotFoundException;
+use OCP\Files\Storage\IVersionedStorage;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Lock\LockedException;
 use OCP\User;
@@ -376,11 +377,13 @@ class Trashbin {
 				'trashPath' => Filesystem::normalizePath($filename . '.d' . $timestamp)
 			]);
 
-			self::retainVersions($filename, $owner, $ownerPath, $timestamp, $sourceStorage);
+			if (!$sourceStorage->instanceOfStorage(IVersionedStorage::class)) {
+				self::retainVersions($filename, $owner, $ownerPath, $timestamp, $sourceStorage);
 
-			// if owner !== user we need to also add a copy to the owners trash
-			if ($user !== $owner) {
-				self::copyFilesToUser($ownerPath, $owner, $file_path, $user, $timestamp);
+				// if owner !== user we need to also add a copy to the owners trash
+				if ($user !== $owner) {
+					self::copyFilesToUser($ownerPath, $owner, $file_path, $user, $timestamp);
+				}
 			}
 		}
 

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -47,6 +47,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Lock\LockedException;
 use OCP\User;
+use OCP\Util;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -267,7 +268,7 @@ class Trashbin {
 		$query = \OC_DB::prepare("INSERT INTO `*PREFIX*files_trash` (`id`,`timestamp`,`location`,`user`) VALUES (?,?,?,?)");
 		$result = $query->execute([$targetFilename, $timestamp, $targetLocation, $user]);
 		if (!$result) {
-			\OCP\Util::writeLog('files_trashbin', 'trash bin database couldn\'t be updated for the files owner', \OCP\Util::ERROR);
+			Util::writeLog('files_trashbin', 'trash bin database couldn\'t be updated for the files owner', Util::ERROR);
 		}
 	}
 
@@ -279,6 +280,7 @@ class Trashbin {
 	 * isn't any trashbin available
 	 */
 	public static function move2trash($file_path) {
+
 		// get the user for which the filesystem is setup
 		$root = Filesystem::getRoot();
 		list(, $user) = \explode('/', $root);
@@ -316,11 +318,25 @@ class Trashbin {
 		$timestamp = \time();
 
 		$trashPath = '/files_trashbin/files/' . $filename . '.d' . $timestamp;
+		$trashVersionsPath = '/files_trashbin/versions/' . $filename . '.d' . $timestamp;
 
 		/** @var \OC\Files\Storage\Storage $trashStorage */
 		list($trashStorage, $trashInternalPath) = $ownerView->resolvePath($trashPath);
+		list($trashVersionStorage, $trashVersionInternalPath) = $ownerView->resolvePath($trashVersionsPath);
 		/** @var \OC\Files\Storage\Storage $sourceStorage */
 		list($sourceStorage, $sourceInternalPath) = $ownerView->resolvePath('/files/' . $ownerPath);
+
+		Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'before_moveToTrash', [
+			'filePath' => Filesystem::normalizePath($file_path),
+			'trashPath' => Filesystem::normalizePath($filename . '.d' . $timestamp),
+			'sourceStorage' => $sourceStorage,
+			'sourceInternalPath' => $sourceInternalPath,
+			'trashStorage' => $trashStorage,
+			'trashInternalPath' => $trashInternalPath,
+			'trashVersionStorage' => $trashVersionStorage,
+			'trashVersionInternalPath' => $trashVersionInternalPath,
+		]);
+
 		try {
 			$moveSuccessful = true;
 			if ($trashStorage->file_exists($trashInternalPath)) {
@@ -332,7 +348,7 @@ class Trashbin {
 			if ($trashStorage->file_exists($trashInternalPath)) {
 				$trashStorage->unlink($trashInternalPath);
 			}
-			\OCP\Util::writeLog('files_trashbin', 'Couldn\'t move ' . $file_path . ' to the trash bin', \OCP\Util::ERROR);
+			Util::writeLog('files_trashbin', 'Couldn\'t move ' . $file_path . ' to the trash bin', Util::ERROR);
 		}
 
 		if ($sourceStorage->file_exists($sourceInternalPath)) { // failed to delete the original file, abort
@@ -350,9 +366,9 @@ class Trashbin {
 			$query = \OC_DB::prepare("INSERT INTO `*PREFIX*files_trash` (`id`,`timestamp`,`location`,`user`) VALUES (?,?,?,?)");
 			$result = $query->execute([$filename, $timestamp, $location, $owner]);
 			if (!$result) {
-				\OCP\Util::writeLog('files_trashbin', 'trash bin database couldn\'t be updated', \OCP\Util::ERROR);
+				Util::writeLog('files_trashbin', 'trash bin database couldn\'t be updated', Util::ERROR);
 			}
-			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
+			Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
 				'trashPath' => Filesystem::normalizePath($filename . '.d' . $timestamp)]);
 
 			self::retainVersions($filename, $owner, $ownerPath, $timestamp, $sourceStorage);
@@ -522,8 +538,8 @@ class Trashbin {
 			if ($timestamp) {
 				$location = self::getLocation($user, $filename, $timestamp);
 				if ($location === false) {
-					\OCP\Util::writeLog('files_trashbin', 'Original location of file ' . $filename .
-						' not found in database, hence restoring into user\'s root instead', \OCP\Util::DEBUG);
+					Util::writeLog('files_trashbin', 'Original location of file ' . $filename .
+						' not found in database, hence restoring into user\'s root instead', Util::DEBUG);
 				} else {
 					// if location no longer exists, restore file in the root directory
 					if ($location !== '/' &&
@@ -556,8 +572,10 @@ class Trashbin {
 			$view->chroot('/' . $user . '/files');
 			$view->touch('/' . $targetLocation, $mtime);
 			$view->chroot($fakeRoot);
-			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', ['filePath' => Filesystem::normalizePath('/' . $targetLocation),
-				'trashPath' => Filesystem::normalizePath($file)]);
+			Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', [
+				'filePath' => Filesystem::normalizePath('/' . $targetLocation),
+				'trashPath' => Filesystem::normalizePath($file)
+			]);
 
 			self::restoreVersions($view, $file, $filename, $targetLocation, $timestamp);
 
@@ -648,7 +666,7 @@ class Trashbin {
 		// Array to store the relative path in (after the file is deleted, the view won't be able to relativise the path anymore)
 		$filePaths = [];
 		foreach ($fileInfos as $fileInfo) {
-			$filePaths[] = $view->getRelativePath($fileInfo->getPath());
+			$filePaths[$fileInfo->getId()] = $view->getRelativePath($fileInfo->getPath());
 		}
 		unset($fileInfos); // save memory
 
@@ -656,8 +674,8 @@ class Trashbin {
 		\OC_Hook::emit('\OCP\Trashbin', 'preDeleteAll', ['paths' => $filePaths]);
 
 		// Single-File Hooks
-		foreach ($filePaths as $path) {
-			self::emitTrashbinPreDelete($user, $path);
+		foreach ($filePaths as $fileId => $path) {
+			self::emitTrashbinPreDelete($user, $path, $fileId);
 		}
 
 		// actual file deletion
@@ -669,8 +687,8 @@ class Trashbin {
 		\OC_Hook::emit('\OCP\Trashbin', 'deleteAll', ['paths' => $filePaths]);
 
 		// Single-File Hooks
-		foreach ($filePaths as $path) {
-			self::emitTrashbinPostDelete($user, $path);
+		foreach ($filePaths as $fileId => $path) {
+			self::emitTrashbinPostDelete($user, $path, $fileId);
 		}
 
 		$view->mkdir('files_trashbin');
@@ -685,11 +703,15 @@ class Trashbin {
 	 * @param string $uid
 	 * @param string $path
 	 */
-	protected static function emitTrashbinPreDelete($uid, $path) {
+	protected static function emitTrashbinPreDelete($uid, $path, $fileId) {
 		\OC_Hook::emit(
 			'\OCP\Trashbin',
 			'preDelete',
-			['path' => $path, 'user' => $uid]
+			[
+				'path' => $path,
+				'user' => $uid,
+				'fileId' => $fileId
+			]
 		);
 	}
 
@@ -699,11 +721,14 @@ class Trashbin {
 	 * @param string $uid
 	 * @param string $path
 	 */
-	protected static function emitTrashbinPostDelete($uid, $path) {
+	protected static function emitTrashbinPostDelete($uid, $path, $fileId) {
 		\OC_Hook::emit(
 			'\OCP\Trashbin',
 			'delete',
-			['path' => $path, 'user' => $uid]
+			[
+				'path' => $path,
+				'user' => $uid,
+				'fileId' => $fileId]
 		);
 	}
 
@@ -739,9 +764,10 @@ class Trashbin {
 		} else {
 			$size += $view->filesize('/files_trashbin/files/' . $file);
 		}
-		self::emitTrashbinPreDelete($user, "/files_trashbin/files/$file");
+		$fileId = $view->getFileInfo('/files_trashbin/files/' . $file);
+		self::emitTrashbinPreDelete($user, "/files_trashbin/files/$file", $fileId);
 		$view->unlink('/files_trashbin/files/' . $file);
-		self::emitTrashbinPostDelete($user, "/files_trashbin/files/$file");
+		self::emitTrashbinPostDelete($user, "/files_trashbin/files/$file", $fileId);
 
 		return $size;
 	}
@@ -1011,15 +1037,15 @@ class Trashbin {
 	 */
 	public static function registerHooks() {
 		// create storage wrapper on setup
-		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', 'OCA\Files_Trashbin\Storage', 'setupStorage');
+		Util::connectHook('OC_Filesystem', 'preSetup', 'OCA\Files_Trashbin\Storage', 'setupStorage');
 		//Listen to delete user signal
-		\OCP\Util::connectHook('OC_User', 'pre_deleteUser', 'OCA\Files_Trashbin\Hooks', 'deleteUser_hook');
+		Util::connectHook('OC_User', 'pre_deleteUser', 'OCA\Files_Trashbin\Hooks', 'deleteUser_hook');
 		//Listen to post write hook
-		\OCP\Util::connectHook('OC_Filesystem', 'post_write', 'OCA\Files_Trashbin\Hooks', 'post_write_hook');
+		Util::connectHook('OC_Filesystem', 'post_write', 'OCA\Files_Trashbin\Hooks', 'post_write_hook');
 		// pre and post-rename, disable trash logic for the copy+unlink case
-		\OCP\Util::connectHook('OC_Filesystem', 'delete', 'OCA\Files_Trashbin\Trashbin', 'ensureFileScannedHook');
-		\OCP\Util::connectHook('OC_Filesystem', 'rename', 'OCA\Files_Trashbin\Storage', 'preRenameHook');
-		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Files_Trashbin\Storage', 'postRenameHook');
+		Util::connectHook('OC_Filesystem', 'delete', 'OCA\Files_Trashbin\Trashbin', 'ensureFileScannedHook');
+		Util::connectHook('OC_Filesystem', 'rename', 'OCA\Files_Trashbin\Storage', 'preRenameHook');
+		Util::connectHook('OC_Filesystem', 'post_rename', 'OCA\Files_Trashbin\Storage', 'postRenameHook');
 	}
 
 	/**
@@ -1076,6 +1102,6 @@ class Trashbin {
 	 * @return string
 	 */
 	public static function preview_icon($path) {
-		return \OCP\Util::linkToRoute('core_ajax_trashbin_preview', ['x' => 32, 'y' => 32, 'file' => $path]);
+		return Util::linkToRoute('core_ajax_trashbin_preview', ['x' => 32, 'y' => 32, 'file' => $path]);
 	}
 }

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -371,8 +371,10 @@ class Trashbin {
 			if (!$result) {
 				Util::writeLog('files_trashbin', 'trash bin database couldn\'t be updated', Util::ERROR);
 			}
-			Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
-				'trashPath' => Filesystem::normalizePath($filename . '.d' . $timestamp)]);
+			Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', [
+				'filePath' => Filesystem::normalizePath($file_path),
+				'trashPath' => Filesystem::normalizePath($filename . '.d' . $timestamp)
+			]);
 
 			self::retainVersions($filename, $owner, $ownerPath, $timestamp, $sourceStorage);
 
@@ -566,6 +568,12 @@ class Trashbin {
 		}
 		$mtime = $view->filemtime($source);
 
+		Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'pre_restore', [
+			'user' => $user,
+			'source' => $source,
+			'target' => $target
+		]);
+
 		// restore file
 		$restoreResult = $view->rename($source, $target);
 
@@ -730,7 +738,7 @@ class Trashbin {
 	 * @throws HintException
 	 * @throws ServerNotAvailableException
 	 */
-	protected static function emitTrashbinPostDelete($uid, $path, $fileInfo, $originalLocation) {
+	protected static function emitTrashbinPostDelete($uid, $path, $fileInfo, $originalLocation = null) {
 		\OC_Hook::emit(
 			'\OCP\Trashbin',
 			'delete',

--- a/changelog/unreleased/39091
+++ b/changelog/unreleased/39091
@@ -1,0 +1,7 @@
+Change: Allow storage implementations to have their own encryption key storage
+
+The default encryption key storage location is not suitable for all storage
+implementations because e.g. the storage is not linked to a user.
+This is required for files_spaces.
+
+https://github.com/owncloud/core/pull/39091

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -141,6 +141,14 @@ class Storage implements IStorage {
 	 * @inheritdoc
 	 */
 	public function setFileKey($path, $keyId, $key, $encryptionModuleId) {
+		$mount = $this->mountManager->find($path);
+		if ($mount) {
+			$result = $mount->getStorage()->setFileKey($mount->getInternalPath($path), $keyId, $key, $encryptionModuleId);
+			if ($result !== null) {
+				return $result;
+			}
+		}
+
 		$keyDir = $this->getFileKeyDir($encryptionModuleId, $path);
 		return $this->setKey($keyDir . $keyId, $key);
 	}

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -176,6 +176,12 @@ class Storage implements IStorage {
 	 * @inheritdoc
 	 */
 	public function deleteAllFileKeys($path) {
+		$mount = $this->mountManager->find($path);
+		$keyPath = $mount ? $mount->getStorage()->getEncryptionFileKeyDirectory('', $mount->getInternalPath($path)) : null;
+		if ($keyPath) {
+			return false;
+		}
+
 		$keyDir = $this->getFileKeyDir('', $path);
 		return !$this->view->file_exists($keyDir) || $this->view->deleteAll($keyDir);
 	}
@@ -348,6 +354,13 @@ class Storage implements IStorage {
 	 * @return string
 	 */
 	protected function getPathToKeys($path) {
+		# ask the storage implementation for the key storage
+		$mount = $this->mountManager->find($path);
+		$keyPath = $mount ? $mount->getStorage()->getEncryptionFileKeyDirectory('', $mount->getInternalPath($path)) : null;
+		if ($keyPath) {
+			return $keyPath;
+		}
+
 		list($owner, $relativePath) = $this->util->getUidAndFilename($path);
 		$systemWideMountPoint = $this->util->isSystemWideMountPoint($relativePath, $owner);
 

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -338,7 +338,9 @@ class Storage implements IStorage {
 
 		if ($this->view->file_exists($sourcePath)) {
 			$this->keySetPreparation(\dirname($targetPath));
-			$this->view->rename($sourcePath, $targetPath);
+			if ($sourcePath !== $targetPath) {
+				$this->view->rename($sourcePath, $targetPath);
+			}
 
 			return true;
 		}

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -96,6 +96,17 @@ class Storage implements IStorage {
 	 */
 	public function getFileKey($path, $keyId, $encryptionModuleId) {
 		$realFile = $this->util->stripPartialFileExtension($path);
+		$mount = $this->mountManager->find($realFile);
+		if ($mount) {
+			$result = $mount->getStorage()->getFileKey($mount->getInternalPath($realFile), $keyId, $encryptionModuleId);
+			if ($result !== null) {
+				if ($result === '' && $realFile !== $path) {
+					return $mount->getStorage()->getFileKey($mount->getInternalPath($path), $keyId, $encryptionModuleId);
+				}
+				return $result;
+			}
+		}
+
 		$keyDir = $this->getFileKeyDir($encryptionModuleId, $realFile);
 		$key = $this->getKey($keyDir . $keyId);
 

--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -99,6 +99,8 @@ class Util {
 		$this->config = $config;
 
 		$this->excludedPaths[] = 'files_encryption';
+		$this->excludedPaths[] = 'files_spaces';
+
 		// contains certificates
 		$this->excludedPaths[] = 'files_external';
 		$this->excludedPaths[] = 'avatars';

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -797,4 +797,8 @@ abstract class Common implements Storage, ILockingStorage, IVersionedStorage, IP
 			return $lock;
 		}, $locks);
 	}
+
+	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string {
+		return null;
+	}
 }

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -802,7 +802,11 @@ abstract class Common implements Storage, ILockingStorage, IVersionedStorage, IP
 		return null;
 	}
 
-	public function getFileKey(string $path, string $keyId, string $encryptionModuleId): ?string {
+	public function getFileKey(string $internalPath, string $keyId, string $encryptionModuleId): ?string {
+		return null;
+	}
+
+	public function setFileKey(string $internalPath, string $keyId, $key, string $encryptionModuleId): ?bool {
 		return null;
 	}
 }

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -801,4 +801,8 @@ abstract class Common implements Storage, ILockingStorage, IVersionedStorage, IP
 	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string {
 		return null;
 	}
+
+	public function getFileKey(string $path, string $keyId, string $encryptionModuleId): ?string {
+		return null;
+	}
 }

--- a/lib/private/Files/Storage/Storage.php
+++ b/lib/private/Files/Storage/Storage.php
@@ -115,4 +115,6 @@ interface Storage extends \OCP\Files\Storage {
 	 * @throws \OCP\Lock\LockedException
 	 */
 	public function changeLock($path, $type, ILockingProvider $provider);
+
+	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string;
 }

--- a/lib/private/Files/Storage/Storage.php
+++ b/lib/private/Files/Storage/Storage.php
@@ -117,4 +117,6 @@ interface Storage extends \OCP\Files\Storage {
 	public function changeLock($path, $type, ILockingProvider $provider);
 
 	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string;
+
+	public function getFileKey(string $path, string $keyId, string $encryptionModuleId): ?string;
 }

--- a/lib/private/Files/Storage/Storage.php
+++ b/lib/private/Files/Storage/Storage.php
@@ -118,5 +118,7 @@ interface Storage extends \OCP\Files\Storage {
 
 	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string;
 
-	public function getFileKey(string $path, string $keyId, string $encryptionModuleId): ?string;
+	public function getFileKey(string $internalPath, string $keyId, string $encryptionModuleId): ?string;
+
+	public function setFileKey(string $internalPath, string $keyId, $key, string $encryptionModuleId): ?bool;
 }

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -254,7 +254,11 @@ class Encryption extends Wrapper implements Storage\IVersionedStorage {
 
 		$encryptionModule = ($this->encryptionManager->isEnabled()) ? $this->getEncryptionModule($path) : "";
 		if ($encryptionModule) {
-			$this->keyStorage->deleteAllFileKeys($this->getFullPath($path));
+			# TODO: stupid short cut - we better have an capabilities method or something
+			$keyPath = $this->storage->getEncryptionFileKeyDirectory($encryptionModule->getId(), $path);
+			if (!$keyPath) {
+				$this->keyStorage->deleteAllFileKeys($this->getFullPath($path));
+			}
 		}
 
 		return $this->storage->unlink($path);

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -1132,10 +1132,10 @@ class Encryption extends Wrapper implements Storage\IVersionedStorage {
 			$fileEncryptionVersion = null;
 			$info = $this->storage->getVersion($internalPath, $versionId);
 
-			if ($info['size']) {
+			if (isset($info['size'])) {
 				$unencryptedSize = $info['size'];
 			}
-			if ($info['encryptedVersion']) {
+			if (isset($info['encryptedVersion'])) {
 				$fileEncryptionVersion = $info['encryptedVersion'];
 			}
 			$headerSize = $this->getHeaderSize($stream);

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -479,11 +479,15 @@ class Encryption extends Wrapper implements Storage\IVersionedStorage {
 					return false;
 				}
 
+				$sourceFileOfRename = null;
 				if (isset($this->sourcePath[$path])) {
 					$sourceFileOfRename = $this->sourcePath[$path];
-				} else {
-					$sourceFileOfRename = null;
+					$mount = $this->mountManager->find($sourceFileOfRename);
+					if ($mount) {
+						$data = $mount->getStorage()->getCache()->get($mount->getInternalPath($sourceFileOfRename));
+					}
 				}
+				$encryptedVersion = $data['encryptedVersion'] ?? null;
 				$handle = \OC\Files\Stream\Encryption::wrap(
 					$source,
 					$path,
@@ -501,7 +505,7 @@ class Encryption extends Wrapper implements Storage\IVersionedStorage {
 					$headerSize,
 					$signed,
 					$sourceFileOfRename,
-					null # TODO: maybe fill it?
+					$encryptedVersion,
 				);
 				unset($this->sourcePath[$path]);
 

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -91,6 +91,8 @@ class Encryption extends Wrapper implements Storage\IVersionedStorage {
 
 	private static $disableWriteEncryption = false;
 
+	private $inCopyKeys = false;
+
 	/**
 	 * @param array $parameters
 	 * @param IManager $encryptionManager
@@ -309,7 +311,11 @@ class Encryption extends Wrapper implements Storage\IVersionedStorage {
 			$this->util->isExcluded($fullPath) === false &&
 			$this->encryptionManager->isEnabled()
 		) {
-			$this->keyStorage->deleteAllFileKeys($fullPath);
+			# TODO: stupid short cut - we better have an capabilities method or something
+			$keyPath = $this->storage->getEncryptionFileKeyDirectory('', $path);
+			if (!$keyPath) {
+				$this->keyStorage->deleteAllFileKeys($fullPath);
+			}
 		}
 
 		return $result;
@@ -1062,11 +1068,17 @@ class Encryption extends Wrapper implements Storage\IVersionedStorage {
 	 * @return bool
 	 */
 	protected function copyKeys($source, $target) {
-		if (!$this->util->isExcluded($source)) {
-			return $this->keyStorage->copyKeys($source, $target);
+		if ($this->inCopyKeys) {
+			return false;
 		}
+		if ($this->util->isExcluded($source)) {
+			return false;
+		}
+		$this->inCopyKeys = true;
 
-		return false;
+		$result = $this->keyStorage->copyKeys($source, $target);
+		$this->inCopyKeys = false;
+		return $result;
 	}
 
 	/**

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -47,6 +47,9 @@ use OCP\Files\Cache\ICacheEntry;
 class Encryption extends Wrapper implements Storage\IVersionedStorage {
 	use LocalTempFileTrait;
 
+	/** @var bool */
+	public static $forceDisableUpdateEncryptedVersion = false;
+
 	/** @var string */
 	private $mountPoint;
 
@@ -709,6 +712,9 @@ class Encryption extends Wrapper implements Storage\IVersionedStorage {
 	 * @param bool $isRename
 	 */
 	private function updateEncryptedVersion(Storage $sourceStorage, $sourceInternalPath, $targetInternalPath, $isRename) {
+		if (self::$forceDisableUpdateEncryptedVersion) {
+			return;
+		}
 		$isEncrypted = $this->encryptionManager->isEnabled() && $this->mount->getOption('encrypt', true) ? 1 : 0;
 		$cacheInformation = [
 			'encrypted' => (bool)$isEncrypted,

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -651,4 +651,8 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IPersistent
 
 		return [];
 	}
+
+	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string {
+		return $this->getWrapperStorage()->getEncryptionFileKeyDirectory($encryptionModuleId, $path);
+	}
 }

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -655,4 +655,8 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IPersistent
 	public function getEncryptionFileKeyDirectory(string $encryptionModuleId, string $path): ?string {
 		return $this->getWrapperStorage()->getEncryptionFileKeyDirectory($encryptionModuleId, $path);
 	}
+
+	public function getFileKey(string $path, string $keyId, string $encryptionModuleId): ?string {
+		return $this->getWrapperStorage()->getFileKey($path, $keyId, $encryptionModuleId);
+	}
 }

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -656,7 +656,11 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IPersistent
 		return $this->getWrapperStorage()->getEncryptionFileKeyDirectory($encryptionModuleId, $path);
 	}
 
-	public function getFileKey(string $path, string $keyId, string $encryptionModuleId): ?string {
-		return $this->getWrapperStorage()->getFileKey($path, $keyId, $encryptionModuleId);
+	public function getFileKey(string $internalPath, string $keyId, string $encryptionModuleId): ?string {
+		return $this->getWrapperStorage()->getFileKey($internalPath, $keyId, $encryptionModuleId);
+	}
+
+	public function setFileKey(string $internalPath, string $keyId, $key, string $encryptionModuleId): ?bool {
+		return $this->getWrapperStorage()->setFileKey($internalPath, $keyId, $key, $encryptionModuleId);
 	}
 }

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -116,7 +116,8 @@ class Encryption extends Wrapper {
 			'encryptionStorage',
 			'headerSize',
 			'signed',
-			'sourceFileOfRename'
+			'sourceFileOfRename',
+			'fileEncryptionVersion'
 		];
 	}
 
@@ -160,7 +161,8 @@ class Encryption extends Wrapper {
 		$unencryptedSize,
 		$headerSize,
 		$signed,
-		$sourceFileOfRename = null,
+		$sourceFileOfRename,
+		$fileEncryptionVersion,
 		$wrapper =  'OC\Files\Stream\Encryption'
 	) {
 		$context = \stream_context_create([
@@ -179,7 +181,8 @@ class Encryption extends Wrapper {
 				'encryptionStorage' => $encStorage,
 				'headerSize' => $headerSize,
 				'signed' => $signed,
-				'sourceFileOfRename' => $sourceFileOfRename
+				'sourceFileOfRename' => $sourceFileOfRename,
+				'fileEncryptionVersion' => $fileEncryptionVersion
 			]
 		]);
 
@@ -259,7 +262,7 @@ class Encryption extends Wrapper {
 		}
 
 		$accessList = $this->file->getAccessList($sharePath);
-		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $mode, $this->header, $accessList, $context['sourceFileOfRename']);
+		$this->newHeader = $this->encryptionModule->begin($this->fullPath, $this->uid, $mode, $this->header, $accessList, $context['sourceFileOfRename'], $context['fileEncryptionVersion'] ?? null);
 		$this->unencryptedBlockSize = $this->encryptionModule->getUnencryptedBlockSize($this->signed);
 		
 		if (

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -839,6 +839,8 @@ class View {
 						[
 							Filesystem::signal_param_oldpath => $this->getHookPath($path1),
 							Filesystem::signal_param_newpath => $this->getHookPath($path2),
+							Filesystem::signal_param_oldpath.'_abs' => $absolutePath1,
+							Filesystem::signal_param_newpath.'_abs' => $absolutePath2,
 							Filesystem::signal_param_run => &$run
 						]
 					);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -216,7 +216,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			return new Encryption\Keys\Storage(
 				$view,
 				$util,
-				$c->getUserSession()
+				$c->getUserSession(),
+				$c->getMountManager()
 			);
 		});
 		$this->registerService('TagMapper', function (Server $c) {

--- a/lib/public/Encryption/IEncryptionModule.php
+++ b/lib/public/Encryption/IEncryptionModule.php
@@ -66,7 +66,7 @@ interface IEncryptionModule {
 	 *                       or if no additional data is needed return a empty array
 	 * @since 8.1.0
 	 */
-	public function begin($path, $user, $mode, array $header, array $accessList, $sourceFileOfRename);
+	public function begin($path, $user, $mode, array $header, array $accessList, $sourceFileOfRename, $fileEncryptionVersion);
 
 	/**
 	 * last chunk received. This is the place where you can perform some final

--- a/settings/ChangePassword/Controller.php
+++ b/settings/ChangePassword/Controller.php
@@ -123,7 +123,6 @@ class Controller {
 				$keyStorage,
 				$crypt,
 				\OC::$server->getConfig(),
-				\OC::$server->getUserSession(),
 				/* @phan-suppress-next-line PhanUndeclaredClassMethod */
 				new \OCA\Encryption\Session(\OC::$server->getSession()),
 				\OC::$server->getLogger(),

--- a/tests/lib/Encryption/Keys/StorageTest.php
+++ b/tests/lib/Encryption/Keys/StorageTest.php
@@ -25,11 +25,16 @@ namespace Test\Encryption\Keys;
 
 use OC\Encryption\Keys\Storage;
 use OC\Encryption\Util;
+use OC\Files\Filesystem;
 use OC\Files\View;
+use OCP\Files\Mount\IMountManager;
+use OCP\Files\Mount\IMountPoint;
 use OCP\IUser;
 use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 use Test\Traits\UserTrait;
+use OCP\IConfig;
 
 /**
  * Class StorageTest
@@ -44,56 +49,66 @@ class StorageTest extends TestCase {
 	/** @var Storage */
 	protected $storage;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | Util */
+	/** @var MockObject | Util */
 	protected $util;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | View */
+	/** @var MockObject | View */
 	protected $view;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject */
+	/** @var MockObject */
 	protected $config;
+	/**
+	 * @var string[]
+	 */
+	private $mkdirStack;
+	/**
+	 * @var IMountManager|MockObject
+	 */
+	private $mountManager;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->util = $this->getMockBuilder('OC\Encryption\Util')
+		$this->util = $this->getMockBuilder(Util::class)
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->util->method('getKeyStorageRoot')->willReturn('');
 
-		$this->view = $this->getMockBuilder('OC\Files\View')
+		$this->view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->config = $this->getMockBuilder('OCP\IConfig')
+		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->mountManager = $this->createMock(IMountManager::class);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user1');
-		/** @var IUserSession | \PHPUnit\Framework\MockObject\MockObject $userSession */
+		/** @var IUserSession | MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession->method('getUser')->willReturn($user);
 
 		$this->createUser('user1', '123456');
 		$this->createUser('user2', '123456');
-		$this->storage = new Storage($this->view, $this->util, $userSession);
+		$this->storage = new Storage($this->view, $this->util, $userSession, $this->mountManager);
 	}
 
 	public function tearDown(): void {
-		\OC\Files\Filesystem::tearDown();
+		Filesystem::tearDown();
 		parent::tearDown();
 	}
 
-	public function testSetFileKey() {
-		$this->util->expects($this->any())
+	public function testSetFileKey(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(false);
 		$this->view->expects($this->once())
@@ -109,7 +124,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function dataTestGetFileKey() {
+	public function dataTestGetFileKey(): array {
 		return [
 			['/files/foo.txt', '/files/foo.txt', true, 'key'],
 			['/files/foo.txt.ocTransferId2111130212.part', '/files/foo.txt', true, 'key'],
@@ -125,8 +140,8 @@ class StorageTest extends TestCase {
 	 * @param bool $originalKeyExists
 	 * @param string $expectedKeyContent
 	 */
-	public function testGetFileKey($path, $strippedPartialName, $originalKeyExists, $expectedKeyContent) {
-		$this->util->expects($this->any())
+	public function testGetFileKey($path, $strippedPartialName, $originalKeyExists, $expectedKeyContent): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturnMap([
 				['user1/files/foo.txt', ['user1', '/files/foo.txt']],
@@ -137,7 +152,7 @@ class StorageTest extends TestCase {
 		$this->util->expects($this->once())
 			->method('stripPartialFileExtension')
 			->willReturn('user1' . $strippedPartialName);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(false);
 
@@ -176,14 +191,14 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testSetFileKeySystemWide() {
-		$this->util->expects($this->any())
+	public function testSetFileKeySystemWide(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(true);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
 		$this->view->expects($this->once())
@@ -199,14 +214,14 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testGetFileKeySystemWide() {
-		$this->util->expects($this->any())
+	public function testGetFileKeySystemWide(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(true);
 		$this->view->expects($this->once())
@@ -224,7 +239,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testSetSystemUserKey() {
+	public function testSetSystemUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_put_contents')
 			->with(
@@ -238,7 +253,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testSetUserKey() {
+	public function testSetUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_put_contents')
 			->with(
@@ -252,7 +267,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testGetSystemUserKey() {
+	public function testGetSystemUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_get_contents')
 			->with($this->equalTo('/files_encryption/encModule/shareKey_56884'))
@@ -268,7 +283,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testGetUserKey() {
+	public function testGetUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_get_contents')
 			->with($this->equalTo('/user1/files_encryption/encModule/user1.publicKey'))
@@ -284,7 +299,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testGetUserKeyShared() {
+	public function testGetUserKeyShared(): void {
 		$this->view->expects($this->once())
 			->method('file_get_contents')
 			->with($this->equalTo('/user2/files_encryption/encModule/user2.publicKey'))
@@ -304,7 +319,7 @@ class StorageTest extends TestCase {
 		$this->assertTrue($this->isUserHomeMounted('user2'));
 	}
 
-	public function testGetUserKeyWhenKeyStorageIsOutsideHome() {
+	public function testGetUserKeyWhenKeyStorageIsOutsideHome(): void {
 		$this->view->expects($this->once())
 			->method('file_get_contents')
 			->with($this->equalTo('/enckeys/user2/files_encryption/encModule/user2.publicKey'))
@@ -318,9 +333,9 @@ class StorageTest extends TestCase {
 		$user->method('getUID')->willReturn('user1');
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession->method('getUser')->willReturn($user);
-		$util = $this->createMock(\OC\Encryption\Util::class);
+		$util = $this->createMock(Util::class);
 		$util->method('getKeyStorageRoot')->willReturn('enckeys');
-		$storage = new Storage($this->view, $util, $userSession);
+		$storage = new Storage($this->view, $util, $userSession, $this->mountManager);
 
 		$this->assertFalse($this->isUserHomeMounted('user2'));
 
@@ -338,7 +353,7 @@ class StorageTest extends TestCase {
 	 * @param string $userId
 	 * @return boolean true if mounted, false otherwise
 	 */
-	private function isUserHomeMounted($userId) {
+	private function isUserHomeMounted($userId): bool {
 		// verify that user2's FS got mounted when retrieving the key
 		$mountManager = \OC::$server->getMountManager();
 		$mounts = $mountManager->getAll();
@@ -349,7 +364,7 @@ class StorageTest extends TestCase {
 		return !empty($mounts);
 	}
 
-	public function testDeleteUserKey() {
+	public function testDeleteUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_exists')
 			->with($this->equalTo('/user1/files_encryption/encModule/user1.publicKey'))
@@ -364,7 +379,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testDeleteSystemUserKey() {
+	public function testDeleteSystemUserKey(): void {
 		$this->view->expects($this->once())
 			->method('file_exists')
 			->with($this->equalTo('/files_encryption/encModule/shareKey_56884'))
@@ -379,14 +394,14 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testDeleteFileKeySystemWide() {
-		$this->util->expects($this->any())
+	public function testDeleteFileKeySystemWide(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(true);
 		$this->view->expects($this->once())
@@ -403,14 +418,14 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function testDeleteFileKey() {
-		$this->util->expects($this->any())
+	public function testDeleteFileKey(): void {
+		$this->util
 			->method('getUidAndFilename')
 			->willReturn(['user1', '/files/foo.txt']);
-		$this->util->expects($this->any())
+		$this->util
 			->method('stripPartialFileExtension')
 			->willReturnArgument(0);
-		$this->util->expects($this->any())
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn(false);
 		$this->view->expects($this->once())
@@ -430,11 +445,11 @@ class StorageTest extends TestCase {
 	/**
 	 * @dataProvider dataProviderCopyRename
 	 */
-	public function testRenameKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget) {
-		$this->view->expects($this->any())
+	public function testRenameKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget): void {
+		$this->view
 			->method('file_exists')
 			->willReturn(true);
-		$this->view->expects($this->any())
+		$this->view
 			->method('is_dir')
 			->willReturn(true);
 		$this->view->expects($this->once())
@@ -444,12 +459,12 @@ class StorageTest extends TestCase {
 				$this->equalTo($expectedTarget)
 			)
 			->willReturn(true);
-		$this->util->expects($this->any())
+		$this->util
 			->method('getUidAndFilename')
-			->will($this->returnCallback([$this, 'getUidAndFilenameCallback']));
-		$this->util->expects($this->any())
+			->willReturnCallback([$this, 'getUidAndFilenameCallback']);
+		$this->util
 			->method('isSystemWideMountPoint')
-			->willReturnCallback(function ($path, $owner) use ($systemWideMountSource, $systemWideMountTarget) {
+			->willReturnCallback(function ($path) use ($systemWideMountSource, $systemWideMountTarget) {
 				if (\strpos($path, 'source.txt') !== false) {
 					return $systemWideMountSource;
 				}
@@ -462,11 +477,11 @@ class StorageTest extends TestCase {
 	/**
 	 * @dataProvider dataProviderCopyRename
 	 */
-	public function testCopyKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget) {
-		$this->view->expects($this->any())
+	public function testCopyKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget): void {
+		$this->view
 			->method('file_exists')
 			->willReturn(true);
-		$this->view->expects($this->any())
+		$this->view
 			->method('is_dir')
 			->willReturn(true);
 		$this->view->expects($this->once())
@@ -476,12 +491,12 @@ class StorageTest extends TestCase {
 				$this->equalTo($expectedTarget)
 			)
 			->willReturn(true);
-		$this->util->expects($this->any())
+		$this->util
 			->method('getUidAndFilename')
-			->will($this->returnCallback([$this, 'getUidAndFilenameCallback']));
-		$this->util->expects($this->any())
+			->willReturnCallback([$this, 'getUidAndFilenameCallback']);
+		$this->util
 			->method('isSystemWideMountPoint')
-			->willReturnCallback(function ($path, $owner) use ($systemWideMountSource, $systemWideMountTarget) {
+			->willReturnCallback(function ($path) use ($systemWideMountSource, $systemWideMountTarget) {
 				if (\strpos($path, 'source.txt') !== false) {
 					return $systemWideMountSource;
 				}
@@ -491,7 +506,7 @@ class StorageTest extends TestCase {
 		$this->storage->copyKeys($source, $target);
 	}
 
-	public function getUidAndFilenameCallback() {
+	public function getUidAndFilenameCallback(): array {
 		$args = \func_get_args();
 
 		$path = $args[0];
@@ -500,7 +515,7 @@ class StorageTest extends TestCase {
 		return [$parts[1], '/' . \implode('/', \array_slice($parts, 2))];
 	}
 
-	public function dataProviderCopyRename() {
+	public function dataProviderCopyRename(): array {
 		return [
 			['/user1/files/source.txt', '/user1/files/target.txt', false, false,
 				'/user1/files_encryption/keys/files/source.txt/', '/user1/files_encryption/keys/files/target.txt/'],
@@ -538,13 +553,13 @@ class StorageTest extends TestCase {
 	 * @param string $storageRoot
 	 * @param string $expected
 	 */
-	public function testGetPathToKeys($path, $systemWideMountPoint, $storageRoot, $expected) {
-		$this->invokePrivate($this->storage, 'root_dir', [$storageRoot]);
+	public function testGetPathToKeys($path, $systemWideMountPoint, $storageRoot, $expected): void {
+		self::invokePrivate($this->storage, 'root_dir', [$storageRoot]);
 
-		$this->util->expects($this->any())
+		$this->util
 			->method('getUidAndFilename')
-			->will($this->returnCallback([$this, 'getUidAndFilenameCallback']));
-		$this->util->expects($this->any())
+			->willReturnCallback([$this, 'getUidAndFilenameCallback']);
+		$this->util
 			->method('isSystemWideMountPoint')
 			->willReturn($systemWideMountPoint);
 
@@ -554,7 +569,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	public function dataTestGetPathToKeys() {
+	public function dataTestGetPathToKeys(): array {
 		return [
 			['/user1/files/source.txt', false, '', '/user1/files_encryption/keys/files/source.txt/'],
 			['/user1/files/source.txt', true, '', '/files_encryption/keys/files/source.txt/'],
@@ -563,16 +578,16 @@ class StorageTest extends TestCase {
 		];
 	}
 
-	public function testKeySetPreparation() {
-		$this->view->expects($this->any())
+	public function testKeySetPreparation(): void {
+		$this->view
 			->method('file_exists')
 			->willReturn(false);
-		$this->view->expects($this->any())
+		$this->view
 			->method('is_dir')
 			->willReturn(false);
-		$this->view->expects($this->any())
+		$this->view
 			->method('mkdir')
-			->will($this->returnCallback([$this, 'mkdirCallback']));
+			->willReturnCallback([$this, 'mkdirCallback']);
 
 		$this->mkdirStack = [
 			'/user1/files_encryption/keys/foo',
@@ -583,7 +598,7 @@ class StorageTest extends TestCase {
 		self::invokePrivate($this->storage, 'keySetPreparation', ['/user1/files_encryption/keys/foo']);
 	}
 
-	public function mkdirCallback() {
+	public function mkdirCallback(): void {
 		$args = \func_get_args();
 		$expected = \array_pop($this->mkdirStack);
 		$this->assertSame($expected, $args[0]);
@@ -591,35 +606,44 @@ class StorageTest extends TestCase {
 
 	/**
 	 * @dataProvider dataTestGetFileKeyDir
-	 *
-	 * @param bool $isSystemWideMountPoint
-	 * @param string $storageRoot
-	 * @param string $expected
 	 */
-	public function testGetFileKeyDir($isSystemWideMountPoint, $storageRoot, $expected) {
+	public function testGetFileKeyDir($isSystemWideMountPoint, $storageRoot, $expected, $hasMountPoint = false, $storagePath = null, $expectDefaultImpl = true): void {
 		$path = '/user1/files/foo/bar.txt';
 		$owner = 'user1';
 		$relativePath = '/foo/bar.txt';
 
-		$this->invokePrivate($this->storage, 'root_dir', [$storageRoot]);
+		if ($hasMountPoint) {
+			$storage = $this->createMock(\OC\Files\Storage\Storage::class);
+			$storage->method('getEncryptionFileKeyDirectory')
+				->with('OC_DEFAULT_MODULE', $relativePath)
+				->willReturn($storagePath);
+			$mount = $this->createMock(IMountPoint::class);
+			$mount->method('getStorage')->willReturn($storage);
+			$mount->method('getInternalPath')->willReturn($relativePath);
+			$this->mountManager->method('find')->willReturn($mount);
+		}
 
-		$this->util->expects($this->once())->method('isSystemWideMountPoint')
+		self::invokePrivate($this->storage, 'root_dir', [$storageRoot]);
+
+		$this->util->expects($expectDefaultImpl ? $this->once(): $this->never())->method('isSystemWideMountPoint')
 			->willReturn($isSystemWideMountPoint);
-		$this->util->expects($this->once())->method('getUidAndFilename')
+		$this->util->expects($expectDefaultImpl ? $this->once(): $this->never())->method('getUidAndFilename')
 			->with($path)->willReturn([$owner, $relativePath]);
 
 		$this->assertSame(
 			$expected,
-			$this->invokePrivate($this->storage, 'getFileKeyDir', ['OC_DEFAULT_MODULE', $path])
+			self::invokePrivate($this->storage, 'getFileKeyDir', ['OC_DEFAULT_MODULE', $path])
 		);
 	}
 
-	public function dataTestGetFileKeyDir() {
+	public function dataTestGetFileKeyDir(): array {
 		return [
 			[false, '', '/user1/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/'],
 			[true, '', '/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/'],
 			[false, 'newStorageRoot', '/newStorageRoot/user1/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/'],
 			[true, 'newStorageRoot', '/newStorageRoot/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/'],
+			[false, '', '/user1/files_encryption/keys/foo/bar.txt/OC_DEFAULT_MODULE/', true, null],
+			[false, '', '/foo/bar/keys/foo/bar.txt/OC_DEFAULT_MODULE/', true, '/foo/bar/keys/foo/bar.txt/OC_DEFAULT_MODULE/', false],
 		];
 	}
 }

--- a/tests/lib/Files/Stream/EncryptionTest.php
+++ b/tests/lib/Files/Stream/EncryptionTest.php
@@ -67,6 +67,8 @@ class EncryptionTest extends TestCase {
 			$size,
 			$unencryptedSize,
 			8192,
+			null,
+			null,
 			$wrapper
 		);
 	}


### PR DESCRIPTION
## Description
This allows storage implementations to specify the location for encryption keys
https://github.com/owncloud/files_spaces needs this because the space does not belong to a user.


## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4687
- alternative approach to #39091


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
