### PR TITLE
[full-ci] added last_login to getUser()

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -224,6 +224,7 @@ class Users {
 		$data['displayname'] = $targetUserObject->getDisplayName();
 		$data['home'] = $targetUserObject->getHome();
 		$data['two_factor_auth_enabled'] = $this->twoFactorAuthManager->isTwoFactorAuthenticated($targetUserObject) ? 'true' : 'false';
+		$data['last_login'] = $targetUserObject->getLastLogin();
 
 		return new Result($data);
 	}

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -729,6 +729,10 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('isEnabled')
 			->willReturn('true');
+		$targetUser
+			->expects($this->once())
+			->method('getLastLogin')
+			->willReturn('1618230656');
 
 		$expected = new Result(
 			[
@@ -738,6 +742,7 @@ class UsersTest extends OriginalTest {
 				'displayname' => 'Demo User',
 				'home' => '/var/ocdata/UserToGet',
 				'two_factor_auth_enabled' => 'false',
+				'last_login' => '1618230656'
 			]
 		);
 		$this->assertEquals($expected, $this->api->getUser(['userid' => 'UserToGet']));
@@ -796,6 +801,10 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('isEnabled')
 			->willReturn('true');
+		$targetUser
+			->expects($this->once())
+			->method('getLastLogin')
+			->willReturn('1618230656');
 
 		$expected = new Result(
 			[
@@ -804,7 +813,8 @@ class UsersTest extends OriginalTest {
 				'email' => 'demo@owncloud.com',
 				'home' => '/var/ocdata/UserToGet',
 				'displayname' => 'Demo User',
-				'two_factor_auth_enabled' => 'false'
+				'two_factor_auth_enabled' => 'false',
+				'last_login' => '1618230656'
 			]
 		);
 		$this->assertEquals($expected, $this->api->getUser(['userid' => 'UserToGet']));
@@ -897,6 +907,10 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('getEMailAddress')
 			->will($this->returnValue('subadmin@owncloud.com'));
+		$targetUser
+			->expects($this->once())
+			->method('getLastLogin')
+			->willReturn('1618230656');
 
 		$expected = new Result([
 			'quota' => ['DummyValue', 'definition' => null],
@@ -904,6 +918,7 @@ class UsersTest extends OriginalTest {
 			'displayname' => 'Subadmin User',
 			'home' => '/var/ocdata/UserToGet',
 			'two_factor_auth_enabled' => 'false',
+			'last_login' => '1618230656'
 		]);
 		$this->assertEquals($expected, $this->api->getUser(['userid' => 'subadmin']));
 	}

--- a/changelog/unreleased/39351
+++ b/changelog/unreleased/39351
@@ -1,0 +1,7 @@
+Enhancement: Add last_login to Provisioning API get user response
+
+The response to a Provisioning API GET request to the cloud/users/username
+endpoint now includes the last_login time in the response.
+The value is a Unix timestamp in seconds.
+
+https://github.com/owncloud/core/pull/38351

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -17,7 +17,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.3
   Scenario Outline: admin gets an existing user with special characters in the username
@@ -30,11 +30,12 @@ Feature: get user
     And the display name returned by the API should be "<displayname>"
     And the email address returned by the API should be "<email>"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
     Examples:
       | username | displayname  | email               |
       | a@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
+
 
   Scenario: admin gets an existing user, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
@@ -45,7 +46,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
+
 
   Scenario: admin tries to get a nonexistent user
     When the administrator retrieves the information of user "not-a-user" using the provisioning API
@@ -67,7 +69,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS
   Scenario: a subadmin tries to get information of a user not in their group
@@ -81,6 +83,7 @@ Feature: get user
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the API should not return any data
+
 
   Scenario: a normal user tries to get information of another user
     Given these users have been created with default attributes and without skeleton files:
@@ -102,7 +105,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
+
 
   Scenario: a normal user gets their own information, providing uppercase username as authentication
     Given these users have been created with default attributes and without skeleton files:
@@ -113,7 +117,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.3
   Scenario: a normal user gets their own information, providing uppercase username in the URL
@@ -125,7 +129,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.3
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
@@ -137,7 +141,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
+
 
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
     Given these users have been created with default attributes and without skeleton files:
@@ -148,7 +153,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
+
 
   Scenario: admin gets information of a user with admin permissions
     Given these users have been created with default attributes and without skeleton files:
@@ -160,7 +166,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Admin Alice"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
@@ -177,7 +183,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Regular User"
     And the quota definition returned by the API should be "default"
-    And the last login returned by the API should be "0"
+    And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS
   Scenario: a subadmin should not be able to get information of another subadmin of same group

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -17,6 +17,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
 
   @skipOnOcV10.3
   Scenario Outline: admin gets an existing user with special characters in the username
@@ -29,6 +30,7 @@ Feature: get user
     And the display name returned by the API should be "<displayname>"
     And the email address returned by the API should be "<email>"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
     Examples:
       | username | displayname  | email               |
       | a@-+_.b  | A weird b    | a.b@example.com     |
@@ -43,6 +45,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
 
   Scenario: admin tries to get a nonexistent user
     When the administrator retrieves the information of user "not-a-user" using the provisioning API
@@ -64,6 +67,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
 
   @notToImplementOnOCIS
   Scenario: a subadmin tries to get information of a user not in their group
@@ -98,6 +102,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
 
   Scenario: a normal user gets their own information, providing uppercase username as authentication
     Given these users have been created with default attributes and without skeleton files:
@@ -108,6 +113,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
 
   @skipOnOcV10.3
   Scenario: a normal user gets their own information, providing uppercase username in the URL
@@ -119,6 +125,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
 
   @skipOnOcV10.3
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
@@ -130,6 +137,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
 
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
     Given these users have been created with default attributes and without skeleton files:
@@ -140,6 +148,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
 
   Scenario: admin gets information of a user with admin permissions
     Given these users have been created with default attributes and without skeleton files:
@@ -151,6 +160,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Admin Alice"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
+
   @notToImplementOnOCIS
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
@@ -166,6 +177,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Regular User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be "0"
+
   @notToImplementOnOCIS
   Scenario: a subadmin should not be able to get information of another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -17,6 +17,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.3
   Scenario Outline: admin gets an existing user with special characters in the username
@@ -29,10 +30,12 @@ Feature: get user
     And the display name returned by the API should be "<displayname>"
     And the email address returned by the API should be "<email>"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
     Examples:
       | username | displayname  | email               |
       | a@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
+
 
   Scenario: admin gets an existing user, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
@@ -43,6 +46,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
+
 
   Scenario: admin tries to get a nonexistent user
     When the administrator retrieves the information of user "not-a-user" using the provisioning API
@@ -64,6 +69,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS
   Scenario: a subadmin tries to get information of a user not in their group
@@ -99,6 +105,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
+
 
   Scenario: a normal user gets their own information, providing uppercase username as authentication
     Given these users have been created with default attributes and without skeleton files:
@@ -109,6 +117,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.3
   Scenario: a normal user gets their own information, providing uppercase username in the URL
@@ -120,6 +129,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.3
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
@@ -131,6 +141,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
+
 
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
     Given these users have been created with default attributes and without skeleton files:
@@ -141,6 +153,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
+
   @notToImplementOnOCIS
   Scenario: admin gets information of a user with admin permissions
     Given these users have been created with default attributes and without skeleton files:
@@ -152,6 +166,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Admin Alice"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
+
   @notToImplementOnOCIS
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
@@ -167,6 +183,8 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Regular User"
     And the quota definition returned by the API should be "default"
+    And the last login returned by the API should be a current Unix timestamp
+
   @notToImplementOnOCIS
   Scenario: a subadmin should not be able to get information of another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -50,6 +50,11 @@ class FeatureContext extends BehatVariablesContext {
 	use WebDav;
 
 	/**
+	 * @var int Unix timestamp seconds
+	 */
+	private $scenarioStartTime;
+
+	/**
 	 * @var string
 	 */
 	private $adminUsername = '';
@@ -3284,6 +3289,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @throws Exception
 	 */
 	public function before(BeforeScenarioScope $scope):void {
+		$this->scenarioStartTime = \time();
 		// Get the environment
 		$environment = $scope->getEnvironment();
 		// registers context in every suite, as every suite has FeatureContext

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -4913,6 +4913,18 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Then /^the last login returned by the API should be a current Unix timestamp$/
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theLastLoginReturnedByTheApiShouldBe():void {
+		$responseLastLogin = (string) $this->getResponseXml(null, __METHOD__)->data[0]->last_login;
+		Assert::assertIsNumeric($responseLastLogin);
+		Assert::assertGreaterThan($this->scenarioStartTime, (int) $responseLastLogin);
+	}
+
+	/**
 	 * Parses the xml answer to get the array of users returned.
 	 *
 	 * @param ResponseInterface $resp


### PR DESCRIPTION
## Description
This is the code from https://github.com/ctcq/core/tree/provisioning-api-last-login - I have rebased it and adjusted the acceptance tests.

## Related Issue
#38624 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4201
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
