### PR TITLE
[tests-only] Pin coverage folder name for JavaScript tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1180,10 +1180,10 @@ def javascript(ctx, withCoverage):
                         "from_secret": "cache_s3_endpoint",
                     },
                     "bucket": "cache",
-                    "source": "tests/output/coverage/Firefox 93.0.0 (Ubuntu 0.0.0)/lcov.info",
+                    "source": "tests/output/coverage/lcov.info",
                     "target": "%s/%s/coverage" % (ctx.repo.slug, ctx.build.commit + "-${DRONE_BUILD_NUMBER}"),
                     "path_style": True,
-                    "strip_prefix": "tests/output/coverage/Firefox 93.0.0 (Ubuntu 0.0.0)",
+                    "strip_prefix": "tests/output/coverage",
                     "access_key": {
                         "from_secret": "cache_s3_access_key",
                     },

--- a/tests/karma.config.js
+++ b/tests/karma.config.js
@@ -277,7 +277,8 @@ module.exports = function(config) {
 		preprocessors: preprocessors,
 
 		coverageReporter: {
-			dir:'tests/output/coverage',
+			dir: 'tests/output/coverage',
+			subdir: '.',
 			reporters: [
 				{ type: 'html' },
 				{ type: 'cobertura' },


### PR DESCRIPTION
## Description
This way we don't have to adjust the folder name with each new FireFox version.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39365

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
