### PR TITLE
Implement activity translations for rename and move actions

### DIFF
--- a/apps/files/lib/Activity.php
+++ b/apps/files/lib/Activity.php
@@ -204,7 +204,7 @@ class Activity implements IExtension {
 			case 'renamed_by':
 				return (string) $l->t('%2$s renamed %3$s to %1$s', $params);
 			case 'moved_self':
-				return (string) $l->t('You moved %2$s to %1$s ', $params);
+				return (string) $l->t('You moved %2$s to %1$s', $params);
 			case 'moved_by':
 				return (string) $l->t('%2$s moved %3$s to %1$s', $params);
 			case 'moved_in_share_by':
@@ -275,7 +275,7 @@ class Activity implements IExtension {
 				case 'renamed_by':
 					return [
 						0 => 'file',
-						1 => 'user',
+						1 => 'username',
 						2 => 'file',
 					];
 				case 'moved_self':
@@ -286,18 +286,18 @@ class Activity implements IExtension {
 				case 'moved_by':
 					return [
 						0 => 'file',
-						1 => 'user',
+						1 => 'username',
 						2 => 'file',
 					];
 				case 'moved_in_share_by':
 					return [
 						0 => 'file',
-						1 => 'user',
+						1 => 'username',
 					];
 				case 'moved_out_share_by':
 					return [
 						0 => 'file',
-						1 => 'user',
+						1 => 'username',
 					];
 				case 'restored_by':
 					return [

--- a/apps/files/lib/Activity.php
+++ b/apps/files/lib/Activity.php
@@ -42,6 +42,8 @@ class Activity implements IExtension {
 	public const TYPE_SHARE_DELETED = 'file_deleted';
 	public const TYPE_SHARE_RESTORED = 'file_restored';
 	public const TYPE_FAVORITES = 'files_favorites';
+	public const TYPE_FILE_RENAMED = 'file_renamed';
+	public const TYPE_FILE_MOVED = 'file_moved';
 
 	/** @var IL10N */
 	protected $l;
@@ -112,6 +114,8 @@ class Activity implements IExtension {
 			],
 			self::TYPE_SHARE_DELETED => (string) $l->t('A file or folder has been <strong>deleted</strong>'),
 			self::TYPE_SHARE_RESTORED => (string) $l->t('A file or folder has been <strong>restored</strong>'),
+			self::TYPE_FILE_RENAMED => (string) $l->t('A file or folder has been <strong>renamed</strong>'),
+			self::TYPE_FILE_MOVED => (string) $l->t('A file or folder has been <strong>moved</strong>'),
 		];
 	}
 
@@ -129,6 +133,8 @@ class Activity implements IExtension {
 			$settings[] = self::TYPE_SHARE_CHANGED;
 			$settings[] = self::TYPE_SHARE_DELETED;
 			$settings[] = self::TYPE_SHARE_RESTORED;
+			$settings[] = self::TYPE_FILE_RENAMED;
+			$settings[] = self::TYPE_FILE_MOVED;
 			return $settings;
 		}
 
@@ -193,6 +199,18 @@ class Activity implements IExtension {
 				return (string) $l->t('You restored %1$s', $params);
 			case 'restored_by':
 				return (string) $l->t('%2$s restored %1$s', $params);
+			case 'renamed_self':
+				return (string) $l->t('You renamed %2$s to %1$s', $params);
+			case 'renamed_by':
+				return (string) $l->t('%2$s renamed %3$s to %1$s', $params);
+			case 'moved_self':
+				return (string) $l->t('You moved %2$s to %1$s ', $params);
+			case 'moved_by':
+				return (string) $l->t('%2$s moved %3$s to %1$s', $params);
+			case 'moved_in_share_by':
+				return (string) $l->t('%2$s moved %1$s into the share', $params);
+			case 'moved_out_share_by':
+				return (string) $l->t('%2$s moved %1$s out of the share', $params);
 
 			default:
 				return false;
@@ -213,6 +231,14 @@ class Activity implements IExtension {
 				return (string) $l->t('Deleted by %2$s', $params);
 			case 'restored_by':
 				return (string) $l->t('Restored by %2$s', $params);
+			case 'moved_self':
+				return (string) $l->t('You moved this file to %1$s', $params);
+			case 'moved_by':
+				return (string) $l->t('%2$s moved this file to %1$s', $params);
+			case 'moved_in_share_by':
+				return (string) $l->t('%2$s moved this file into the share', $params);
+			case 'moved_out_share_by':
+				return (string) $l->t('%2$s moved this file out of the share', $params);
 
 			default:
 				return false;
@@ -241,6 +267,38 @@ class Activity implements IExtension {
 				case 'deleted_self':
 				case 'deleted_by':
 				case 'restored_self':
+				case 'renamed_self':
+					return [
+						0 => 'file',
+						1 => 'file',
+					];
+				case 'renamed_by':
+					return [
+						0 => 'file',
+						1 => 'user',
+						2 => 'file',
+					];
+				case 'moved_self':
+					return [
+						0 => 'file',
+						1 => 'file',
+					];
+				case 'moved_by':
+					return [
+						0 => 'file',
+						1 => 'user',
+						2 => 'file',
+					];
+				case 'moved_in_share_by':
+					return [
+						0 => 'file',
+						1 => 'user',
+					];
+				case 'moved_out_share_by':
+					return [
+						0 => 'file',
+						1 => 'user',
+					];
 				case 'restored_by':
 					return [
 						0 => 'file',
@@ -267,6 +325,10 @@ class Activity implements IExtension {
 				return 'icon-add-color';
 			case self::TYPE_SHARE_DELETED:
 				return 'icon-delete-color';
+			case self::TYPE_FILE_RENAMED:
+				return 'icon-rename';
+			case self::TYPE_FILE_MOVED:
+				return 'icon-move';
 
 			default:
 				return false;

--- a/apps/files/tests/ActivityTest.php
+++ b/apps/files/tests/ActivityTest.php
@@ -114,24 +114,28 @@ class ActivityTest extends TestCase {
 	public function testNotificationTypes() {
 		$result = $this->activityExtension->getNotificationTypes('en');
 		$this->assertIsArray($result, 'Asserting getNotificationTypes() returns an array');
-		$this->assertCount(5, $result);
+		$this->assertCount(7, $result);
 		$this->assertArrayHasKey(Activity::TYPE_SHARE_CREATED, $result);
 		$this->assertArrayHasKey(Activity::TYPE_SHARE_CHANGED, $result);
 		$this->assertArrayHasKey(Activity::TYPE_FAVORITES, $result);
 		$this->assertArrayHasKey(Activity::TYPE_SHARE_DELETED, $result);
 		$this->assertArrayHasKey(Activity::TYPE_SHARE_RESTORED, $result);
+		$this->assertArrayHasKey(Activity::TYPE_FILE_RENAMED, $result);
+		$this->assertArrayHasKey(Activity::TYPE_FILE_MOVED, $result);
 	}
 
 	public function testDefaultTypes() {
 		$result = $this->activityExtension->getDefaultTypes('stream');
 		$this->assertIsArray($result, 'Asserting getDefaultTypes(stream) returns an array');
-		$this->assertCount(4, $result);
+		$this->assertCount(6, $result);
 		$result = \array_flip($result);
 		$this->assertArrayHasKey(Activity::TYPE_SHARE_CREATED, $result);
 		$this->assertArrayHasKey(Activity::TYPE_SHARE_CHANGED, $result);
 		$this->assertArrayNotHasKey(Activity::TYPE_FAVORITES, $result);
 		$this->assertArrayHasKey(Activity::TYPE_SHARE_DELETED, $result);
 		$this->assertArrayHasKey(Activity::TYPE_SHARE_RESTORED, $result);
+		$this->assertArrayHasKey(Activity::TYPE_FILE_RENAMED, $result);
+		$this->assertArrayHasKey(Activity::TYPE_FILE_MOVED, $result);
 
 		$result = $this->activityExtension->getDefaultTypes('email');
 		$this->assertFalse($result, 'Asserting getDefaultTypes(email) returns false');

--- a/apps/files/tests/ActivityTest.php
+++ b/apps/files/tests/ActivityTest.php
@@ -34,7 +34,7 @@ use Test\TestCase;
  */
 class ActivityTest extends TestCase {
 
-	/** @var \OCP\Activity\IManager */
+	/** @var \OCP\Activity\IManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $activityManager;
 
 	/** @var \OCP\IRequest|\PHPUnit\Framework\MockObject\MockObject */
@@ -71,11 +71,10 @@ class ActivityTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->activityManager = new \OC\Activity\Manager(
-			$this->request,
-			$this->session,
-			$this->config
-		);
+		$this->activityManager = $this->getMockBuilder('OC\Activity\Manager')
+			->setConstructorArgs([$this->request, $this->session, $this->config])
+			->setMethods(['isFormattingFilteredObject'])
+			->getMock();
 
 		$this->l10nFactory = $this->getMockBuilder('OCP\L10N\IFactory')
 			->disableOriginalConstructor()
@@ -141,38 +140,89 @@ class ActivityTest extends TestCase {
 		$this->assertFalse($result, 'Asserting getDefaultTypes(email) returns false');
 	}
 
-	public function testTranslate() {
+	public function translateData() {
+		return [
+			// long translations
+			['created_self', ['file.txt'], 'You created file.txt', false],
+			['created_by', ['file.txt', 'user'], 'user created file.txt', false],
+			['created_public', ['file.txt'], 'file.txt was created in a public folder', false],
+			['changed_self', ['file.txt'], 'You changed file.txt', false],
+			['changed_by', ['file.txt', 'user'], 'user changed file.txt', false],
+			['deleted_self', ['file.txt'], 'You deleted file.txt', false],
+			['deleted_by', ['file.txt', 'user'], 'user deleted file.txt', false],
+			['restored_self', ['file.txt'], 'You restored file.txt', false],
+			['restored_by', ['file.txt', 'user'], 'user restored file.txt', false],
+			['renamed_self', ['fileRenamed.txt', 'file.txt'], 'You renamed file.txt to fileRenamed.txt', false],
+			['renamed_by', ['fileRenamed.txt', 'user', 'file.txt'], 'user renamed file.txt to fileRenamed.txt', false],
+			['moved_self', ['fileMoved.txt', 'file.txt'], 'You moved file.txt to fileMoved.txt', false],
+			['moved_by', ['fileMoved.txt', 'user', 'file.txt'], 'user moved file.txt to fileMoved.txt', false],
+			['moved_in_share_by', ['fileMoved.txt', 'user'], 'user moved fileMoved.txt into the share', false],
+			['moved_out_share_by', ['fileMoved.txt', 'user'], 'user moved fileMoved.txt out of the share', false],
+
+			// short translations
+			['changed_by', ['file.txt', 'user'], 'Changed by user', true],
+			['deleted_by', ['file.txt', 'user'], 'Deleted by user', true],
+			['restored_by', ['file.txt', 'user'], 'Restored by user', true],
+			['moved_self', ['fileMoved.txt'], 'You moved this file to fileMoved.txt', true],
+			['moved_by', ['fileMoved.txt', 'user'], 'user moved this file to fileMoved.txt', true],
+			['moved_in_share_by', ['fileMoved.txt', 'user'], 'user moved this file into the share', true],
+			['moved_out_share_by', ['fileMoved.txt', 'user'], 'user moved this file out of the share', true],
+		];
+	}
+
+	/**
+	 * @dataProvider translateData
+	 *
+	 * @param string $text
+	 * @param array $params
+	 * @param string $expected
+	 * @param boolean $lookForShortTranslation
+	 */
+	public function testTranslate($text, $params, $expected, $lookForShortTranslation) {
 		$this->assertFalse(
 			$this->activityExtension->translate('files_sharing', '', [], false, false, 'en'),
 			'Asserting that no translations are set for files_sharing'
 		);
 
-		// Test english
-		$this->assertNotFalse(
-			$this->activityExtension->translate('files', 'deleted_self', ['file'], false, false, 'en'),
-			'Asserting that translations are set for files.deleted_self'
-		);
-		$this->assertStringStartsWith(
-			'You deleted ',
-			$this->activityExtension->translate('files', 'deleted_self', ['file'], false, false, 'en')
-		);
-
-		// Test translation
-		$this->assertNotFalse(
-			$this->activityExtension->translate('files', 'deleted_self', ['file'], false, false, 'de'),
-			'Asserting that translations are set for files.deleted_self'
-		);
-		$this->assertStringStartsWith(
-			'translate(You deleted ',
-			$this->activityExtension->translate('files', 'deleted_self', ['file'], false, false, 'de')
-		);
+		$this->activityManager->method('isFormattingFilteredObject')->willReturn($lookForShortTranslation);
+		$translation = $this->activityExtension->translate(Activity::APP_FILES, $text, $params, false, false, 'en');
+		$this->assertEquals($expected, $translation);
 	}
 
-	public function testGetSpecialParameterList() {
+	public function specialParameterData() {
+		return [
+			['created_self', [0 => 'file', 1 => 'file']],
+			['created_by', [0 => 'file', 1 => 'file']],
+			['created_public', [0 => 'file', 1 => 'file']],
+			['changed_self', [0 => 'file', 1 => 'file']],
+			['changed_by', [0 => 'file', 1 => 'file']],
+			['deleted_self', [0 => 'file', 1 => 'file']],
+			['deleted_by', [0 => 'file', 1 => 'file']],
+			['restored_self', [0 => 'file', 1 => 'file']],
+			['renamed_self', [0 => 'file', 1 => 'file']],
+			['renamed_by', [0 => 'file', 1 => 'username', 2 => 'file']],
+			['moved_self', [0 => 'file', 1 => 'file']],
+			['moved_by', [0 => 'file', 1 => 'username', 2 => 'file']],
+			['moved_in_share_by', [0 => 'file', 1 => 'username']],
+			['moved_out_share_by', [0 => 'file', 1 => 'username']],
+			['restored_by', [0 => 'file', 1 => 'username']],
+		];
+	}
+
+	/**
+	 * @dataProvider specialParameterData
+	 *
+	 * @param string $text
+	 * @param string $expected
+	 */
+	public function testGetSpecialParameterList($text, $expected) {
 		$this->assertFalse(
 			$this->activityExtension->getSpecialParameterList('files_sharing', ''),
 			'Asserting that no special parameters are set for files_sharing'
 		);
+
+		$specialParameters = $this->activityExtension->getSpecialParameterList(Activity::APP_FILES, $text);
+		$this->assertEquals($expected, $specialParameters);
 	}
 
 	public function typeIconData() {

--- a/changelog/unreleased/39430
+++ b/changelog/unreleased/39430
@@ -1,0 +1,5 @@
+Enhancement: Add activity translations for rename and move actions
+
+https://github.com/owncloud/core/pull/39430
+https://github.com/owncloud/enterprise/issues/4806
+https://github.com/owncloud/activity/issues/375


### PR DESCRIPTION
## Description
Needed for https://github.com/owncloud/activity/pull/1018.

## Related Issue
- related https://github.com/owncloud/enterprise/issues/4806
- related https://github.com/owncloud/activity/issues/375
- related https://github.com/owncloud/enterprise/issues/4375
- related https://github.com/owncloud/enterprise/issues/2947

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
