### PR TITLE
[tests-only] skip new propfindOnLocalStorage tests on old oC10

### DIFF
--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage
+@cli @local_storage @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: get file info using PROPFIND
 
   Background:

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
@@ -1,4 +1,4 @@
-@cli @local_storage
+@cli @local_storage @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: get file info using PROPFIND
 
   Background:


### PR DESCRIPTION
## Description
These test scenarios were added in PR #39471 issue #39350 

They fail on older core version 10.8.0 and earlier, so skip in that case:
https://drone.owncloud.com/owncloud/user_ldap/3585/142/14
```
runsh: Total unexpected failed scenarios throughout the test run:
cliLocalStorage/propfindOnLocalStorage.feature:32
cliLocalStorage/propfindOnLocalStorage.feature:51
cliLocalStorage/propfindOnLocalStorage.feature:52
cliLocalStorage/propfindOnLocalStorage.feature:65
cliLocalStorage/propfindOnLocalStorage.feature:66
cliLocalStorage/propfindOnLocalStorage.feature:80
cliLocalStorage/propfindOnLocalStorage.feature:81
cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature:31
cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature:32
cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature:53
cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature:54
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
