### PR TITLE
Allow setting multiple default file actions

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -287,7 +287,7 @@
 			if (!defaultActions.length) {
 				return undefined;
 			}
-			return defaultActions.pop();
+			return defaultActions[defaultActions.length - 1];
 		},
 
 		/**
@@ -333,7 +333,7 @@
 				if (defaultNames.indexOf(action.name) >= 0) {
 					defaultActions.push(action)
 				}
-			})
+			});
 			return defaultActions;
 		},
 

--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -180,13 +180,18 @@
 			this._actionFilters = [];
 		},
 		/**
-		 * Sets the default action for a given mime type.
+		 * Adds an app to the list of default actions for a given mime type.
 		 *
 		 * @param {String} mime mime type
 		 * @param {String} name action name
 		 */
 		setDefault: function (mime, name) {
-			this.defaults[mime] = name;
+			if (!this.defaults[mime]) {
+				this.defaults[mime] = [];
+			}
+			if (this.defaults[mime].indexOf(name) < 0) {
+				this.defaults[mime].push(name);
+			}
 			this._notifyUpdateListeners('setDefault', {defaultAction: {mime: mime, name: name}});
 		},
 
@@ -218,85 +223,9 @@
 		 * @return {Object.<OCA.Files.FileAction>} array of action specs
 		 */
 		getActions: function (mime, type, permissions) {
-			return this._getActions(mime, type, permissions, false);
-		},
-
-		/**
-		 * Returns an array of file actions matching the given conditions while
-		 * omitting the actions which apply to all mime types ("Rename", "Download" etc.)
-		 *
-		 * @param {string} mime mime type
-		 * @param {string} type "dir" or "file"
-		 * @param {int} permissions permissions
-		 *
-		 * @return {Object.<OCA.Files.FileAction>} array of action specs
-		 */
-		getActionsWithoutAll: function (mime, type, permissions) {
-			return this._getActions(mime, type, permissions, true);
-		},
-
-		/**
-		 * Returns the default file action handler for the given conditions
-		 *
-		 * @param {string} mime mime type
-		 * @param {string} type "dir" or "file"
-		 * @param {int} permissions permissions
-		 *
-		 * @return {OCA.Files.FileActions~actionHandler} action handler
-		 *
-		 * @deprecated use getDefaultFileAction instead
-		 */
-		getDefault: function (mime, type, permissions) {
-			var defaultActionSpec = this.getDefaultFileAction(mime, type, permissions);
-			if (defaultActionSpec) {
-				return defaultActionSpec.action;
-			}
-			return undefined;
-		},
-
-		/**
-		 * Returns the default file action handler for the given conditions
-		 *
-		 * @param {string} mime mime type
-		 * @param {string} type "dir" or "file"
-		 * @param {int} permissions permissions
-		 *
-		 * @return {OCA.Files.FileActions~actionHandler} action handler
-		 * @since 8.2
-		 */
-		getDefaultFileAction: function(mime, type, permissions) {
-			var mimePart;
-			if (mime) {
-				mimePart = mime.substr(0, mime.indexOf('/'));
-			}
-			var name = false;
-			if (mime && this.defaults[mime]) {
-				name = this.defaults[mime];
-			} else if (mime && this.defaults[mimePart]) {
-				name = this.defaults[mimePart];
-			} else if (type && this.defaults[type]) {
-				name = this.defaults[type];
-			} else {
-				name = this.defaults.all;
-			}
-			var actions = this.getActions(mime, type, permissions);
-			return actions[name];
-		},
-
-		/**
-		 * Returns an array of file actions matching the given conditions
-		 *
-		 * @param {string} mime mime type
-		 * @param {string} type "dir" or "file"
-		 * @param {int} permissions permissions
-		 * @param {boolean} excludeAll excludeAll
-		 *
-		 * @return {Object.<OCA.Files.FileAction>} array of action specs
-		 */
-		_getActions: function (mime, type, permissions, excludeAll) {
 			var actions = {};
 
-			if (this.actions.all && excludeAll !== true) {
+			if (this.actions.all) {
 				actions = $.extend(actions, this.actions.all);
 			}
 			if (type) {//type is 'dir' or 'file'
@@ -320,6 +249,92 @@
 				}
 			});
 			return filteredActions;
