### PR TITLE
[tests-only] [full-ci] Tests/version metadata continued

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -469,3 +469,42 @@ Feature: dav-versions
       | header              | value                                                                |
       | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
     And the downloaded content should be "uploaded content"
+
+
+  Scenario: enable file versioning and check the history of changes from multiple users
+    Given the administrator has enabled the file version storage feature
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "David" has been created with default attributes and without skeleton files
+    And user "Alice" creates folder "/test" using the WebDAV API
+    And user "Alice" shares folder "/test" with user "Brian" with permissions "all" using the sharing API
+    And user "Alice" shares folder "/test" with user "Carol" with permissions "all" using the sharing API
+    And user "Alice" shares folder "/test" with user "David" with permissions "all" using the sharing API
+    And user "Alice" has uploaded file with content "uploaded content alice" to "/test/textfile0.txt"
+    And user "Brian" has uploaded file with content "uploaded content brian" to "/test/textfile0.txt"
+    And user "Carol" has uploaded file with content "uploaded content carol" to "/test/textfile0.txt"
+    And user "David" has uploaded file with content "uploaded content david" to "/test/textfile0.txt"
+    When user "Alice" gets the number of versions of file "/test/textfile0.txt"
+    Then the number of versions should be "3"
+    When user "Alice" downloads the version of file "/test/textfile0.txt" with the index "1"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "uploaded content carol"
+    When user "Alice" downloads the version of file "test/textfile0.txt" with the index "2"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "uploaded content brian"
+    When user "Alice" downloads the version of file "test/textfile0.txt" with the index "3"
+    Then the HTTP status code should be "200"
+    And the following headers should be set
+      | header              | value                                                                |
+      | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
+    And the downloaded content should be "uploaded content alice"
+    When user "Alice" gets the version metadata of file "/test/textfile0.txt"
+    Then the author of the created version with index "1" should be "Carol"
+    And the author of the created version with index "2" should be "Brian"
+    And the author of the created version with index "3" should be "Alice"

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1148,6 +1148,8 @@ class FeatureContext extends BehatVariablesContext {
 		$this->response = $response;
 		//after a new response reset the response xml
 		$this->responseXml = [];
+		//after a new response reset the response xml object
+		$this->responseXmlObject = null;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -98,6 +98,37 @@ class FilesVersionsContext implements Context {
 	}
 
 	/**
+	 * @When user :user gets the version metadata of file :file
+	 *
+	 * @param string $user
+	 * @param string $file
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userGetsVersionMetadataOfFile(string $user, string $file):void {
+		$user = $this->featureContext->getActualUsername($user);
+		$fileId = $this->featureContext->getFileIdForPath($user, $file);
+		$body = '<?xml version="1.0"?>
+<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+  <d:prop>
+    <oc:meta-version-edited-by />
+    <oc:meta-version-edited-by-name />
+  </d:prop>
+</d:propfind>';
+		$response = $this->featureContext->makeDavRequest(
+			$user,
+			"PROPFIND",
+			$this->getVersionsPathForFileId($fileId),
+			null,
+			$body,
+			null,
+			'2'
+		);
+		$this->featureContext->setResponse($response);
+	}
+
+	/**
 	 * @When user :user restores version index :versionIndex of file :path using the WebDAV API
 	 * @Given user :user has restored version index :versionIndex of file :path
 	 *


### PR DESCRIPTION
## Description
This is on top of the code in PR #39516 "Version Metadata Continued"

I have adjusted "Scenario: enable file versioning and check the history of changes from multiple users" so that it expects the behavior that I think we want to have.

## Related Issue
Part of https://github.com/owncloud/enterprise/issues/4518
and #39504 
