### PR TITLE
Remove unused activity messages

### DIFF
--- a/apps/files/lib/Activity.php
+++ b/apps/files/lib/Activity.php
@@ -207,10 +207,6 @@ class Activity implements IExtension {
 				return (string) $l->t('You moved %2$s to %1$s', $params);
 			case 'moved_by':
 				return (string) $l->t('%2$s moved %3$s to %1$s', $params);
-			case 'moved_in_share_by':
-				return (string) $l->t('%2$s moved %1$s into the share', $params);
-			case 'moved_out_share_by':
-				return (string) $l->t('%2$s moved %1$s out of the share', $params);
 
 			default:
 				return false;
@@ -235,10 +231,6 @@ class Activity implements IExtension {
 				return (string) $l->t('You moved this file to %1$s', $params);
 			case 'moved_by':
 				return (string) $l->t('%2$s moved this file to %1$s', $params);
-			case 'moved_in_share_by':
-				return (string) $l->t('%2$s moved this file into the share', $params);
-			case 'moved_out_share_by':
-				return (string) $l->t('%2$s moved this file out of the share', $params);
 
 			default:
 				return false;
@@ -315,16 +307,6 @@ class Activity implements IExtension {
 						0 => 'file',
 						1 => 'username',
 						2 => 'file',
-					];
-				case 'moved_in_share_by':
-					return [
-						0 => 'file',
-						1 => 'username',
-					];
-				case 'moved_out_share_by':
-					return [
-						0 => 'file',
-						1 => 'username',
 					];
 				case 'restored_by':
 					return [

--- a/apps/files/tests/ActivityTest.php
+++ b/apps/files/tests/ActivityTest.php
@@ -156,8 +156,6 @@ class ActivityTest extends TestCase {
 			['renamed_by', ['fileRenamed.txt', 'user', 'file.txt'], 'user renamed file.txt to fileRenamed.txt', false],
 			['moved_self', ['fileMoved.txt', 'file.txt'], 'You moved file.txt to fileMoved.txt', false],
 			['moved_by', ['fileMoved.txt', 'user', 'file.txt'], 'user moved file.txt to fileMoved.txt', false],
-			['moved_in_share_by', ['fileMoved.txt', 'user'], 'user moved fileMoved.txt into the share', false],
-			['moved_out_share_by', ['fileMoved.txt', 'user'], 'user moved fileMoved.txt out of the share', false],
 
 			// short translations
 			['changed_by', ['file.txt', 'user'], 'Changed by user', true],
@@ -165,8 +163,6 @@ class ActivityTest extends TestCase {
 			['restored_by', ['file.txt', 'user'], 'Restored by user', true],
 			['moved_self', ['fileMoved.txt'], 'You moved this file to fileMoved.txt', true],
 			['moved_by', ['fileMoved.txt', 'user'], 'user moved this file to fileMoved.txt', true],
-			['moved_in_share_by', ['fileMoved.txt', 'user'], 'user moved this file into the share', true],
-			['moved_out_share_by', ['fileMoved.txt', 'user'], 'user moved this file out of the share', true],
 		];
 	}
 
@@ -203,8 +199,6 @@ class ActivityTest extends TestCase {
 			['renamed_by', [0 => 'file', 1 => 'username', 2 => 'file']],
 			['moved_self', [0 => 'file', 1 => 'file']],
 			['moved_by', [0 => 'file', 1 => 'username', 2 => 'file']],
-			['moved_in_share_by', [0 => 'file', 1 => 'username']],
-			['moved_out_share_by', [0 => 'file', 1 => 'username']],
 			['restored_by', [0 => 'file', 1 => 'username']],
 		];
 	}

--- a/changelog/unreleased/39430
+++ b/changelog/unreleased/39430
@@ -2,5 +2,6 @@ Enhancement: Add activity translations for rename and move actions
 
 https://github.com/owncloud/core/pull/39430
 https://github.com/owncloud/core/pull/39438
+https://github.com/owncloud/core/pull/39450
 https://github.com/owncloud/enterprise/issues/4806
 https://github.com/owncloud/activity/issues/375


### PR DESCRIPTION
## Description
In addition to https://github.com/owncloud/core/pull/39430: Two of the new messages have been adjusted in the activity app and can be removed here therefore.

* `moved_in_share_by` -> `created_by`
* `moved_out_share_by` -> `deleted_by`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
