### PR TITLE
[tests-only][full-ci] Add CLI tests for versions:expire command

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -440,22 +440,28 @@ class OccContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function deleteAllVersionsForUserUsingOccCommand(string $user):void {
+	public function deleteAllVersionsForUserUsingOccCommand(string $user = ""): void {
 		$this->invokingTheCommand(
 			"versions:cleanup $user"
 		);
 	}
 
 	/**
-	 * @param string $users space-separated usernames
+	 * @param string $users space-separated usernames. E.g. "Alice Brian" (without <quote>)
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function deleteAllVersionsForSpecificUsersUsingOccCommand(string $users):void {
-		$this->invokingTheCommand(
-			"versions:cleanup $users"
-		);
+	public function deleteAllVersionsForMultipleUsersUsingOccCommand(string $users): void {
+		$this->deleteAllVersionsForUserUsingOccCommand($users);
+	}
+
+	/**
+	 * @return void
+	 * @throws Exception
+	 */
+	public function deleteAllVersionsForAllUsersUsingOccCommand(): void {
+		$this->deleteAllVersionsForUserUsingOccCommand();
 	}
 
 	/**
@@ -464,20 +470,28 @@ class OccContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function deleteAllExpiredVersionsForUserUsingOccCommand(string $user):void {
+	public function deleteExpiredVersionsForUserUsingOccCommand(string $user = ""): void {
 		$this->invokingTheCommand(
 			"versions:expire $user"
 		);
 	}
 
 	/**
+	 * @param string $users space-separated usernames. E.g. "Alice Brian" (without <quote>)
+	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function deleteAllVersionsForAllUsersUsingTheOccCommand():void {
-		$this->invokingTheCommand(
-			"versions:cleanup"
-		);
+	public function deleteExpiredVersionsForMultipleUsersUsingOccCommand(string $users): void {
+		$this->deleteExpiredVersionsForUserUsingOccCommand($users);
+	}
+	
+	/**
+	 * @return void
+	 * @throws Exception
+	 */
+	public function deleteExpiredVersionsForAllUsersUsingOccCommand(): void {
+		$this->deleteExpiredVersionsForUserUsingOccCommand();
 	}
 
 	/**
@@ -2521,6 +2535,7 @@ class OccContext implements Context {
 
 	/**
 	 * @When the administrator deletes all the versions for user :user
+	 * @When the administrator tries to delete all the versions for user :user
 	 *
 	 * @param string $user
 	 *
@@ -2548,20 +2563,60 @@ class OccContext implements Context {
 			array_push($usernamesArray, $username["username"]);
 		}
 		$users = implode(" ", $usernamesArray);
-		$this->deleteAllVersionsForSpecificUsersUsingOccCommand($users);
+		$this->deleteAllVersionsForMultipleUsersUsingOccCommand($users);
 	}
 
 	/**
-	 * @When the administrator deletes all the expired versions for user :user
+	 * @When the administrator deletes the file versions for all users
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorDeletesVersionsForAllUsers(): void {
+		$this->deleteAllVersionsForAllUsersUsingOccCommand();
+	}
+
+	/**
+	 * @When the administrator deletes the expired versions for user :user
+	 * @When the administrator tries to delete the expired versions for user :user
 	 *
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theAdministratorDeletesAllTheExpiredVersionsForUser(string $user):void {
+	public function theAdministratorDeletesExpiredVersionsForUser(string $user): void {
 		$user = $this->featureContext->getActualUsername($user);
-		$this->deleteAllExpiredVersionsForUserUsingOccCommand($user);
+		$this->deleteExpiredVersionsForUserUsingOccCommand($user);
+	}
+
+	/**
+	 * @When the administrator deletes the expired versions for the following users:
+	 *
+	 * @param TableNode $usersTable
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorDeletesExpiredVersionsForSpecificUsers(TableNode $usersTable): void {
+		$this->featureContext->verifyTableNodeColumns($usersTable, ["username"]);
+		$usernames = $usersTable->getHash();
+		$usernamesArray = [];
+		foreach ($usernames as $username) {
+			array_push($usernamesArray, $username["username"]);
+		}
+		$users = implode(" ", $usernamesArray);
+		$this->deleteExpiredVersionsForMultipleUsersUsingOccCommand($users);
+	}
+
+	/**
+	 * @When the administrator deletes the expired versions for all users
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorDeletesExpiredVersionsForAllUsers(): void {
+		$this->deleteExpiredVersionsForAllUsersUsingOccCommand();
 	}
 
 	/**
@@ -2779,7 +2834,7 @@ class OccContext implements Context {
 	 * @throws Exception
 	 */
 	public function theAdministratorHasClearedTheVersionsForAllUsers():void {
-		$this->deleteAllVersionsForAllUsersUsingTheOccCommand();
+		$this->deleteAllVersionsForAllUsersUsingOccCommand();
 		Assert::assertStringContainsString(
 			"Delete all versions",
 			\trim($this->featureContext->getStdOutOfOccCommand()),

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2852,6 +2852,41 @@ trait WebDav {
 	}
 
 	/**
+	 * @Given user :user has uploaded file :filename with content :content and mtime of :days days ago using the WebDAV API
+	 *
+	 * @param string $user
+	 * @param string $filename
+	 * @param string $content
+	 * @param string $days In days, e.g. "7"
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userUploadsFileWithContentAndWithMtimeOfDaysAgoUsingWebdavApi(
+		string $user,
+		string $filename,
+		string $content,
+		string $days
+	): void {
+		$today = new DateTime();
+		$interval = new DateInterval('P' . $days . 'D');
+		$mtime = $today->sub($interval)->format('U');
+
+		$user = $this->getActualUsername($user);
+
+		$this->response = WebDavHelper::makeDavRequest(
+			$this->getBaseUrl(),
+			$user,
+			$this->getPasswordForUser($user),
+			"PUT",
+			$filename,
+			["X-OC-Mtime" => $mtime],
+			$this->getStepLineRef(),
+			$content
+		);
+	}
+
+	/**
 	 * @Then as :user the mtime of the file :resource should be :mtime
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/cliMain/fileVersions.feature
+++ b/tests/acceptance/features/cliMain/fileVersions.feature
@@ -1,7 +1,7 @@
 @cli
 Feature: check file versions
 
-  Scenario: the admin clears the versions of a file for a single user
+  Scenario: the admin clears the file versions for a user
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
     And user "Alice" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
@@ -12,9 +12,10 @@ Feature: check file versions
     Then the version folder of file "/sharingfolder/sharefile.txt" for user "Alice" should contain "0" elements
 
 
-  Scenario: the admin clears the versions of a file for specific users
+  Scenario: the admin clears the file versions for multiple users
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
     And user "Alice" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
     And user "Alice" has uploaded file with content "version 1" to "/sharingfolder/sharefile.txt"
@@ -25,14 +26,105 @@ Feature: check file versions
     And user "Brian" has uploaded file with content "version 1" to "/sharingfolder/sharefile.txt"
     And user "Brian" has uploaded file with content "version 2" to "/sharingfolder/sharefile.txt"
     And user "Brian" has uploaded file with content "version 3" to "/sharingfolder/sharefile.txt"
+    And user "Carol" has created folder "/sharingfolder"
+    And user "Carol" has uploaded file with content "old content" to "/sharingfolder/sharefile.txt"
+    And user "Carol" has uploaded file with content "version 1" to "/sharingfolder/sharefile.txt"
+    And user "Carol" has uploaded file with content "version 2" to "/sharingfolder/sharefile.txt"
+    And user "Carol" has uploaded file with content "version 3" to "/sharingfolder/sharefile.txt"
     When the administrator deletes all the versions for the following users:
       | username |
       | Alice    |
       | Brian    |
     Then the version folder of file "/sharingfolder/sharefile.txt" for user "Alice" should contain "0" elements
     And the version folder of file "/sharingfolder/sharefile.txt" for user "Brian" should contain "0" elements
+    And the version folder of file "/sharingfolder/sharefile.txt" for user "Carol" should contain "3" elements
+
+
+  Scenario: the admin clears the file versions for all users
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "old content" to "/textfile.txt"
+    And user "Alice" has uploaded file with content "version 1" to "/textfile.txt"
+    And user "Alice" has uploaded file with content "version 2" to "/textfile.txt"
+    And user "Brian" has uploaded file with content "old content" to "/textfile.txt"
+    And user "Brian" has uploaded file with content "version 1" to "/textfile.txt"
+    And user "Brian" has uploaded file with content "version 2" to "/textfile.txt"
+    And user "Carol" has uploaded file with content "old content" to "/textfile.txt"
+    And user "Carol" has uploaded file with content "version 1" to "/textfile.txt"
+    And user "Carol" has uploaded file with content "version 2" to "/textfile.txt"
+    When the administrator deletes the file versions for all users
+    Then the version folder of file "/textfile.txt" for user "Alice" should contain "0" elements
+    And the version folder of file "/textfile.txt" for user "Brian" should contain "0" elements
+    And the version folder of file "/textfile.txt" for user "Carol" should contain "0" elements
 
 
   Scenario: the admin tries to clear the versions of a file for an invalid user
-    When the administrator deletes all the versions for user "Alice"
+    When the administrator tries to delete all the versions for user "Alice"
+    Then the command output should contain the text "Unknown user Alice"
+
+
+  Scenario: the admin clears the expired versions for a user
+    Given the administrator has added system config key "versions_retention_obligation" with value "auto, 10"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "/textfile.txt" with content "some content" and mtime of "11" days ago using the WebDAV API
+    And user "Alice" has uploaded file "/textfile.txt" with content "version 1" and mtime of "5" days ago using the WebDAV API
+    And user "Alice" has uploaded file "/textfile.txt" with content "version 2" and mtime of "2" days ago using the WebDAV API
+    Then the version folder of file "/textfile.txt" for user "Alice" should contain "2" elements
+    When the administrator deletes the expired versions for user "Alice"
+    Then the version folder of file "/textfile.txt" for user "Alice" should contain "1" elements
+
+
+  Scenario: the admin clears the expired versions for multiple users
+    Given the administrator has added system config key "versions_retention_obligation" with value "auto, 10"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "/textfile.txt" with content "some content" and mtime of "11" days ago using the WebDAV API
+    And user "Alice" has uploaded file "/textfile.txt" with content "version 1" and mtime of "5" days ago using the WebDAV API
+    And user "Alice" has uploaded file "/textfile.txt" with content "version 2" and mtime of "2" days ago using the WebDAV API
+    And user "Brian" has uploaded file "/textfile.txt" with content "some content" and mtime of "11" days ago using the WebDAV API
+    And user "Brian" has uploaded file "/textfile.txt" with content "version 1" and mtime of "5" days ago using the WebDAV API
+    And user "Brian" has uploaded file "/textfile.txt" with content "version 2" and mtime of "2" days ago using the WebDAV API
+    And user "Carol" has uploaded file "/textfile.txt" with content "some content" and mtime of "11" days ago using the WebDAV API
+    And user "Carol" has uploaded file "/textfile.txt" with content "version 1" and mtime of "5" days ago using the WebDAV API
+    And user "Carol" has uploaded file "/textfile.txt" with content "version 2" and mtime of "2" days ago using the WebDAV API
+    Then the version folder of file "/textfile.txt" for user "Alice" should contain "2" elements
+    And the version folder of file "/textfile.txt" for user "Brian" should contain "2" elements
+    And the version folder of file "/textfile.txt" for user "Carol" should contain "2" elements
+    When the administrator deletes the expired versions for the following users:
+      | username |
+      | Alice    |
+      | Brian    |
+    Then the version folder of file "/textfile.txt" for user "Alice" should contain "1" elements
+    And the version folder of file "/textfile.txt" for user "Brian" should contain "1" elements
+    And the version folder of file "/textfile.txt" for user "Carol" should contain "2" elements
+
+
+  Scenario: the admin clears the expired versions for all users
+    Given the administrator has added system config key "versions_retention_obligation" with value "auto, 10"
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file "/textfile.txt" with content "some content" and mtime of "11" days ago using the WebDAV API
+    And user "Alice" has uploaded file "/textfile.txt" with content "version 1" and mtime of "5" days ago using the WebDAV API
+    And user "Alice" has uploaded file "/textfile.txt" with content "version 2" and mtime of "2" days ago using the WebDAV API
+    And user "Brian" has uploaded file "/textfile.txt" with content "some content" and mtime of "11" days ago using the WebDAV API
+    And user "Brian" has uploaded file "/textfile.txt" with content "version 1" and mtime of "5" days ago using the WebDAV API
+    And user "Brian" has uploaded file "/textfile.txt" with content "version 2" and mtime of "2" days ago using the WebDAV API
+    And user "Carol" has uploaded file "/textfile.txt" with content "some content" and mtime of "11" days ago using the WebDAV API
+    And user "Carol" has uploaded file "/textfile.txt" with content "version 1" and mtime of "5" days ago using the WebDAV API
+    And user "Carol" has uploaded file "/textfile.txt" with content "version 2" and mtime of "2" days ago using the WebDAV API
+    Then the version folder of file "/textfile.txt" for user "Alice" should contain "2" elements
+    And the version folder of file "/textfile.txt" for user "Brian" should contain "2" elements
+    And the version folder of file "/textfile.txt" for user "Carol" should contain "2" elements
+    When the administrator deletes the expired versions for all users
+    Then the version folder of file "/textfile.txt" for user "Alice" should contain "1" elements
+    And the version folder of file "/textfile.txt" for user "Brian" should contain "1" elements
+    And the version folder of file "/textfile.txt" for user "Carol" should contain "1" elements
+
+
+  Scenario: the admin tries to clear the expired versions for an invalid user
+    Given the administrator has added system config key "versions_retention_obligation" with value "auto, 10"
+    When the administrator tries to delete the expired versions for user "Alice"
     Then the command output should contain the text "Unknown user Alice"


### PR DESCRIPTION
## Description
Added CLI tests for `versions:expire` command

## Related Issue
- Fixes https://github.com/owncloud/core/issues/39165

## Motivation and Context

## How Has This Been Tested?
- test environment: CI

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
