### PR TITLE
Prevent encrypted files from being corrupted when overwriting them

### DIFF
--- a/changelog/unreleased/39623
+++ b/changelog/unreleased/39623
@@ -1,0 +1,7 @@
+Bugfix: Prevent encrypted files from being corrupted when overwriting them
+
+Fixed an issue where overwriting an encrypted file by a share recipient
+would corrupt it. This is a regression which was introduced by #39516.
+
+https://github.com/owncloud/core/pull/39623
+https://github.com/owncloud/encryption/issues/315

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -998,19 +998,22 @@ class Encryption extends Wrapper {
 			}
 		}
 
-		// Don't try to decrypt files which are marked unencrypted in file-cache
-		$info = $this->getCache()->get($path);
-		if (!isset($info['encrypted']) || $info['encrypted'] === false) {
-			return [];
-		}
-
 		$firstBlock = $this->readFirstBlock($path);
 		$result = $this->parseRawHeader($firstBlock);
 
 		// if the header doesn't contain a encryption module we check if it is a
 		// legacy file. If true, we add the default encryption module
-		if (!isset($result[Util::HEADER_ENCRYPTION_MODULE_KEY]) && $exists) {
-			$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
+		if (!isset($result[Util::HEADER_ENCRYPTION_MODULE_KEY])) {
+			if (!empty($result)) {
+				$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
+			} elseif ($exists) {
+				// if the header was empty we have to check first if it is a encrypted file at all
+				// We would do query to filecache only if we know that entry in filecache exists
+				$info = $this->getCache()->get($path);
+				if (isset($info['encrypted']) && $info['encrypted'] === true) {
+					$result[Util::HEADER_ENCRYPTION_MODULE_KEY] = 'OC_DEFAULT_MODULE';
+				}
+			}
 		}
 
 		return $result;

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -570,15 +570,6 @@ class EncryptionTest extends Storage {
 					$this->arrayCache
 				]
 			)->getMock();
-
-		$cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
-			->disableOriginalConstructor()->getMock();
-		$cache->expects($this->any())
-			->method('get')
-			->willReturnCallback(function ($path) {
-				return ['encrypted' => true, 'path' => $path];
-			});
-
 		$instance = $this->getMockBuilder(Encryption::class)
 			->setConstructorArgs(
 				[
@@ -591,13 +582,11 @@ class EncryptionTest extends Storage {
 					$this->encryptionManager, $util, $this->logger, $this->file, null, $this->keyStore, $this->update, $this->mountManager, $this->arrayCache
 				]
 			)
-			->setMethods(['getCache','readFirstBlock', 'parseRawHeader'])
+			->setMethods(['readFirstBlock', 'parseRawHeader'])
 			->getMock();
 
 		$instance->expects($this->once())->method(('parseRawHeader'))
 			->willReturn([Util::HEADER_ENCRYPTION_MODULE_KEY => 'OC_DEFAULT_MODULE']);
-
-		$instance->expects($this->once())->method('getCache')->willReturn($cache);
 
 		if ($strippedPathExists) {
 			$instance->expects($this->once())->method('readFirstBlock')
@@ -613,11 +602,6 @@ class EncryptionTest extends Storage {
 			->method('file_exists')
 			->with($strippedPath)
 			->willReturn($strippedPathExists);
-
-		$instance->expects($this->once())
-			->method('getCache')
-			->willReturn($cache);
-
 		$this->invokePrivate($instance, 'getHeader', [$path]);
 	}
 


### PR DESCRIPTION
## Description
This fixes an issue where overwriting an encrypted file by a share recipient would corrupt it.

This is a regression which was introduced by https://github.com/owncloud/core/pull/39516. An early return was implement in the `getHeader()` method which caused trouble with a) part files and b) the fix-encrypted-version-command. Therefore I reverted the change as it seemed to be an optimization only.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/encryption/issues/315

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
