### PR TITLE
[tests-only] [full-ci] Fix install core from tarball

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2883,6 +2883,7 @@ def installCoreFromTarball(version, db, logLevel = "2", ssl = False, federatedSe
             "php occ config:system:set trusted_domains 1 --value=server",
         ] + ([
             "php occ config:system:set trusted_domains 2 --value=federated",
+            "php occ config:system:set csrf.disabled --value=true",
         ] if federatedServerNeeded else []) + [
         ] + ([
             "php occ config:system:set trusted_domains 3 --value=proxy",

--- a/.drone.star
+++ b/.drone.star
@@ -2760,8 +2760,10 @@ def fixPermissions(phpVersion, federatedServerNeeded, selUserNeeded = False, pat
         "image": "owncloudci/php:%s" % phpVersion,
         "pull": "always",
         "commands": [
-            "chown -R www-data %s" % pathOfServerUnderTest,
+            "chown -R www-data %s" % dir["server"],
         ] + ([
+            "chown -R www-data %s" % pathOfServerUnderTest,
+        ] if (pathOfServerUnderTest != dir["server"]) else []) + ([
             "chown -R www-data %s" % dir["federated"],
         ] if federatedServerNeeded else []) + ([
             "chmod 777 /home/seluser/Downloads/",


### PR DESCRIPTION
## Description
1) set csrf.disabled when running federated tests in `installCoreFromTarball` - that had been missed.
2) fixPermissions on both server-under-test and test-runner folders in CI - when we are testing against a tarball, the test-runner and the unpacked tarball (system-under-test) are in different folders. In that case set the owner to `www-data` for both. Both the test-runner and the system-under-test processes are running as `www-data`. If we don't do this, then the test-runner complains when trying to install its test tool dependencies etc. (whenever it tries to write to the folders that have the test code)

## How Has This Been Tested?
CI - I have cherry-picked these from #39652 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
