### PR TITLE
[tests-only] [full-ci] Standardize waitTillPageIsLoaded parameters and return

### DIFF
--- a/tests/acceptance/features/lib/AdminAppsSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminAppsSettingsPage.php
@@ -97,8 +97,8 @@ class AdminAppsSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitForAjaxCallsToStartAndFinish($session);
 		$this->waitTillXpathIsVisible(
 			$this->appEnableDisableButtonXpath,

--- a/tests/acceptance/features/lib/AdminEncryptionSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminEncryptionSettingsPage.php
@@ -79,8 +79,8 @@ class AdminEncryptionSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {

--- a/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
@@ -295,8 +295,8 @@ class AdminGeneralSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitForAjaxCallsToStartAndFinish($session);
 		$this->waitTillXpathIsVisible(
 			$this->ownCloudVersionStringXpath,

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -814,8 +814,8 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitTillXpathIsVisible(
 			$this->shareApiCheckboxXpath,
 			$timeout_msec

--- a/tests/acceptance/features/lib/AdminStorageSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminStorageSettingsPage.php
@@ -415,8 +415,8 @@ class AdminStorageSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitForAjaxCallsToStartAndFinish($session);
 		$this->waitTillXpathIsVisible(
 			$this->filesExternalFormXpath,

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -504,8 +504,8 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = LONG_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = LONG_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->initAjaxCounters($session);
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -676,8 +676,8 @@ class DetailsDialog extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -65,16 +65,17 @@ class FileActionsMenu extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
-	 * @param string $xpath the xpath of the element to wait for
-	 *                      required to be set
+	 * @param string|null $xpath the xpath of the element to wait for
+	 *                           required to be set
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
-		$xpath = null
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
+		?string $xpath = null
+	):void {
 		if ($xpath === null) {
 			throw new \InvalidArgumentException('$xpath needs to be set');
 		}

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -981,16 +981,17 @@ class SharingDialog extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
-	 * @param string $xpath the xpath of the element to wait for
-	 *                      required to be set
+	 * @param string|null $xpath the xpath of the element to wait for
+	 *                           required to be set
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
-		$xpath = null
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
+		?string $xpath = null
+	):void {
 		if ($xpath === null) {
 			throw new \InvalidArgumentException('$xpath needs to be set');
 		}

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -322,16 +322,17 @@ class EditPublicLinkPopup extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
-	 * @param string $xpath the xpath of the element to wait for
-	 *                      required to be set
+	 * @param string|null $xpath the xpath of the element to wait for
+	 *                           required to be set
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
-		$xpath = null
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
+		?string $xpath = null
+	):void {
 		if ($xpath === null) {
 			throw new \InvalidArgumentException('$xpath needs to be set');
 		}

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -73,16 +73,17 @@ class PublicLinkTab extends OwncloudPage {
 	 *
 	 * @param Session $session
 	 * @param int $timeout_msec
-	 * @param string $xpath the xpath of the element to wait for
-	 *                      required to be set
+	 * @param string|null $xpath the xpath of the element to wait for
+	 *                           required to be set
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
-		$xpath = null
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
+		?string $xpath = null
+	):void {
 		if ($xpath === null) {
 			throw new \InvalidArgumentException('$xpath needs to be set');
 		}

--- a/tests/acceptance/features/lib/GeneralErrorPage.php
+++ b/tests/acceptance/features/lib/GeneralErrorPage.php
@@ -56,8 +56,8 @@ class GeneralErrorPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {

--- a/tests/acceptance/features/lib/GeneralExceptionPage.php
+++ b/tests/acceptance/features/lib/GeneralExceptionPage.php
@@ -72,8 +72,8 @@ class GeneralExceptionPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitTillXpathIsVisible($this->exceptionTitleXpath, $timeout_msec);
 	}
 }

--- a/tests/acceptance/features/lib/NotificationsAppDialog.php
+++ b/tests/acceptance/features/lib/NotificationsAppDialog.php
@@ -97,8 +97,8 @@ class NotificationsAppDialog extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitTillXpathIsVisible(
 			$this->notificationContainerXpath,
 			$timeout_msec

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -58,8 +58,8 @@ class OwncloudPage extends Page {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	): void {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {

--- a/tests/acceptance/features/lib/OwncloudPageElement/SettingsMenu.php
+++ b/tests/acceptance/features/lib/OwncloudPageElement/SettingsMenu.php
@@ -59,8 +59,8 @@ class SettingsMenu extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitTillXpathIsVisible($this->logoutButtonXpath, $timeout_msec);
 	}
 }

--- a/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
@@ -69,8 +69,8 @@ class PersonalEncryptionSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -83,8 +83,8 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitTillXpathIsVisible(
 			$this->personalProfilePanelXpath,
 			$timeout_msec

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
@@ -148,8 +148,8 @@ class PersonalSecuritySettingsPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitForOutstandingAjaxCalls($session);
 		$this->waitTillXpathIsVisible(
 			$this->corsInputFieldXpath,

--- a/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
@@ -108,8 +108,8 @@ class PersonalSharingSettingsPage extends SharingSettingsPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->waitForOutstandingAjaxCalls($session);
 		$this->waitTillXpathIsVisible(
 			$this->personalSharingPanelDivXpath,

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -420,8 +420,8 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = LONG_UI_WAIT_TIMEOUT_MILLISEC
-	) {
+		int $timeout_msec = LONG_UI_WAIT_TIMEOUT_MILLISEC
+	):void {
 		$this->initAjaxCounters($session);
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -853,6 +853,7 @@ class UsersPage extends OwncloudPage {
 	 * @throws ElementNotFoundException|Exception
 	 */
 	public function addOrRemoveUserToGroup(Session $session, string $user, string $group, bool $add = true, bool $failIfElementNotFound = true): void {
+		$this->waitForAjaxCallsToStartAndFinish($session);
 		$userTr = $this->findUserInTable($user);
 		$groupsField = $userTr->find('xpath', $this->groupsFieldXpath);
 		$userGroupsInput = $groupsField->find("xpath", $this->userGroupsInputXpath);

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -924,7 +924,7 @@ class UsersPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
+		int $timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	): void {
 		// There is always at least the "admin" user in the displayed list of users
 		// So wait for the user list to have at least 1 real user in it


### PR DESCRIPTION
## Description
Define the parameter types and return type for all declarations of `waitTillPageIsLoaded` in the acceptance tests. That will prevent PHP warnings (see issue).

## Related Issue
- Fixes #39356 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
