### PR TITLE
Load l10n js files from correct app folder

### DIFF
--- a/changelog/unreleased/39482
+++ b/changelog/unreleased/39482
@@ -1,0 +1,8 @@
+Bugfix: Load l10n js files from the correct app folder
+
+With this PR, we ensure that the translations will be loaded from the correct
+app folder path.
+For example, if you have two versions of an app, where one version is in the
+apps folder and the other one in the apps-external folder.
+
+https://github.com/owncloud/core/pull/39482

--- a/changelog/unreleased/39482
+++ b/changelog/unreleased/39482
@@ -4,5 +4,8 @@ With this PR, we ensure that the translations will be loaded from the correct
 app folder path.
 For example, if you have two versions of an app, where one version is in the
 apps folder and the other one in the apps-external folder.
+The change also ensures that theme translations will be loaded additionally
+instead of replacing the whole app translations.
+This has the advantage that the user can cherry-pick single words to translate.
 
 https://github.com/owncloud/core/pull/39482

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -40,6 +40,9 @@ class JSResourceLocator extends ResourceLocator {
 		}
 
 		if (\strpos($script, '/l10n/') !== false) {
+			$app = \substr($fullScript, 0, \strpos($fullScript, '/'));
+			$appFolderLocation = \explode('/', $this->appManager->getAppWebPath($app))[1] ?? 'apps';
+
 			// For language files we try to load them all, so themes can overwrite
 			// single l10n strings without having to translate all of them.
 			$found = 0;
@@ -47,7 +50,7 @@ class JSResourceLocator extends ResourceLocator {
 			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$fullScript, $webRoot);
 			$found += $this->appendOnceIfExist($this->serverroot, $fullScript);
 			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$fullScript, $webRoot);
-			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$fullScript, $webRoot);
+			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$appFolderLocation.'/'.$fullScript, $webRoot);
 
 			if ($found) {
 				return;

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -50,7 +50,21 @@ class JSResourceLocator extends ResourceLocator {
 			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/core/'.$fullScript, $webRoot);
 			$found += $this->appendOnceIfExist($this->serverroot, $fullScript);
 			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$fullScript, $webRoot);
-			$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/'.$appFolderLocation.'/'.$fullScript, $webRoot);
+
+			/**
+			 * Try to load translations from the app folder, there might be concurrent versions of the same app in the apps and apps-external folder,
+			 * loading the translations from the newest version
+			 **/
+			$found += $this->appendOnceIfExist($baseDirectory, $appFolderLocation.'/'.$fullScript, $webRoot);
+
+			/**
+			 * Try to load translations from theme if exists, translations should be present in
+			 * theme-folder/apps/app-folder/l10n
+			 * theme translations will extend/overwrite native app translations
+			 **/
+			if($themeDirectory !== ""){
+				$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$fullScript, $webRoot);
+			}
 
 			if ($found) {
 				return;

--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -53,7 +53,7 @@ class JSResourceLocator extends ResourceLocator {
 
 			/**
 			 * Try to load translations from the app folder, there might be concurrent versions of the same app in the apps and apps-external folder,
-			 * loading the translations from the newest version
+			 * loading the translations from the active version
 			 **/
 			$found += $this->appendOnceIfExist($baseDirectory, $appFolderLocation.'/'.$fullScript, $webRoot);
 
@@ -62,7 +62,7 @@ class JSResourceLocator extends ResourceLocator {
 			 * theme-folder/apps/app-folder/l10n
 			 * theme translations will extend/overwrite native app translations
 			 **/
-			if($themeDirectory !== ""){
+			if (!empty($themeDirectory)) {
 				$found += $this->appendOnceIfExist($baseDirectory, $themeDirectory.'/apps/'.$fullScript, $webRoot);
 			}
 

--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -139,13 +139,14 @@ class JSResourceLocatorTest extends TestCase {
 			->with('randomapp')
 			->willReturn('/var/www/apps/randomapp');
 
-		$locator->expects($this->exactly(6))
+		$locator->expects($this->exactly(7))
 			->method('appendOnceIfExist')
 			->withConsecutive(
 				['/var/www/owncloud', 'core/randomapp/l10n/en_GB.js', ''],
 				['/var/www/apps', 'theme-best/core/randomapp/l10n/en_GB.js', ''],
 				['/var/www/owncloud', 'randomapp/l10n/en_GB.js', ''],
 				['/var/www/apps', 'theme-best/randomapp/l10n/en_GB.js', ''],
+				['/var/www/apps', 'apps/randomapp/l10n/en_GB.js', ''],
 				['/var/www/apps', 'theme-best/apps/randomapp/l10n/en_GB.js', ''],
 				['/var/www/apps/randomapp', 'l10n/en_GB.js', '']
 			);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Bugfix: Load l10n js files from the correct app folder

With this PR, we ensure that the translations will be loaded from the correct
app folder path.
For example, if you have two versions of an app, where one version is in the
apps folder and the other one in the apps-external folder.
The change also ensures that theme translations will be loaded additionally
instead of replacing the whole app translations.
This has the advantage that the user can cherry-pick single words to translate.

## Reproduction steps
1. Download the ownCloud 10.8 server (files_mediaviewer is located in the apps folder)
2. Download the files_mediaviewer 1.0.5 (RC release)
3. Extract files_mediaviewer into the apps-external folder (this is the location, where it typically lands, if you install the new version via market app)
4. Open ownCloud in the web browser
5. Open the network tab
6. files_medaviewer js files will be loaded from **apps-external**/files_mediaviewer/*.js (correct)
7. files_medaviewer language js files will be loaded from **apps**/files_mediaviewer/*.js (**incorrect**)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
