### PR TITLE
[tests-only] Adjust firefox version in code coverage file

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1180,10 +1180,10 @@ def javascript(ctx, withCoverage):
                         "from_secret": "cache_s3_endpoint",
                     },
                     "bucket": "cache",
-                    "source": "tests/output/coverage/Firefox 92.0.0 (Ubuntu 0.0.0)/lcov.info",
+                    "source": "tests/output/coverage/Firefox 93.0.0 (Ubuntu 0.0.0)/lcov.info",
                     "target": "%s/%s/coverage" % (ctx.repo.slug, ctx.build.commit + "-${DRONE_BUILD_NUMBER}"),
                     "path_style": True,
-                    "strip_prefix": "tests/output/coverage/Firefox 92.0.0 (Ubuntu 0.0.0)",
+                    "strip_prefix": "tests/output/coverage/Firefox 93.0.0 (Ubuntu 0.0.0)",
                     "access_key": {
                         "from_secret": "cache_s3_access_key",
                     },


### PR DESCRIPTION
Firefox seems to have a new version in our docker image, therefore we need to update the name for the test coverage.