### PR TITLE
[10.9.0] Change remote to federated in text strings

### DIFF
--- a/apps/files_sharing/lib/Activity.php
+++ b/apps/files_sharing/lib/Activity.php
@@ -312,9 +312,9 @@ class Activity implements IExtension {
 			case self::SUBJECT_REMOTE_SHARE_RECEIVED:
 				if (\sizeof($params) > 1) {
 					// New activity ownCloud 8.2+
-					return (string) $l->t('Received remote share from %1$s', $params);
+					return (string) $l->t('Received federated share from %1$s', $params);
 				}
-				return (string) $l->t('Received remote share from %s', $params);
+				return (string) $l->t('Received federated share from %s', $params);
 
 			default:
 				return false;

--- a/changelog/unreleased/38877
+++ b/changelog/unreleased/38877
@@ -6,5 +6,6 @@ shares in error messages and on the user interface have been changed to
 references to federated shares. All user-facing text now calls these federated
 shares.
 
+https://github.com/owncloud/core/pull/39578
 https://github.com/owncloud/core/pull/38877
 https://github.com/owncloud/core/issues/38871

--- a/changelog/unreleased/39411
+++ b/changelog/unreleased/39411
@@ -1,8 +1,8 @@
-Bugfix: Faulty file list entry after accepting a remote share
+Bugfix: Faulty file list entry after accepting a federated share
 
 With this change, we reload the shared with you file list if the user accepts
 or declines a share.
-This solves the issue after accepting a remote share the table record was not
+This solves the issue after accepting a federated share the table record was not
 pointing to the correct location.
 
 https://github.com/owncloud/core/pull/39411


### PR DESCRIPTION
## Description
Changes 2 more "remote share" to "federated share" in user-facing strings.

## Related Issue
- Fixes #38871 

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
