### PR TITLE
Enhancement: Extend occ dav:cleanup-chunks command with local option

### DIFF
--- a/apps/dav/lib/Command/CleanupChunks.php
+++ b/apps/dav/lib/Command/CleanupChunks.php
@@ -18,8 +18,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OCA\DAV\Command;
 
+use OC\Files\View;
 use OCA\DAV\Upload\UploadFolder;
 use OCA\DAV\Upload\UploadHome;
 use OCP\IUser;
@@ -28,6 +30,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanupChunks extends Command {
@@ -52,30 +55,59 @@ class CleanupChunks extends Command {
 				InputArgument::OPTIONAL,
 				'minimum age of uploads to cleanup (in days - minimum 2 days - maximum 100)',
 				2
+			)
+			->addOption(
+				'local',
+				'l',
+				InputOption::VALUE_NONE,
+				'only delete chunks that exist on the local filesystem, 
+				this applies to setups with multiple servers connected to the same database and 
+				chunk folder is not shared among'
 			);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		$checkUploadExistsLocal = $input->getOption('local') === true;
 		$d = $input->getArgument('minimum-age-in-days');
 		$d = \max(2, \min($d, 100));
 		$cutOffTime = new \DateTime("$d days ago");
 		$output->writeln("Cleaning chunks older than $d days({$cutOffTime->format('c')})");
-		$this->userManager->callForSeenUsers(function (IUser $user) use ($output, $cutOffTime) {
-			$output->writeln("Cleaning chunks for {$user->getUID()}");
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($output, $cutOffTime, $checkUploadExistsLocal) {
 			\OC_Util::tearDownFS();
 			\OC_Util::setupFS($user->getUID());
 
+			$view = new View('/' . $user->getUID() . '/uploads');
 			$home = new UploadHome(['user' => $user]);
 			$uploads = $home->getChildren();
+			$filteredUploads = [];
+
+			foreach ($uploads as $upload) {
+				/** @var UploadFolder $upload */
+				if ($upload->getLastModified() >= $cutOffTime->getTimestamp()) {
+					continue;
+				}
+
+				if ($checkUploadExistsLocal === true &&
+					$view->file_exists($upload->getName()) !== true) {
+					continue;
+				}
+
+				$filteredUploads[] = $upload;
+			}
+
+			if (empty($filteredUploads)) {
+				return;
+			}
+
+			$output->writeln(sprintf("Cleaning %d chunks for %s", \count($filteredUploads), $user->getUID()));
 
 			$p = new ProgressBar($output);
-			$p->start(\count($uploads));
-			foreach ($uploads as $upload) {
+			$p->start(\count($filteredUploads));
+
+			foreach ($filteredUploads as $upload) {
 				$p->advance();
 				/** @var UploadFolder $upload */
-				if ($upload->getLastModified() < $cutOffTime->getTimestamp()) {
-					$upload->delete();
-				}
+				$upload->delete();
 			}
 
 			$p->finish();

--- a/changelog/unreleased/39394
+++ b/changelog/unreleased/39394
@@ -1,0 +1,12 @@
+Enhancement: Extend occ dav:cleanup-chunks command with local option
+
+If an admin runs a setup with multiple servers, connected to the same database
+and sets the configuration for the chunking directory 'dav.chunk_base_dir' to a
+unique place on the server, the command occ dav:cleanup-chunks might fail.
+This happens as the oc_filecache table doesn't give us the information on which
+server the directory is.
+Therefore the local option has been added to the command, with this precondition
+only files that are on the local filesystem will be removed.
+
+https://github.com/owncloud/core/pull/39394
+https://github.com/owncloud/enterprise/issues/4824


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
If an admin runs a setup with multiple servers, connected to the same database
and sets the configuration for the chunking directory 'dav.chunk_base_dir' to a
unique place on the server, the command occ dav:cleanup-chunks might fail.
This happens as the oc_filecache table doesn't give us the information on which
server the directory is.
Therefore the local option has been added to the command, with this precondition
only files that are on the local filesystem will be removed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4824

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4352
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
