### PR TITLE
[tests-only] [fulll-ci] Remove stream_for from PublicWebDavContext

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -327,7 +327,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function publiclyUploadingFile(string $source, string $publicWebDAVAPIVersion):void {
-		$file = \GuzzleHttp\Psr7\stream_for(\fopen($source, 'r'));
+		$file = \fopen($source, 'r');
 		$this->publicUploadContent(
 			\basename($source),
 			'',


### PR DESCRIPTION
## Description
`\GuzzleHttp\Psr7\stream_for()` was removed since guzzle v5. It no longer exists in guzzle v7.

This piece of leftover code only seems to be called from tests in files_antivirus and files_classifier. I discovered the problem when bumping guzzle to v7 in the acceptance tests:
https://drone.owncloud.com/owncloud/files_classifier/2369/18/11
```
    When the public uploads file "confidential.docx" from the files classifier test data folder using the old WebDAV API                  # FilesClassifierContext::publiclyUploadingFile()
      Fatal error: Call to undefined function GuzzleHttp\Psr7\stream_for() (Behat\Testwork\Call\Exception\FatalThrowableError)
```


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
