### PR TITLE
[tests-only] skip new group name test on oC 10.9.1

### DIFF
--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -154,7 +154,7 @@ Feature: add groups
     And the HTTP status code should be "401"
     And group "another-new-group" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: admin tries to create a group that has white space at the end of the name
     When the administrator sends a group creation request for group "white-space-at-end " using the provisioning API
     Then the OCS status code should be "101"
@@ -162,7 +162,7 @@ Feature: add groups
     And group "white-space-at-end " should not exist
     And group "white-space-at-end" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: admin tries to create a group that has white space at the start of the name
     When the administrator sends a group creation request for group " white-space-at-start" using the provisioning API
     Then the OCS status code should be "101"
@@ -170,7 +170,7 @@ Feature: add groups
     And group " white-space-at-start" should not exist
     But group "white-space-at-start" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: admin tries to create a group that is a single space
     When the administrator sends a group creation request for group " " using the provisioning API
     Then the OCS status code should be "101"


### PR DESCRIPTION
10.9.1 is a hotfix release that does not include the fix in https://github.com/owncloud/core/pull/39540 so this tests will fail e.g. https://drone.owncloud.com/owncloud/encryption/2251/73/18 so skip them
