### PR TITLE
[tests-only] Add tests to demonstrate group names with leading and trailing spaces

### DIFF
--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -153,3 +153,34 @@ Feature: add groups
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "another-new-group" should not exist
+
+
+  Scenario: admin creates a group that has white space at the end of the name
+    When the administrator sends a group creation request for group "white-space-at-end " using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # Note: it seems that white space at the end of a group name gets stripped off
+    # Groups "white-space-at-end " and "white-space-at-end" seem to be effectively the same
+    And group "white-space-at-end " should exist
+    And group "white-space-at-end" should exist
+
+
+  Scenario: admin creates a group that has white space at the start of the name
+    When the administrator sends a group creation request for group " white-space-at-start" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group " white-space-at-start" should exist
+    But group "white-space-at-start" should not exist
+
+
+  Scenario: admin creates a group that is a single space
+    When the administrator sends a group creation request for group " " using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group " " should exist
+
+
+  Scenario: admin tries to create a group that is the empty string
+    When the administrator tries to send a group creation request for group "" using the provisioning API
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -149,3 +149,34 @@ Feature: add groups
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "another-new-group" should not exist
+
+
+  Scenario: admin creates a group that has white space at the end of the name
+    When the administrator sends a group creation request for group "white-space-at-end " using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    # Note: it seems that white space at the end of a group name gets stripped off
+    # Groups "white-space-at-end " and "white-space-at-end" seem to be effectively the same
+    And group "white-space-at-end " should exist
+    And group "white-space-at-end" should exist
+
+
+  Scenario: admin creates a group that has white space at the start of the name
+    When the administrator sends a group creation request for group " white-space-at-start" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group " white-space-at-start" should exist
+    But group "white-space-at-start" should not exist
+
+
+  Scenario: admin creates a group that is a single space
+    When the administrator sends a group creation request for group " " using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group " " should exist
+
+
+  Scenario: admin tries to create a group that is the empty string
+    When the administrator tries to send a group creation request for group "" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"


### PR DESCRIPTION
## Description
This adds extra acceptance test scenarios that demonstrate the current behavior when adding groups with leading or trailing spaces in the name, or the group name " " (a single space).

Needs input about if the current behavior or some different behavior is required.

## Related Issue
https://github.com/owncloud/enterprise/issues/4890

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
