### PR TITLE
Do not allow htaccesstest.txt as a username

### DIFF
--- a/changelog/unreleased/39570
+++ b/changelog/unreleased/39570
@@ -1,0 +1,7 @@
+Bugfix: Prohibit username htaccesstest.txt
+
+htaccesstest.txt is a special file that can be in the data directory.
+That is not allowed as a username.
+
+https://github.com/owncloud/core/pull/39572
+https://github.com/owncloud/core/issues/39570

--- a/lib/public/User/Constants.php
+++ b/lib/public/User/Constants.php
@@ -55,6 +55,7 @@ class Constants {
 	public const FILES_THAT_ARE_NOT_USERS = [
 		'.htaccess',
 		'.ocdata',
+		'htaccesstest.txt',
 		'owncloud.db',
 		'owncloud.log',
 		'index.html'


### PR DESCRIPTION
## Description
See title and issue.

## Related Issue
- Fixes #39570 

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
