### PR TITLE
[tests-only] [full-ci] Run CI against federated 10.8.0 server

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -179,7 +179,7 @@ config = {
                 "apiFederationToShares2",
             ],
             "federatedServerNeeded": True,
-            "federatedServerVersions": ["git", "latest", "10.7.0"],
+            "federatedServerVersions": ["git", "latest", "10.8.0"],
         },
         "cli": {
             "suites": [
@@ -242,7 +242,7 @@ config = {
                 "cliExternalStorage",
             ],
             "federatedServerNeeded": True,
-            "federatedServerVersions": ["git", "latest", "10.7.0"],
+            "federatedServerVersions": ["git", "latest", "10.8.0"],
         },
         "webUI": {
             "suites": {
@@ -306,7 +306,7 @@ config = {
                 "webUISharingExternal2": "webUISharingExt2",
             },
             "federatedServerNeeded": True,
-            "federatedServerVersions": ["git", "latest", "10.7.0"],
+            "federatedServerVersions": ["git", "latest", "10.8.0"],
         },
         "webUIFirefox": {
             "suites": {


### PR DESCRIPTION
## Description
We run federated acceptance tests against federated servers running:
- current core master
- core latest
- core "latest minus one"

Update "latest minus one" from 10.7.0 to 10.8.0 (we don't have a higher-level way to say "latest-1")

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
