### PR TITLE
[10.9.0] occ user:home:list-users --all command

### DIFF
--- a/changelog/10.9.0_2021-12-09/39579
+++ b/changelog/10.9.0_2021-12-09/39579
@@ -4,6 +4,8 @@ Added two new users commands:
 
 * `occ user:home:list-dirs` List all homes which are currently used by users
 * `occ user:home:list-users <path>` List all users who have their home in a given path
+* `occ user:home:list-users --all` List all users for every home path
 
 https://github.com/owncloud/core/pull/39579
+https://github.com/owncloud/core/pull/39583
 https://github.com/owncloud/core/issues/39502

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -166,7 +166,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\User\LastSeen(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\ListUsers(\OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\HomeListDirs(\OC::$server->getUserManager()));
-	$application->add(new OC\Core\Command\User\HomeListUsers(\OC::$server->getDatabaseConnection()));
+	$application->add(new OC\Core\Command\User\HomeListUsers(\OC::$server->getDatabaseConnection(), \OC::$server->getUserManager()));
 	$application->add(new OC\Core\Command\User\ListUserGroups(\OC::$server->getUserManager(), \OC::$server->getGroupManager()));
 	$application->add(new OC\Core\Command\User\Report(\OC::$server->getUserManager(), new UserTypeHelper()));
 	$application->add(new OC\Core\Command\User\ResetPassword(


### PR DESCRIPTION
## Description
Docs PR https://github.com/owncloud/docs/pull/4499 has a command that puts together the `occ user:home:list-dirs` and `occ user:home:list-users` commands to generate a list of users for each different home path in the system.

```
occ user:home:list-dirs | \
  sed -e 's/  - //' | tr '\n' '\0' | xargs -0 -t -n 1 \
  occ user:home:list-users
occ user:home:list-users /mnt/newhome_1 
  - lisa
occ user:home:list-users /var/www/owncloud/data 
  - admin
  - user01
```

That looks like "magic" and actually we can quite easily do that in the existing `occ user:home:list-users` command.

Instead of only being able to match a single path, this PR enhances the command so that it has a `--all` option. If `--all` is specified, then the command lists every home path, with the users that are in each home path.

An alternative would be to add an option to `occ user:home:list-dirs` to list all the users in each of the home paths.

## Related Issue

#39502 

## How Has This Been Tested?
CI unit tests and local run of occ command:
```
$ php occ user:home:list-users --all
  - /home/phil/git/owncloud/core/data:
    - admin
    - uu1
    - uu2
    - uu3
    - uu4
    - uu5
``` 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
