### PR TITLE
[tests-only] Use when step for the test scenario with only Then steps.

### DIFF
--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -6,10 +6,10 @@ Feature: admin general settings
 
   Background:
     Given the administrator has changed their own email address to "admin@owncloud.com"
-    And the administrator has browsed to the admin general settings page
 
   @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: administrator sets email server settings
+    Given the administrator has browsed to the admin general settings page
     When the administrator sets the following email server settings using the webUI
       | setting                 | value          |
       | send mode               | smtp           |
@@ -28,12 +28,14 @@ Feature: admin general settings
 
   @smokeTest
   Scenario: administrator sets legal URLs
+    Given the administrator has browsed to the admin general settings page
     When the administrator sets the value of imprint url to "imprinturl.html" using the webUI
     And the administrator logs out of the webUI
     Then the imprint url on the login page should link to "imprinturl.html"
 
   @smokeTest
   Scenario: administrator sets legal URLs containing underscore
+    Given the administrator has browsed to the admin general settings page
     When the administrator sets the value of privacy policy url to "privacy_policy.html" using the webUI
     And the administrator logs out of the webUI
     Then the privacy policy url on the login page should link to "privacy_policy.html"
@@ -41,6 +43,7 @@ Feature: admin general settings
   @smokeTest @skipOnDockerContainerTesting
   Scenario: administrator sets update channel
     Given the administrator has invoked occ command "config:app:set core OC_Channel --value git"
+    And the administrator has browsed to the admin general settings page
     When the user reloads the current page of the webUI
     And the administrator sets the value of update channel to "daily" using the webUI
     Then the update channel should be "daily"
@@ -48,6 +51,7 @@ Feature: admin general settings
   @smokeTest @skipOnFIREFOX @skipOnDockerContainerTesting
   Scenario: administrator changes the cron job
     Given the administrator has invoked occ command "config:app:set core backgroundjobs_mode --value ajax"
+    And the administrator has browsed to the admin general settings page
     When the user reloads the current page of the webUI
     And the administrator sets the value of cron job to "webcron" using the webUI
     Then the background jobs mode should be "webcron"
@@ -55,10 +59,12 @@ Feature: admin general settings
   @smokeTest @skipOnDockerContainerTesting
   Scenario: administrator changes the log level
     Given the administrator has invoked occ command "config:system:set loglevel --value 0"
+    And the administrator has browsed to the admin general settings page
     When the user reloads the current page of the webUI
     And the administrator sets the value of log level to 1 using the webUI
     Then the log level should be "1"
 
   Scenario: administrator should be able to see system status
+    When the administrator browses to the admin general settings page
     Then the version of the owncloud installation should be displayed on the admin general settings page
     And the version string of the owncloud installation should be displayed on the admin general settings page


### PR DESCRIPTION
## Description
A scenario in `adminGeneralSettings.feature`

> Scenario: administrator should be able to see system status

does not have any when step. A proper e2e test case should not only have `Given` and `Then`.

- In the scenario, the admin user expects to see owncloud detail after browsing to the settings page. So, the browsing step can be used as the `when` step here.


## Related Issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
