### PR TITLE
[tests-only] Fix parameter type for connectToLdap

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -524,13 +524,13 @@ trait Provisioning {
 	}
 
 	/**
-	 * @param string $suiteParameters
+	 * @param array $suiteParameters
 	 *
 	 * @return void
 	 * @throws Exception
 	 * @throws \LdapException
 	 */
-	public function connectToLdap(string $suiteParameters):void {
+	public function connectToLdap(array $suiteParameters):void {
 		$useSsl = false;
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$this->ldapBaseDN = OcisHelper::getBaseDN();


### PR DESCRIPTION
## Description
PR #39275 was merged yesterday. It accidentally set the type of the parameter to `connectToLdap` to `string`. That was not noticed in core CI, because this function is only called from CI of things with LDAP.

user_ldap nightly CI  failed: https://drone.owncloud.com/owncloud/user_ldap/3549/81/17
```
Type error: Argument 1 passed to FeatureContext::connectToLdap() must be of the type string, array given, called in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/FeatureContext.php on line 3271 (Behat\Testwork\Call\Exception\FatalThrowableError)
```

This should fix the problem.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
