### PR TITLE
[tests-only] [full-ci] Fix parameter types in acceptance test code

### DIFF
--- a/tests/TestHelpers/TranslationHelper.php
+++ b/tests/TestHelpers/TranslationHelper.php
@@ -30,11 +30,11 @@ namespace TestHelpers;
  */
 class TranslationHelper {
 	/**
-	 * @param $language
+	 * @param string|null $language
 	 *
 	 * @return string
 	 */
-	public static function getLanguage($language) {
+	public static function getLanguage(?string $language): ?string {
 		if (!isset($language)) {
 			if (\getenv('OC_LANGUAGE') !== false) {
 				$language = \getenv('OC_LANGUAGE');

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -798,7 +798,7 @@ class OCSContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theOCSStatusMessageShouldBe(string $statusMessage, ?string $language=null):void {
+	public function theOCSStatusMessageShouldBe(string $statusMessage, ?string $language = null):void {
 		$language = TranslationHelper::getLanguage($language);
 		$statusMessage = $this->getActualStatusMessage($statusMessage, $language);
 
@@ -907,11 +907,11 @@ class OCSContext implements Context {
 	 * convert status message in the desired language
 	 *
 	 * @param string $statusMessage
-	 * @param string $language
+	 * @param string|null $language
 	 *
 	 * @return string
 	 */
-	public function getActualStatusMessage(string $statusMessage, string $language):string {
+	public function getActualStatusMessage(string $statusMessage, ?string $language = null):string {
 		if ($language !== null) {
 			$multiLingualMessage = \json_decode(
 				\file_get_contents(__DIR__ . "/../../fixtures/multiLanguageErrors.json"),

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -166,14 +166,14 @@ class OCSContext implements Context {
 	/**
 	 * @param string $verb
 	 * @param string $url
-	 * @param TableNode $body
+	 * @param TableNode|null $body
 	 *
 	 * @return void
 	 */
 	public function adminSendsHttpMethodToOcsApiEndpointWithBody(
 		string $verb,
 		string $url,
-		TableNode $body
+		?TableNode $body
 	):void {
 		$admin = $this->featureContext->getAdminUsername();
 		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
@@ -187,11 +187,11 @@ class OCSContext implements Context {
 	/**
 	 * @param string $verb
 	 * @param string $url
-	 * @param TableNode $body
+	 * @param TableNode|null $body
 	 *
 	 * @return void
 	 */
-	public function theUserSendsToOcsApiEndpointWithBody(string $verb, string $url, TableNode $body):void {
+	public function theUserSendsToOcsApiEndpointWithBody(string $verb, string $url, ?TableNode $body = null):void {
 		$this->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->featureContext->getCurrentUser(),
 			$verb,

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1338,7 +1338,7 @@ trait Provisioning {
 			$this->getAdminUsername(),
 			"POST",
 			"/cloud/users",
-			$userAttributes
+			new TableNode($userAttributes)
 		);
 		$this->addUserToCreatedUsersList(
 			$username,

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -3722,7 +3722,7 @@ trait Provisioning {
 		$attribute,
 		$entry,
 		$value,
-		$append=false
+		$append = false
 	) {
 		$ldapEntry = $this->ldap->getEntry($entry . "," . $this->ldapBaseDN);
 		Laminas\Ldap\Attribute::setAttribute($ldapEntry, $attribute, $value, $append);

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -552,7 +552,7 @@ class PublicWebDavContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function publiclyOverwritingContent(string $filename, string $body = 'test', string $publicWebDAVAPIVersion='old'):void {
+	public function publiclyOverwritingContent(string $filename, string $body = 'test', string $publicWebDAVAPIVersion = 'old'):void {
 		$this->publicUploadContent($filename, '', $body, false, [], $publicWebDAVAPIVersion);
 	}
 
@@ -1233,7 +1233,7 @@ class PublicWebDavContext implements Context {
 	public function thePublicUploadsFileToLastSharedFolderWithMtimeUsingTheWebdavApi(
 		string $fileName,
 		string $mtime,
-		string $davVersion="old"
+		string $davVersion = "old"
 	):void {
 		$mtime = new DateTime($mtime);
 		$mtime = $mtime->format('U');

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -22,6 +22,7 @@
  *
  */
 
+use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Psr\Http\Message\ResponseInterface;
 use PHPUnit\Framework\Assert;

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1902,7 +1902,7 @@ trait Sharing {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userGetsInfoOfLastShareUsingTheSharingApi(string $user, ?string $language=null):void {
+	public function userGetsInfoOfLastShareUsingTheSharingApi(string $user, ?string $language = null):void {
 		if (isset($this->lastShareData->data[0]->id)) {
 			$share_id = $this->lastShareData->data[0]->id;
 		} else {
@@ -1994,7 +1994,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function getShareData(string $user, string $share_id, ?string $language=null):void {
+	public function getShareData(string $user, string $share_id, ?string $language = null):void {
 		$user = $this->getActualUsername($user);
 		$url = $this->getSharesEndpointPath("/$share_id");
 		$headers = [];

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -980,7 +980,7 @@ class WebDavPropertiesContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function storeEtagOfElement(string $user, string $path, ?string $storePath=""):void {
+	public function storeEtagOfElement(string $user, string $path, ?string $storePath = ""):void {
 		if ($storePath === "") {
 			$storePath = $path;
 		}


### PR DESCRIPTION
## Description
1) Some test scenarios are failing in oC10 apps 
```
    And the OCS status message should be "Expiration date is in the past"                                                       # OCSContext::theOCSStatusMessageShouldBe()
      Type error: Argument 2 passed to OCSContext::getActualStatusMessage() must be of the type string, null given, called in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/OCSContext.php on line 803 (Behat\Testwork\Call\Exception\FatalThrowableError)
```
https://drone.owncloud.com/owncloud/customgroups/2054/14/9

The `$language` parameter to `OCSContext::getActualStatusMessage()` can be `null` - fix the type declaration.

2) Problem with TableNode parameter in tests:
```
    When the user sends HTTP method "GET" to OCS API endpoint "/apps/notifications/api/v1/notifications?format=json" # OCSContext::theUserSendsToOcsApiEndpoint()
      Type error: Argument 3 passed to OCSContext::theUserSendsToOcsApiEndpointWithBody() must be an instance of Behat\Gherkin\Node\TableNode, null given, called in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/OCSContext.php on line 54 (Behat\Testwork\Call\Exception\FatalThrowableError)
```
https://drone.owncloud.com/owncloud/notifications/1808/25/10

The functions are adjusted to allow `TableNode` or `null`

3)  Add missing use PyStringNode to Sharing.php
```
    But the downloading of file "simple-folder/lorem.txt" for user "Brian" should fail with error message                                              # FeatureContext::userDownloadsFailWithMessage()
      """
      Access to this resource has been denied because it is in view-only mode.
      """
      Type error: Argument 3 passed to FeatureContext::userDownloadsFailWithMessage() must be an instance of PyStringNode, instance of Behat\Gherkin\Node\PyStringNode given, called in /var/www/owncloud/testrunner/apps/richdocuments/vendor-bin/behat/vendor/behat/behat/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php on line 110 (Behat\Testwork\Call\Exception\FatalThrowableError)
```
https://github.com/owncloud/core/pull/39392

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
