### PR TITLE
[tests-only] Add more error checking in SetupHelper runOcc

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -890,56 +890,66 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		}
 
 		$return = [];
-		$resultXml = \simplexml_load_string($result->getBody()->getContents());
+		$contents = $result->getBody()->getContents();
+		$resultXml = \simplexml_load_string($contents);
+
+		if ($resultXml === false) {
+			throw new Exception(
+				"Response is not valid XML after executing 'occ $args'. " .
+				$isTestingAppEnabledText .
+				$contents
+			);
+		}
+
 		$return['code'] = $resultXml->xpath("//ocs/data/code");
 		$return['stdOut'] = $resultXml->xpath("//ocs/data/stdOut");
 		$return['stdErr'] = $resultXml->xpath("//ocs/data/stdErr");
 
 		if (!isset($return['code'][0])) {
 			throw new Exception(
-				"Return code not found after executing 'occ'. " .
+				"Return code not found after executing 'occ $args'. " .
 				$isTestingAppEnabledText .
-				$result->getBody()
+				$contents
 			);
 		}
 
 		if (!isset($return['stdOut'][0])) {
 			throw new Exception(
-				"Return stdOut not found after executing 'occ'. " .
+				"Return stdOut not found after executing 'occ $args'. " .
 				$isTestingAppEnabledText .
-				$result->getBody()
+				$contents
 			);
 		}
 
 		if (!isset($return['stdErr'][0])) {
 			throw new Exception(
-				"Return stdOut not found after executing 'occ'. " .
+				"Return stdErr not found after executing 'occ $args'. " .
 				$isTestingAppEnabledText .
-				$result->getBody()
+				$contents
 			);
 		}
 
 		if (!\is_a($return['code'][0], "SimpleXMLElement")) {
 			throw new Exception(
-				"Return code is not a SimpleXMLElement after executing 'occ'. " .
+				"Return code is not a SimpleXMLElement after executing 'occ $args'. " .
 				$isTestingAppEnabledText .
-				$result->getBody()
+				$contents
 			);
 		}
 
 		if (!\is_a($return['stdOut'][0], "SimpleXMLElement")) {
 			throw new Exception(
-				"Return stdOut is not a SimpleXMLElement after executing 'occ'. " .
+				"Return stdOut is not a SimpleXMLElement after executing 'occ $args'. " .
 				$isTestingAppEnabledText .
-				$result->getBody()
+				$contents
 			);
 		}
 
 		if (!\is_a($return['stdErr'][0], "SimpleXMLElement")) {
 			throw new Exception(
-				"Return stdErr is not a SimpleXMLElement after executing 'occ'. " .
+				"Return stdErr is not a SimpleXMLElement after executing 'occ $args'. " .
 				$isTestingAppEnabledText .
-				$result->getBody()
+				$contents
 			);
 		}
 


### PR DESCRIPTION
## Description
SetupHelper `runOcc` is used by acceptance test code that sets various settings when the acceptance tests start (among other things). If the system-under-test is not completely set up, not available, responding with some unexpected response etc, then the call to `simplexml_load_string` to format the expected XML of the response might fail and it is currently difficult for the person running the test to understand what might be the problem.

With this PR, if `simplexml_load_string` has a problem then an exception is thrown that reports the attempted `occ` command and the contents of the response. That will help the person running the test to read the response - and the response might have a good clue about what setup is missing from the system-under-test.

## How Has This Been Tested?
Local acceptance test run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
