### PR TITLE
[tests-only] [full-ci] Implement truly empty skeleton in tests

### DIFF
--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -21,14 +21,14 @@ Feature: quota
 
   @smokeTest
   Scenario: Uploading a file as owner having insufficient quota (except new chunking)
-    Given the quota of user "Alice" has been set to "20 B"
+    Given the quota of user "Alice" has been set to "10 B"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
     And as "Alice" the files uploaded to "/testquota.txt" with all mechanisms except new chunking should not exist
 
   @smokeTest @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Uploading a file as owner having insufficient quota (new chunking)
-    Given the quota of user "Alice" has been set to "20 B"
+    Given the quota of user "Alice" has been set to "10 B"
     And using new DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the HTTP status code should be "507"
@@ -52,7 +52,7 @@ Feature: quota
 
   Scenario: Overwriting a file as owner having insufficient quota (except new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
-    And the quota of user "Alice" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 B"
     When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
@@ -60,7 +60,7 @@ Feature: quota
   @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Overwriting a file as owner having insufficient quota (new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
-    And the quota of user "Alice" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 B"
     And using new DAV path
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the HTTP status code should be "507"
@@ -73,7 +73,7 @@ Feature: quota
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
-    And the quota of user "Brian" has been set to "20 B"
+    And the quota of user "Brian" has been set to "10 B"
     And the quota of user "Alice" has been set to "10 MB"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
@@ -83,7 +83,7 @@ Feature: quota
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
-    And the quota of user "Brian" has been set to "20 B"
+    And the quota of user "Brian" has been set to "10 B"
     And the quota of user "Alice" has been set to "10 MB"
     And using new DAV path
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
@@ -95,7 +95,7 @@ Feature: quota
     And user "Alice" has created folder "/testquota"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "10 MB"
-    And the quota of user "Alice" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 B"
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
     And as "Brian" the files uploaded to "/testquota/testquota.txt" with all mechanisms except new chunking should not exist
@@ -106,9 +106,9 @@ Feature: quota
     And user "Alice" has created folder "/testquota"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "10 MB"
-    And the quota of user "Alice" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 B"
     And using new DAV path
-    When user "Brian" uploads file "filesForUpload/davtest.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the HTTP status code should be "507"
     And as "Brian" file "/testquota/testquota.txt" should not exist
 
@@ -118,7 +118,7 @@ Feature: quota
     And user "Alice" has created folder "/testquota"
     And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
-    And the quota of user "Brian" has been set to "20 B"
+    And the quota of user "Brian" has been set to "10 B"
     And the quota of user "Alice" has been set to "10 MB"
     When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
@@ -129,10 +129,10 @@ Feature: quota
     And user "Alice" has created folder "/testquota"
     And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
-    And the quota of user "Brian" has been set to "20 B"
+    And the quota of user "Brian" has been set to "10 B"
     And the quota of user "Alice" has been set to "10 MB"
     And using new DAV path
-    When user "Brian" uploads file "filesForUpload/davtest.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the HTTP status code should be between "201" and "204"
 
   @files_sharing-app-required
@@ -142,7 +142,7 @@ Feature: quota
     And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "10 MB"
-    And the quota of user "Alice" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 B"
     When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota/testquota.txt" for user "Alice" should be "test"
@@ -154,9 +154,9 @@ Feature: quota
     And user "Alice" has uploaded file with content "test" to "/testquota/testquota.txt"
     And user "Alice" has shared folder "/testquota" with user "Brian" with permissions "all"
     And the quota of user "Brian" has been set to "10 MB"
-    And the quota of user "Alice" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 B"
     And using new DAV path
-    When user "Brian" uploads file "filesForUpload/davtest.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/testquota/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the HTTP status code should be "507"
     And the content of file "/testquota/testquota.txt" for user "Alice" should be "test"
 
@@ -167,7 +167,7 @@ Feature: quota
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
-    And the quota of user "Brian" has been set to "20 B"
+    And the quota of user "Brian" has been set to "10 B"
     And the quota of user "Alice" has been set to "10 MB"
     When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
@@ -177,10 +177,10 @@ Feature: quota
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
-    And the quota of user "Brian" has been set to "20 B"
+    And the quota of user "Brian" has been set to "10 B"
     And the quota of user "Alice" has been set to "10 MB"
     And using new DAV path
-    When user "Brian" uploads file "filesForUpload/davtest.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
+    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the HTTP status code should be between "201" and "204"
 
   @files_sharing-app-required
@@ -189,7 +189,7 @@ Feature: quota
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
     And the quota of user "Brian" has been set to "10 MB"
-    And the quota of user "Alice" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 B"
     When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
@@ -200,7 +200,7 @@ Feature: quota
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And user "Alice" has shared file "/testquota.txt" with user "Brian" with permissions "share,update,read"
     And the quota of user "Brian" has been set to "10 MB"
-    And the quota of user "Alice" has been set to "20 B"
+    And the quota of user "Alice" has been set to "10 B"
     And using new DAV path
     When user "Brian" uploads file "filesForUpload/textfile.txt" to "/testquota.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the HTTP status code should be "507"

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -5570,13 +5570,14 @@ trait Provisioning {
 	 * In ownCloud 10 there is always a skeleton directory. If none is specified
 	 * then whatever is in core/skeleton is used. That contains different files
 	 * and folders depending on the build that is being tested. So for testing
-	 * we have "tiny" skeleton that contains just one file. That provides a
-	 * consistent skeleton for test scenarios that specify "without skeleton files"
+	 * we have "empty" skeleton that is created on-the-fly by the testing app.
+	 * That provides a consistent skeleton for test scenarios that specify
+	 * "without skeleton files"
 	 *
 	 * @return string name of the smallest skeleton folder
 	 */
 	private function getSmallestSkeletonDirName(): string {
-		return "tiny";
+		return "empty";
 	}
 
 	/**
@@ -5593,9 +5594,15 @@ trait Provisioning {
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$originalSkeletonPath = \getenv("SKELETON_DIR");
 			if ($skeletonType !== '') {
+				$skeletonDirName = $skeletonType . "Skeleton";
+				$newSkeletonPath = \dirname($originalSkeletonPath) . '/' . $skeletonDirName;
+				// We cannot have a really empty skeleton folder committed by git.
+				// So create it on-the-fly if a test scenario wants an empty skeleton.
+				if (($skeletonDirName === "emptySkeleton") && !\file_exists($newSkeletonPath)) {
+					\mkdir($newSkeletonPath);
+				}
 				\putenv(
-					"SKELETON_DIR=" .
-					\dirname($originalSkeletonPath) . '/' . $skeletonType . "Skeleton"
+					"SKELETON_DIR=" . $newSkeletonPath
 				);
 			}
 		} else {


### PR DESCRIPTION
## Description
The existing "tiny" skeleton is not really empty - it has a `.gitignore` file because the only way to commit a folder in git is if it has a file in it. So a test step like:
`Given these users have been created with default attributes and without skeleton files:`

really creates users that have a single file in the skeleton - `.gitignore`

https://github.com/owncloud/testing/pull/186 has added a feature to the testing app that specially knows about `emptySkeleton`. It creates that on-the-fly when requested, so that it is truly empty.

This PR makes use of that, when testing on oC10 (which uses the testing app). On oCIS this PR creates the `emptySkeleton` folder locally as needed.

Now "without skeleton files" will really mean that. And will make some quota and other test scenarios a bit easier.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
