### PR TITLE
Fix x-icon position in select2 search fields

### DIFF
--- a/changelog/unreleased/39146
+++ b/changelog/unreleased/39146
@@ -7,3 +7,4 @@ This PR add small CSS fixes to the Tags selection dialogue:
 
 https://github.com/owncloud/core/pull/39146
 https://github.com/owncloud/core/pull/39517
+https://github.com/owncloud/core/pull/39563

--- a/core/css/share.css
+++ b/core/css/share.css
@@ -303,5 +303,9 @@ a.toggleShareDetails:hover {
 }
 
 .select2-container-multi .select2-choices .select2-search-choice {
+	padding: 3px 18px 3px 5px;
+}
+
+.systemTagsInputFieldContainer .select2-container-multi .select2-choices .select2-search-choice {
 	padding: .2em 0.6em;
 }


### PR DESCRIPTION
## Description
This was a regression introduced by https://github.com/owncloud/core/pull/39146. The original padding has been restored.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39559

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/50302941/144879714-48568a7c-73ed-43b6-b16a-0e760705fe9f.png)

![image](https://user-images.githubusercontent.com/50302941/144879744-4d015c13-9682-4fb0-968e-0a7742cecbab.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
