### PR TITLE
Remove BOM from text preview content

### DIFF
--- a/changelog/unreleased/39644
+++ b/changelog/unreleased/39644
@@ -1,0 +1,7 @@
+Bugfix: Text file previews have faulty content if a byte order mark is present
+
+While having a valid byte order mark in a text file, the preview was corrupt.
+With this change, the BOM will be removed and the preview will be rendered
+correctly.
+
+https://github.com/owncloud/core/pull/39644

--- a/changelog/unreleased/39644
+++ b/changelog/unreleased/39644
@@ -5,3 +5,4 @@ With this change, the BOM will be removed and the preview will be rendered
 correctly.
 
 https://github.com/owncloud/core/pull/39644
+https://github.com/owncloud/core/issues/39645

--- a/lib/private/Preview/TXT.php
+++ b/lib/private/Preview/TXT.php
@@ -54,6 +54,9 @@ class TXT implements IProvider2 {
 		$content = \stream_get_contents($stream, 2048);
 		\fclose($stream);
 
+		// Remove byte order mark
+		$content = \str_replace("\xEF\xBB\xBF", '', $content);
+
 		//don't create previews of empty text files
 		if (\trim($content) === '') {
 			return false;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Bugfix: Text file previews have faulty content if a byte order mark is present

While having a valid byte order mark in a text file, the preview was corrupt.
With this change, the BOM will be removed and the preview will be rendered
correctly.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