+		},
+
+		/**
+		 * Returns the default file action handler for the given conditions
+		 *
+		 * @param {string} mime mime type
+		 * @param {string} type "dir" or "file"
+		 * @param {int} permissions permissions
+		 *
+		 * @return {OCA.Files.FileActions~actionHandler} action handler
+		 *
+		 * @deprecated use getDefaultFileActions instead
+		 */
+		getDefault: function (mime, type, permissions) {
+			var defaultActionSpec = this.getDefaultFileAction(mime, type, permissions);
+			if (defaultActionSpec) {
+				return defaultActionSpec.action;
+			}
+			return undefined;
+		},
+
+		/**
+		 * Returns the last default file action handler for the given conditions
+		 *
+		 * @param {string} mime mime type
+		 * @param {string} type "dir" or "file"
+		 * @param {int} permissions permissions
+		 *
+		 * @return {OCA.Files.FileActions~actionHandler} action handler
+		 * @since 8.2
+		 *
+		 * @deprecated use getDefaultFileActions instead
+		 */
+		getDefaultFileAction: function(mime, type, permissions) {
+			const defaultActions = this.getDefaultFileActions(mime, type, permissions);
+			if (!defaultActions.length) {
+				return undefined;
+			}
+			return defaultActions.pop();
+		},
+
+		/**
+		 * Returns all default file action handlers for the given conditions
+		 *
+		 * @param {string} mime mime type
+		 * @param {string} type "dir" or "file"
+		 * @param {int} permissions permissions
+		 *
+		 * @return {Array.<OCA.Files.FileActions~actionHandler>} action handlers
+		 * @since 10.9
+		 */
+		 getDefaultFileActions: function(mime, type, permissions) {
+			var mimePart;
+			if (mime) {
+				mimePart = mime.substr(0, mime.indexOf('/'));
+			}
+
+			var defaultNames = [];
+			if (mime && this.defaults[mime]) {
+				defaultNames = defaultNames.concat(this.defaults[mime]);
+			}
+
+			if (mimePart && this.defaults[mimePart]) {
+				defaultNames = defaultNames.concat(this.defaults[mimePart]);
+			}
+
+			if (type && this.defaults[type]) {
+				defaultNames = defaultNames.concat(this.defaults[type]);
+			}
+
+			if (!defaultNames.length) {
+				if (!this.defaults.all) {
+					return [];
+				}
+
+				defaultNames = this.defaults.all;
+			}
+
+			var actions = this.getActions(mime, type, permissions);
+			var defaultActions = [];
+			_.each(actions, function (action) {
+				if (defaultNames.indexOf(action.name) >= 0) {
+					defaultActions.push(action)
+				}
+			})
+			return defaultActions;
 		},
 
 		/**
@@ -571,15 +586,17 @@
 			nameLinks = parent.children('a.name');
 			nameLinks.find('.fileactions, .nametext .action').remove();
 			nameLinks.append('<span class="fileactions" />');
-			var defaultAction = this.getDefaultFileAction(
+			var defaultActions = this.getDefaultFileActions(
 				this.getCurrentMimeType(),
 				this.getCurrentType(),
 				this.getCurrentPermissions()
 			);
-
+			var defaultActionNames = _.map(defaultActions, function(actionSpec) {
+				return actionSpec.name;
+			});
 			var hasDropDownActions = false;
 			$.each(actions, function (name, actionSpec) {
-				var isDefault = !!(defaultAction && actionSpec.name === defaultAction.name);
+				var isDefault = defaultActionNames.indexOf(actionSpec.name) >= 0;
 				if (actionSpec.type && actionSpec.type === FileActions.TYPE_INLINE) {
 					self._renderInlineAction(
 						actionSpec,

--- a/apps/files/js/fileactionsapplicationselectmenu.js
+++ b/apps/files/js/fileactionsapplicationselectmenu.js
@@ -96,14 +96,8 @@
 				fileActions.getCurrentPermissions()
 			);
 
-			var items = [];
-
-			Object.keys(actions).forEach(function (actionKey) {
-				items.push(actions[actionKey]);
-			});
-
 			this.$el.html(this.template({
-				items: items
+				items: actions
 			}));
 		},
 

--- a/apps/files/js/fileactionsapplicationselectmenu.js
+++ b/apps/files/js/fileactionsapplicationselectmenu.js
@@ -90,7 +90,7 @@
 
 		render: function() {
 			var fileActions = this._context.fileActions;
-			var actions = fileActions.getActionsWithoutAll(
+			var actions = fileActions.getDefaultFileActions(
 				fileActions.getCurrentMimeType(),
 				fileActions.getCurrentType(),
 				fileActions.getCurrentPermissions()

--- a/apps/files/js/fileactionsmenu.js
+++ b/apps/files/js/fileactionsmenu.js
@@ -98,23 +98,23 @@
 				fileActions.getCurrentPermissions()
 			);
 
-			var defaultAction = fileActions.getDefaultFileAction(
+			var defaultActions = fileActions.getDefaultFileActions(
 				fileActions.getCurrentMimeType(),
 				fileActions.getCurrentType(),
 				fileActions.getCurrentPermissions()
 			);
+			var defaultActionNames = _.map(defaultActions, function(actionSpec) {
+				return actionSpec.name;
+			});
 
 			actions = fileActions._advancedFilter(actions, this._context);
 
 			// always show default actions for files but not for directories
 			var items = _.filter(actions, function(actionSpec) {
+				var isDefault = defaultActionNames.indexOf(actionSpec.name) >= 0;
 				return (
 					actionSpec.type === OCA.Files.FileActions.TYPE_DROPDOWN &&
-					(
-						!defaultAction ||
-						actionSpec.name !== defaultAction.name ||
-						fileActions.getCurrentType() !== 'dir'
-					)
+					(!isDefault || fileActions.getCurrentType() !== 'dir')
 				);
 			});
 			items = _.map(items, function(item) {

--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -688,7 +688,7 @@
 						var mime = this.fileActions.getCurrentMimeType();
 						var type = this.fileActions.getCurrentType();
 						var permissions = this.fileActions.getCurrentPermissions();
-						var actionsWithoutAll = this.fileActions.getActionsWithoutAll(mime,type, permissions);
+						var defaultActions = this.fileActions.getDefaultFileActions(mime,type, permissions);
 						var context = {
 							$file: $tr,
 							fileList: this,
@@ -697,7 +697,7 @@
 						};
 
 						// don't show app drawer for directories as we want to open them per default
-						if (Object.keys(actionsWithoutAll).length > 1 && type !== 'dir') {
+						if (defaultActions.length > 1 && type !== 'dir') {
 							var appSelectMenu = new OCA.Files.FileActionsApplicationSelectMenu();
 							appSelectMenu.show(context, $tr.find('td.filename'));
 							event.preventDefault();

--- a/apps/files/tests/js/favoritespluginspec.js
+++ b/apps/files/tests/js/favoritespluginspec.js
@@ -58,7 +58,7 @@ describe('OCA.Files.FavoritesPlugin tests', function() {
 			expect(fileActions.actions.all.Rename).toBeDefined();
 			expect(fileActions.actions.all.Download).toBeDefined();
 
-			expect(fileActions.defaults.dir).toEqual('Open');
+			expect(fileActions.defaults.dir).toEqual(['Open']);
 		});
 		it('provides custom file actions', function() {
 			var actionStub = sinon.stub();

--- a/apps/files/tests/js/fileactionsSpec.js
+++ b/apps/files/tests/js/fileactionsSpec.js
@@ -305,25 +305,6 @@ describe('OCA.Files.FileActions tests', function() {
 			expect(Object.keys(actions).indexOf('View PDF file') >= 0).toEqual(true);
 			expect(Object.keys(actions).indexOf('Edit PDF file') <= 0).toEqual(true);
 		});
-		it('get file actions for a specific mime type omitting the ones which apply to all mime types', function() {
-			fileActions.registerAction({
-				mime: 'application/pdf',
-				name: 'View PDF file',
-				type: OCA.Files.FileActions.TYPE_INLINE,
-				permissions: OC.PERMISSION_READ,
-				icon: OC.imagePath('core', 'actions/test')
-			});
-
-			var actions = fileActions.getActionsWithoutAll(
-				'application/pdf',
-				OCA.Files.FileActions.TYPE_INLINE,
-				OC.PERMISSION_READ
-			);
-
-			expect(Object.keys(actions).length).toEqual(1);
-			expect(Object.keys(actions).indexOf('View PDF file') >= 0).toEqual(true);
-			expect(Object.keys(actions).indexOf('Testdefault') <= 0).toEqual(true);
-		});
 	});
 	describe('action handler', function() {
 		var actionStub, $tr, clock;

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -2351,7 +2351,7 @@ describe('OCA.Files.FileList tests', function() {
 			expect(context.fileActions).toBeDefined();
 			expect(context.dir).toEqual('/subdir');
 		});
-		it('clicking on a file name will render the app drawer context menu if more than one action applies for this mime type', function() {
+		it('clicking on a file name will render the app drawer context menu if more than one action is default for this mime type', function() {
 			var actionStub = sinon.stub();
 			fileList.setFiles(testFiles);
 			fileList.fileActions.registerAction({
@@ -2375,6 +2375,7 @@ describe('OCA.Files.FileList tests', function() {
 			});
 
 			fileList.fileActions.setDefault('text/plain', 'View file');
+			fileList.fileActions.setDefault('text/plain', 'Edit file');
 			var $tr = fileList.findFileEl('One.txt');
 			$tr.find('td.filename .nametext').click();
 			expect(actionStub.calledOnce).toEqual(false);

--- a/apps/files_sharing/tests/js/appSpec.js
+++ b/apps/files_sharing/tests/js/appSpec.js
@@ -76,7 +76,7 @@ describe('OCA.Sharing.App tests', function() {
 				expect(fileActions.actions.all.Rename).toBeDefined();
 				expect(fileActions.actions.all.Download).toBeDefined();
 
-				expect(fileActions.defaults.dir).toEqual('Open');
+				expect(fileActions.defaults.dir).toEqual(['Open']);
 			});
 		});
 		it('provides custom file actions', function() {

--- a/apps/files_trashbin/tests/js/appSpec.js
+++ b/apps/files_trashbin/tests/js/appSpec.js
@@ -63,7 +63,7 @@ describe('OCA.Trashbin.App tests', function() {
 			expect(fileActions.actions.all.Rename).not.toBeDefined();
 			expect(fileActions.actions.all.Download).not.toBeDefined();
 
-			expect(fileActions.defaults.dir).toEqual('Open');
+			expect(fileActions.defaults.dir).toEqual(['Open']);
 		});
 	});
 });

--- a/changelog/unreleased/39541
+++ b/changelog/unreleased/39541
@@ -1,0 +1,10 @@
+Change: Allow setting multiple default file actions
+
+This change allows a mime type to have multiple default file actions. In the
+past, registering an action as default would overwrite existing defaults.
+
+In case multiple file actions apply to a mime type, clicking on a file will
+show the app drawer context menu.
+
+https://github.com/owncloud/core/pull/39541
+https://github.com/owncloud/enterprise/issues/4634


### PR DESCRIPTION
## Description
This change allows a mime type to have multiple default file actions. In the past, registering an action as default would overwrite existing defaults.

In case multiple file actions apply to a mime type, clicking on a file will show the app drawer context menu.

This approach allows apps to control where their actions will be displayed and is also more clean than the old and confusing `getActionsWithoutAll` method.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/4634
- Fixes https://github.com/ONLYOFFICE/onlyoffice-owncloud/issues/365

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4439
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
