### PR TITLE
[tests-only] Fix acceptance test code publiclyUploadingFile

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -327,11 +327,10 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function publiclyUploadingFile(string $source, string $publicWebDAVAPIVersion):void {
-		$file = \fopen($source, 'r');
 		$this->publicUploadContent(
 			\basename($source),
 			'',
-			$file->getContents(),
+			\file_get_contents($source),
 			false,
 			[],
 			$publicWebDAVAPIVersion


### PR DESCRIPTION
## Description
I didn't fix this properly yesterday. In nightly CI:
https://drone.owncloud.com/owncloud/files_classifier/2370/18/11
```
Fatal error: Call to a member function getContents() on resource (Behat\Testwork\Call\Exception\FatalThrowableError)
```

This fixes it by using `file_get_contents` and pass the actual content.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
