### PR TITLE
[tests-only] Enabled skipped webui comment scenario in CI

### DIFF
--- a/tests/acceptance/features/webUIComments/comments.feature
+++ b/tests/acceptance/features/webUIComments/comments.feature
@@ -26,7 +26,7 @@ Feature: Add, delete and edit comments in files and folders
       | 😀 🤖       |
       | नेपालि      |
 
-  @skipOnFIREFOX @files_sharing-app-required @skipOnOcV10 @issue-39213
+  @skipOnFIREFOX @files_sharing-app-required
   Scenario Outline: Add comment on a shared file and check it is shown in other user's UI
     When the user renames file "lorem.txt" to "new-lorem.txt" using the webUI
     And the user browses directly to display the "comments" details of file "new-lorem.txt" in folder "/"


### PR DESCRIPTION
## Description
- a scenario `webUIComments/comments.feature:40 41 42` was previously behaving flaky in core CI
- a test PR had been made to check its pass/fail consistency in core CI (https://github.com/owncloud/core/pull/39374)
- tests pass without a failure for multiple times run
- skip tag from the scenario is now removed

## Related Issue
- Part of https://github.com/owncloud/core/issues/39213

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 🤖 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)
