### PR TITLE
Fix group administrator permissions

### DIFF
--- a/changelog/unreleased/39477
+++ b/changelog/unreleased/39477
@@ -1,0 +1,9 @@
+Bugfix: Group administrator permissions
+
+This fixes an issue where group administrators were
+unable to change email addresses and resend
+invitation emails for users in their groups.
+
+https://github.com/owncloud/core/pull/39477
+https://github.com/owncloud/core/issues/39475
+https://github.com/owncloud/core/issues/39476

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -671,7 +671,7 @@ class UsersController extends Controller {
 			);
 		}
 
-		'@phan-var \OC\Group\Manager $this->groupManager';
+		/* @phan-suppress-next-line PhanUndeclaredMethod */
 		if (!$this->isAdmin && !$this->groupManager->getSubAdmin()->isUserAccessible($currentUser, $user)) {
 			$this->log->error($currentUser->getUID() . " cannot resend invitation for $userId", ['app' => 'settings']);
 			return new JSONResponse(

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -3009,7 +3009,9 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->container['UserManager']->expects($this->once())
 			->method('get')
 			->willReturn($user);
-
+		$this->container['GroupManager']->expects($this->once())
+			->method('getSubAdmin')
+			->willReturn(true);
 		$this->container['SecureRandom']->expects($this->once())
 			->method('generate')
 			->willReturn('foOBaZ1');

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -3009,9 +3009,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->container['UserManager']->expects($this->once())
 			->method('get')
 			->willReturn($user);
-		$this->container['GroupManager']->expects($this->once())
-			->method('getSubAdmin')
-			->willReturn(true);
+
 		$this->container['SecureRandom']->expects($this->once())
 			->method('generate')
 			->willReturn('foOBaZ1');
@@ -3047,6 +3045,7 @@ class UsersControllerTest extends \Test\TestCase {
 			->with($message)
 			->willReturn([]);
 
+		$this->container['IsAdmin'] = true;
 		$result = $this->container['UsersController']->resendInvitation('foo');
 		$this->assertEquals(
 			new Http\JSONResponse(),

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -140,7 +140,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator (attempts to create|creates) a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)? using the webUI$/
+	 * @When /^the (?:administrator|subadmin|user) (attempts to create|creates) a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)? using the webUI$/
 	 *
 	 * @param string|null $attemptTo
 	 * @param string|null $username
@@ -221,7 +221,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When /^the administrator (attempts to create|creates) a user with the name "([^"]*)" and the email "([^"]*)" without a password(?: that is a member of these groups)? using the webUI$/
+	 * @When /^the (?:administrator|subadmin|user) (attempts to create|creates) a user with the name "([^"]*)" and the email "([^"]*)" without a password(?: that is a member of these groups)? using the webUI$/
 	 *
 	 * @param string $attemptTo
 	 * @param string $username
@@ -247,7 +247,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the administrator resends invitation email for user with the name :username using the webUI
+	 * @When the administrator/subadmin resends the invitation email for user :username using the webUI
 	 *
 	 * @param string $username
 	 *

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -94,7 +94,7 @@ Feature: add users
   @smokeTest @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: user sets his own password after being created with an Email address only and invitation link resend
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
-    And the administrator resends invitation email for user with the name "<username>" using the webUI
+    And the administrator resends the invitation email for user "<username>" using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "guiusr1@owncloud" in Email number 2 using the webUI
     Then the user should see an error message saying "The token provided is invalid."

--- a/tests/acceptance/features/webUIAddUsers/addUsersBySubAdmin.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsersBySubAdmin.feature
@@ -1,0 +1,63 @@
+@webUI @insulated @disablePreviews @mailhog
+Feature: add users
+  As a subadmin
+  I want to add users
+  So that unauthorised access is impossible
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+    And group "grp1" has been created
+    And user "Alice" has been added to group "grp1"
+    And user "Alice" has been made a subadmin of group "grp1"
+    And user "Alice" has logged in using the webUI
+    And the user has browsed to the users page
+
+  Scenario: a subadmin uses the webUI to create a simple user
+    When the subadmin creates a user with the name "guiusr1" and the password "%regular%" using the webUI
+    And the user logs out of the webUI
+    And user "guiusr1" logs in using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
+
+  @skipOnLDAP
+  Scenario: a subadmin uses the webUI to create a simple user with an Email address but without a password
+    When the subadmin creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
+    Then the email address "guiusr1@owncloud" should have received an email with the body containing
+      """
+      just letting you know that you now have an %productname% account.
+
+      Your username: guiusr1
+      Access it:
+      """
+
+  @skipOnLDAP
+  Scenario: user sets his own password after being created with an Email address only by a subadmin
+    When the subadmin creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
+    And the user logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" using the webUI
+    And the user sets the password to "%regular%" and confirms with the same password using the webUI
+    Then the user should be redirected to the login page
+    And the email address "guiusr1@owncloud" should have received an email with the body containing
+      """
+      Password changed successfully
+      """
+    When the user logs in with username "guiusr1" and password "%regular%" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"
+
+  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario: user sets his own password after being created with an Email address only and invitation link resent by a subadmin
+    When the subadmin creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
+    And the subadmin resends the invitation email for user "guiusr1" using the webUI
+    And the user logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" in Email number 2 using the webUI
+    Then the user should see an error message saying "The token provided is invalid."
+    And the user follows the password set link received by "guiusr1@owncloud" in Email number 1 using the webUI
+    And the user sets the password to "%regular%" and confirms with the same password using the webUI
+    And the user should be redirected to the login page
+    And the email address "guiusr1@owncloud" should have received an email with the body containing
+      """
+      Password changed successfully
+      """
+    When the user logs in with username "guiusr1" and password "%regular%" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - %productname%"


### PR DESCRIPTION
## Description
This fixes an issue where group administrators were unable to change email addresses and resend invitation emails for users in their groups. It should be possible [according to the docs](https://doc.owncloud.com/server/next/admin_manual/configuration/user/user_configuration.html#granting-administrator-privileges).

This is a regression which has been introduced with 10.8 (see https://github.com/owncloud/core/pull/38963).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39475
- Fixes https://github.com/owncloud/core/issues/39476

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
