### PR TITLE
[tests-only] Fix return type of getLastShareId()

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1939,11 +1939,14 @@ trait Sharing {
 	/**
 	 * Retrieves the id of the last shared file
 	 *
-	 * @return SimpleXMLElement|null
+	 * @return string|null
 	 */
-	public function getLastShareId():?SimpleXMLElement {
+	public function getLastShareId():?string {
 		if ($this->lastShareData && $this->lastShareData->data) {
-			return $this->lastShareData->data[0]->id;
+			// id is a SimpleXMLElement object that contains the share id
+			// which is a string.
+			// (It might be a numeric string or might not, either is fine.)
+			return (string) $this->lastShareData->data[0]->id;
 		} else {
 			return null;
 		}


### PR DESCRIPTION
## Description
Change `getLastShareId()` so that it really returns the share-id as a string.

It is currently returning a `SimpleXMLElement` but callers are actually making use of it as a string. An exception is thrown if running with `strict_types` or with PHP 8.0

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
