### PR TITLE
Downgrade bower_components/clipboard to 2.0.6

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -16,7 +16,7 @@
     "@bower_components/bootstrap": "twbs/bootstrap#3.4.1",
     "@bower_components/bowser": "ded/bowser#1.9.4",
     "@bower_components/browser-update": "Graffino/Browser-Update#v2.0.5",
-    "@bower_components/clipboard": "zenorocha/clipboard.js#v2.0.8",
+    "@bower_components/clipboard": "zenorocha/clipboard.js#v2.0.4",
     "@bower_components/davclient.js": "owncloud/davclient.js#0.1.3",
     "@bower_components/es6-promise": "components/es6-promise#4.2.4",
     "@bower_components/handlebars": "components/handlebars.js#v4.7.7",

--- a/build/package.json
+++ b/build/package.json
@@ -16,7 +16,7 @@
     "@bower_components/bootstrap": "twbs/bootstrap#3.4.1",
     "@bower_components/bowser": "ded/bowser#1.9.4",
     "@bower_components/browser-update": "Graffino/Browser-Update#v2.0.5",
-    "@bower_components/clipboard": "zenorocha/clipboard.js#v2.0.4",
+    "@bower_components/clipboard": "zenorocha/clipboard.js#v2.0.6",
     "@bower_components/davclient.js": "owncloud/davclient.js#0.1.3",
     "@bower_components/es6-promise": "components/es6-promise#4.2.4",
     "@bower_components/handlebars": "components/handlebars.js#v4.7.7",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -209,7 +209,6 @@
 
 "@bower_components/base64@davidchambers/Base64.js#1.1.0":
   version "1.1.0"
-  uid "660b299aa4854843fd35d42b30eda9273125b9da"
   resolved "https://codeload.github.com/davidchambers/Base64.js/tar.gz/660b299aa4854843fd35d42b30eda9273125b9da"
 
 "@bower_components/blueimp-md5@blueimp/JavaScript-MD5#1.0.1":
@@ -228,9 +227,9 @@
   version "2.0.5"
   resolved "https://codeload.github.com/Graffino/Browser-Update/tar.gz/76efd225894bf77c411aa8cced870fe6327ac259"
 
-"@bower_components/clipboard@zenorocha/clipboard.js#v2.0.4":
-  version "2.0.4"
-  resolved "https://codeload.github.com/zenorocha/clipboard.js/tar.gz/d17eca050e705ae4932fd1be3e96abe38bd3397c"
+"@bower_components/clipboard@zenorocha/clipboard.js#v2.0.6":
+  version "2.0.6"
+  resolved "https://codeload.github.com/zenorocha/clipboard.js/tar.gz/fddd2aac5f8772c468b36e8607ab9b0704ee73c6"
   dependencies:
     good-listener "^1.2.2"
     select "^1.1.2"
@@ -246,7 +245,6 @@
 
 "@bower_components/handlebars@components/handlebars.js#v4.7.7":
   version "4.7.7"
-  uid "17bcc2c774d5ee604f926cef2d1ef7c55972a3a6"
   resolved "https://codeload.github.com/components/handlebars.js/tar.gz/17bcc2c774d5ee604f926cef2d1ef7c55972a3a6"
 
 "@bower_components/jcrop@tapmodo/Jcrop#0.9.12":
@@ -271,7 +269,6 @@
 
 "@bower_components/moment@moment/moment#2.29.1":
   version "2.29.1"
-  uid b7ec8e2ec068e03de4f832f28362675bb9e02261
   resolved "https://codeload.github.com/moment/moment/tar.gz/b7ec8e2ec068e03de4f832f28362675bb9e02261"
 
 "@bower_components/select2@ivaynberg/select2#3.5.4":

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -228,10 +228,9 @@
   version "2.0.5"
   resolved "https://codeload.github.com/Graffino/Browser-Update/tar.gz/76efd225894bf77c411aa8cced870fe6327ac259"
 
-"@bower_components/clipboard@zenorocha/clipboard.js#v2.0.8":
-  version "2.0.8"
-  uid "7dea403fbb5257809623cd1d635bd4a3878ea982"
-  resolved "https://codeload.github.com/zenorocha/clipboard.js/tar.gz/7dea403fbb5257809623cd1d635bd4a3878ea982"
+"@bower_components/clipboard@zenorocha/clipboard.js#v2.0.4":
+  version "2.0.4"
+  resolved "https://codeload.github.com/zenorocha/clipboard.js/tar.gz/d17eca050e705ae4932fd1be3e96abe38bd3397c"
   dependencies:
     good-listener "^1.2.2"
     select "^1.1.2"

--- a/changelog/unreleased/JSdependencies20211020onward
+++ b/changelog/unreleased/JSdependencies20211020onward
@@ -6,11 +6,11 @@ The following have been updated:
 - bower_components/handlebars (4.5.3 to 4.7.7)
 - bower_components/moment (2.24.0 to 2.29.1)
 - bower_components/base64 (1.0.2 to 1.1.0)
-- bower_components/clipboard (2.0.4 to 2.0.8)
+- bower_components/clipboard (2.0.4 to 2.0.6)
 
 https://github.com/owncloud/core/pull/39385
 https://github.com/owncloud/core/pull/39145
 https://github.com/owncloud/core/pull/38670
 https://github.com/owncloud/core/pull/38671
-https://github.com/owncloud/core/pull/38672
+https://github.com/owncloud/core/pull/39407
 https://github.com/owncloud/core/pull/36633


### PR DESCRIPTION
## Description
The latest version of `zenorocha/clipboard.js` has a faulty `dist` folder, therefore we go for `2.0.6`. The earlier upgrade to `2.0.8` has been reverted.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39400

