### PR TITLE
Update sabre/dav (4.1.5 to 4.2.0)

### DIFF
--- a/changelog/unreleased/PHPdependencies20210721onward
+++ b/changelog/unreleased/PHPdependencies20210721onward
@@ -16,6 +16,7 @@ The following have been updated:
 - phpseclib/phpseclib (3.0.9 to 3.0.11)
 - pimple/pimple (3.2.3 to 3.5.0)
 - punic/punic (3.6.0 to 3.7.0)
+- sabre/dav (4.1.5 to 4.2.0)
 - sabre/event (5.1.2 to 5.1.4)
 - sabre/http (5.1.1 to 5.1.3)
 - sabre/vobject (4.3.5 to 4.4.0)
@@ -55,3 +56,4 @@ https://github.com/owncloud/core/pull/39485
 https://github.com/owncloud/core/pull/39487
 https://github.com/owncloud/core/pull/39492
 https://github.com/owncloud/core/pull/39495
+https://github.com/owncloud/core/pull/39496

--- a/composer.lock
+++ b/composer.lock
@@ -2663,16 +2663,16 @@
         },
         {
             "name": "sabre/dav",
-            "version": "4.1.5",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/dav.git",
-                "reference": "c1afdc77a95efea6ee40c03c45f57c3c0c80ec22"
+                "reference": "af125a40abdac787c438a6fed6da3451bcaa0886"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/dav/zipball/c1afdc77a95efea6ee40c03c45f57c3c0c80ec22",
-                "reference": "c1afdc77a95efea6ee40c03c45f57c3c0c80ec22",
+                "url": "https://api.github.com/repos/sabre-io/dav/zipball/af125a40abdac787c438a6fed6da3451bcaa0886",
+                "reference": "af125a40abdac787c438a6fed6da3451bcaa0886",
                 "shasum": ""
             },
             "require": {
@@ -2745,7 +2745,7 @@
                 "issues": "https://github.com/sabre-io/dav/issues",
                 "source": "https://github.com/fruux/sabre-dav"
             },
-            "time": "2021-02-12T07:54:23+00:00"
+            "time": "2021-11-17T04:45:57+00:00"
         },
         {
             "name": "sabre/event",

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
@@ -14,7 +14,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Brian" moves file "PARENT/parent.txt" to "PARENT/renamed-file.txt" sending the locktoken of file "PARENT" of user "Alice" using the WebDAV API
-    Then the HTTP status code should be "403"
+    Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/parent.txt" should not exist
     But as "Alice" file "/PARENT/renamed-file.txt" should exist
     Examples:

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
@@ -1,7 +1,7 @@
 @api @notToImplementOnOCIS @issue-ocis-reva-172
 Feature: actions on a locked item are possible if the token is sent with the request
 
-  @issue-34338 @files_sharing-app-required
+  @issue-34338 @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
     Given these users have been created with default attributes and without skeleton files:
       | username |


### PR DESCRIPTION
## Description
1) sabre/dav dependency update:
```
$ composer update
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading sabre/dav (4.1.5 => 4.2.0)
Writing lock file
```

https://github.com/sabre-io/dav/releases/tag/4.2.0

2) The behavior for issue #34338 has changed a bit. Previously Brian got a 403 (forbidden) response when trying to move a file in a folder locked by Alice, but the file was actually moved (renamed). Now Brian gets a 201 response, and the file is moved (renamed) just like before. At least the HTTP status now matches what happened "for real" to the file.

Note: the issue is still a problem - a 423 (locked) should be returned and the file should not be moved (renamed). But that is something still to be looked at and fixed separately - it might be another sabre/dav problem.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
