### PR TITLE
[tests-only] Fix return type of function getFileIdForPath

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -44,7 +44,7 @@ class WebDavHelper {
 	 * @param string|null $path
 	 * @param string|null $xRequestId
 	 *
-	 * @return int
+	 * @return string
 	 * @throws Exception
 	 */
 	public static function getFileIdForPath(
@@ -53,7 +53,7 @@ class WebDavHelper {
 		?string $password,
 		?string $path,
 		?string $xRequestId = ''
-	):int {
+	): string {
 		$body
 			= '<?xml version="1.0"?>
 <d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -4413,9 +4413,9 @@ trait WebDav {
 	 * @param string $user
 	 * @param string $path
 	 *
-	 * @return int|null
+	 * @return string|null
 	 */
-	public function getFileIdForPath(string $user, string $path):?int {
+	public function getFileIdForPath(string $user, string $path): ?string {
 		$user = $this->getActualUsername($user);
 		try {
 			return WebDavHelper::getFileIdForPath(


### PR DESCRIPTION
## Description
oCIS returns fileId as string

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- test environment:
- ...

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
