### PR TITLE
Enhancement: Right click on filelist table row opens ownCloud context menu

### DIFF
--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2351,6 +2351,18 @@ describe('OCA.Files.FileList tests', function() {
 			expect(context.fileActions).toBeDefined();
 			expect(context.dir).toEqual('/subdir');
 		});
+		it('Right clicking on a file row will open action menu', function() {
+			fileList.setFiles(testFiles);
+			var $tr = fileList.findFileEl('One.txt');
+
+			$tr.trigger({
+				type: 'mouseup',
+				which: 3
+			});
+
+			var $menu = fileList.$el.find('.fileActionsMenu.open');
+			expect($menu.length).toEqual(1);
+		});
 		it('clicking on a file name will render the app drawer context menu if more than one action applies for this mime type', function() {
 			var actionStub = sinon.stub();
 			fileList.setFiles(testFiles);

--- a/changelog/unreleased/39376
+++ b/changelog/unreleased/39376
@@ -1,0 +1,3 @@
+Enhancement: Right click on file list table row opens action context menu
+
+https://github.com/owncloud/core/pull/39376

--- a/core/css/apps.css
+++ b/core/css/apps.css
@@ -348,6 +348,12 @@
 	border-width: 10px;
 	margin-left: -10px;
 }
+
+/* class to disable arrow */
+.no-arrow.bubble:after {
+	border: none;
+}
+
 .bubble .action {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)" !important;
 	filter: alpha(opacity=50) !important;

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1588,6 +1588,16 @@ function initCore() {
 		OC.hideMenus();
 	});
 
+	/**
+	 * This event gets fired, if you press the escape key
+	 * So we can close the open menus, for example the #settings menu
+	 */
+	$(window).on('keyup',function(event){
+		if (event.key === "Escape"){
+			OC.hideMenus();
+		}
+	});
+
 	// toggle for menus
 	$(document).on('mouseup.closemenus', function (event) {
 		var $el = $(event.target);


### PR DESCRIPTION
## Description
Enhancement: Right click on filelist table row opens ownCloud context menu

## Related Issue
- Fixes <issue_link>

## How Has This Been Tested?
See comment https://github.com/owncloud/core/pull/39376#pullrequestreview-787877769

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/26169327/138066271-6e5c294f-e7b8-484a-ba6c-1633de599c7a.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
