### PR TITLE
[tests-only] [full-ci] fix default value of skeleton in createUser

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2995,7 +2995,7 @@ trait Provisioning {
 		bool $initialize = true,
 		?string $method = null,
 		bool $setDefault = true,
-		?bool $skeleton = null
+		bool $skeleton = true
 	):void {
 		if ($password === null) {
 			$password = $this->getPasswordForUser($user);


### PR DESCRIPTION
## Description
The value of the `$skeleton` boolean parameter to `createUser()` should always be a boolean, never `null`. Set it to `true` by default, because mostly we do want a skeleton (even if it is the empty skeleton). It is rare that we want to remove the skeleton dir setting completely.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
