### PR TITLE
[tests-only] Improve test fail message for folderShouldBeDownloaded

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2407,7 +2407,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		$actualFolder = explode(" ", $output);
 
 		if (!\in_array($expectedFolder, $actualFolder)) {
-			Assert::fail("could not find folder ' $expectedFolder' in downloads");
+			Assert::fail("Could not find folder '$expectedFolder' in downloads. The latest download found was '$folder'");
 		}
 	}
 


### PR DESCRIPTION
## Description
2 scenarios failed last night in encryption CI:
https://drone.owncloud.com/owncloud/encryption/2144/165/18
```
  Scenario: download multiple folders                            # /var/www/owncloud/testrunner/tests/acceptance/features/webUIFiles/download.feature:24
    Given user "Alice" has created folder "simple-folder"        # FeatureContext::userHasCreatedFolder()
    And user "Alice" has created folder "simple-folder1"         # FeatureContext::userHasCreatedFolder()
    And user "Alice" has created folder "simple-folder2"         # FeatureContext::userHasCreatedFolder()
    And user "Alice" has logged in using the webUI               # WebUILoginContext::theUserHasLoggedInUsingTheWebUI()
    When the user selects folder "simple-folder" using the webUI # WebUIFilesContext::theUserSelectsFolderUsingTheWebui()
    And the user selects folder "simple-folder1" using the webUI # WebUIFilesContext::theUserSelectsFolderUsingTheWebui()
    And the user selects folder "simple-folder2" using the webUI # WebUIFilesContext::theUserSelectsFolderUsingTheWebui()
    And the user clicks the download button on the webUI         # WebUIFilesContext::theUserDownloadsFolderUsingTheDownloadButtonOnTheWebui()
    Then folder "download.zip" should be downloaded              # WebUIFilesContext::folderShouldBeDownloaded()
      could not find folder ' download.zip' in downloads
SCENARIO RESULT: (fail)

  Scenario: download all files and folder                                                            # /var/www/owncloud/testrunner/tests/acceptance/features/webUIFiles/download.feature:36
    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt" # FeatureContext::userHasUploadedAFileWithContentTo()
    And user "Alice" has created folder "simple-folder"                                              # FeatureContext::userHasCreatedFolder()
    And user "Alice" has created folder "simple-folder1"                                             # FeatureContext::userHasCreatedFolder()
    And user "Alice" has created folder "simple-folder2"                                             # FeatureContext::userHasCreatedFolder()
    And user "Alice" has logged in using the webUI                                                   # WebUILoginContext::theUserHasLoggedInUsingTheWebUI()
    When the user selects folder "simple-folder" using the webUI                                     # WebUIFilesContext::theUserSelectsFolderUsingTheWebui()
    And the user selects folder "simple-folder1" using the webUI                                     # WebUIFilesContext::theUserSelectsFolderUsingTheWebui()
    And the user selects folder "simple-folder2" using the webUI                                     # WebUIFilesContext::theUserSelectsFolderUsingTheWebui()
    And the user selects file "textfile0.txt" using the webUI                                        # WebUIFilesContext::theUserSelectsFolderUsingTheWebui()
    And the user clicks the download button on the webUI                                             # WebUIFilesContext::theUserDownloadsFolderUsingTheDownloadButtonOnTheWebui()
    Then folder "download.zip" should be downloaded                                                  # WebUIFilesContext::folderShouldBeDownloaded()
      could not find folder ' download.zip' in downloads
SCENARIO RESULT: (fail)
```

It was in a pipeline that tests the encryption app against core latest (currently 10.8.0). It is not clear why `download.zip` was not found - maybe something has happened that changed the name of the zip file? It would be nice to see the name of the actual downloaded file that was found (if any).

This PR improves the test fail message.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
