### PR TITLE
Hide resend invitation mail - if user is guest

### DIFF
--- a/changelog/unreleased/39602
+++ b/changelog/unreleased/39602
@@ -1,0 +1,8 @@
+Bugfix: Don't resend invitation mail if a user is guest
+
+With this change the resend invitation mail action in the user management
+UI for guest users has been removed, it is not appropriate for this type
+of user.
+
+https://github.com/owncloud/core/pull/39602
+https://github.com/owncloud/enterprise/issues/4868

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -666,7 +666,7 @@ class UsersController extends Controller {
 		$user = $this->userManager->get($userId);
 		$currentUser = $this->userSession->getUser();
 
-		if ($user === null || $this->userTypeHelper->isGuestUser($userId)) {
+		if ($user === null || $this->userTypeHelper->isGuestUser($userId) === true) {
 			$this->log->error('User: ' . $userId . ' does not exist', ['app' => 'settings']);
 			return new JSONResponse(
 				[

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -666,7 +666,7 @@ class UsersController extends Controller {
 		$user = $this->userManager->get($userId);
 		$currentUser = $this->userSession->getUser();
 
-		if ($user === null) {
+		if ($user === null || $this->userTypeHelper->isGuestUser($userId)) {
 			$this->log->error('User: ' . $userId . ' does not exist', ['app' => 'settings']);
 			return new JSONResponse(
 				[

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -31,6 +31,7 @@
 namespace OC\Settings\Controller;
 
 use OC\AppFramework\Http;
+use OC\Helper\UserTypeHelper;
 use OC\User\Session;
 use OC\User\User;
 use OCP\App\IAppManager;
@@ -94,6 +95,8 @@ class UsersController extends Controller {
 	protected $timeFactory;
 	/** @var EventDispatcherInterface */
 	private $eventDispatcher;
+	/** @var UserTypeHelper */
+	private $userTypeHelper;
 
 	/**
 	 * @param string $appName
@@ -151,6 +154,7 @@ class UsersController extends Controller {
 		$this->urlGenerator = $urlGenerator;
 		$this->avatarManager = $avatarManager;
 		$this->eventDispatcher = $eventDispatcher;
+		$this->userTypeHelper = new UserTypeHelper($this->config);
 
 		// check for encryption state - TODO see formatUserForIndex
 		if ($appManager->isEnabledForUser('encryption')) {
@@ -222,6 +226,7 @@ class UsersController extends Controller {
 			'email' => $displayName,
 			'isRestoreDisabled' => !$restorePossible,
 			'isAvatarAvailable' => $avatarAvailable,
+			'isGuest' => $this->userTypeHelper->isGuestUser($user->getUID()),
 		];
 	}
 

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -115,7 +115,7 @@ var UserList = {
 		/**
 		 * resend invitation email action
 		 */
-		if (user.lastLogin === 0) {
+		if (user.lastLogin === 0 && user.isGuest !== true) {
 			var resendImage = $('<img class="action">').attr({
 				src: OC.imagePath('core', 'actions/mail')
 			});

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -116,7 +116,6 @@ class UsersControllerTest extends \Test\TestCase {
 		$foo = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$foo
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('foo'));
 		$foo
@@ -148,7 +147,6 @@ class UsersControllerTest extends \Test\TestCase {
 		$admin = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$admin
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('admin'));
 		$admin
@@ -182,7 +180,6 @@ class UsersControllerTest extends \Test\TestCase {
 		$bar = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$bar
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('bar'));
 		$bar
@@ -273,6 +270,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => 'foo@bar.com',
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => true,
+					'isGuest' => false,
 				],
 				1 => [
 					'name' => 'admin',
@@ -287,6 +285,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => 'admin@bar.com',
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => false,
+					'isGuest' => false,
 				],
 				2 => [
 					'name' => 'bar',
@@ -301,6 +300,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => 'bar@dummy.com',
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => true,
+					'isGuest' => false,
 				],
 			]
 		);
@@ -321,7 +321,6 @@ class UsersControllerTest extends \Test\TestCase {
 		$foo = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$foo
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('foo'));
 		$foo
@@ -353,7 +352,6 @@ class UsersControllerTest extends \Test\TestCase {
 		$admin = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$admin
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('admin'));
 		$admin
@@ -387,7 +385,6 @@ class UsersControllerTest extends \Test\TestCase {
 		$bar = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$bar
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('bar'));
 		$bar
@@ -493,6 +490,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => 'bar@dummy.com',
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => true,
+					'isGuest' => false,
 				],
 				1=> [
 					'name' => 'foo',
@@ -507,6 +505,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => 'foo@bar.com',
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => true,
+					'isGuest' => false,
 				],
 				2 => [
 					'name' => 'admin',
@@ -521,6 +520,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => 'admin@bar.com',
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => false,
+					'isGuest' => false,
 				],
 			]
 		);
@@ -535,11 +535,11 @@ class UsersControllerTest extends \Test\TestCase {
 	 */
 	public function testIndexWithSearch() {
 		$this->container['IsAdmin'] = true;
+		$this->container['Config']->method('getUserValue')->willReturn(false, false, true);
 
 		$foo = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$foo
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('foo'));
 		$foo
@@ -571,7 +571,6 @@ class UsersControllerTest extends \Test\TestCase {
 		$admin = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$admin
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('admin'));
 		$admin
@@ -605,7 +604,6 @@ class UsersControllerTest extends \Test\TestCase {
 		$bar = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$bar
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('bar'));
 		$bar
@@ -671,6 +669,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => 'foo@bar.com',
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => true,
+					'isGuest' => false,
 				],
 				1 => [
 					'name' => 'admin',
@@ -685,6 +684,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => 'admin@bar.com',
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => false,
+					'isGuest' => false,
 				],
 				2 => [
 					'name' => 'bar',
@@ -699,6 +699,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => 'bar@dummy.com',
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => true,
+					'isGuest' => true,
 				],
 			]
 		);
@@ -712,7 +713,6 @@ class UsersControllerTest extends \Test\TestCase {
 		$user = $this->getMockBuilder('\OC\User\User')
 			->disableOriginalConstructor()->getMock();
 		$user
-			->expects($this->exactly(2))
 			->method('getUID')
 			->will($this->returnValue('foo'));
 		$user
@@ -780,6 +780,7 @@ class UsersControllerTest extends \Test\TestCase {
 					'email' => null,
 					'isRestoreDisabled' => false,
 					'isAvatarAvailable' => true,
+					'isGuest' => false,
 				]
 			]
 		);
@@ -853,6 +854,7 @@ class UsersControllerTest extends \Test\TestCase {
 				'email' => null,
 				'isRestoreDisabled' => false,
 				'isAvatarAvailable' => true,
+				'isGuest' => false,
 			],
 			Http::STATUS_CREATED
 		);
@@ -943,6 +945,7 @@ class UsersControllerTest extends \Test\TestCase {
 				'email' => null,
 				'isRestoreDisabled' => false,
 				'isAvatarAvailable' => true,
+				'isGuest' => false,
 			],
 			Http::STATUS_CREATED
 		);
@@ -1027,6 +1030,7 @@ class UsersControllerTest extends \Test\TestCase {
 				'email' => null,
 				'isRestoreDisabled' => false,
 				'isAvatarAvailable' => true,
+				'isGuest' => false,
 			],
 			Http::STATUS_CREATED
 		);
@@ -1128,6 +1132,7 @@ class UsersControllerTest extends \Test\TestCase {
 				'email' => null,
 				'isRestoreDisabled' => false,
 				'isAvatarAvailable' => true,
+				'isGuest' => false,
 			],
 			Http::STATUS_CREATED
 		);
