### PR TITLE
Do not allow white space at the start or end of a group name

### DIFF
--- a/apps/provisioning_api/lib/Groups.php
+++ b/apps/provisioning_api/lib/Groups.php
@@ -136,6 +136,10 @@ class Groups {
 			\OCP\Util::writeLog('provisioning_api', 'Group name not supplied', \OCP\Util::ERROR);
 			return new OC_OCS_Result(null, 101, 'Invalid group name');
 		}
+		if (\trim($groupId) !== $groupId) {
+			\OCP\Util::writeLog('provisioning_api', 'Group name must not start or end with white space', \OCP\Util::ERROR);
+			return new OC_OCS_Result(null, 101, 'Invalid group name');
+		}
 		// Check if it exists
 		if ($this->groupManager->groupExists($groupId)) {
 			return new OC_OCS_Result(null, 102);

--- a/apps/provisioning_api/tests/GroupsTest.php
+++ b/apps/provisioning_api/tests/GroupsTest.php
@@ -333,11 +333,26 @@ class GroupsTest extends \Test\TestCase {
 		$this->assertEquals([], $result->getData());
 	}
 
-	public function testAddGroupEmptyGroup() {
+	public function dataAddGroupWithInvalidName() {
+		return [
+			[''],
+			[' '],
+			[' white-space-at-start'],
+			['white-space-at-end '],
+			[' white-space-at-both-ends '],
+		];
+	}
+
+	/**
+	 * @dataProvider dataAddGroupWithInvalidName
+	 *
+	 * @param string $groupName
+	 */
+	public function testAddGroupWithInvalidName($groupName) {
 		$this->request
 			->method('getParam')
 			->with('groupid')
-			->willReturn('');
+			->willReturn($groupName);
 
 		$result = $this->api->addGroup([]);
 

--- a/changelog/unreleased/39540
+++ b/changelog/unreleased/39540
@@ -1,0 +1,3 @@
+Bugfix: Prevent group names starting or ending with white space
+
+https://github.com/owncloud/core/pull/39540

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -210,7 +210,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return \OC\Group\Group
 	 */
 	public function createGroup($gid) {
-		if ($gid === '' || $gid === null) {
+		if ($gid === '' || $gid === null || \trim($gid) !== $gid) {
 			return false;
 		} elseif ($group = $this->get($gid)) {
 			return $group;

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -153,3 +153,34 @@ Feature: add groups
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "another-new-group" should not exist
+
+
+  Scenario: admin creates a group that has white space at the end of the name
+    When the administrator sends a group creation request for group "white-space-at-end " using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # Note: it seems that white space at the end of a group name gets stripped off
+    # Groups "white-space-at-end " and "white-space-at-end" seem to be effectively the same
+    And group "white-space-at-end " should exist
+    And group "white-space-at-end" should exist
+
+
+  Scenario: admin creates a group that has white space at the start of the name
+    When the administrator sends a group creation request for group " white-space-at-start" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group " white-space-at-start" should exist
+    But group "white-space-at-start" should not exist
+
+
+  Scenario: admin creates a group that is a single space
+    When the administrator sends a group creation request for group " " using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And group " " should exist
+
+
+  Scenario: admin tries to create a group that is the empty string
+    When the administrator tries to send a group creation request for group "" using the provisioning API
+    Then the OCS status code should be "101"
+    And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -155,29 +155,27 @@ Feature: add groups
     And group "another-new-group" should not exist
 
 
-  Scenario: admin creates a group that has white space at the end of the name
+  Scenario: admin tries to create a group that has white space at the end of the name
     When the administrator sends a group creation request for group "white-space-at-end " using the provisioning API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "101"
     And the HTTP status code should be "200"
-    # Note: it seems that white space at the end of a group name gets stripped off
-    # Groups "white-space-at-end " and "white-space-at-end" seem to be effectively the same
-    And group "white-space-at-end " should exist
-    And group "white-space-at-end" should exist
+    And group "white-space-at-end " should not exist
+    And group "white-space-at-end" should not exist
 
 
-  Scenario: admin creates a group that has white space at the start of the name
+  Scenario: admin tries to create a group that has white space at the start of the name
     When the administrator sends a group creation request for group " white-space-at-start" using the provisioning API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "101"
     And the HTTP status code should be "200"
-    And group " white-space-at-start" should exist
+    And group " white-space-at-start" should not exist
     But group "white-space-at-start" should not exist
 
 
-  Scenario: admin creates a group that is a single space
+  Scenario: admin tries to create a group that is a single space
     When the administrator sends a group creation request for group " " using the provisioning API
-    Then the OCS status code should be "100"
+    Then the OCS status code should be "101"
     And the HTTP status code should be "200"
-    And group " " should exist
+    And group " " should not exist
 
 
   Scenario: admin tries to create a group that is the empty string

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -151,29 +151,27 @@ Feature: add groups
     And group "another-new-group" should not exist
 
 
-  Scenario: admin creates a group that has white space at the end of the name
+  Scenario: admin tries to create a group that has white space at the end of the name
     When the administrator sends a group creation request for group "white-space-at-end " using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    # Note: it seems that white space at the end of a group name gets stripped off
-    # Groups "white-space-at-end " and "white-space-at-end" seem to be effectively the same
-    And group "white-space-at-end " should exist
-    And group "white-space-at-end" should exist
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And group "white-space-at-end " should not exist
+    And group "white-space-at-end" should not exist
 
 
-  Scenario: admin creates a group that has white space at the start of the name
+  Scenario: admin tries to create a group that has white space at the start of the name
     When the administrator sends a group creation request for group " white-space-at-start" using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    And group " white-space-at-start" should exist
-    But group "white-space-at-start" should not exist
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And group " white-space-at-start" should not exist
+    And group "white-space-at-start" should not exist
 
 
-  Scenario: admin creates a group that is a single space
+  Scenario: admin tries to create a group that is a single space
     When the administrator sends a group creation request for group " " using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    And group " " should exist
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"
+    And group " " should not exist
 
 
   Scenario: admin tries to create a group that is the empty string

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -149,3 +149,34 @@ Feature: add groups
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
     And group "another-new-group" should not exist
+
+
+  Scenario: admin creates a group that has white space at the end of the name
+    When the administrator sends a group creation request for group "white-space-at-end " using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    # Note: it seems that white space at the end of a group name gets stripped off
+    # Groups "white-space-at-end " and "white-space-at-end" seem to be effectively the same
+    And group "white-space-at-end " should exist
+    And group "white-space-at-end" should exist
+
+
+  Scenario: admin creates a group that has white space at the start of the name
+    When the administrator sends a group creation request for group " white-space-at-start" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group " white-space-at-start" should exist
+    But group "white-space-at-start" should not exist
+
+
+  Scenario: admin creates a group that is a single space
+    When the administrator sends a group creation request for group " " using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And group " " should exist
+
+
+  Scenario: admin tries to create a group that is the empty string
+    When the administrator tries to send a group creation request for group "" using the provisioning API
+    Then the OCS status code should be "400"
+    And the HTTP status code should be "400"

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -422,6 +422,12 @@ class OccUsersGroupsContext implements Context {
 	 * @throws Exception
 	 */
 	public function theAdministratorCreatesGroupUsingTheOccCommand(string $group):void {
+		if (($group === '') || (\trim($group) !== $group)) {
+			// The group name is empty or has white space at the start or end.
+			// Quote the group name so that the white space is really sent to the
+			// occ command as part of the requested group name.
+			$group = "'$group'";
+		}
 		$this->occContext->invokingTheCommand(
 			"group:add $group"
 		);

--- a/tests/acceptance/features/cliProvisioning/addGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addGroup.feature
@@ -33,3 +33,28 @@ Feature: add group
     When the administrator creates group "brand-new-group" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'The group "brand-new-group" already exists'
+
+  Scenario: admin tries to create a group that has white space at the end of the name
+    When the administrator creates group "white-space-at-end " using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'Group "white-space-at-end " could not be created'
+    And group "white-space-at-end " should not exist
+    And group "white-space-at-end" should not exist
+
+  Scenario: admin tries to create a group that has white space at the start of the name
+    When the administrator creates group " white-space-at-start" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'Group " white-space-at-start" could not be created'
+    And group " white-space-at-start" should not exist
+    And group "white-space-at-start" should not exist
+
+  Scenario: admin tries to create a group that is a single space
+    When the administrator creates group " " using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'Group " " could not be created'
+    And group " " should not exist
+
+  Scenario: admin tries to create a group that is the empty string
+    When the administrator creates group "" using the occ command
+    Then the command should have failed with exit code 1
+    And the command output should contain the text 'Group "" could not be created'

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -243,6 +243,26 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals('group1', $group->getGID());
 	}
 
+	public function dataCreateGroupWithInvalidName() {
+		return [
+			[''],
+			[' '],
+			[' white-space-at-start'],
+			['white-space-at-end '],
+			[' white-space-at-both-ends '],
+		];
+	}
+
+	/**
+	 * @dataProvider dataCreateGroupWithInvalidName
+	 *
+	 * @param string $groupName
+	 */
+	public function testCreateInvalidGroupName(string $groupName) {
+		$group = $this->manager->createGroup($groupName);
+		$this->assertFalse($group);
+	}
+
 	public function testCreateWithDispatcher() {
 		/**
 		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend


### PR DESCRIPTION
## Description
Do not allow a group to be created with a name that has white space:
- at the beginning, or
- at the end, or
- has only white space

This is on top of PR #39530 which demonstrates the current behavior for groups with white space at the beginning or end of the group name.

The Provisioning API acts as if "finance" and "finance " are the same group, because of:
https://stackoverflow.com/questions/17876478/why-the-sql-server-ignore-the-empty-space-at-the-end-automatically
https://support.microsoft.com/en-us/topic/inf-how-sql-server-compares-strings-with-trailing-spaces-b62b1a2d-27d3-4260-216d-a605719003b0

1) If I create group "finance" first, then try to create group "finance ", the groupExists checks find that "finance " exists already, and refuses to create it.

2) If I create group "finance " first, then try to create group "finance", the groupExists checks find that "finance" exists already, and refuses to create it.

Item (1) seems a reasonable "accident" of the code - it prevents creating an extra group name with a space on the end.

Item (2) is a bit odd - if we accidentally create group "finance " then we are stuck with "finance " in the database. And when we do an API request like:
```
curl -X GET http://admin:admin@172.17.0.1:8080/ocs/v1.php/cloud/groups
```

We get elements with that space at the end of the name like:
```
<element>finance </element>
```

And to query the group directly we have to:
```
curl -X GET http://admin:admin@172.17.0.1:8080/ocs/v1.php/cloud/groups/finance%20
```

Also: https://jira.atlassian.com/browse/CWD-4290
That claims that pgsql will behave differently than mySQL/MariaDb, and likely happily add separate table rows for "finance" and "finance " groups, so they will be treated as different groups in an oC10 installation using pgsql.

So that is another reason to refuse to create groups (or any string data) with trailing spaces - different databases, and implementations not using an SQL database, might behave differently.

Therefore this PR prevents creation of a group with a name that ends in white space, including a group name that is only white space.

It seems silly to allow group names that start with white space, like " finance", that would be strangely inconsistent with banning white space at the end of the name. So this PR also prevents white space at the start of a group name.

As well as unit test cases, I have added API acceptance test scenarios, because we want oCIS to behave the same. IMO oCIS currently allows spaces at the beginning and end, and considers all combinations like " finance", "finance" and "finance " to be separate valid groups.



## Related Issue
https://github.com/owncloud/enterprise/issues/4890

#39533 - sorts out the requirements/rules for that issue.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
