### PR TITLE
Reload shared with you file list if share state has been changed

### DIFF
--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -230,29 +230,17 @@ OCA.Sharing.App = {
 		var isRemote = targetFileData.shareLocationType === 'remote';
 		function responseCallback(response, status) {
 			if (status === 'success') {
-				// note: there could be multiple shares/responses but
-				// we assume that the relevant content is the same
-				// for all (state, file_target)
-				var data = response.ocs.data[0];
-				// If we declined a remote share we need to hide it from the list
-				if (isRemote === true && newState === OC.Share.STATE_REJECTED) {
-					return context.fileList.remove(context.$file.attr('data-file'), {updateSummary:true});
-				}
 				var meta = response.ocs.meta;
 				if (meta.status === 'ok') {
-					context.fileInfoModel.set({
-						shareState: data.state,
-						name: OC.basename(data.file_target),
-						path: OC.dirname(data.file_target)
-					});
+					context.fileList.reload();
 				} else {
 					OC.Notification.show(
 						t('files_sharing', 'An error occurred while updating share state: {message}',
 							{message: meta.message}, 0, {escape: false}), {type: 'error'}
 					);
+					context.fileList.showFileBusyState(context.$file, false);
 				}
 			}
-			context.fileList.showFileBusyState(context.$file, false);
 		}
 
 		context.fileList.showFileBusyState(context.$file, true);

--- a/apps/files_sharing/tests/js/appSpec.js
+++ b/apps/files_sharing/tests/js/appSpec.js
@@ -210,7 +210,7 @@ describe('OCA.Sharing.App tests', function() {
 
 			_.each(actionProvider, function(spec) {
 				it('sends server request when ' + spec.description + ' a share', function() {
-					var updateRowSpy = sinon.spy(fileListIn, 'updateRow');
+					var reloadSpy = sinon.spy(fileListIn, 'reload');
 					fileData.shareState = OC.Share.STATE_PENDING;
 					var $tr = fileListIn.add(fileData);
 
@@ -236,9 +236,15 @@ describe('OCA.Sharing.App tests', function() {
 					};
 					request.respond(200, {'Content-Type': 'application/json'}, JSON.stringify(response));
 
-					expect(updateRowSpy.calledOnce).toEqual(true);
+					expect(reloadSpy.calledOnce).toEqual(true);
 
-					$tr = updateRowSpy.getCall(0).returnValue;
+					var newFileData = $.extend(true, fileData, {
+						name : 'testdir (2)',
+						shareState: spec.newState,
+						path: '/dir'
+					});
+
+					$tr = fileListIn.add(newFileData);
 
 					expect(parseInt($tr.attr('data-share-state'), 10)).toEqual(spec.newState);
 					expect($tr.attr('data-file')).toEqual('testdir (2)');

--- a/changelog/unreleased/39411
+++ b/changelog/unreleased/39411
@@ -1,0 +1,9 @@
+Bugfix: Faulty file list entry after accepting a remote share
+
+With this change, we reload the shared with you file list if the user accepts
+or declines a share.
+This solves the issue after accepting a remote share the table record was not
+pointing to the correct location.
+
+https://github.com/owncloud/core/pull/39411
+https://github.com/owncloud/enterprise/issues/4823


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Bugfix: Faulty file list entry after accepting a remote share

With this change, we reload the shared with you file list if the user accepts
or declines a share.
This solves the issue after accepting a remote share the table record was not
pointing to the correct location.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4823

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
