### PR TITLE
Show explicit error message while moving a mount point into another m…

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -488,7 +488,13 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 			}
 
 			$renameOkay = $this->fileView->rename($sourcePath, $destinationPath);
+
 			if (!$renameOkay) {
+				list($targetStorage, $targetInternalPath) = \OC\Files\Filesystem::resolvePath($destinationPath);
+				if ($isMovableMount === true && $targetStorage->instanceOfStorage('\OCP\Files\IHomeStorage') !== true) {
+					throw new SabreForbidden('It is not allowed to move one mount point into another one');
+				}
+
 				throw new SabreForbidden('There was an error while renaming the file or directory');
 			}
 		} catch (StorageNotAvailableException $e) {

--- a/changelog/unreleased/39584
+++ b/changelog/unreleased/39584
@@ -1,0 +1,9 @@
+Enhancement: Show detailed error message if moving a mount into another fails
+
+With this change, a detailed error message is shown when moving a mount point
+into another mount point fails.
+This is for example the case while moving a shared folder into a SFTP
+external storage.
+
+https://github.com/owncloud/core/pull/39584
+https://github.com/owncloud/core/issues/39550

--- a/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
+++ b/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
@@ -375,7 +375,7 @@ Feature: using files external service with storage as webdav_owncloud
     # File should not be moved but here the file is moved to mount storage
     But as "Brian" file "TestMountPoint/test.txt" should exist
 
-  @issue-39550
+
   Scenario: share receiver tries to move a folder that they have received from someone, to external storage
     Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
@@ -390,16 +390,10 @@ Feature: using files external service with storage as webdav_owncloud
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "testFolder"
     And user "Brian" has shared folder "/testFolder" with user "Carol"
-    When user "Brian" moves folder "/testFolder" to "TestMountPoint/testFolder" using the WebDAV API
-    Then the HTTP status code should be "500"
-    # Uncomment the following line after the issue has been fixed
-    # Then the HTTP status code should be "403"
-    # Remove the following line after the issue has been fixed
-    And the HTTP response message should be "You are not allowed to share /Brian/files/TestMountPoint/testFolder"
-    # Uncomment the following line after the issue has been fixed
-    # And the HTTP response message should be "It is not allowed to move one mount point into another one"
+    When user "Carol" moves folder "/testFolder" to "TestMountPoint/testFolder" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And the HTTP response message should be "It is not allowed to move one mount point into another one"
 
-  @issue-39550
   Scenario: share receiver tries to move a file that they have received from someone, to external storage
     Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
@@ -414,11 +408,6 @@ Feature: using files external service with storage as webdav_owncloud
     And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has uploaded file with content "Test content for moving file." to "test.txt"
     And user "Brian" has shared file "test.txt" with user "Carol"
-    When user "Brian" moves file "/test.txt" to "TestMountPoint/test.txt" using the WebDAV API
-    Then the HTTP status code should be "500"
-    # Uncomment the following line after the issue has been fixed
-    # Then the HTTP status code should be "403"
-    # Remove the following line after the issue has been fixed
-    And the HTTP response message should be "You are not allowed to share /Brian/files/TestMountPoint/test.txt"
-    # Uncomment the following line after the issue has been fixed
-    # And the HTTP response message should be "It is not allowed to move one mount point into another one"
+    When user "Carol" moves file "/test.txt" to "TestMountPoint/test.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And the HTTP response message should be "It is not allowed to move one mount point into another one"


### PR DESCRIPTION
Enhancement: Show detailed error message if moving a mount into another fails

With this change, a detailed error message is shown when moving a mount point
into another mount point fails.
This is for example the case while moving a shared folder into a SFTP
external storage.
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39550

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
