### PR TITLE
[full-ci][tests-only] Skip acceptance tests that do not work for oCIS

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -44,6 +44,7 @@ Feature: edit users
     And the OCS status code should be "100"
     And the display name of user "brand-new-user" should be "A New User"
 
+
   Scenario: the administrator can clear a user display name and then it defaults to the username
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "A New User"
@@ -59,6 +60,7 @@ Feature: edit users
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"
     And the quota definition of user "brand-new-user" should be "12 MB"
+
 
   Scenario: the administrator can override an existing user email
     Given user "brand-new-user" has been created with default attributes and without skeleton files
@@ -97,6 +99,7 @@ Feature: edit users
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
     And the quota definition of user "brand-new-user" should be "12 MB"
 
+
   Scenario: a normal user should be able to change their email address
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
@@ -105,6 +108,7 @@ Feature: edit users
     And the attributes of user "brand-new-user" returned by the API should include
       | email | brand-new-user@example.com |
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
+
 
   Scenario Outline: a normal user should be able to change their display name
     Given user "brand-new-user" has been created with default attributes and without skeleton files
@@ -119,6 +123,7 @@ Feature: edit users
       | Alan Border     |
       | Phil Cyclist 🚴 |
 
+
   Scenario: a normal user should not be able to change their quota
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
@@ -127,11 +132,12 @@ Feature: edit users
     And the attributes of user "brand-new-user" returned by the API should include
       | quota definition | default |
     And the quota definition of user "brand-new-user" should be "default"
+
   @notToImplementOnOCIS
   Scenario: the administrator can edit user information with admin permissions
     Given these users have been created with default attributes and without skeleton files:
-      | username            |
-      | another-admin       |
+      | username      |
+      | another-admin |
     And user "another-admin" has been added to group "admin"
     When user "another-admin" changes the quota of user "another-admin" to "12MB" using the provisioning API
     And user "another-admin" changes the email of user "another-admin" to "another-admin@example.com" using the provisioning API
@@ -139,6 +145,7 @@ Feature: edit users
     Then the display name of user "another-admin" should be "Anne Brown"
     And the email address of user "another-admin" should be "another-admin@example.com"
     And the quota definition of user "another-admin" should be "12 MB"
+
   @notToImplementOnOCIS
   Scenario: a subadmin should be able to edit user information with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
@@ -155,8 +162,9 @@ Feature: edit users
     Then the display name of user "another-subadmin" should be "Anne Brown"
     And the email address of user "another-subadmin" should be "brand-new-user@example.com"
     And the quota definition of user "another-subadmin" should be "12 MB"
+
   @notToImplementOnOCIS
-    Scenario: a subadmin should not be able to edit user information of another subadmin of same group
+  Scenario: a subadmin should not be able to edit user information of another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
       | subadmin         |
@@ -176,6 +184,7 @@ Feature: edit users
     And the display name of user "another-subadmin" should be "Regular User"
     And the email address of user "another-subadmin" should be "another-subadmin@owncloud.com"
     And the quota definition of user "another-subadmin" should be "default"
+
 
   Scenario: a normal user should not be able to edit another user's information
     Given these users have been created with default attributes and without skeleton files:
@@ -202,7 +211,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address
     Given user "Alice" has been created with default attributes and without skeleton files
     When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
@@ -224,7 +233,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name
     Given user "Alice" has been created with default attributes and without skeleton files
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -37,12 +37,14 @@ Feature: edit users
     And the OCS status code should be "200"
     And the display name of user "brand-new-user" should be "A New User"
 
+
   Scenario: the administrator can edit a user display name
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     When the administrator changes the display name of user "brand-new-user" to "A New User" using the provisioning API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the display name of user "brand-new-user" should be "A New User"
+
 
   Scenario: the administrator can clear a user display name and then it defaults to the username
     Given user "brand-new-user" has been created with default attributes and without skeleton files
@@ -59,6 +61,7 @@ Feature: edit users
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
     And the quota definition of user "brand-new-user" should be "12 MB"
+
 
   Scenario: the administrator can override existing user email
     Given user "brand-new-user" has been created with default attributes and without skeleton files
@@ -97,6 +100,7 @@ Feature: edit users
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
     And the quota definition of user "brand-new-user" should be "12 MB"
 
