### PR TITLE
[tests-only] Remember space id for users after the first fetch

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -36,6 +36,12 @@ use DateTime;
  *
  */
 class WebDavHelper {
+
+	/**
+	 * @var array of users with their different spaces ids
+	 */
+	public static $spacesIdRef = [];
+
 	/**
 	 * returns the id of a file
 	 *
@@ -373,8 +379,12 @@ class WebDavHelper {
 	 *
 	 * @return string
 	 * @throws GuzzleException
+	 * @throws Exception
 	 */
 	public static function getPersonalSpaceIdForUser(string $baseUrl, string $user, string $password, string $xRequestId):string {
+		if (\array_key_exists($user, self::$spacesIdRef) && \array_key_exists("personal", self::$spacesIdRef[$user])) {
+			return self::$spacesIdRef[$user]["personal"];
+		}
 		$drivesPath = 'graph/v1.0/me/drives';
 		$fullUrl = $baseUrl . $drivesPath;
 		$response = HttpRequestHelper::get(
@@ -392,7 +402,13 @@ class WebDavHelper {
 				break;
 			}
 		}
-		return $personalSpaceId;
+
+		if ($personalSpaceId) {
+			self::$spacesIdRef[$user] = [];
+			self::$spacesIdRef[$user]["personal"] = $personalSpaceId;
+			return $personalSpaceId;
+		}
+		throw new Exception("Personal space not found for user " . $user);
 	}
 
 	/**


### PR DESCRIPTION
## Description
- save the space id after the first fetch


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/core/issues/39642

## Motivation and Context
- do not request multiple times for the same space id

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
