### PR TITLE
Bump sabre/uri (2.2.1 => 2.2.2)

### DIFF
--- a/changelog/unreleased/PHPdependencies20210721onward
+++ b/changelog/unreleased/PHPdependencies20210721onward
@@ -19,6 +19,7 @@ The following have been updated:
 - sabre/event (5.1.2 to 5.1.4)
 - sabre/http (5.1.1 to 5.1.3)
 - sabre/vobject (4.3.5 to 4.3.7)
+- sabre/uri (2.2.1 to 2.2.2)
 - sabre/xml (2.2.3 to 2.2.5)
 - swiftmailer/swiftmailer (v6.2.7 to v6.3.0)
 
@@ -38,3 +39,4 @@ https://github.com/owncloud/core/pull/39427
 https://github.com/owncloud/core/pull/39433
 https://github.com/owncloud/core/pull/39434
 https://github.com/owncloud/core/pull/39453
+https://github.com/owncloud/core/pull/39456

--- a/composer.lock
+++ b/composer.lock
@@ -2878,23 +2878,23 @@
         },
         {
             "name": "sabre/uri",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/uri.git",
-                "reference": "f502edffafea8d746825bd5f0b923a60fd2715ff"
+                "reference": "7cb0f489578afad5006e85cd60f18ff33f2d440d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/uri/zipball/f502edffafea8d746825bd5f0b923a60fd2715ff",
-                "reference": "f502edffafea8d746825bd5f0b923a60fd2715ff",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/7cb0f489578afad5006e85cd60f18ff33f2d440d",
+                "reference": "7cb0f489578afad5006e85cd60f18ff33f2d440d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.16.1",
+                "friendsofphp/php-cs-fixer": "~2.17.1",
                 "phpstan/phpstan": "^0.12",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.0"
             },
@@ -2931,7 +2931,7 @@
                 "issues": "https://github.com/sabre-io/uri/issues",
                 "source": "https://github.com/fruux/sabre-uri"
             },
-            "time": "2020-10-03T10:33:23+00:00"
+            "time": "2021-11-04T09:29:58+00:00"
         },
         {
             "name": "sabre/vobject",


### PR DESCRIPTION
## Description
```
$ composer update
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading sabre/uri (2.2.1 => 2.2.2)
Writing lock file
```

This is another sabre patch release that I got done late yesterday: 
https://github.com/sabre-io/uri/releases/tag/2.2.2

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
