### PR TITLE
Bump symfony/console (v4.4.30 => v4.4.33)

### DIFF
--- a/changelog/unreleased/PHPdependencies20210727onwardSymfony
+++ b/changelog/unreleased/PHPdependencies20210727onwardSymfony
@@ -1,7 +1,7 @@
 Change: Update Symfony components
 
 The following Symfony components have been updated to:
-- console 4.4.30
+- console 4.4.33
 - event-dispatcher 4.4.30
 - process 4.4.30
 - routing 4.4.30
@@ -20,3 +20,5 @@ https://github.com/owncloud/core/pull/39153
 https://symfony.com/blog/symfony-4-4-31-released
 https://symfony.com/blog/symfony-4-4-32-released
 https://github.com/owncloud/core/pull/39298
+https://symfony.com/blog/symfony-4-4-33-released
+https://github.com/owncloud/core/pull/39440

--- a/composer.lock
+++ b/composer.lock
@@ -3183,16 +3183,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.30",
+            "version": "v4.4.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a3f7189a0665ee33b50e9e228c46f50f5acbed22"
+                "reference": "8dbd23ef7a8884051482183ddee8d9061b5feed0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a3f7189a0665ee33b50e9e228c46f50f5acbed22",
-                "reference": "a3f7189a0665ee33b50e9e228c46f50f5acbed22",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8dbd23ef7a8884051482183ddee8d9061b5feed0",
+                "reference": "8dbd23ef7a8884051482183ddee8d9061b5feed0",
                 "shasum": ""
             },
             "require": {
@@ -3253,7 +3253,7 @@
             "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/console/tree/v4.4.30"
+                "source": "https://github.com/symfony/console/tree/v4.4.33"
             },
             "funding": [
                 {
@@ -3269,7 +3269,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-25T19:27:26+00:00"
+            "time": "2021-10-25T16:36:08+00:00"
         },
         {
             "name": "symfony/event-dispatcher",


### PR DESCRIPTION
## Description
```
$ composer update
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading symfony/console (v4.4.30 => v4.4.33)
Writing lock file
```

https://symfony.com/blog/symfony-4-4-33-released

Of the components that we use, only the console component had a patch release this month.

## How Has This Been Tested?
CI - we have quite a lot of automated "cli" tests of the `occ` commands.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
