### PR TITLE
[tests-only] Add spaces as a new WebDAV url type

### DIFF
--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -26,6 +26,11 @@ Feature: upload file
       | old         | /s,a,m,p,l,e.txt  |
       | new         | /s,a,m,p,l,e.txt  |
 
+    @skipOnOcV10
+    Examples:
+      | dav_version | file_name   |
+      | spaces      | /upload.txt |
+
 
   Scenario Outline: upload a file and check download content
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2529,6 +2529,31 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * fetches personal space id for provided user
+	 *
+	 * @param string $user
+	 * @param string|null $password
+	 *
+	 * @return mixed
+	 * @throws GuzzleException
+	 */
+	public function getPersonalSpaceIdForUser(string $user, string $password = null):string {
+		$fullUrl = $this->getBaseUrl() . '/graph/v1.0/me/drives';
+		if (!$password) {
+			$password = $this->getPasswordForUser($user);
+		}
+		$response = HttpRequestHelper::get(
+			$fullUrl,
+			$this->getStepLineRef(),
+			$user,
+			$password
+		);
+		$json = \json_decode($response->getBody()->getContents());
+		// assuming the first space is the personal space
+		return $json->value[0]->id;
+	}
+
+	/**
 	 * @Then the json responded should match with
 	 *
 	 * @param PyStringNode $jsonExpected

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -22,6 +22,7 @@
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Ring\Exception\ConnectException;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
@@ -48,6 +49,11 @@ trait WebDav {
 	 * @var boolean
 	 */
 	private $usingOldDavPath = true;
+
+	/**
+	 * @var boolean
+	 */
+	private $usingSpacesDavPath = false;
 
 	/**
 	 * @var ResponseInterface[]
@@ -211,17 +217,26 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^using (old|new) (?:dav|DAV) path$/
+	 * @return string
+	 */
+	public function getSpacesDavPath():string {
+		return "dav/spaces";
+	}
+
+	/**
+	 * @Given /^using (old|new|spaces) (?:dav|DAV) path$/
 	 *
-	 * @param string $oldOrNewDavPath
+	 * @param string $davChoice
 	 *
 	 * @return void
 	 */
-	public function usingOldOrNewDavPath(string $oldOrNewDavPath):void {
-		if ($oldOrNewDavPath === 'old') {
+	public function usingOldOrNewDavPath(string $davChoice):void {
+		if ($davChoice === 'old') {
 			$this->usingOldDavPath();
-		} else {
+		} elseif ($davChoice === 'new') {
 			$this->usingNewDavPath();
+		} else {
+			$this->usingSpacesDavPath();
 		}
 	}
 
@@ -245,6 +260,19 @@ trait WebDav {
 		$this->davPath = $this->getNewDavPath();
 		$this->usingOldDavPath = false;
 		$this->customDavPath = null;
+		$this->usingSpacesDavPath = false;
+	}
+
+	/**
+	 * Select the spaces dav path as the default for later scenario steps
+	 *
+	 * @return void
+	 */
+	public function usingSpacesDavPath():void {
+		$this->davPath = $this->getSpacesDavPath();
+		$this->usingOldDavPath = false;
+		$this->customDavPath = null;
+		$this->usingSpacesDavPath = true;
 	}
 
 	/**
@@ -284,9 +312,13 @@ trait WebDav {
 	 *
 	 * @param string|null $for the category of endpoint that the DAV path will be used for
 	 *
-	 * @return int DAV path version (1 or 2) selected, or appropriate for the endpoint
+	 * @return int|null DAV path version (1 or 2) selected, or appropriate for the endpoint
+	 * null if spaces dav path is used
 	 */
-	public function getDavPathVersion(?string $for = null):int {
+	public function getDavPathVersion(?string $for = null):?int {
+		if ($this->usingSpacesDavPath) {
+			return null;
+		}
 		if ($for === 'systemtags') {
 			// systemtags only exists since DAV v2
 			return 2;
@@ -335,6 +367,7 @@ trait WebDav {
 	 * @param string|null $doDavRequestAsUser
 	 *
 	 * @return ResponseInterface
+	 * @throws GuzzleException|JsonException
 	 */
 	public function makeDavRequest(
 		?string $user,
@@ -354,12 +387,19 @@ trait WebDav {
 			$path = $this->customDavPath . $path;
 		}
 
-		if ($davPathVersion === null) {
-			$davPathVersion = $this->getDavPathVersion();
-		}
-
 		if ($password === null) {
 			$password = $this->getPasswordForUser($user);
+		}
+
+		if ($this->usingSpacesDavPath) {
+			$spaceId = $this->getPersonalSpaceIdForUser($user, $password);
+		} else {
+			if ($davPathVersion === null) {
+				$davPathVersion = $this->getDavPathVersion();
+			} else {
+				$davPathVersion = (int)$davPathVersion;
+			}
+			$spaceId = null;
 		}
 		return WebDavHelper::makeDavRequest(
 			$this->getBaseUrl(),
@@ -370,7 +410,7 @@ trait WebDav {
 			$headers,
 			$this->getStepLineRef(),
 			$body,
-			(int) $davPathVersion,
+			$davPathVersion,
 			$type,
 			null,
 			"basic",
@@ -378,7 +418,9 @@ trait WebDav {
 			$this->httpRequestTimeout,
 			null,
 			$urlParameter,
-			$doDavRequestAsUser
+			$doDavRequestAsUser,
+			$this->usingSpacesDavPath,
+			$spaceId
 		);
 	}
 


### PR DESCRIPTION
## Description
- added support for spaces WebDAV type in e2e test scenarios
- uses `acceptance-test-changes-waiting-2021-11` as base branch

## Related Issue
- https://github.com/owncloud/ocis/issues/2854

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 
- https://github.com/owncloud/ocis/pull/2887

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)