### PR TITLE
Bump phan PHP analysis v4 to v5

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -304,7 +304,9 @@ class MigrationService {
 			case 'latest':
 				$this->ensureMigrationsAreLoaded();
 
-				return @\end($this->getAvailableVersions());
+				// A variable must be used because \end() must pass the array by reference
+				$availableVersionsArray = $this->getAvailableVersions();
+				return @\end($availableVersionsArray);
 		}
 		return '0';
 	}
@@ -336,7 +338,9 @@ class MigrationService {
 		if (\count($m) === 0) {
 			return '0';
 		}
-		return @\end(\array_values($m));
+		// A variable must be used because \end() must pass the array by reference
+		$migratedVersionsArray = \array_values($m);
+		return @\end($migratedVersionsArray);
 	}
 
 	/**

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^4.0"
+        "phan/phan": "^5.2"
     }
 }


### PR DESCRIPTION
## Description
`phan` v5 was released a while ago: https://github.com/phan/phan/releases

Update from v4 to v5.

It reported:
```
php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan --config-file .phan/config.php --require-config-exists -p
   analyze ████████████████████████████████████████████████████████████ 100.0% 2180MB/2236MB
lib/private/DB/MigrationService.php:307 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of \end(array|object &$array)
lib/private/DB/MigrationService.php:339 PhanTypeNonVarPassByRef Only variables can be passed by reference at argument 1 of \end(array|object &$array)
make: *** [Makefile:233: test-php-phan] Error 1
```

And that is correct - there are calls to `\end()` and those should be passed an actual local variable that is an array. I corrected the code.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
