### PR TITLE
Disable move and rename activies per default

### DIFF
--- a/apps/files/lib/Activity.php
+++ b/apps/files/lib/Activity.php
@@ -133,8 +133,6 @@ class Activity implements IExtension {
 			$settings[] = self::TYPE_SHARE_CHANGED;
 			$settings[] = self::TYPE_SHARE_DELETED;
 			$settings[] = self::TYPE_SHARE_RESTORED;
-			$settings[] = self::TYPE_FILE_RENAMED;
-			$settings[] = self::TYPE_FILE_MOVED;
 			return $settings;
 		}
 

--- a/changelog/unreleased/39430
+++ b/changelog/unreleased/39430
@@ -3,5 +3,6 @@ Enhancement: Add activity translations for rename and move actions
 https://github.com/owncloud/core/pull/39430
 https://github.com/owncloud/core/pull/39438
 https://github.com/owncloud/core/pull/39450
+https://github.com/owncloud/core/pull/39482
 https://github.com/owncloud/enterprise/issues/4806
 https://github.com/owncloud/activity/issues/375


### PR DESCRIPTION
## Description
As requested in https://github.com/owncloud/enterprise/issues/2947#issuecomment-966198283.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
