### PR TITLE
[tests-only] Get personal space id from the request helper

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2566,40 +2566,6 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * fetches personal space id for provided user
-	 *
-	 * @param string $user
-	 * @param string|null $password
-	 *
-	 * @return mixed
-	 * @throws GuzzleException
-	 */
-	public function getPersonalSpaceIdForUser(string $user, string $password = null):string {
-		$drivesPath = '/graph/v1.0/me/drives';
-		$fullUrl = $this->getBaseUrl() . $drivesPath;
-		if (!$password) {
-			$password = $this->getPasswordForUser($user);
-		}
-		$response = HttpRequestHelper::get(
-			$fullUrl,
-			$this->getStepLineRef(),
-			$user,
-			$password
-		);
-		$this->setResponse($response);
-		$this->theHTTPStatusCodeShouldBeSuccess();
-		$bodyContents = $response->getBody()->getContents();
-		Assert::assertNotEmpty($bodyContents, "The response body of the request to $drivesPath was empty");
-		$json = \json_decode($bodyContents);
-		Assert::assertNotNull(
-			$json,
-			"There was an error decoding the response of the request to $drivesPath\nThe response content was:\n$bodyContents"
-		);
-		// assuming the first space is the personal space
-		return $json->value[0]->id;
-	}
-
-	/**
 	 * @Then the json responded should match with
 	 *
 	 * @param PyStringNode $jsonExpected

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -312,12 +312,11 @@ trait WebDav {
 	 *
 	 * @param string|null $for the category of endpoint that the DAV path will be used for
 	 *
-	 * @return int|null DAV path version (1 or 2) selected, or appropriate for the endpoint
-	 * null if spaces dav path is used
+	 * @return int DAV path version (1, 2 or 3) selected, or appropriate for the endpoint
 	 */
 	public function getDavPathVersion(?string $for = null):?int {
 		if ($this->usingSpacesDavPath) {
-			return null;
+			return 3;
 		}
 		if ($for === 'systemtags') {
 			// systemtags only exists since DAV v2
@@ -387,20 +386,16 @@ trait WebDav {
 			$path = $this->customDavPath . $path;
 		}
 
+		if ($davPathVersion === null) {
+			$davPathVersion = $this->getDavPathVersion();
+		} else {
+			$davPathVersion = (int) $davPathVersion;
+		}
+
 		if ($password === null) {
 			$password = $this->getPasswordForUser($user);
 		}
 
-		if ($this->usingSpacesDavPath) {
-			$spaceId = $this->getPersonalSpaceIdForUser($user, $password);
-		} else {
-			if ($davPathVersion === null) {
-				$davPathVersion = $this->getDavPathVersion();
-			} else {
-				$davPathVersion = (int)$davPathVersion;
-			}
-			$spaceId = null;
-		}
 		return WebDavHelper::makeDavRequest(
 			$this->getBaseUrl(),
 			$user,
@@ -418,9 +413,7 @@ trait WebDav {
 			$this->httpRequestTimeout,
 			null,
 			$urlParameter,
-			$doDavRequestAsUser,
-			$this->usingSpacesDavPath,
-			$spaceId
+			$doDavRequestAsUser
 		);
 	}
 


### PR DESCRIPTION
## Description
every time we'd to send the space `id` and `usingSpaces` bool to the request fn `makeDavRequest`

With this PR
- we do not have to send these params in every calling fns, but get the space id within the `makeDavRequest`
- updated personal space id getter

## Related
- https://github.com/owncloud/core/pull/39599
- https://github.com/owncloud/ocis/issues/2854
- https://github.com/owncloud/core/issues/39642