### PR TITLE
Adjust text of occ encryption command messages

### DIFF
--- a/changelog/unreleased/39395
+++ b/changelog/unreleased/39395
@@ -1,0 +1,5 @@
+Bugfix: Adjust text of occ encryption command messages
+
+The text of some encryption command messages has been improved.
+
+https://github.com/owncloud/core/pull/39395

--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -110,7 +110,7 @@ class DecryptAll extends Command {
 		$this->setHelp(
 			'This will disable server-side encryption and decrypt all files for '
 			. 'all users if it is supported by your encryption module. '
-			. 'Please make sure that no user access his files during this process!'
+			. 'Please make sure that no user accesses their files during this process!'
 		);
 		$this->addArgument(
 			'user',
@@ -161,7 +161,7 @@ class DecryptAll extends Command {
 			$output->writeln("You are about to start to decrypt all files stored in $message.");
 			$output->writeln('It will depend on the encryption module and your setup if this is possible.');
 			$output->writeln('Depending on the number and size of your files this can take some time');
-			$output->writeln('Please make sure that no user access his files during this process!');
+			$output->writeln('Please make sure that no user accesses their files during this process!');
 			$output->writeln('');
 			$question = new ConfirmationQuestion('Do you really want to continue? (y/n) ', false);
 			if (($confirmed === 'yes') || $this->questionHelper->ask($input, $output, $question)) {

--- a/core/Command/Encryption/Disable.php
+++ b/core/Command/Encryption/Disable.php
@@ -60,7 +60,7 @@ class Disable extends Command {
 		$hasEncryptedFiles = (bool) $results->fetchColumn(0);
 		$results->closeCursor();
 		if ($hasEncryptedFiles !== false) {
-			$output->writeln('<info>The system still have encrypted files. Please decrypt them all before disabling encryption.</info>');
+			$output->writeln('<info>The system still has encrypted files. Please decrypt them all before disabling encryption.</info>');
 			return 1;
 		}
 

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -98,7 +98,7 @@ class EncryptAll extends Command {
 		$this->setDescription('Encrypt all files for all users.');
 		$this->setHelp(
 			'This will encrypt all files for all users. '
-			. 'Please make sure that no user access his files during this process!'
+			. 'Please make sure that no user accesses their files during this process!'
 		);
 		$this->addOption(
 			'yes',

--- a/tests/Core/Command/Encryption/DisableTest.php
+++ b/tests/Core/Command/Encryption/DisableTest.php
@@ -131,7 +131,7 @@ class DisableTest extends TestCase {
 		} else {
 			$this->consoleOutput->expects($this->once())
 				->method('writeln')
-				->with($this->stringContains('<info>The system still have encrypted files. Please decrypt them all before disabling encryption.</info>'));
+				->with($this->stringContains('<info>The system still has encrypted files. Please decrypt them all before disabling encryption.</info>'));
 			$expectedExitCode = 1;
 		}
 

--- a/tests/acceptance/features/cliEncryption/encryption.feature
+++ b/tests/acceptance/features/cliEncryption/encryption.feature
@@ -52,7 +52,7 @@ Feature: encryption command
     Given the administrator has uploaded file with content "uploaded content" to "/lorem.txt"
     When the administrator disables encryption using the occ command
     Then the command should have failed with exit code 1
-    And the command output should contain the text "The system still have encrypted files. Please decrypt them all before disabling encryption."
+    And the command output should contain the text "The system still has encrypted files. Please decrypt them all before disabling encryption."
 
 
   Scenario: move encryption keys to a different folder
@@ -68,4 +68,4 @@ Feature: encryption command
     Given the administrator has decrypted everything
     When the administrator disables encryption using the occ command
     Then the command should have failed with exit code 1
-    And the command output should contain the text "The system still have encrypted files. Please decrypt them all before disabling encryption"
+    And the command output should contain the text "The system still has encrypted files. Please decrypt them all before disabling encryption"


### PR DESCRIPTION
## Description
When reviewing PR #39217 I noticed a few improvements that could be made to the messages in `occ encryption` commands. These are the changes.

Mote: these `occ` command texts are not translated. So these changes won't cause a hassle in Transifex.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