+
   Scenario: a normal user should be able to change their email address
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     When user "brand-new-user" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
@@ -105,6 +109,7 @@ Feature: edit users
     And the attributes of user "brand-new-user" returned by the API should include
       | email | brand-new-user@example.com |
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
+
 
   Scenario Outline: a normal user should be able to change their display name
     Given user "brand-new-user" has been created with default attributes and without skeleton files
@@ -119,6 +124,7 @@ Feature: edit users
       | Alan Border     |
       | Phil Cyclist 🚴 |
 
+
   Scenario: a normal user should not be able to change their quota
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     When user "brand-new-user" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
@@ -127,11 +133,12 @@ Feature: edit users
     And the attributes of user "brand-new-user" returned by the API should include
       | quota definition | default |
     And the quota definition of user "brand-new-user" should be "default"
+
   @notToImplementOnOCIS
   Scenario: the administrator can edit user information with admin permissions
     Given these users have been created with default attributes and without skeleton files:
-      | username            |
-      | another-admin       |
+      | username      |
+      | another-admin |
     And user "another-admin" has been added to group "admin"
     When user "another-admin" changes the quota of user "another-admin" to "12MB" using the provisioning API
     And user "another-admin" changes the email of user "another-admin" to "another-admin@example.com" using the provisioning API
@@ -139,6 +146,7 @@ Feature: edit users
     Then the display name of user "another-admin" should be "Anne Brown"
     And the email address of user "another-admin" should be "another-admin@example.com"
     And the quota definition of user "another-admin" should be "12 MB"
+
   @notToImplementOnOCIS
   Scenario: a subadmin should be able to edit user information with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
@@ -155,6 +163,7 @@ Feature: edit users
     Then the display name of user "another-subadmin" should be "Anne Brown"
     And the email address of user "another-subadmin" should be "brand-new-user@example.com"
     And the quota definition of user "another-subadmin" should be "12 MB"
+
   @notToImplementOnOCIS
   Scenario: a subadmin should not be able to edit user information of another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
@@ -176,6 +185,7 @@ Feature: edit users
     And the display name of user "another-subadmin" should be "Regular User"
     And the email address of user "another-subadmin" should be "another-subadmin@owncloud.com"
     And the quota definition of user "another-subadmin" should be "default"
+
 
   Scenario: a normal user should not be able to edit another user's information
     Given these users have been created with default attributes and without skeleton files:
@@ -202,7 +212,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address
     Given user "Alice" has been created with default attributes and without skeleton files
     When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
@@ -224,12 +234,12 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name
     Given user "Alice" has been created with default attributes and without skeleton files
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
     And user "Alice" tries to change the display name of user "Alice" to "Alice Wonderland" using the provisioning API
-    #Then the OCS status code should be "997"
+    Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And the attributes of user "Alice" returned by the API should include
       | displayname | Alice Hansen |

--- a/tests/acceptance/features/apiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/apiWebdavOperations/propfind.feature
@@ -7,7 +7,6 @@ Feature: PROPFIND
     When user "Alice" requests "/remote.php/dav/files" with "PROPFIND" using basic auth
     Then the HTTP status code should be "405"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: PROPFIND to "/remote.php/dav/files" with depth header
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has set depth_infinity_allowed to <depth_infinity_allowed>
@@ -15,9 +14,15 @@ Feature: PROPFIND
       | header | value   |
       | depth  | <depth> |
     Then the HTTP status code should be "<http_status>"
-  Examples:
+    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+    Examples:
       | depth_infinity_allowed | depth    | http_status |
       | 1                      | 0        | 207         |
       | 1                      | infinity | 207         |
       | 0                      | 0        | 207         |
       | 0                      | infinity | 412         |
+    @skipOnOcV10
+    Examples:
+      | depth_infinity_allowed | depth    | http_status |
+      | 1                      | 0        | 207         |
+      | 1                      | infinity | 207         |

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -253,7 +253,7 @@ Feature: previews of files downloaded through the webdav API
     And as user "Brian" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     And as user "Carol" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
   Scenario: JPEG preview quality can be determined by config
     Given user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "/testavatar_low.jpg"
     And the administrator has updated system config key "previewJPEGImageDisplayQuality" with value "1"


### PR DESCRIPTION
## Description
On oC10 the admin can set system-wide settings like:
- do not let users change their display name
- do not let users change their email address
- specify the JPEG preview quality

These system-wide settings are not implemented on oCIS. Decisions about many of those settings will be made in the future. For now, skip the related acceptance tests.

## How Has This Been Tested?
- test environment: CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
