### PR TITLE
[tests-only] Skip changed getUser tests on old oC10

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -7,7 +7,7 @@ Feature: get user
   Background:
     Given using OCS API version "1"
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: admin gets an existing user
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -19,7 +19,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.3
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: admin gets an existing user with special characters in the username
     Given these users have been created without skeleton files:
       | username   | displayname   | email   |
@@ -36,7 +36,7 @@ Feature: get user
       | a@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: admin gets an existing user, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -55,7 +55,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a subadmin gets information of a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -95,7 +95,7 @@ Feature: get user
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a normal user gets their own information
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -107,7 +107,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a normal user gets their own information, providing uppercase username as authentication
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -119,7 +119,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.3
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a normal user gets their own information, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -131,7 +131,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.3
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -143,7 +143,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -155,7 +155,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: admin gets information of a user with admin permissions
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -168,7 +168,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -7,7 +7,7 @@ Feature: get user
   Background:
     Given using OCS API version "2"
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: admin gets an existing user
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -19,7 +19,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.3
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: admin gets an existing user with special characters in the username
     Given these users have been created without skeleton files:
       | username   | displayname   | email   |
@@ -36,7 +36,7 @@ Feature: get user
       | a@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: admin gets an existing user, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -55,7 +55,7 @@ Feature: get user
     And the HTTP status code should be "404"
     And the API should not return any data
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a subadmin gets information of a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -95,7 +95,7 @@ Feature: get user
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a normal user gets their own information
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -107,7 +107,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a normal user gets their own information, providing uppercase username as authentication
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -119,7 +119,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.3
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a normal user gets their own information, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -131,7 +131,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.3
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -143,7 +143,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -155,7 +155,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: admin gets information of a user with admin permissions
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -168,7 +168,7 @@ Feature: get user
     And the quota definition returned by the API should be "default"
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |


### PR DESCRIPTION
## Description
PR #39351 added `last_login` to a get-user Provisioning API  response. That does not exist in oC10.8.0 and before, so skip the tests in that case.

## Related Issue
- Fixes https://github.com/owncloud/files_primary_s3/issues/507

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
