### PR TITLE
[tests-only] skip tests that no longer work on oC10.8.0

### DIFF
--- a/tests/acceptance/features/webUIFiles/download.feature
+++ b/tests/acceptance/features/webUIFiles/download.feature
@@ -20,7 +20,7 @@ Feature: Download resource
     And the user clicks the download button on the webUI
     Then folder "simple-folder.zip" should be downloaded
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: download multiple folders
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "simple-folder1"
@@ -32,7 +32,7 @@ Feature: Download resource
     And the user clicks the download button on the webUI
     Then folder "download.zip" should be downloaded
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: download all files and folder
     Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Alice" has created folder "simple-folder"

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -107,6 +107,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to the "comments" tab in the details panel using the webUI
     Then the "comments" details panel should be visible
 
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Breadcrumb through folders
     Given user "Alice" has created folder "<grand-parent>"
     And user "Alice" has created folder "<grand-parent>/<parent>"

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -514,7 +514,7 @@ Feature: Sharing files and folders with internal groups
       | share_with  | grp3                 |
       | permissions | 31                   |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: Reshares with groups where the same file ends up in different mountpoints that are renamed should have correct permissions
     Given these groups have been created:
       | groupname |


### PR DESCRIPTION
## Description
1) there have been fixes to the filename of multi-file-folder downloads. Those test scenarios do not work against oC10.8.0 and before
2) There have been changes to the "home" breadcrumb on the files and trashbin UI pages. The xpath to the UI  element is now different. So the new test code will not work against the old web UI in 10.8.0 and before

Skip these tests on oC10.8.0 and before.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
