### PR TITLE
[tests-only] Fix trim in OcisHelper

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -66,7 +66,7 @@ class OcisHelper {
 	 */
 	public static function getDeleteUserDataCommand() {
 		$cmd = \getenv("DELETE_USER_DATA_CMD");
-		if (\trim($cmd) === "") {
+		if ($cmd === false || \trim($cmd) === "") {
 			return false;
 		}
 		return $cmd;


### PR DESCRIPTION
## Description
Fixes https://drone.owncloud.com/owncloud/ocis/7890/31/6
```
Type error: trim() expects parameter 1 to be string, bool given (Behat\Testwork\Call\Exception\FatalThrowableError)
  │
  └─ @AfterScenario # FeatureContext::afterScenario()
```

`getenv` returns `false` when the env var is not defined. We don't want to try and `trim` that.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
