### PR TITLE
[tests-only] Bump phpstan to v0.12 to v1.0

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
   bootstrapFiles:
     - %currentWorkingDirectory%/lib/base.php
-  excludes_analyse:
+  excludePaths:
     - %currentWorkingDirectory%/core/ajax/update.php
     - %currentWorkingDirectory%/apps/*/tests*
     - %currentWorkingDirectory%/apps/*/composer/*

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^0.12.92"
+        "phpstan/phpstan": "^1.0"
     }
 }


### PR DESCRIPTION
## Description
`phpstan` PHP Static Analysis Tool major version 1 has been released: https://github.com/phpstan/phpstan/releases

Use it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
