### PR TITLE
Bugfix: Clicking in the middle of the row in the file list downloads the file

### DIFF
--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -68,17 +68,6 @@
 	top: 44px;
 }
 
-/* make sure there's enough room for the file actions */
-#body-user #filestable {
-	min-width: 688px;
-	/* 768 (mobile break) - 80 (nav width) */
-}
-
-#body-user #controls {
-	min-width: 688px;
-	/* 768 (mobile break) - 80 (nav width) */
-}
-
 #filestable tbody tr {
 	background-color: #fff;
 	height: 51px;

--- a/apps/files/css/files.css
+++ b/apps/files/css/files.css
@@ -389,6 +389,7 @@ table td.upload {
 table td.filename .nametext {
 	float: left;
 	padding: 15px 0;
+	text-overflow: ellipsis;
 }
 
 .column-last > span:first-child,
@@ -405,10 +406,8 @@ table td.filename .nametext {
 	left: 55px;
 	padding: 0;
 	overflow: hidden;
-	text-overflow: clip;
 	max-width: 800px;
 	height: 100%;
-	width: 100%;
 }
 
 .has-favorites #fileList td.filename a.name {

--- a/apps/files/css/mobile.css
+++ b/apps/files/css/mobile.css
@@ -39,10 +39,15 @@ table.multiselect thead {
 	opacity: .3 !important;
 }
 
+table td.filename .nametext {
+		max-width: 180px;
+}
+
 /* ellipsis on file names */
 table td.filename .nametext .innernametext {
-	max-width: 90%;
+	max-width: 100px;
 }
+
 
 /* proper notification area for multi line messages */
 #notification-container {

--- a/changelog/unreleased/39361
+++ b/changelog/unreleased/39361
@@ -1,0 +1,11 @@
+Bugfix: Clicking in the middle of the row in the file list downloads the file
+
+This change addresses the issue if the user clicks in on a row in the file list,
+the file gets downloaded or open with the default viewer.
+This was not intended, the download or default opening should only happen if
+the user clicks directly on the file name.
+Problems with mobile devices, where the file name was too long to display,
+has been also solved.
+
+https://github.com/owncloud/core/pull/39361
+https://github.com/owncloud/core/issues/39329


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This change addresses the issue if the user clicks in on a row in the file list,
the file gets downloaded or open with the default viewer.
This was not intended, the download or default opening should only happen if
the user clicks directly on the file name.
Problems with mobile devices, where the file name was too long to display,
has been also solved.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39329


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- MS Edge
- IE 11
- Google Chrome
- Firefox
- Safari

## Screenshots (if appropriate):

### Mobile view
- Before
![image](https://user-images.githubusercontent.com/26169327/137689604-8ad349fe-28e7-461c-918f-4d9cf19d7cf5.png)


- After
![image](https://user-images.githubusercontent.com/26169327/137689505-66e8b973-61c8-4560-8e3e-507e9fc231fd.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
