### PR TITLE
[tests-only] Fix TableNode constructor in Provisioning.php test code

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1317,8 +1317,9 @@ trait Provisioning {
 		$table = $table->getRowsHash();
 		$username = $this->getActualUsername($table["username"]);
 		$password = $this->getActualPassword($table["password"]);
-		$displayname = \array_key_exists("displayname", $table) ? $table["displayname"] : "";
-		$email = \array_key_exists("email", $table) ? $table["email"] : "";
+		$displayname = \array_key_exists("displayname", $table) ? $table["displayname"] : null;
+		$email = \array_key_exists("email", $table) ? $table["email"] : null;
+
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			if ($email === null) {
 				$email = $username . '@owncloud.com';
@@ -1328,9 +1329,15 @@ trait Provisioning {
 		$userAttributes = [
 			["userid", $username],
 			["password", $password],
-			["displayname", $displayname],
-			["email", $email]
 		];
+
+		if ($displayname !== null) {
+			$userAttributes[] = ["displayname", $displayname];
+		}
+
+		if ($email !== null) {
+			$userAttributes[] = ["email", $email];
+		}
 
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$userAttributes[] = ["username", $username];

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1317,21 +1317,23 @@ trait Provisioning {
 		$table = $table->getRowsHash();
 		$username = $this->getActualUsername($table["username"]);
 		$password = $this->getActualPassword($table["password"]);
-		$displayname = \array_key_exists("displayname", $table) ? $table["displayname"] : null;
-		$email = \array_key_exists("email", $table) ? $table["email"] : null;
-		$userAttributes = [
-			"userid" => $username,
-			"password" => $password,
-			"displayname" => $displayname,
-			"email" => $email
-		];
-
+		$displayname = \array_key_exists("displayname", $table) ? $table["displayname"] : "";
+		$email = \array_key_exists("email", $table) ? $table["email"] : "";
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			if ($email === null) {
 				$email = $username . '@owncloud.com';
 			}
-			$userAttributes["username"] = $username;
-			$userAttributes["email"] = $email;
+		}
+
+		$userAttributes = [
+			["userid", $username],
+			["password", $password],
+			["displayname", $displayname],
+			["email", $email]
+		];
+
+		if (OcisHelper::isTestingOnOcisOrReva()) {
+			$userAttributes[] = ["username", $username];
 		}
 
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(


### PR DESCRIPTION
## Description
The structure of the `$userAttributes` array was not suitable for passing to `new TableNode($userAttributes)` and resulted in the error in the linked issue.

This PR fixes the array format.

I made some demonstration changes in user_ldap PR https://github.com/owncloud/user_ldap/pull/692 and that passes. The temporary code there has been used as the basis of this fix to the code in core.

## Related Issue
- Fixes https://github.com/owncloud/user_ldap/issues/691

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
