### PR TITLE
Fix version file name for share recipients in shared folders

### DIFF
--- a/changelog/unreleased/39314
+++ b/changelog/unreleased/39314
@@ -5,4 +5,5 @@ file name for share recipients. Before, the name has been the
 timestamp of the version file.
 
 https://github.com/owncloud/core/pull/39314
+https://github.com/owncloud/core/pull/39415
 https://github.com/owncloud/core/issues/36228

--- a/lib/private/Files/Meta/MetaFileVersionNode.php
+++ b/lib/private/Files/Meta/MetaFileVersionNode.php
@@ -147,7 +147,9 @@ class MetaFileVersionNode extends AbstractFile implements IPreviewNode, IProvide
 	 * @inheritdoc
 	 */
 	public function getContentDispositionFileName() {
-		if ($this->storage->instanceOfStorage(SharedStorage::class)) {
+		// internalPath is empty for the share receiver if a single file was shared.
+		// We need to retrieve the file name via the mount point then.
+		if ($this->storage->instanceOfStorage(SharedStorage::class) && $this->internalPath === '') {
 			$mountPoint = $this->storage->getMountPoint();
 			return \basename($mountPoint);
 		}


### PR DESCRIPTION
## Description
Version file names have been fixed for share recipients on single files via https://github.com/owncloud/core/pull/39314. It was working correctly for shared folders, but the change reverted it. This PR is necessary to make both cases work.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39412

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
