### PR TITLE
add expiration extension to tus option requests

### DIFF
--- a/tests/acceptance/features/apiWebdavUploadTUS/optionsRequest.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/optionsRequest.feature
@@ -10,11 +10,11 @@ Feature: OPTIONS request
       | /remote.php/webdav/               |
       | /remote.php/dav/files/%username%/ |
     Then the following headers should be set
-      | header                 | value                                  |
-      | Tus-Resumable          | 1.0.0                                  |
-      | Tus-Version            | 1.0.0                                  |
-      | Tus-Extension          | creation,creation-with-upload,checksum |
-      | Tus-Checksum-Algorithm | md5,sha1,adler32                       |
+      | header                 | value                                             |
+      | Tus-Resumable          | 1.0.0                                             |
+      | Tus-Version            | 1.0.0                                             |
+      | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
+      | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |
 
 
   Scenario: send OPTIONS request to webDav endpoints using the TUS protocol without any authentication
@@ -23,11 +23,11 @@ Feature: OPTIONS request
       | /remote.php/webdav/               |
       | /remote.php/dav/files/%username%/ |
     Then the following headers should be set
-      | header                 | value                                  |
-      | Tus-Resumable          | 1.0.0                                  |
-      | Tus-Version            | 1.0.0                                  |
-      | Tus-Extension          | creation,creation-with-upload,checksum |
-      | Tus-Checksum-Algorithm | md5,sha1,adler32                       |
+      | header                 | value                                             |
+      | Tus-Resumable          | 1.0.0                                             |
+      | Tus-Version            | 1.0.0                                             |
+      | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
+      | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |
 
 
   Scenario: send OPTIONS request to webDav endpoints using the TUS protocol with valid username and wrong password
@@ -36,11 +36,11 @@ Feature: OPTIONS request
       | /remote.php/webdav/               |
       | /remote.php/dav/files/%username%/ |
     Then the following headers should be set
-      | header                 | value                                  |
-      | Tus-Resumable          | 1.0.0                                  |
-      | Tus-Version            | 1.0.0                                  |
-      | Tus-Extension          | creation,creation-with-upload,checksum |
-      | Tus-Checksum-Algorithm | md5,sha1,adler32                       |
+      | header                 | value                                             |
+      | Tus-Resumable          | 1.0.0                                             |
+      | Tus-Version            | 1.0.0                                             |
+      | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
+      | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |
 
 
   Scenario: send OPTIONS requests to webDav endpoints using valid password and username of different user
@@ -50,8 +50,8 @@ Feature: OPTIONS request
       | /remote.php/webdav/               |
       | /remote.php/dav/files/%username%/ |
     Then the following headers should be set
-      | header                 | value                                  |
-      | Tus-Resumable          | 1.0.0                                  |
-      | Tus-Version            | 1.0.0                                  |
-      | Tus-Extension          | creation,creation-with-upload,checksum |
-      | Tus-Checksum-Algorithm | md5,sha1,adler32                       |
+      | header                 | value                                             |
+      | Tus-Resumable          | 1.0.0                                             |
+      | Tus-Version            | 1.0.0                                             |
+      | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
+      | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |


### PR DESCRIPTION
## Description
The testsuite does currently not expect the tus expiration extension on option requests, but REVA is returning it already. This PR updates the testsuite, so that we can remove these tests from the expected failures list.

The current behaviour can be seen here: https://drone.cernbox.cern.ch/cs3org/reva/4593/26/7

Tus spec about expiration extension on option requests: https://tus.io/protocols/resumable-upload.html#options

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Removes some expected failures from https://github.com/owncloud/ocis/issues/1755 (even though they are not really related to the issue)

## Motivation and Context
Slim down the expected failures in REVA / oCIS
