### PR TITLE
fix: tear down the file system before setting up the file system for …

### DIFF
--- a/apps/dav/lib/Connector/PublicAuth.php
+++ b/apps/dav/lib/Connector/PublicAuth.php
@@ -87,6 +87,7 @@ class PublicAuth extends AbstractBasic {
 		try {
 			$share = $this->shareManager->getShareByToken($username);
 		} catch (ShareNotFound $e) {
+			\OC::$server->getLogger()->error("PublicAuth: share for found $username");
 			return false;
 		}
 

--- a/changelog/unreleased/39518
+++ b/changelog/unreleased/39518
@@ -1,0 +1,3 @@
+Bugfix: Properly setup share owner file system on public link shares
+
+https://github.com/owncloud/core/pull/39518


### PR DESCRIPTION
…the share owner of a public share + more logging

## Description
In some rare cases (observed in some shib setups) public links don't work properly.
This happens because the session holds the currently logged in user which is not the share owner.
As a result the file system could not be set up properly.

This PR adds logging and forces teardown of the file system before setting up the file system for the share owner.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4835

## How Has This Been Tested?
- test environment: Unclear why this happen in one environment but not the other :see_no_evil: 
- see on an environment which uses shibboleth with ADFS
- create public link on a folder
- open link in browser where a different user then the share owner is logged in
- see a white space instead of the file listing


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
