### PR TITLE
Add user:home:list-dirs and user:home:list-users commands

### DIFF
--- a/changelog/unreleased/39579
+++ b/changelog/unreleased/39579
@@ -1,0 +1,9 @@
+Enhancement: Add user:home:list-dirs and user:home:list-users commands
+
+Added two new users commands:
+
+* `occ user:home:list-dirs` List all homes which are currently used by users
+* `occ user:home:list-users <path>` List all users who have their home in a given path
+
+https://github.com/owncloud/core/pull/39579
+https://github.com/owncloud/core/issues/39502

--- a/core/Command/User/HomeListDirs.php
+++ b/core/Command/User/HomeListDirs.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Command\User;
+
+use OC\Core\Command\Base;
+use OCP\IUserManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class HomeListDirs extends Base {
+	/** @var \OCP\IUserManager */
+	protected $userManager;
+
+	/**
+	 * @param IUserManager $userManager
+	 */
+	public function __construct(IUserManager $userManager) {
+		parent::__construct();
+		$this->userManager = $userManager;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('user:home:list-dirs')
+			->setDescription('List all available user home directories that are currently in use');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$users = $this->userManager->search(null);
+		$homePaths = [];
+		foreach ($users as $user) {
+			$home = $user->getHome();
+			// Strip away the UID at the end of the path
+			$strippedHome = substr($home, 0, strrpos($home, '/'));
+			if (!\in_array($strippedHome, $homePaths)) {
+				$homePaths[] = $strippedHome;
+			}
+		}
+
+		parent::writeArrayInOutputFormat($input, $output, \array_unique($homePaths), self::DEFAULT_OUTPUT_PREFIX);
+		return 0;
+	}
+}

--- a/core/Command/User/HomeListDirs.php
+++ b/core/Command/User/HomeListDirs.php
@@ -43,7 +43,7 @@ class HomeListDirs extends Base {
 
 		$this
 			->setName('user:home:list-dirs')
-			->setDescription('List all available user home directories that are currently in use');
+			->setDescription('List all available root directories for user homes that are currently in use');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -165,6 +165,8 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\Inactive(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\ListUsers(\OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\User\HomeListDirs(\OC::$server->getUserManager()));
+	$application->add(new OC\Core\Command\User\HomeListUsers(\OC::$server->getDatabaseConnection()));
 	$application->add(new OC\Core\Command\User\ListUserGroups(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Report(\OC::$server->getUserManager(), new UserTypeHelper()));
 	$application->add(new OC\Core\Command\User\ResetPassword(

--- a/tests/Core/Command/User/HomeListDirsTest.php
+++ b/tests/Core/Command/User/HomeListDirsTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\User;
+
+use OC\Core\Command\User\HomeListDirs;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class HomeListDirsTest
+ */
+class HomeListDirsTest extends TestCase {
+	/** @var CommandTester */
+	private $commandTester;
+
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
+	private $userManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$command = new HomeListDirs($this->userManager);
+		$this->commandTester = new CommandTester($command);
+	}
+
+	public function testCommandInput() {
+		$homePath = '/path/to/homes';
+		$user1Mock = $this->createMock(IUser::class);
+		$user1Mock->method('getHome')->willReturn("$homePath/user1");
+		$user2Mock = $this->createMock(IUser::class);
+		$user2Mock->method('getHome')->willReturn("$homePath/user2");
+
+		$this->userManager->method('search')->willReturn([$user1Mock, $user2Mock]);
+		$this->commandTester->execute([]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertStringContainsString($homePath, $output);
+	}
+}

--- a/tests/Core/Command/User/HomeListUsersTest.php
+++ b/tests/Core/Command/User/HomeListUsersTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author Jannik Stehle <jstehle@owncloud.com>
+ *
+ * @copyright Copyright (c) 2021, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Core\Command\User;
+
+use Doctrine\DBAL\ForwardCompatibility\DriverStatement;
+use OC\Core\Command\User\HomeListUsers;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class HomeListUsersTest
+ *
+ * @group DB
+ */
+class HomeListUsersTest extends TestCase {
+	/** @var CommandTester */
+	private $commandTester;
+
+	/** @var IDBConnection | \PHPUnit\Framework\MockObject\MockObject */
+	private $connection;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->connection = $this->getMockBuilder('\OC\DB\Connection')
+			->disableOriginalConstructor()
+			->getMock();
+		$command = new HomeListUsers($this->connection);
+		$this->commandTester = new CommandTester($command);
+	}
+
+	public function testCommandInput() {
+		$homePath = '/path/to/homes';
+		$uid = 'user1';
+
+		$resultMock = $this->createMock(DriverStatement::class);
+		$resultMock->method('fetch')->willReturnOnConsecutiveCalls(['user_id' => $uid], false);
+		$queryMock = $this->getMockBuilder('\OC\DB\QueryBuilder\QueryBuilder')
+			->setConstructorArgs([$this->connection])
+			->setMethods(['execute'])
+			->getMock();
+		$queryMock->method('execute')->willReturn($resultMock);
+		$this->connection->method('getQueryBuilder')->willReturn($queryMock);
+
+		$this->commandTester->execute(['path' => $homePath]);
+		$output = $this->commandTester->getDisplay();
+		$this->assertStringContainsString($uid, $output);
+	}
+}


### PR DESCRIPTION
## Description
Implement two new users commands:

* `occ user:home:list-dirs` List all homes which are currently used by users
* `occ user:home:list-users <path>` List all users who have their home in a given path

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39502

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4492 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
