### PR TITLE
[tests-only]Fixed flaky test detected in files_classifiers

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLinkOc10Issue37683.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLinkOc10Issue37683.feature
@@ -18,8 +18,8 @@ Feature: copying from public link share
     And as "Alice" folder "/PARENT/testFolder" should exist
     And as "Alice" folder "/PARENT/copy1.txt" should exist
     And as "Alice" file "/PARENT/copy1.txt/testfile.txt" should exist
-    And the content of file "/PARENT/testFolder/testfile.txt" for user "Alice" should be "some data"
     And the content of file "/PARENT/copy1.txt/testfile.txt" for user "Alice" should be "some data"
+    And the content of file "/PARENT/testFolder/testfile.txt" for user "Alice" should be "some data"
 
   @issue-ocis-reva-373 @issue-37683
   Scenario: Copy file within a public link folder to a file with name same as an existing folder


### PR DESCRIPTION
## Description
after some [debugging](https://github.com/owncloud/files_classifier/pull/561) the test scenario apiSharePublicLink2/copyFromPublicLinkOc10Issue37683.feature:9 that was failing in files_classifiers is turned out to be order dependent. And we can make the test pass by swapping the steps to check content in original and copied file.

## Related Issue
- Fixes https://github.com/owncloud/files_classifier/issues/537
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 🤖 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
