### PR TITLE
Add default app setting on a user basis

### DIFF
--- a/changelog/unreleased/39600
+++ b/changelog/unreleased/39600
@@ -1,0 +1,3 @@
+Enhancement: Add default app setting on a user basis
+
+https://github.com/owncloud/core/pull/39600

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1175,7 +1175,17 @@ class OC_Util {
 				$location = $urlGenerator->getAbsoluteURL($defaultPage);
 			} else {
 				$appId = 'files';
-				$defaultApps = \explode(',', \OC::$server->getConfig()->getSystemValue('defaultapp', 'files'));
+				$uid = \OC_User::getUser();
+				$config = \OC::$server->getConfig();
+				$defaultApps = \explode(',', $config->getSystemValue('defaultapp', 'files'));
+
+				if ($uid) {
+					$userDefaultApp = $config->getUserValue($uid, 'core', 'defaultapp', null);
+					if ($userDefaultApp) {
+						\array_unshift($defaultApps, $userDefaultApp);
+					}
+				}
+
 				// find the first app that is enabled for the current user
 				foreach ($defaultApps as $defaultApp) {
 					$defaultApp = OC_App::cleanAppId(\strip_tags($defaultApp));

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -362,6 +362,25 @@ class UtilTest extends \Test\TestCase {
 		$this->assertSame('http://localhost'.\OC::$WEBROOT.'/apps/files/', OC_Util::getDefaultPageUrl());
 	}
 
+	public function testGetDefaultPageUrlWithUserConfig() {
+		$uid = $this->getUniqueID();
+		$userDefaultApp = 'user_default_app';
+		\OC_User::setUserId($uid);
+		\OC::$server->getConfig()->setUserValue($uid, 'core', 'defaultapp', $userDefaultApp);
+
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->expects($this->any())
+			->method('isEnabledForUser')
+			->willReturn(true);
+		Dummy_OC_Util::$appManager = $appManager;
+
+		\putenv('front_controller_active=true');
+		$_REQUEST['redirect_url'] = 'myRedirectUrl.com@foo.com:a';
+		$this->assertSame('http://localhost'.\OC::$WEBROOT.'/apps/' . $userDefaultApp . '/', Dummy_OC_Util::getDefaultPageUrl());
+		\OC::$server->getConfig()->deleteUserValue($uid, 'core', 'defaultapp');
+		\OC_User::setUserId(null);
+	}
+
 	/**
 	 * Test needUpgrade() when the core version is increased
 	 */


### PR DESCRIPTION
## Description
This change allows users to to have their own default app defined. The setting is stored in the user preference table and uses its existing API. It will overwrite the system-wide `defaultapp` setting if set.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Related https://github.com/owncloud/enterprise/issues/4694

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4508
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
