### PR TITLE
[10.9.0] Return all quota fields in Provisioning API get-user requests

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -218,7 +218,7 @@ class Users {
 		}
 
 		// Find the data
-		$data['quota'] = $this->fillStorageInfo($userId);
+		$data['quota'] = $this->fillStorageInfo($targetUserObject->getUID());
 		$data['quota']['definition'] = $targetUserObject->getQuota();
 		$data['email'] = $targetUserObject->getEMailAddress();
 		$data['displayname'] = $targetUserObject->getDisplayName();

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -723,6 +723,10 @@ class UsersTest extends OriginalTest {
 			->will($this->returnValue(['DummyValue']));
 		$targetUser
 			->expects($this->once())
+			->method('getUID')
+			->will($this->returnValue('UserToGet'));
+		$targetUser
+			->expects($this->once())
 			->method('getDisplayName')
 			->will($this->returnValue('Demo User'));
 		$targetUser
@@ -797,6 +801,10 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('getDisplayName')
 			->will($this->returnValue('Demo User'));
+		$targetUser
+			->expects($this->once())
+			->method('getUID')
+			->will($this->returnValue('UserToGet'));
 		$targetUser
 			->expects($this->once())
 			->method('isEnabled')
@@ -903,6 +911,10 @@ class UsersTest extends OriginalTest {
 			->expects($this->once())
 			->method('getDisplayName')
 			->will($this->returnValue('Subadmin User'));
+		$targetUser
+			->expects($this->once())
+			->method('getUID')
+			->will($this->returnValue('subadmin'));
 		$targetUser
 			->expects($this->once())
 			->method('getEMailAddress')

--- a/changelog/10.9.0_2021-12-09/39577
+++ b/changelog/10.9.0_2021-12-09/39577
@@ -1,0 +1,7 @@
+Bugfix: Provisioning API quota is incomplete when username casing is not exact
+
+The Provisioning API now returns all the quota information for a user even when
+the username casing is different in the API request.
+
+https://github.com/owncloud/core/pull/39586
+https://github.com/owncloud/core/issues/39577

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -17,6 +17,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -30,6 +31,7 @@ Feature: get user
     And the display name returned by the API should be "<displayname>"
     And the email address returned by the API should be "<email>"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
     Examples:
       | username | displayname  | email               |
@@ -46,6 +48,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
 
@@ -69,6 +72,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS
@@ -105,6 +109,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -117,6 +122,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -129,6 +135,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -141,6 +148,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -153,6 +161,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -166,6 +175,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Admin Alice"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -183,6 +193,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Regular User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -17,6 +17,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -30,6 +31,7 @@ Feature: get user
     And the display name returned by the API should be "<displayname>"
     And the email address returned by the API should be "<email>"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
     Examples:
       | username | displayname  | email               |
@@ -46,6 +48,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Brand New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
 
@@ -69,6 +72,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS
@@ -105,6 +109,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -117,6 +122,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -129,6 +135,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -141,6 +148,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -153,6 +161,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -166,6 +175,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Admin Alice"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -183,6 +193,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the display name returned by the API should be "Regular User"
     And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
   @notToImplementOnOCIS

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -4883,6 +4883,47 @@ trait Provisioning {
 	}
 
 	/**
+	 * @Then /^the free, used, total and relative quota returned by the API should exist and be valid numbers$/
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theQuotaFieldsReturnedByTheApiShouldBValid():void {
+		$quotaData = $this->getResponseXml(null, __METHOD__)->data[0]->quota;
+		$missingQuotaDataString = "";
+		if (!isset($quotaData->free)) {
+			$missingQuotaDataString .= "free ";
+		}
+		if (!isset($quotaData->used)) {
+			$missingQuotaDataString .= "used ";
+		}
+		if (!isset($quotaData->total)) {
+			$missingQuotaDataString .= "total ";
+		}
+		if (!isset($quotaData->relative)) {
+			$missingQuotaDataString .= "relative ";
+		}
+		Assert::assertSame(
+			"",
+			$missingQuotaDataString,
+			"These quota data items are missing: $missingQuotaDataString"
+		);
+		$freeQuota = (string) $quotaData->free;
+		Assert::assertIsNumeric($freeQuota, "free quota '$freeQuota' is not numeric");
+		$usedQuota = (string) $quotaData->used;
+		Assert::assertIsNumeric($usedQuota, "used quota '$usedQuota' is not numeric");
+		$totalQuota = (string) $quotaData->total;
+		Assert::assertIsNumeric($totalQuota, "total quota '$totalQuota' is not numeric");
+		$relativeQuota = (string) $quotaData->relative;
+		Assert::assertIsNumeric($relativeQuota, "free quota '$relativeQuota' is not numeric");
+		Assert::assertSame(
+			(int) $freeQuota + (int) $usedQuota,
+			(int) $totalQuota,
+			"free $freeQuota plus used $usedQuota quota is not equal to total quota $totalQuota"
+		);
+	}
+
+	/**
 	 * @Then /^the quota definition returned by the API should be "([^"]*)"$/
 	 *
 	 * @param string $expectedQuotaDefinition a string that describes the quota


### PR DESCRIPTION
## Description
Pass the exact actual username to `fillStorageInfo` so that it will find the storage and calculate the quota fields, even if the username in the incoming API request has different case.

## Related Issue
- Fixes #39577 

## How Has This Been Tested?
Acceptance tests. Without the code change, these tests scenarios fail for me locally:
```
--- Failed scenarios:

    /home/phil/git/owncloud/core/tests/acceptance/features/apiProvisioning-v1/getUser.feature:42
    /home/phil/git/owncloud/core/tests/acceptance/features/apiProvisioning-v1/getUser.feature:129
    /home/phil/git/owncloud/core/tests/acceptance/features/apiProvisioning-v1/getUser.feature:142

--- Failed scenarios:

    /home/phil/git/owncloud/core/tests/acceptance/features/apiProvisioning-v2/getUser.feature:42
    /home/phil/git/owncloud/core/tests/acceptance/features/apiProvisioning-v2/getUser.feature:129
    /home/phil/git/owncloud/core/tests/acceptance/features/apiProvisioning-v2/getUser.feature:142
```

With the back-end code change, the tests all pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
