### PR TITLE
Add quality setting for JP(E)G preview images

### DIFF
--- a/changelog/unreleased/39349
+++ b/changelog/unreleased/39349
@@ -1,0 +1,7 @@
+Enhancement: Add quality setting for JP(E)G preview images
+
+A new config setting `previewJPEGImageDisplayQuality` has been introduced
+with which the quality of generated JP(E)G previews can be determined.
+
+https://github.com/owncloud/core/pull/39349
+https://github.com/owncloud/enterprise/issues/4702

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -991,6 +991,25 @@ $CONFIG = [
   ],
 
 /**
+ * Define the jpeg preview quality
+ *
+ * This setting defines the JP(E)G image quality in [%] for displaying thumbnails and image
+ * previews for apps like 'files_mediaviewer'. Note that this setting is for displaying
+ * only and has no impact on the stored thumbnail / preview quality or size.
+ * The scale ranges from 1 to 100, where 1 is the lowest and 100 the highest.
+ * It defaults to -1 which is equivalent to approximately 75% of the original
+ * image quality.
+ *
+ * Note that any value over 80 may result in an unnecessary increase of the
+ * displayed image and has larger responses sizes when requesting images,
+ * without much increase of the image quality.
+ *
+ * For more information see:
+ * https://www.php.net/manual/en/function.imagejpeg.php
+ */
+'previewJPEGImageDisplayQuality' => -1,
+
+/**
  * Comments
  *
  * Global settings for the Comments infrastructure

--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -56,6 +56,8 @@ class OC_Image implements \OCP\IImage {
 	private $fileInfo;
 	/** @var \OCP\ILogger */
 	private $logger;
+	/** @var \OCP\IConfig */
+	private $config;
 	/** @var array|false */
 	private $exifData;
 
@@ -81,11 +83,17 @@ class OC_Image implements \OCP\IImage {
 	 * @param resource|string $imageRef The path to a local file, a base64 encoded string or a resource created by
 	 * an imagecreate* function.
 	 * @param \OCP\ILogger $logger
+	 * @param \OCP\IConfig $config
 	 */
-	public function __construct($imageRef = null, $logger = null) {
+	public function __construct($imageRef = null, $logger = null, $config = null) {
 		$this->logger = $logger;
 		if ($logger === null) {
 			$this->logger = \OC::$server->getLogger();
+		}
+
+		$this->config = $config;
+		if ($config === null) {
+			$this->config = \OC::$server->getConfig();
 		}
 
 		if (\OC_Util::fileInfoLoaded()) {
@@ -270,7 +278,7 @@ class OC_Image implements \OCP\IImage {
 				$retVal = \imagegif($this->resource, $filePath);
 				break;
 			case IMAGETYPE_JPEG:
-				$retVal = \imagejpeg($this->resource, $filePath);
+				$retVal = \imagejpeg($this->resource, $filePath, (int)$this->config->getSystemValue('previewJPEGImageDisplayQuality', -1));
 				break;
 			case IMAGETYPE_PNG:
 				$retVal = \imagepng($this->resource, $filePath);

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -252,3 +252,16 @@ Feature: previews of files downloaded through the webdav API
     Then as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     And as user "Carol" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario: JPEG preview quality can be determined by config
+    Given user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "/testavatar_low.jpg"
+    And the administrator has updated system config key "previewJPEGImageDisplayQuality" with value "1"
+    And user "Alice" downloads the preview of "/testavatar_low.jpg" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the requested JPEG image should have a quality value of "1"
+    Then user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "/testavatar_high.jpg"
+    And the administrator has updated system config key "previewJPEGImageDisplayQuality" with value "100"
+    And user "Alice" downloads the preview of "/testavatar_high.jpg" with width "32" and height "32" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the requested JPEG image should have a quality value of "100"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -4300,6 +4300,20 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then the requested JPEG image should have a quality value of :size
+	 *
+	 * @param string $value
+	 *
+	 * @return void
+	 */
+	public function jpgQualityValueShouldBe(string $value): void {
+		$this->responseBodyContent = $this->response->getBody()->getContents();
+		// quality value is embedded in the string content for JPEG images
+		$qualityString = "quality = $value";
+		Assert::assertStringContainsString($qualityString, $this->responseBodyContent);
+	}
+
+	/**
 	 * @Then the downloaded preview content should match with :preview fixtures preview content
 	 *
 	 * @param string $filename relative path from fixtures directory


### PR DESCRIPTION
## Description
A new config setting `previewJPEGImageDisplayQuality` has been introduced with which the quality of generated JP(E)G previews can be determined.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Relates to https://github.com/owncloud/enterprise/issues/4702

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4142
- [x] Changelog item
