### PR TITLE
[tests-only] Version metadata API acceptance test

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -469,3 +469,33 @@ Feature: dav-versions
       | header              | value                                                                |
       | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
     And the downloaded content should be "uploaded content"
+
+
+  Scenario: enable file versioning and check the history of changes from multiple users
+    Given the administrator has enabled file version storage feature
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Alice" creates folder "/test" using the WebDAV API
+    And user "Alice" shares folder "/test" with user "Brian" with permissions "all" using the sharing API
+    And user "Alice" shares folder "/test" with user "Carol" with permissions "all" using the sharing API
+    When user "Alice" has uploaded file with content "uploaded content" to "/test/textfile0.txt"
+    When user "Brian" has uploaded file with content "uploaded content new" to "/test/textfile0.txt"
+    When user "Carol" has uploaded file with content "uploaded content new again" to "/test/textfile0.txt"
+    When user "Alice" gets the number of versions of file "/test/textfile0.txt"
+    Then the author of the created version with index "1" should be "Carol"
+    Then the author of the created version with index "2" should be "Brian"
+    And user "Alice" downloads the version of file "/test/textfile0.txt" with the index "1"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "uploaded content new again"
+    When user "Alice" downloads the version of file "test/textfile0.txt" with the index "2"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "uploaded content new"
+    When user "Alice" deletes folder "/test/" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" folder "/test/" should not exist
+

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1148,6 +1148,8 @@ class FeatureContext extends BehatVariablesContext {
 		$this->response = $response;
 		//after a new response reset the response xml
 		$this->responseXml = [];
+		//after a new response reset the response xml object
+		$this->responseXmlObject = null;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -98,6 +98,37 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
+	 * @When user :user gets the version metadata of file :file
+	 *
+	 * @param string $user
+	 * @param string $file
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userGetsVersionMetadataOfFile(string $user, string $file):void {
+		$user = $this->featureContext->getActualUsername($user);
+		$fileId = $this->featureContext->getFileIdForPath($user, $file);
+		$body = '<?xml version="1.0"?>
+<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+  <d:prop>
+    <oc:meta-version-edited-by />
+    <oc:meta-version-edited-by-name />
+  </d:prop>
+</d:propfind>';
+		$response = $this->featureContext->makeDavRequest(
+			$user,
+			"PROPFIND",
+			$this->getVersionsPathForFileId($fileId),
+			null,
+			$body,
+			null,
+			'2'
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @When user :user restores version index :versionIndex of file :path using the WebDAV API
 	 * @Given user :user has restored version index :versionIndex of file :path
 	 *

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -5052,4 +5052,62 @@ trait WebDav {
 			);
 		}
 	}
+
+	/**
+	 * @Given /^the administrator has (enabled|disabled) file version storage feature/
+	 *
+	 * @param string $enabledOrDisabled
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorHasEnabledTheFileVersionStorage($enabledOrDisabled) {
+		$switch = ($enabledOrDisabled !== "disabled");
+		if ($switch) {
+			$value = 'true';
+		} else {
+			$value = 'false';
+		}
+		$this->runOcc(
+			[
+				'config:system:set',
+				'file_storage.save_version_author',
+				'--type',
+				'boolean',
+				'--value',
+				$value]
+		);
+	}
+	/**
+	 * @Then the author of the created version with index :arg1 should be :arg2
+	 *
+	 * @param string $index
+	 * @param string $user
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAuthorOfEditedVersionFile($index, $user) {
+		$expectedUser = $this->getUserDisplayName($user);
+		$resXml = $this->getResponseXmlObject();
+		if ($resXml === null) {
+			$resXml = HttpRequestHelper::getResponseXml(
+				$this->getResponse(),
+				__METHOD__
+			);
+		}
+		$xmlPart = $resXml->xpath("//oc:meta-version-edited-by//text()");
+		if (!isset($xmlPart[$index - 1])) {
+			Assert::fail(
+				'could not find version with index "' . $index . '"'
+			);
+		}
+		$actualUser = $xmlPart[$index - 1][0];
+		Assert::assertEquals(
+			$expectedUser,
+			$actualUser,
+			"Expected user of version was '$expectedUser', but got '$actualUser'"
+		);
+	}
 }
+

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -430,6 +430,7 @@ trait WebDav {
 				$this->getResponse(),
 				__METHOD__
 			);
+			$this->setResponseXmlObject($resXml);
 		}
 		$xmlPart = $resXml->xpath("//d:getlastmodified");
 		$actualNumber = \count($xmlPart);
@@ -5054,14 +5055,14 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^the administrator has (enabled|disabled) file version storage feature/
+	 * @Given /^the administrator has (enabled|disabled) the file version storage feature/
 	 *
 	 * @param string $enabledOrDisabled
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theAdministratorHasEnabledTheFileVersionStorage($enabledOrDisabled) {
+	public function theAdministratorHasEnabledTheFileVersionStorage(string $enabledOrDisabled): void {
 		$switch = ($enabledOrDisabled !== "disabled");
 		if ($switch) {
 			$value = 'true';
@@ -5078,23 +5079,25 @@ trait WebDav {
 				$value]
 		);
 	}
+
 	/**
-	 * @Then the author of the created version with index :arg1 should be :arg2
+	 * @Then the author of the created version with index :index should be :expectedUser
 	 *
 	 * @param string $index
-	 * @param string $user
+	 * @param string $expectedUser
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theAuthorOfEditedVersionFile($index, $user) {
-		$expectedUser = $this->getUserDisplayName($user);
+	public function theAuthorOfEditedVersionFile(string $index, string $expectedUser): void {
+		$expectedUserDisplayName = $this->getUserDisplayName($expectedUser);
 		$resXml = $this->getResponseXmlObject();
 		if ($resXml === null) {
 			$resXml = HttpRequestHelper::getResponseXml(
 				$this->getResponse(),
 				__METHOD__
 			);
+			$this->setResponseXmlObject($resXml);
 		}
 		$xmlPart = $resXml->xpath("//oc:meta-version-edited-by//text()");
 		if (!isset($xmlPart[$index - 1])) {
@@ -5108,6 +5111,18 @@ trait WebDav {
 			$actualUser,
 			"Expected user of version was '$expectedUser', but got '$actualUser'"
 		);
+
+		$xmlPart = $resXml->xpath("//oc:meta-version-edited-by-name//text()");
+		if (!isset($xmlPart[$index - 1])) {
+			Assert::fail(
+				'could not find version with index "' . $index . '"'
+			);
+		}
+		$actualUserDisplayName = $xmlPart[$index - 1][0];
+		Assert::assertEquals(
+			$expectedUserDisplayName,
+			$actualUserDisplayName,
+			"Expected user of version was '$expectedUser', but got '$actualUser'"
+		);
 	}
 }
-


### PR DESCRIPTION
## Description
This is the rebased code from PR #39478 with an extra commit to get the test scenario passing.

I have added commented steps in the test scenario to indicate what I think the actual behavior should be.

The actual steps demonstrate the existing behavior, which is not correct.

This is part of issue #39504 

This is a test that should be made to pass in #39516 - which is intended to fix the issue. That will likely be fixed in `release-10.9.0` branch. So we can't merge this test PR.

## How Has This Been Tested?
CI and local run of the new test scenario

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
