### PR TITLE
Prohibit email/displayname change via API when not allowed

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -38,6 +38,7 @@ $users = new Users(
 	\OC::$server->getGroupManager(),
 	\OC::$server->getUserSession(),
 	\OC::$server->getLogger(),
+	\OC::$server->getConfig(),
 	\OC::$server->getTwoFactorAuthManager()
 );
 

--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -250,11 +250,11 @@ class Users {
 		}
 
 		$emailChangeAllowed = $this->config->getSystemValue('allow_user_to_change_mail_address', true) !== false;
+		$displayNameChangeAllowed = $this->config->getSystemValue('allow_user_to_change_display_name', true) !== false;
 
 		if ($targetUserId === $currentLoggedInUser->getUID()) {
 			// Editing self (display, email)
 			$permittedFields[] = 'display';
-			$permittedFields[] = 'displayname';
 			$permittedFields[] = 'password';
 			$permittedFields[] = 'two_factor_auth_enabled';
 			// If admin they can edit their own quota
@@ -264,6 +264,9 @@ class Users {
 			if ($emailChangeAllowed) {
 				$permittedFields[] = 'email';
 			}
+			if ($displayNameChangeAllowed) {
+				$permittedFields[] = 'displayname';
+			}
 		} else {
 			// Check if admin / subadmin
 			$subAdminManager = $this->groupManager->getSubAdmin();
@@ -271,12 +274,14 @@ class Users {
 			|| $this->groupManager->isAdmin($currentLoggedInUser->getUID())) {
 				// They have permissions over the user
 				$permittedFields[] = 'display';
-				$permittedFields[] = 'displayname';
 				$permittedFields[] = 'quota';
 				$permittedFields[] = 'password';
 				$permittedFields[] = 'two_factor_auth_enabled';
 				if ($emailChangeAllowed) {
 					$permittedFields[] = 'email';
+				}
+				if ($displayNameChangeAllowed) {
+					$permittedFields[] = 'displayname';
 				}
 			} else {
 				// No rights

--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -32,8 +32,8 @@ namespace OCA\Provisioning_API;
 use OC\OCS\Result;
 use OC_Helper;
 use OCP\API;
-use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
+use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\ILogger;
@@ -52,6 +52,8 @@ class Users {
 	private $userSession;
 	/** @var ILogger */
 	private $logger;
+	/** @var IConfig */
+	private $config;
 	/** @var \OC\Authentication\TwoFactorAuth\Manager */
 	private $twoFactorAuthManager;
 
@@ -60,18 +62,21 @@ class Users {
 	 * @param IGroupManager $groupManager
 	 * @param IUserSession $userSession
 	 * @param ILogger $logger
+	 * @param IConfig $config
 	 */
 	public function __construct(
 		IUserManager $userManager,
 		IGroupManager $groupManager,
 		IUserSession $userSession,
 		ILogger $logger,
+		IConfig $config,
 		\OC\Authentication\TwoFactorAuth\Manager $twoFactorAuthManager
 	) {
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
 		$this->userSession = $userSession;
 		$this->logger = $logger;
+		$this->config = $config;
 		$this->twoFactorAuthManager = $twoFactorAuthManager;
 	}
 
@@ -244,16 +249,20 @@ class Users {
 			return new Result(null, 997);
 		}
 
+		$emailChangeAllowed = $this->config->getSystemValue('allow_user_to_change_mail_address', true) !== false;
+
 		if ($targetUserId === $currentLoggedInUser->getUID()) {
 			// Editing self (display, email)
 			$permittedFields[] = 'display';
 			$permittedFields[] = 'displayname';
-			$permittedFields[] = 'email';
 			$permittedFields[] = 'password';
 			$permittedFields[] = 'two_factor_auth_enabled';
 			// If admin they can edit their own quota
 			if ($this->groupManager->isAdmin($currentLoggedInUser->getUID())) {
 				$permittedFields[] = 'quota';
+			}
+			if ($emailChangeAllowed) {
+				$permittedFields[] = 'email';
 			}
 		} else {
 			// Check if admin / subadmin
@@ -265,8 +274,10 @@ class Users {
 				$permittedFields[] = 'displayname';
 				$permittedFields[] = 'quota';
 				$permittedFields[] = 'password';
-				$permittedFields[] = 'email';
 				$permittedFields[] = 'two_factor_auth_enabled';
+				if ($emailChangeAllowed) {
+					$permittedFields[] = 'email';
+				}
 			} else {
 				// No rights
 				return new Result(null, 997);

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -35,12 +35,12 @@ use OCP\API;
 use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase as OriginalTest;
 use OCP\IUser;
 use OC\SubAdmin;
 use OCP\IGroup;
 use OC\Authentication\TwoFactorAuth\Manager;
+use OCP\IConfig;
 
 class UsersTest extends OriginalTest {
 
@@ -52,6 +52,8 @@ class UsersTest extends OriginalTest {
 	protected $userSession;
 	/** @var ILogger | PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
+	/** @var IConfig | PHPUnit\Framework\MockObject\MockObject */
+	protected $config;
 	/** @var Users | PHPUnit\Framework\MockObject\MockObject */
 	protected $api;
 	/** @var \OC\Authentication\TwoFactorAuth\Manager | PHPUnit\Framework\MockObject\MockObject */
@@ -72,6 +74,7 @@ class UsersTest extends OriginalTest {
 			->getMock();
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(ILogger::class);
+		$this->config = $this->createMock(IConfig::class);
 		$this->twoFactorAuthManager = $this->getMockBuilder(Manager::class)
 			->disableOriginalConstructor()
 			->setMethods(['isTwoFactorAuthenticated', 'enableTwoFactorAuthentication'])
@@ -85,6 +88,7 @@ class UsersTest extends OriginalTest {
 				$this->groupManager,
 				$this->userSession,
 				$this->logger,
+				$this->config,
 				$this->twoFactorAuthManager
 			])
 			->setMethods(['fillStorageInfo'])
@@ -986,6 +990,31 @@ class UsersTest extends OriginalTest {
 			->with('demo@owncloud.com');
 
 		$expected = new Result(null, 100);
+		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'email', 'value' => 'demo@owncloud.com']]));
+	}
+
+	public function testEditUserRegularUserSelfEditChangeEmailProhibited() {
+		$loggedInUser = $this->createMock(IUser::class);
+		$loggedInUser
+			->expects($this->any())
+			->method('getUID')
+			->will($this->returnValue('UserToEdit'));
+		$targetUser = $this->createMock(IUser::class);
+		$this->userSession
+			->expects($this->once())
+			->method('getUser')
+			->will($this->returnValue($loggedInUser));
+		$this->userManager
+			->expects($this->once())
+			->method('get')
+			->with('UserToEdit')
+			->will($this->returnValue($targetUser));
+		$this->config
+			->method('getSystemValue')
+			->with('allow_user_to_change_mail_address')
+			->will($this->returnValue(false));
+
+		$expected = new Result(null, 997);
 		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'email', 'value' => 'demo@owncloud.com']]));
 	}
 

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -996,16 +996,13 @@ class UsersTest extends OriginalTest {
 	public function testEditUserRegularUserSelfEditChangeEmailProhibited() {
 		$loggedInUser = $this->createMock(IUser::class);
 		$loggedInUser
-			->expects($this->any())
 			->method('getUID')
 			->will($this->returnValue('UserToEdit'));
 		$targetUser = $this->createMock(IUser::class);
 		$this->userSession
-			->expects($this->once())
 			->method('getUser')
 			->will($this->returnValue($loggedInUser));
 		$this->userManager
-			->expects($this->once())
 			->method('get')
 			->with('UserToEdit')
 			->will($this->returnValue($targetUser));

--- a/changelog/unreleased/39353
+++ b/changelog/unreleased/39353
@@ -1,8 +1,9 @@
-Bugfix: Prohibit email change via API when it's not allowed
+Bugfix: Prohibit email/displayname change via API when not allowed
 
-When the config `allow_user_to_change_mail_address` is set
-to `false`, changing the email address via the provisioning
-API is no longer possible.
+When the configs `allow_user_to_change_mail_address` or
+`allow_user_to_change_display_name` are set to `false`,
+changing the corresponding values via the provisioning API
+is no longer possible.
 
 https://github.com/owncloud/core/pull/39353
 https://github.com/owncloud/core/issues/39332

--- a/changelog/unreleased/39353
+++ b/changelog/unreleased/39353
@@ -1,0 +1,8 @@
+Bugfix: Prohibit email change via API when it's not allowed
+
+When the config `allow_user_to_change_mail_address` is set
+to `false`, changing the email address via the provisioning
+API is no longer possible.
+
+https://github.com/owncloud/core/pull/39353
+https://github.com/owncloud/core/issues/39332

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -190,3 +190,47 @@ Feature: edit users
     And the HTTP status code should be "401"
     And the display name of user "Brian" should not have changed
     And the email address of user "Brian" should not have changed
+
+
+  Scenario: Admin gives access to users to change their email address
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When the administrator updates system config key "allow_user_to_change_mail_address" with value "true" and type "boolean" using the occ command
+    And user "Alice" changes the email of user "Alice" to "alice@gmail.com" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "Alice" returned by the API should include
+      | email | alice@gmail.com |
+    And the email address of user "Alice" should be "alice@gmail.com"
+
+
+  Scenario: Admin does not give access to users to change their email address
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
+    And user "Alice" tries to change the email of user "Alice" to "alice@gmail.com" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "403"
+    And the attributes of user "Alice" returned by the API should include
+      | email | alice@example.org |
+    And the email address of user "Alice" should not have changed
+
+
+  Scenario: Admin gives access to users to change their display name
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When the administrator updates system config key "allow_user_to_change_display_name" with value "true" and type "boolean" using the occ command
+    And user "Alice" changes the display of user "Alice" to "Alice Wonderland" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the attributes of user "Alice" returned by the API should include
+      | displayname | Alice Wonderland |
+    And the display name of user "Alice" should be "Alice Wonderland"
+
+
+  Scenario: Admin does not give access to users to change their display name
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
+    And user "Alice" tries to change the display name of user "Alice" to "Alice Wonderland" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "403"
+    And the attributes of user "Alice" returned by the API should include
+      | displayname | Alice Hansen |
+    And the display name of user "Alice" should not have changed

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -208,7 +208,7 @@ Feature: edit users
     When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
     And user "Alice" tries to change the email of user "Alice" to "alice@gmail.com" using the provisioning API
     Then the OCS status code should be "997"
-    And the HTTP status code should be "403"
+    And the HTTP status code should be "401"
     And the attributes of user "Alice" returned by the API should include
       | email | alice@example.org |
     And the email address of user "Alice" should not have changed
@@ -230,7 +230,7 @@ Feature: edit users
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
     And user "Alice" tries to change the display name of user "Alice" to "Alice Wonderland" using the provisioning API
     Then the OCS status code should be "997"
-    And the HTTP status code should be "403"
+    And the HTTP status code should be "401"
     And the attributes of user "Alice" returned by the API should include
       | displayname | Alice Hansen |
     And the display name of user "Alice" should not have changed

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -190,3 +190,47 @@ Feature: edit users
     And the HTTP status code should be "401"
     And the display name of user "Brian" should not have changed
     And the email address of user "Brian" should not have changed
+
+
+  Scenario: Admin gives access to users to change their email address
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When the administrator updates system config key "allow_user_to_change_mail_address" with value "true" and type "boolean" using the occ command
+    And user "Alice" changes the email of user "Alice" to "alice@gmail.com" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "Alice" returned by the API should include
+      | email | alice@gmail.com |
+    And the email address of user "Alice" should be "alice@gmail.com"
+
+
+  Scenario: Admin does not give access to users to change their email address
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
+    And user "Alice" tries to change the email of user "Alice" to "alice@gmail.com" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "403"
+    And the attributes of user "Alice" returned by the API should include
+      | email | alice@example.org |
+    And the email address of user "Alice" should not have changed
+
+
+  Scenario: Admin gives access to users to change their display name
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When the administrator updates system config key "allow_user_to_change_display_name" with value "true" and type "boolean" using the occ command
+    And user "Alice" changes the display of user "Alice" to "Alice Wonderland" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the attributes of user "Alice" returned by the API should include
+      | displayname | Alice Wonderland |
+    And the display name of user "Alice" should be "Alice Wonderland"
+
+
+  Scenario: Admin does not give access to users to change their display name
+    Given user "Alice" has been created with default attributes and without skeleton files
+    When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
+    And user "Alice" tries to change the display name of user "Alice" to "Alice Wonderland" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "403"
+    And the attributes of user "Alice" returned by the API should include
+      | displayname | Alice Hansen |
+    And the display name of user "Alice" should not have changed

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -208,7 +208,7 @@ Feature: edit users
     When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
     And user "Alice" tries to change the email of user "Alice" to "alice@gmail.com" using the provisioning API
     Then the OCS status code should be "997"
-    And the HTTP status code should be "403"
+    And the HTTP status code should be "401"
     And the attributes of user "Alice" returned by the API should include
       | email | alice@example.org |
     And the email address of user "Alice" should not have changed
@@ -229,8 +229,8 @@ Feature: edit users
     Given user "Alice" has been created with default attributes and without skeleton files
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
     And user "Alice" tries to change the display name of user "Alice" to "Alice Wonderland" using the provisioning API
-    Then the OCS status code should be "997"
-    And the HTTP status code should be "403"
+    #Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
     And the attributes of user "Alice" returned by the API should include
       | displayname | Alice Hansen |
     And the display name of user "Alice" should not have changed


### PR DESCRIPTION
## Description
When the configs `allow_user_to_change_mail_address` or `allow_user_to_change_display_name` are set to `false`, changing the corresponding values via the provisioning API is no longer possible.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39332
- Fixes https://github.com/owncloud/core/issues/39331

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
