### PR TITLE
Correct the parameters in Activity  getSpecialParameterList

### DIFF
--- a/apps/files/lib/Activity.php
+++ b/apps/files/lib/Activity.php
@@ -260,13 +260,40 @@ class Activity implements IExtension {
 		if ($app === self::APP_FILES) {
 			switch ($text) {
 				case 'created_self':
+					return [
+						0 => 'file',
+					];
 				case 'created_by':
+					return [
+						0 => 'file',
+						1 => 'username',
+					];
 				case 'created_public':
+					return [
+						0 => 'file',
+					];
 				case 'changed_self':
+					return [
+						0 => 'file',
+					];
 				case 'changed_by':
+					return [
+						0 => 'file',
+						1 => 'username',
+					];
 				case 'deleted_self':
+					return [
+						0 => 'file',
+					];
 				case 'deleted_by':
+					return [
+						0 => 'file',
+						1 => 'username',
+					];
 				case 'restored_self':
+					return [
+						0 => 'file',
+					];
 				case 'renamed_self':
 					return [
 						0 => 'file',

--- a/apps/files/tests/ActivityTest.php
+++ b/apps/files/tests/ActivityTest.php
@@ -191,14 +191,14 @@ class ActivityTest extends TestCase {
 
 	public function specialParameterData() {
 		return [
-			['created_self', [0 => 'file', 1 => 'file']],
-			['created_by', [0 => 'file', 1 => 'file']],
-			['created_public', [0 => 'file', 1 => 'file']],
-			['changed_self', [0 => 'file', 1 => 'file']],
-			['changed_by', [0 => 'file', 1 => 'file']],
-			['deleted_self', [0 => 'file', 1 => 'file']],
-			['deleted_by', [0 => 'file', 1 => 'file']],
-			['restored_self', [0 => 'file', 1 => 'file']],
+			['created_self', [0 => 'file']],
+			['created_by', [0 => 'file', 1 => 'username']],
+			['created_public', [0 => 'file']],
+			['changed_self', [0 => 'file']],
+			['changed_by', [0 => 'file', 1 => 'username']],
+			['deleted_self', [0 => 'file']],
+			['deleted_by', [0 => 'file', 1 => 'username']],
+			['restored_self', [0 => 'file']],
 			['renamed_self', [0 => 'file', 1 => 'file']],
 			['renamed_by', [0 => 'file', 1 => 'username', 2 => 'file']],
 			['moved_self', [0 => 'file', 1 => 'file']],

--- a/changelog/unreleased/39430
+++ b/changelog/unreleased/39430
@@ -1,5 +1,6 @@
 Enhancement: Add activity translations for rename and move actions
 
 https://github.com/owncloud/core/pull/39430
+https://github.com/owncloud/core/pull/39438
 https://github.com/owncloud/enterprise/issues/4806
 https://github.com/owncloud/activity/issues/375


### PR DESCRIPTION
## Description
PR #39430 implemented activity translations for rename and move actions. In that PR the parameters defined for the existing earlier switch cases in `getSpecialParameterList` were accidentally changed. This caused test fails in the activity app nightly CI like:
https://drone.owncloud.com/owncloud/activity/2253/16/11
```
runsh: Total unexpected failed scenarios throughout the test run:
webUIActivityDeleteRestore/delete.feature:150
webUIActivityDeleteRestore/restore.feature:252
webUIActivityDeleteRestore/restore.feature:270
```

```
  Scenario: Sharer and sharee check activity after sharer deletes shared file                                                 # /var/www/owncloud/testrunner/apps/activity/tests/acceptance/features/webUIActivityDeleteRestore/delete.feature:150
    Given these users have been created with default attributes and without skeleton files:                                   # FeatureContext::theseUsersHaveBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles()
      | username |
      | Brian    |
    And user "Alice" has shared file "textfile0.txt" with user "Brian"                                                        # FeatureContext::userHasSharedFileWithUserUsingTheSharingApi()
    And the user has reloaded the current page of the webUI                                                                   # WebUIGeneralContext::theUserReloadsTheCurrentPageOfTheWebUI()
    When the user deletes file "textfile0.txt" using the webUI                                                                # WebUIFilesContext::theUserDeletesFileUsingTheWebUI()
    And the user browses to the activity page                                                                                 # WebUIActivityContext::userHasBrowsedToTheActivityPage()
    Then the activity number 1 should contain message "You deleted textfile0.txt" in the activity page                        # WebUIActivityContext::theActivityNumberShouldContainMessageInTheActivityPage()
    And the activity number 2 should have a message saying that you have shared file "textfile0.txt" with user "Brian Murphy" # WebUIActivityContext::theActivityNumberShouldHaveAMessageSayingSharedFolderWithUser()
    When the user re-logs in as "Brian" using the webUI                                                                       # WebUILoginContext::theUserRelogsInUsingTheWebUI()
    And the user browses to the activity page                                                                                 # WebUIActivityContext::userHasBrowsedToTheActivityPage()
    Then the activity number 1 should contain message "Alice Hansen deleted textfile0.txt" in the activity page               # WebUIActivityContext::theActivityNumberShouldContainMessageInTheActivityPage()
      Failed asserting that 'Alice deleted textfile0.txt' contains "Alice Hansen deleted textfile0.txt".
```

The user display name is not being substituted in some messages.

This PR fixes the problem. For clarity, I have explicitly specified the exact parameters that are required by each activity type in the switch statement.

## How Has This Been Tested?
Local run of the failing activity app test scenarios is passing.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
