### PR TITLE
[tests-only] [full-ci] Enable declare(strict_types=1) for FeatureContext

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -338,7 +338,9 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 			$adminPassword,
 			$xRequestId
 		);
-		return $sysInfo->server_root;
+		// server_root is a SimpleXMLElement object that "wraps" a string.
+		/// We want the bare string.
+		return (string) $sysInfo->server_root;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -800,7 +800,7 @@ class OccContext implements Context {
 		\system("./occ maintenance:singleuser --on");
 		\system("./occ encryption:decrypt-all -c yes", $status);
 
-		$this->featureContext->setResultOfOccCommand(["code" => $status, "stdOut" => null, "stdErr" => null]);
+		$this->featureContext->setResultOfOccCommand(["code" => $status, "stdOut" => "", "stdErr" => ""]);
 		\system("./occ maintenance:singleuser --off");
 	}
 


### PR DESCRIPTION
## Description
We have declared function parameter and return types where we can. Now enable `strict_types=1` and that gets much more checking of the actual types that are passed around.

1) fixed some code so that it really uses and returns the correct types
2) removed explicit casts and checks from places that no longer require it (types are already checked in parameters etc and the IDE knew when these things are now redundant)
3) removed `{}` from around variables in strings like `"some text {$variable} etc"` to stop the IDE  from always telling me that the `{}` are not needed.
4) other minor refactoring

## Related Issue
Part of https://github.com/owncloud/QA/issues/694

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
