### PR TITLE
Fix so that a null appconfig value is treated as an empty string

### DIFF
--- a/changelog/unreleased/39554
+++ b/changelog/unreleased/39554
@@ -1,0 +1,6 @@
+Bugfix: An app config value of null could not be updated
+
+An app config value that is set to null can now be updated to a not-null value,
+for example, with the occ config:app:set command.
+
+https://github.com/owncloud/core/pull/39554

--- a/changelog/unreleased/39554
+++ b/changelog/unreleased/39554
@@ -1,6 +1,6 @@
-Bugfix: An app config value of null could not be updated
+Bugfix: An app config value of null could be entered but not updated
 
-An app config value that is set to null can now be updated to a not-null value,
-for example, with the occ config:app:set command.
+An app config value now cannot be set to null. Any existing null values are
+now treated as the empty string.
 
 https://github.com/owncloud/core/pull/39554

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -150,6 +150,10 @@ class AppConfig implements IAppConfig {
 	 * @return bool True if the value was inserted or updated, false if the value was the same
 	 */
 	public function setValue($app, $key, $value) {
+		if ($value === null) {
+			$value = '';
+		}
+
 		return $this->emittingCall(function (&$afterArray) use (&$app, &$key, &$value) {
 			if (!$this->hasKey($app, $key)) {
 				$inserted = (bool) $this->conn->insertIfNotExist('*PREFIX*appconfig', [
@@ -185,7 +189,7 @@ class AppConfig implements IAppConfig {
 			 * http://docs.oracle.com/cd/E11882_01/server.112/e26088/conditions002.htm#i1033286
 			 * > Large objects (LOBs) are not supported in comparison conditions.
 			 */
-			if (!($this->conn instanceof \OC\DB\OracleConnection) && ($value !== null)) {
+			if (!($this->conn instanceof \OC\DB\OracleConnection)) {
 				// Only update the value if:
 				// - it is not the same as the value currently in the database, or
 				// - the value in the database is currently NULL
@@ -321,7 +325,7 @@ class AppConfig implements IAppConfig {
 			) {
 				$row['configvalue'] = '0.0.1';
 			}
-			$this->cache[$row['appid']][$row['configkey']] = $row['configvalue'];
+			$this->cache[$row['appid']][$row['configkey']] = ($row['configvalue'] === null) ? '' : $row['configvalue'];
 		}
 		$result->closeCursor();
 

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -241,30 +241,55 @@ class AppConfigTest extends TestCase {
 		$this->assertConfigKey('testapp', 'installed_version', '1.33.7');
 	}
 
-	public function dataSetValueUpdateEmptyValues() {
+	public function dataSetValue() {
 		return [
 			[null, ''],
-			[null, 'non-empty'],
-			['', null],
+			['', ''],
+			['non-empty', 'non-empty'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataSetValue
+	 * @param string|null $inputValue
+	 * @param string|null $returnedValue
+	 */
+	public function testSetValue($inputValue, $returnedValue) {
+		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+
+		$config->setValue('someapp', 'somekey', $inputValue);
+		$this->assertSame(
+			$returnedValue,
+			$config->getValue('someapp', 'somekey', $returnedValue)
+		);
+	}
+
+	public function dataSetValueUpdateValues() {
+		return [
 			['', 'non-empty'],
 			['non-empty', ''],
-			['non-empty', null],
 			['non-empty', 'different-non-empty-string'],
 		];
 	}
 
 	/**
-	 * @dataProvider dataSetValueUpdateEmptyValues
+	 * @dataProvider dataSetValueUpdateValues
 	 * @param string|null $firstValue
 	 * @param string|null $updatedValue
 	 */
-	public function testSetValueUpdateEmptyValues($firstValue, $updatedValue) {
+	public function testSetValueUpdateValues($firstValue, $updatedValue) {
 		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
 
 		$config->setValue('someapp', 'somekey', $firstValue);
-		$this->assertConfigKey('someapp', 'somekey', $firstValue);
+		$this->assertSame(
+			$firstValue,
+			$config->getValue('someapp', 'somekey', $firstValue)
+		);
 		$config->setValue('someapp', 'somekey', $updatedValue);
-		$this->assertConfigKey('someapp', 'somekey', $updatedValue);
+		$this->assertSame(
+			$updatedValue,
+			$config->getValue('someapp', 'somekey', $updatedValue)
+		);
 	}
 
 	public function testSetValueInsert() {

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -239,9 +239,32 @@ class AppConfigTest extends TestCase {
 
 		$this->assertEquals('1.33.7', $config->getValue('testapp', 'installed_version'));
 		$this->assertConfigKey('testapp', 'installed_version', '1.33.7');
+	}
 
-		$config->setValue('someapp', 'somekey', 'somevalue');
-		$this->assertConfigKey('someapp', 'somekey', 'somevalue');
+	public function dataSetValueUpdateEmptyValues() {
+		return [
+			[null, ''],
+			[null, 'non-empty'],
+			['', null],
+			['', 'non-empty'],
+			['non-empty', ''],
+			['non-empty', null],
+			['non-empty', 'different-non-empty-string'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataSetValueUpdateEmptyValues
+	 * @param string|null $firstValue
+	 * @param string|null $updatedValue
+	 */
+	public function testSetValueUpdateEmptyValues($firstValue, $updatedValue) {
+		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+
+		$config->setValue('someapp', 'somekey', $firstValue);
+		$this->assertConfigKey('someapp', 'somekey', $firstValue);
+		$config->setValue('someapp', 'somekey', $updatedValue);
+		$this->assertConfigKey('someapp', 'somekey', $updatedValue);
 	}
 
 	public function testSetValueInsert() {
@@ -456,6 +479,6 @@ class AppConfigTest extends TestCase {
 		$actual = $query->fetch();
 		$query->closeCursor();
 
-		$this->assertEquals($expected, $actual['configvalue']);
+		$this->assertSame($expected, $actual['configvalue']);
 	}
 }


### PR DESCRIPTION
## Description
If an app config key has been set to value NULL then make sure to allow it to be updated to some other value (empty string, or some string...)

This fixes the SQL logic that updates values in the `appconfig` table. The database has already been able to store the value NULL. This PR does not change that ability. The PR makes changing the value to and from NULL work correctly.

https://stackoverflow.com/questions/16186674/mysql-syntax-not-evaluating-not-equal-to-in-presence-of-null has some information about how the database handles this sort of thing.

## Related Issue
- Fixes #39553 

## How Has This Been Tested?
```
$ php occ config:list someapp
{
    "apps": {
        "someapp": []
    }
}
$ php occ config:app:set someapp somename
Config value somename for app someapp set to 
$ php occ config:list someapp
{
    "apps": {
        "someapp": {
            "somename": null
        }
    }
}
$ php occ config:app:set someapp somename --value "somevalue"
Config value somename for app someapp set to somevalue
$ php occ config:list someapp
{
    "apps": {
        "someapp": {
            "somename": "somevalue"
        }
    }
}
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
