### PR TITLE
[tests-only] [full-ci] waitForDavRequestsToFinish before deleting users

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2861,7 +2861,7 @@ class FeatureContext extends BehatVariablesContext {
 					$this,
 					"getOCSPath"
 				],
-				"parameter" => [1]
+				"parameter" => ["1"]
 			],
 			[
 				"code" => "%ocs_path_v2%",
@@ -2869,7 +2869,7 @@ class FeatureContext extends BehatVariablesContext {
 					$this,
 					"getOCSPath"
 				],
-				"parameter" => [2]
+				"parameter" => ["2"]
 			],
 			[
 				"code" => "%productname%",

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -366,12 +366,33 @@ class FeatureContext extends BehatVariablesContext {
 	 * @var Ldap
 	 */
 	private $ldap;
+	/**
+	 * @var string
+	 */
 	private $ldapBaseDN;
+	/**
+	 * @var string
+	 */
 	private $ldapHost;
+	/**
+	 * @var int
+	 */
 	private $ldapPort;
+	/**
+	 * @var string
+	 */
 	private $ldapAdminUser;
+	/**
+	 * @var string
+	 */
 	private $ldapAdminPassword;
+	/**
+	 * @var string
+	 */
 	private $ldapUsersOU;
+	/**
+	 * @var string
+	 */
 	private $ldapGroupsOU;
 	/**
 	 * @var array

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -566,7 +566,7 @@ trait Provisioning {
 
 			$this->ldapBaseDN = (string)$ldapConfig['ldapBase'][0];
 			$this->ldapHost = (string)$ldapConfig['ldapHost'];
-			$this->ldapPort = (string)$ldapConfig['ldapPort'];
+			$this->ldapPort = (int)$ldapConfig['ldapPort'];
 			$this->ldapAdminUser = (string)$ldapConfig['ldapAgentName'];
 		}
 		$this->ldapAdminPassword = (string)$suiteParameters['ldapAdminPassword'];

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -5332,6 +5332,7 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function afterScenario():void {
+		$this->waitForDavRequestsToFinish();
 		$this->restoreParametersAfterScenario();
 
 		if (OcisHelper::isTestingOnOcisOrReva() && $this->someUsersHaveBeenCreated()) {

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -72,14 +72,14 @@ trait WebDav {
 	 */
 	private $customDavPath = null;
 
-	private $oldAsyncSetting = null;
+	private $previousAsyncSetting = null;
 
-	private $oldDavSlowdownSetting = null;
+	private $previousDavSlowdownSetting = null;
 
 	/**
 	 * @var int
 	 */
-	private $newDavSlowdownSettingSeconds = 0;
+	private $currentDavSlowdownSettingSeconds = 0;
 
 	/**
 	 * response content parsed from XML to an array
@@ -480,12 +480,12 @@ trait WebDav {
 		} else {
 			$value = 'false';
 		}
-		if ($this->oldAsyncSetting === null) {
-			$oldAsyncSetting = SetupHelper::runOcc(
+		if ($this->previousAsyncSetting === null) {
+			$previousAsyncSetting = SetupHelper::runOcc(
 				['config:system:get', 'dav.enable.async'],
 				$this->getStepLineRef()
 			)['stdOut'];
-			$this->oldAsyncSetting = \trim($oldAsyncSetting);
+			$this->previousAsyncSetting = \trim($previousAsyncSetting);
 		}
 		$this->runOcc(
 			[
@@ -520,12 +520,12 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function slowdownDavRequests(string $method, int $seconds):void {
-		if ($this->oldDavSlowdownSetting === null) {
-			$oldDavSlowdownSetting = SetupHelper::runOcc(
+		if ($this->previousDavSlowdownSetting === null) {
+			$previousDavSlowdownSetting = SetupHelper::runOcc(
 				['config:system:get', 'dav.slowdown'],
 				$this->getStepLineRef()
 			)['stdOut'];
-			$this->oldDavSlowdownSetting = \trim($oldDavSlowdownSetting);
+			$this->previousDavSlowdownSetting = \trim($previousDavSlowdownSetting);
 		}
 		OcsApiHelper::sendRequest(
 			$this->getBaseUrl(),
@@ -535,7 +535,7 @@ trait WebDav {
 			"/apps/testing/api/v1/davslowdown/$method/$seconds",
 			$this->getStepLineRef()
 		);
-		$this->newDavSlowdownSettingSeconds = $seconds;
+		$this->currentDavSlowdownSettingSeconds = $seconds;
 	}
 
 	/**
@@ -544,11 +544,11 @@ trait WebDav {
 	 * @return void
 	 */
 	public function waitForDavRequestsToFinish():void {
-		if ($this->newDavSlowdownSettingSeconds > 0) {
+		if ($this->currentDavSlowdownSettingSeconds > 0) {
 			// There could be a slowed-down request still happening on the server
 			// Wait just-in-case so that we do not accidentally have an effect on
 			// the next scenario.
-			\sleep($this->newDavSlowdownSettingSeconds);
+			\sleep($this->currentDavSlowdownSettingSeconds);
 		}
 	}
 
@@ -5013,13 +5013,13 @@ trait WebDav {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function resetOldSettingsAfterScenario():void {
-		if ($this->oldAsyncSetting === "") {
+	public function resetPreviousSettingsAfterScenario():void {
+		if ($this->previousAsyncSetting === "") {
 			SetupHelper::runOcc(
 				['config:system:delete', 'dav.enable.async'],
 				$this->getStepLineRef()
 			);
-		} elseif ($this->oldAsyncSetting !== null) {
+		} elseif ($this->previousAsyncSetting !== null) {
 			SetupHelper::runOcc(
 				[
 					'config:system:set',
@@ -5027,23 +5027,23 @@ trait WebDav {
 					'--type',
 					'boolean',
 					'--value',
-					$this->oldAsyncSetting
+					$this->previousAsyncSetting
 				],
 				$this->getStepLineRef()
 			);
 		}
-		if ($this->oldDavSlowdownSetting === "") {
+		if ($this->previousDavSlowdownSetting === "") {
 			SetupHelper::runOcc(
 				['config:system:delete', 'dav.slowdown'],
 				$this->getStepLineRef()
 			);
-		} elseif ($this->oldDavSlowdownSetting !== null) {
+		} elseif ($this->previousDavSlowdownSetting !== null) {
 			SetupHelper::runOcc(
 				[
 					'config:system:set',
 					'dav.slowdown',
 					'--value',
-					$this->oldDavSlowdownSetting
+					$this->previousDavSlowdownSetting
 				],
 				$this->getStepLineRef()
 			);

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -77,6 +77,11 @@ trait WebDav {
 	private $oldDavSlowdownSetting = null;
 
 	/**
+	 * @var int
+	 */
+	private $newDavSlowdownSettingSeconds = 0;
+
+	/**
 	 * response content parsed from XML to an array
 	 *
 	 * @var array
@@ -530,6 +535,21 @@ trait WebDav {
 			"/apps/testing/api/v1/davslowdown/$method/$seconds",
 			$this->getStepLineRef()
 		);
+		$this->newDavSlowdownSettingSeconds = $seconds;
+	}
+
+	/**
+	 * Wait for possible slowed-down DAV requests to finish
+	 *
+	 * @return void
+	 */
+	public function waitForDavRequestsToFinish():void {
+		if ($this->newDavSlowdownSettingSeconds > 0) {
+			// There could be a slowed-down request still happening on the server
+			// Wait just-in-case so that we do not accidentally have an effect on
+			// the next scenario.
+			\sleep($this->newDavSlowdownSettingSeconds);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) If slowdownDavRequests has been used in a test scenario then there
could be DAV requests still "purposely slowly" processing on the
server-under-test. Deleting a user while the user still has such
a request still processing can cause problems, and can effect the
next test scenario. So, before deleting users in AfterScenario
first wait the number of seconds that DAV requests have been slowed
down.

2) Refactored the variable names. "old" and "new" get confused with the "old" and "new" DAV endpoints. Actually the variables refer to previous and current values of scenario settings.

3) Call getOCSPath with string version number - in `substituteInLineCodes` the function `getOCSPath` was being called with an `int` version "number" but actually that should be a string "1" or "2". This was noticed in admin_audit CI: https://drone.owncloud.com/owncloud/admin_audit/2182/26/9
```
    Then the log file should contain at least one entry matching each of these lines: # LoggingContext::logFileShouldContainEntriesMatching()
      | user  | method | url                                                          | message                                                                                               | action     | created | settingName           | settingValue | oldValue | CLI   | actor                             |
      | admin | POST   | /%ocs_path_v1%/apps/testing/api/v1/app/core/shareapi_enabled | user <admin>, displayName <admin> updated appconfig of "core" "shareapi_enabled" from "yes" with "no" | config_set | false   | core.shareapi_enabled | no           | yes      | false | user <admin>, displayName <admin> |
      Type error: Argument 1 passed to FeatureContext::getOCSPath() must be of the type string, int given, called in /var/www/owncloud/testrunner/tests/acceptance/features/bootstrap/FeatureContext.php on line 2980 (Behat\Testwork\Call\Exception\FatalThrowableError)
```

4) Fix type of ldapPort to always be int. Fixes https://drone.owncloud.com/owncloud/user_ldap/3570/27/11
```
Type error: Return value of FeatureContext::getLdapPort() must be of the type int, string returned
```

## Related Issue
- Fixes https://github.com/owncloud/files_primary_s3/issues/501

## How Has This Been Tested?
https://github.com/owncloud/files_primary_s3/pull/503 runs the failing test sequence using the code in this core branch.
Before changing any code, it was failing on most runs. Now it passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
