### PR TITLE
Add missing 'remoteshare.accepted' event parameters

### DIFF
--- a/apps/files_sharing/lib/Controllers/ExternalSharesController.php
+++ b/apps/files_sharing/lib/Controllers/ExternalSharesController.php
@@ -32,6 +32,9 @@ use OCP\Http\Client\IClientService;
 use OCP\IRequest;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use OC\Files\Filesystem;
+use OCA\Files_Sharing\Helper;
+use OCP\Files;
 
 /**
  * Class ExternalSharesController
@@ -91,13 +94,19 @@ class ExternalSharesController extends Controller {
 	public function create($id) {
 		$shareInfo = $this->externalManager->getShare($id);
 		if ($shareInfo !== false) {
+			$mountPoint = $this->externalManager->getShareRecipientMountPoint($shareInfo);
+			$fileId = $this->externalManager->getShareFileId($shareInfo, $mountPoint);
+
 			$event = new GenericEvent(
 				null,
 				[
 					'shareAcceptedFrom' => $shareInfo['owner'],
 					'sharedAcceptedBy' => $shareInfo['user'],
 					'sharedItem' => $shareInfo['name'],
-					'remoteUrl' => $shareInfo['remote']
+					'remoteUrl' => $shareInfo['remote'],
+					'shareId' => $id,
+					'fileId' => $fileId,
+					'shareRecipient' => $shareInfo['user'],
 				]
 			);
 			$this->dispatcher->dispatch('remoteshare.accepted', $event);

--- a/apps/files_sharing/tests/Controllers/ExternalShareControllerTest.php
+++ b/apps/files_sharing/tests/Controllers/ExternalShareControllerTest.php
@@ -95,6 +95,12 @@ class ExternalShareControllerTest extends \Test\TestCase {
 					'remote' => 'abc'
 				]
 			);
+		$this->externalManager
+			->method('getShareRecipientMountPoint')
+			->willReturn('/mountPoint');
+		$this->externalManager
+			->method('getShareFileId')
+			->willReturn('1');
 
 		$called = [];
 		\OC::$server->getEventDispatcher()->addListener('remoteshare.accepted', function ($event) use (&$called) {

--- a/changelog/unreleased/39449
+++ b/changelog/unreleased/39449
@@ -1,0 +1,7 @@
+Bugfix: Add missing `remoteshare.accepted` event parameters
+
+This fix adds missing parameters to the `remoteshare.accepted` event
+when triggered via controller: `shareId`, `fileId`, `shareRecipient`.
+The bugfix is a complement to https://github.com/owncloud/core/pull/38880.
+
+https://github.com/owncloud/core/pull/39449


### PR DESCRIPTION
## Description
This fix adds missing parameters to the `remoteshare.accepted` event when triggered via controller: `shareId`, `fileId`, `shareRecipient`.

The bugfix is a complement to https://github.com/owncloud/core/pull/38880. It will be needed for the next release of the activity app which includes: https://github.com/owncloud/activity/pull/972

Because the "logic" itself already exists (and to avoid code duplication) the relevant parts have been encapsulated into own methods. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
