### PR TITLE
Add priority for JavaScript plugins

### DIFF
--- a/apps/files_sharing/js/sharedialogview.js
+++ b/apps/files_sharing/js/sharedialogview.js
@@ -76,4 +76,4 @@
 	};
 })();
 
-OC.Plugins.register('OC.Share.ShareDialogView', OCA.Sharing.ShareDialogView);
+OC.Plugins.register('OC.Share.ShareDialogView', OCA.Sharing.ShareDialogView, 100);

--- a/changelog/unreleased/39359
+++ b/changelog/unreleased/39359
@@ -1,0 +1,7 @@
+Enhancement: Add priority for JavaScript plugins
+
+JavaScript plugins can now be registered with a specific priority.
+A higher priority means the plugin will be attached/detached before
+others.
+
+https://github.com/owncloud/core/pull/39359

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -874,13 +874,18 @@ OC.Plugins = {
 	 *
 	 * @param {String} targetName app name / class name to hook into
 	 * @param {OC.Plugin} plugin
+	 * @param {String} priority priority of the plugin. sortPluginsByPriority()
+	 * can be used to sort given plugins by their priority.
 	 */
-	register: function (targetName, plugin) {
+	register: function (targetName, plugin, priority) {
+		if (!priority) {
+			priority = 50;
+		}
 		var plugins = this._plugins[targetName];
 		if (!plugins) {
 			plugins = this._plugins[targetName] = [];
 		}
-		plugins.push(plugin);
+		plugins.push({plugin: plugin, priority: priority});
 	},
 
 	/**
@@ -895,6 +900,24 @@ OC.Plugins = {
 	},
 
 	/**
+	 * Sort a list of given plugins by their priority.
+	 * A higher priority means the plugin is listed before others.
+	 *
+	 * @param {Array.<OC.Plugin>} plugins
+	 */
+	sortPluginsByPriority: function (plugins) {
+		return plugins.sort(function(a, b) {
+			if (a.priority > b.priority) {
+				return -1;
+			}
+			if (a.priority < b.priority) {
+				return 1;
+			}
+			return 0;
+		});
+	},
+
+	/**
 	 * Call attach() on all plugins registered to the given target name.
 	 *
 	 * @param {String} targetName app name / class name
@@ -903,9 +926,11 @@ OC.Plugins = {
 	 */
 	attach: function (targetName, targetObject, options) {
 		var plugins = this.getPlugins(targetName);
+		plugins = this.sortPluginsByPriority(plugins);
 		for (var i = 0; i < plugins.length; i++) {
-			if (plugins[i].attach) {
-				plugins[i].attach(targetObject, options);
+			var plugin = plugins[i].plugin;
+			if (plugin.attach) {
+				plugin.attach(targetObject, options);
 			}
 		}
 	},
@@ -919,9 +944,11 @@ OC.Plugins = {
 	 */
 	detach: function (targetName, targetObject, options) {
 		var plugins = this.getPlugins(targetName);
+		plugins = this.sortPluginsByPriority(plugins);
 		for (var i = 0; i < plugins.length; i++) {
-			if (plugins[i].detach) {
-				plugins[i].detach(targetObject, options);
+			var plugin = plugins[i].plugin;
+			if (plugin.detach) {
+				plugin.detach(targetObject, options);
 			}
 		}
 	},


### PR DESCRIPTION
## Description
JavaScript plugins can now be registered with a specific priority. A higher priority means the plugin will be attached/detached before others.

I noticed this because core registers a plugin for `OC.Share.ShareDialogView` as well as the `files_spaces` app. These two conflict with each other because the core plugin needs to be registered first.

## Related Issue
- Related to https://github.com/owncloud/files_spaces/issues/133

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4149
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
