### PR TITLE
Process null app config value

### DIFF
--- a/changelog/unreleased/39554
+++ b/changelog/unreleased/39554
@@ -1,0 +1,6 @@
+Bugfix: An app config value of null could not be updated
+
+An app config value that is set to null can now be updated to a not-null value,
+for example, with the occ config:app:set command.
+
+https://github.com/owncloud/core/pull/39554

--- a/changelog/unreleased/39574
+++ b/changelog/unreleased/39574
@@ -3,4 +3,5 @@ Bugfix: An app config value of null could not be updated
 An app config value that is set to null can now be updated to a not-null value,
 for example, with the occ config:app:set command.
 
-https://github.com/owncloud/core/pull/39554
+https://github.com/owncloud/core/pull/39574
+https://github.com/owncloud/core/issues/39553

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -239,9 +239,32 @@ class AppConfigTest extends TestCase {
 
 		$this->assertEquals('1.33.7', $config->getValue('testapp', 'installed_version'));
 		$this->assertConfigKey('testapp', 'installed_version', '1.33.7');
+	}
 
-		$config->setValue('someapp', 'somekey', 'somevalue');
-		$this->assertConfigKey('someapp', 'somekey', 'somevalue');
+	public function dataSetValueUpdateEmptyValues() {
+		return [
+			[null, ''],
+			[null, 'non-empty'],
+			['', null],
+			['', 'non-empty'],
+			['non-empty', ''],
+			['non-empty', null],
+			['non-empty', 'different-non-empty-string'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataSetValueUpdateEmptyValues
+	 * @param string|null $firstValue
+	 * @param string|null $updatedValue
+	 */
+	public function testSetValueUpdateEmptyValues($firstValue, $updatedValue) {
+		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+
+		$config->setValue('someapp', 'somekey', $firstValue);
+		$this->assertConfigKey('someapp', 'somekey', $firstValue);
+		$config->setValue('someapp', 'somekey', $updatedValue);
+		$this->assertConfigKey('someapp', 'somekey', $updatedValue);
 	}
 
 	public function testSetValueInsert() {
@@ -456,6 +479,6 @@ class AppConfigTest extends TestCase {
 		$actual = $query->fetch();
 		$query->closeCursor();
 
-		$this->assertEquals($expected, $actual['configvalue']);
+		$this->assertSame($expected, $actual['configvalue']);
 	}
 }


### PR DESCRIPTION
## Description
An app config value that is set to null can now be updated to a not-null value, for example, with the occ config:app:set command.

Note: when Oracle stores an app config value of the empty string '' it actually stores `null` and returns `null`. Trying to update the value from `null` to the empty string in Oracle results in no-change. I expanded the unit tests so that they demonstrate this difference.

This PR is an alternative to #39554 - which changes the interface to set/get config values so that `null` is not an available setting, and any current uses of `null` become the empty string.

"someone"  (tm) needs to decide which PR to approve.

## Related Issue
- Fixes #39553 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
