### PR TITLE
Hide legacy animation on login screen

### DIFF
--- a/changelog/unreleased/39352
+++ b/changelog/unreleased/39352
@@ -1,0 +1,6 @@
+Bugfix: Hide legacy login button animation
+
+In some cases the old animation was still displayed on login buttons. 
+This PR hides it in favour of the newly introduced animation.
+
+https://github.com/owncloud/core/pull/39352

--- a/core/css/icons.css
+++ b/core/css/icons.css
@@ -42,6 +42,9 @@
 	transform-origin: center;
 }
 
+/* Disable this loading animation on login screen */
+#body-login button.icon-loading-small:after { display: none; }
+
 .loading:after,
 .loading-small:after,
 .icon-loading:after,
@@ -77,6 +80,9 @@ img.icon-loading-dark, object.icon-loading-dark, video.icon-loading-dark, button
 img.icon-loading-small, object.icon-loading-small, video.icon-loading-small, button.icon-loading-small, textarea.icon-loading-small, input.icon-loading-small, select.icon-loading-small {
 	background-image: url("../img/loading-small.gif");
 }
+
+/* Disable this loading animation on login screen */
+#body-login button.icon-loading-small { background-image: none; }
 
 img.icon-loading-small-dark, object.icon-loading-small-dark, video.icon-loading-small-dark, button.icon-loading-small-dark, textarea.icon-loading-small-dark, input.icon-loading-small-dark, select.icon-loading-small-dark {
 	background-image: url("../img/loading-small-dark.gif");


### PR DESCRIPTION
## Description
Fixes a double displayed login button animation.

## Screenshots (if appropriate):
Before (notice the rotating circle icon behind "Proceed"):
![grafik](https://user-images.githubusercontent.com/16665512/137099418-a42743c5-db7b-414f-a5c0-ee95c547130c.png)

After:
![grafik](https://user-images.githubusercontent.com/16665512/137099604-7072f5d0-d214-4c32-890f-d18c6bfb94aa.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
