### PR TITLE
Add warnings for commands that are incompatible with object storage

### DIFF
--- a/changelog/unreleased/39604
+++ b/changelog/unreleased/39604
@@ -1,0 +1,11 @@
+Enhancement: Add warnings for commands that are incompatible with object storage
+
+The following commands are affected:
+
+* `user:home:list-users`
+* `user:home:list-homes`
+* `user:move`
+* `user:report`
+
+https://github.com/owncloud/core/pull/39604
+https://github.com/owncloud/core/issues/39590

--- a/core/Command/User/HomeListDirs.php
+++ b/core/Command/User/HomeListDirs.php
@@ -22,6 +22,7 @@
 namespace OC\Core\Command\User;
 
 use OC\Core\Command\Base;
+use OC\Files\Filesystem;
 use OCP\IUserManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -47,6 +48,10 @@ class HomeListDirs extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		if (Filesystem::isPrimaryObjectStorageEnabled() === true) {
+			$output->writeln('<info>We detected that the instance is running on a S3 primary object storage, home directories might not be accurate</info>');
+		}
+
 		$users = $this->userManager->search(null);
 		$homePaths = [];
 		foreach ($users as $user) {

--- a/core/Command/User/HomeListUsers.php
+++ b/core/Command/User/HomeListUsers.php
@@ -22,6 +22,7 @@
 namespace OC\Core\Command\User;
 
 use OC\Core\Command\Base;
+use OC\Files\Filesystem;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use Symfony\Component\Console\Input\InputArgument;
@@ -68,6 +69,10 @@ class HomeListUsers extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		if (Filesystem::isPrimaryObjectStorageEnabled() === true) {
+			$output->writeln('<info>We detected that the instance is running on a S3 primary object storage, users might not be accurate</info>');
+		}
+
 		$path = $input->getArgument('path');
 		if ($input->getOption('all')) {
 			if ($path !== null) {

--- a/core/Command/User/MoveHome.php
+++ b/core/Command/User/MoveHome.php
@@ -22,7 +22,8 @@
 namespace OC\Core\Command\User;
 
 use InvalidArgumentException;
-use OC\User\AccountMapper;
+use OC\Files\Filesystem;
+use OC\Files\ObjectStore\ObjectStoreStorage;
 use OCP\IUser;
 use OCP\IUserManager;
 use RuntimeException;
@@ -57,6 +58,12 @@ class MoveHome extends Command {
 		$user = $this->getUser($input);
 		$userId = $user->getUID();
 		$oldHome = $user->getHome();
+
+		$storage = Filesystem::getStorage($userId);
+		if ($storage->instanceOfStorage(ObjectStoreStorage::class)) {
+			$output->writeln('<error>This command is not supported on an S3 primary object storage</error>');
+			return 1;
+		}
 
 		$newLocation = $this->getNewLocationForUser($input, $user);
 		$output->writeln("Move $userId from $oldHome to $newLocation");

--- a/core/Command/User/Report.php
+++ b/core/Command/User/Report.php
@@ -25,11 +25,9 @@
 
 namespace OC\Core\Command\User;
 
-use OC\Files\FileInfo;
-use OC\Files\View;
+use OC\Files\Filesystem;
 use OC\Helper\UserTypeHelper;
 use OCP\IUser;
-use OCP\User;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -60,6 +58,10 @@ class Report extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		if (Filesystem::isPrimaryObjectStorageEnabled() === true) {
+			$output->writeln('<info>We detected that the instance is running on a S3 primary object storage, user directories count might not be accurate</info>');
+		}
+
 		$table = new Table($output);
 		$table->setHeaders(['User Report', '']);
 		$userCountArray = $this->countUsers();
@@ -87,9 +89,8 @@ class Report extends Command {
 			$rows[] = ['No backend enabled that supports user counting', ''];
 		}
 
-		$userDirectoryCount = $this->countUserDirectories();
 		$rows[] = [' '];
-		$rows[] = ['user directories', $userDirectoryCount];
+		$rows[] = ['user directories', $this->countUserDirectories()];
 
 		$table->setRows($rows);
 		$table->render($output);

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -1089,4 +1089,19 @@ class Filesystem {
 	public static function getETag($path) {
 		return self::$defaultInstance->getETag($path);
 	}
+
+	/**
+	 * Determines whether primary object storage is enabled on the instance
+	 *
+	 * @return bool
+	 */
+	public static function isPrimaryObjectStorageEnabled(): bool {
+		$config = \OC::$server->getConfig();
+		$appManager = \OC::$server->getAppManager();
+
+		$objectStorageAppEnabled = $appManager->isEnabledForUser('files_primary_s3');
+		$objectStorage = $config->getSystemValue('objectstore', null);
+
+		return $objectStorageAppEnabled && $objectStorage !== null;
+	}
 }

--- a/tests/Core/Command/User/HomeListUsersTest.php
+++ b/tests/Core/Command/User/HomeListUsersTest.php
@@ -23,8 +23,9 @@ namespace Tests\Core\Command\User;
 
 use Doctrine\DBAL\ForwardCompatibility\DriverStatement;
 use OC\Core\Command\User\HomeListUsers;
-use OC\User\AccountMapper;
+use OC\DB\Connection;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
@@ -40,26 +41,44 @@ class HomeListUsersTest extends TestCase {
 	/** @var IDBConnection | \PHPUnit\Framework\MockObject\MockObject */
 	private $connection;
 
-	/** @var \OCP\IUserManager | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var IUserManager | \PHPUnit\Framework\MockObject\MockObject */
 	protected $userManager;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->connection = $this->getMockBuilder('\OC\DB\Connection')
+		$this->connection = $this->getMockBuilder(Connection::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->userManager = $this->getMockBuilder('\OC\User\Manager')
+		$this->userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()
 			->getMock();
+
 		$command = new HomeListUsers(
 			$this->connection,
-			$this->userManager
+			$this->userManager,
 		);
 		$this->commandTester = new CommandTester($command);
 	}
 
-	public function testCommandInputForHomePath() {
+	public function objectStorageProvider() {
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	/**
+	 * @dataProvider objectStorageProvider
+	 * @param bool $objectStorageUsed
+	 * @return void
+	 */
+	public function testCommandInputForHomePath($objectStorageUsed) {
+		if ($objectStorageUsed) {
+			$this->overwriteConfigWithObjectStorage();
+			$this->overwriteAppManagerWithObjectStorage();
+		}
+
 		$homePath = '/path/to/homes';
 		$uid = 'user1';
 
@@ -75,6 +94,16 @@ class HomeListUsersTest extends TestCase {
 		$this->commandTester->execute(['path' => $homePath]);
 		$output = $this->commandTester->getDisplay();
 		$this->assertStringContainsString($uid, $output);
+
+		if ($objectStorageUsed) {
+			$this->assertStringContainsString('We detected that the instance is running on a S3 primary object storage, users might not be accurate', $output);
+		}
+	}
+
+	protected function tearDown(): void {
+		$this->restoreService('AllConfig');
+		$this->restoreService('AppManager');
+		parent::tearDown();
 	}
 
 	public function testCommandInputAll() {
@@ -89,7 +118,7 @@ class HomeListUsersTest extends TestCase {
 
 		$this->commandTester->execute(['--all' => true]);
 		$output = $this->commandTester->getDisplay();
-		$this->assertSame("  - $path:\n    - $uid\n", $output);
+		$this->assertStringContainsString("  - $path:\n    - $uid\n", $output);
 	}
 
 	public function testCommandInputBoth() {
@@ -102,5 +131,23 @@ class HomeListUsersTest extends TestCase {
 		$this->commandTester->execute([]);
 		$output = $this->commandTester->getDisplay();
 		$this->assertStringContainsString('Not enough arguments (missing: "path").', $output);
+	}
+
+	private function overwriteConfigWithObjectStorage() {
+		$config = $this->createMock('\OCP\IConfig');
+		$config->expects($this->any())
+			->method('getSystemValue')
+			->willReturn(['objectstore' => true]);
+
+		$this->overwriteService('AllConfig', $config);
+	}
+
+	private function overwriteAppManagerWithObjectStorage() {
+		$config = $this->createMock('\OCP\App\IAppManager');
+		$config->expects($this->any())
+			->method('isEnabledForUser')
+			->willReturn(true);
+
+		$this->overwriteService('AppManager', $config);
 	}
 }

--- a/tests/Core/Command/User/MoveHomeTest.php
+++ b/tests/Core/Command/User/MoveHomeTest.php
@@ -74,14 +74,15 @@ class MoveHomeTest extends TestCase {
 		$file = \OC::$server->getUserFolder($this->user->getUID())->newFile('hello.txt');
 		$file->putContent('1234567890');
 
-		if ($file->getStorage()->instanceOfStorage(ObjectStoreStorage::class)) {
-			$this->markTestSkipped('user:move-home is only implemented for posix file systems');
-		}
-
 		$exitCode = $this->commandTester->execute([
 			'user_id' => 'test-user',
 			'new_location' => $this->newLocation
 		]);
+
+		if ($file->getStorage()->instanceOfStorage(ObjectStoreStorage::class)) {
+			self::assertEquals(1, $exitCode, $this->commandTester->getDisplay());
+			return;
+		}
 
 		# assert command output
 		self::assertEquals(0, $exitCode, $this->commandTester->getDisplay());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39590

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