@@ -1645,6 +1650,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->container['IsAdmin'] = true;
 
 		list($user, $expectedResult) = $this->mockUser();
+		$expectedResult['isGuest'] = false;
 
 		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
 			->disableOriginalConstructor()
@@ -1666,6 +1672,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->container['IsAdmin'] = true;
 
 		list($user, $expectedResult) = $this->mockUser();
+		$expectedResult['isGuest'] = false;
 
 		$this->container['OCP\\App\\IAppManager']
 			->expects($this->once())
@@ -1686,13 +1693,21 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$this->container['Config']
 			->method('getUserValue')
-			->with(
-				$this->anything(),
-				$this->equalTo('encryption'),
-				$this->equalTo('recoveryEnabled'),
-				$this->anything()
+			->withConsecutive(
+				[
+					$this->anything(),
+					$this->equalTo('encryption'),
+					$this->equalTo('recoveryEnabled'),
+					$this->anything()
+				],
+				[
+					$this->anything(),
+					$this->anything(),
+					$this->anything(),
+					$this->anything(),
+				]
 			)
-			->will($this->returnValue('1'));
+			->willReturn('1', false);
 
 		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
 			->disableOriginalConstructor()
@@ -1714,6 +1729,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->container['IsAdmin'] = true;
 
 		list($user, $expectedResult) = $this->mockUser();
+		$expectedResult['isGuest'] = false;
 
 		$this->container['OCP\\App\\IAppManager']
 			->method('isEnabledForUser')
@@ -1744,6 +1760,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->container['IsAdmin'] = true;
 
 		list($user, $expectedResult) = $this->mockUser();
+		$expectedResult['isGuest'] = false;
 
 		$this->container['OCP\\App\\IAppManager']
 			->expects($this->once())
@@ -1764,11 +1781,19 @@ class UsersControllerTest extends \Test\TestCase {
 
 		$this->container['Config']
 			->method('getUserValue')
-			->with(
+			->withConsecutive(
+				[
 				$this->anything(),
 				$this->equalTo('encryption'),
 				$this->equalTo('recoveryEnabled'),
 				$this->anything()
+				],
+				[
+					$this->anything(),
+					$this->anything(),
+					$this->anything(),
+					$this->anything()
+				]
 			)
 			->will($this->returnValue('0'));
 
@@ -1794,6 +1819,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->container['IsAdmin'] = true;
 
 		list($user, $expectedResult) = $this->mockUser();
+		$expectedResult['isGuest'] = false;
 
 		$subadmin = $this->getMockBuilder('\OC\SubAdmin')
 			->disableOriginalConstructor()


### PR DESCRIPTION
## Description
Bugfix: Don't resend invitation mail if a user is guest

With this change the resend invitation mail action in the user management
UI for guest users has been removed, it is not appropriate for this type
of user.

## Related Issue
- Part of https://github.com/owncloud/enterprise/issues/4868

## How Has This Been Tested?
- create a guest user by sharing something
- as admin, create an ordinary user
- on the webUI user management page, check the list of users. Hover over the icon area at the right of both users.
- the ordinary user has the "envelope" icon, and clicking it works (resends the invitation email)
- the guest user does not have any "envelope" icon to click on.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
