### PR TITLE
[tests-only] Skip new group tests on old oC10

### DIFF
--- a/tests/acceptance/features/cliProvisioning/addGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addGroup.feature
@@ -34,6 +34,7 @@ Feature: add group
     Then the command should have failed with exit code 1
     And the command output should contain the text 'The group "brand-new-group" already exists'
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: admin tries to create a group that has white space at the end of the name
     When the administrator creates group "white-space-at-end " using the occ command
     Then the command should have failed with exit code 1
@@ -41,6 +42,7 @@ Feature: add group
     And group "white-space-at-end " should not exist
     And group "white-space-at-end" should not exist
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: admin tries to create a group that has white space at the start of the name
     When the administrator creates group " white-space-at-start" using the occ command
     Then the command should have failed with exit code 1
@@ -48,12 +50,14 @@ Feature: add group
     And group " white-space-at-start" should not exist
     And group "white-space-at-start" should not exist
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: admin tries to create a group that is a single space
     When the administrator creates group " " using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Group " " could not be created'
     And group " " should not exist
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: admin tries to create a group that is the empty string
     When the administrator creates group "" using the occ command
     Then the command should have failed with exit code 1


### PR DESCRIPTION
## Description
These new tests for group commands with group names starting or ending with a space are only relevant to current master. Skip them on older oC10.

Similar to PR #39634 

I noticed this when trying to run the current test suite against the 10.9.1RC1 tarball.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
