### PR TITLE
Fix some broken links in config.sample

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -310,7 +310,7 @@ $CONFIG = [
  * Tokens which are not JSON WebToken (JWT) may not have information like the
  * expiry. In these cases, the OpenID Connect Provider needs to call on the token
  * introspection endpoint to get this information. The default value is `false`. See
- * https://tools.ietf.org/html/rfc7662 for more information on token introspection.
+ * https://datatracker.ietf.org/doc/html/rfc7662 for more information on token introspection.
  */
 
 /**

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1318,7 +1318,7 @@ $CONFIG = [
  * https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_large_prefix
  * https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_large_prefix
  * http://www.tocker.ca/benchmarking-innodb-page-compression-performance.html
- * http://mechanics.flite.com/blog/2014/07/29/using-innodb-large-prefix-to-avoid-error-1071/
+ * https://titanwolf.org/Network/Articles/Article?AID=58c487d4-7e0f-4fbe-9262-4285553ef443 (Using innodb_large_prefix to avoid ERROR 1071)
  */
 'mysql.utf8mb4' => false,
 


### PR DESCRIPTION
## Description
Fixes two broken links in config.sample files

## Related Issue

## Motivation and Context
Links should point to the correct location without errors

## How Has This Been Tested?
Text only, no code change

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

There is no must have, but it would be nice to have it merged for 10.9