### PR TITLE
Fix directory name in error message when file name already exists

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2437,7 +2437,7 @@
 										t('files', 'The name "{targetName}" is already used in the folder "{dir}". Please choose a different name.',
 										{
 											targetName: newName,
-											dir: self.getCurrentDirectory(),
+											dir: path,
 										}),
 										{
 											type: 'error'

--- a/changelog/unreleased/39569
+++ b/changelog/unreleased/39569
@@ -1,0 +1,7 @@
+Bugfix: Directory name in error message when file name already exists
+
+This fixes an issue where the wrong directory name was shown when trying to
+rename a file to a name that already exists in the same directory.
+
+https://github.com/owncloud/core/pull/39569
+https://github.com/owncloud/core/issues/39552


### PR DESCRIPTION
## Description
This fixes an issue where the wrong directory name was shown when trying to rename a file to a name that already exists in the same directory.

## Related Issue
- Fixes https://github.com/owncloud/core/issues/39552

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
