### PR TITLE
Use ViewOnlyPlugin when requesting a meta endpoint using WebDAV v2

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -224,7 +224,7 @@ class Server {
 			OC::$server->getLazyRootFolder()
 		));
 
-		if ($this->isRequestForSubtree(['files', 'trash-bin', 'public-files'])) {
+		if ($this->isRequestForSubtree(['files', 'meta', 'trash-bin', 'public-files'])) {
 			\Sabre\DAV\Server::$streamMultiStatus = true;
 			$this->server->addPlugin(new ViewOnlyPlugin(
 				OC::$server->getLogger()

--- a/changelog/unreleased/39575
+++ b/changelog/unreleased/39575
@@ -1,0 +1,7 @@
+Bugfix: Use ViewOnlyPlugin when requesting a meta endpoint using WebDAV v2
+
+This fixes issues where shared files were downloadable despite missing
+permissions, e.g. when shared via secure view.
+
+https://github.com/owncloud/core/pull/39575
+https://github.com/owncloud/enterprise/issues/4916

--- a/changelog/unreleased/39575
+++ b/changelog/unreleased/39575
@@ -1,7 +1,7 @@
 Bugfix: Use ViewOnlyPlugin when requesting a meta endpoint using WebDAV v2
 
-This fixes issues where shared files were downloadable despite missing
-permissions, e.g. when shared via secure view.
+This fixes an issue where versions of shared files were downloadable using the
+new WebDAV API despite missing permissions, e.g. when shared via secure view.
 
 https://github.com/owncloud/core/pull/39575
 https://github.com/owncloud/enterprise/issues/4916


### PR DESCRIPTION
## Description
This fixes an issue where versions of shared files were downloadable using the new WebDAV API despite missing permissions, e.g. when shared via secure view.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/enterprise/issues/4916

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
