### PR TITLE
Fix the preview of text files containing BOM for utf8

### DIFF
--- a/changelog/unreleased/39669
+++ b/changelog/unreleased/39669
@@ -1,0 +1,7 @@
+Bugfix: Text previews had faulty content if BOM was present
+
+The BOM was incorrectly detected and was causing ownCloud to choose
+the wrong font for the text, showing unexpected results.
+The BOM is now processed correctly and the preview is shown as expected
+
+https://github.com/owncloud/core/pull/39669

--- a/lib/private/Preview/TXT.php
+++ b/lib/private/Preview/TXT.php
@@ -138,6 +138,7 @@ class TXT implements IProvider2 {
 			'Hangul' => 'NotoSansCJKkr/NotoSansMonoCJKkr-Regular.otf',  // korean
 			'Devanagari' => 'NotoSansDevanagari/NotoSansDevanagari-Regular.ttf',  // devanagari
 			'Arabic' => 'NotoSansArabic/NotoSansArabic-Regular.ttf',  // arabic
+			'Latin' => 'NotoSans/NotoSans-Regular.ttf',  // latin
 		];
 
 		$countInfo = $info['count'];

--- a/lib/private/Utf8Analyzer.php
+++ b/lib/private/Utf8Analyzer.php
@@ -92,7 +92,7 @@ class Utf8Analyzer {
 		['range' => [0xf900, 0xfaff], 'script' => 'Han'],
 		['range' => [0xfb1d, 0xfb4f], 'script' => 'Hebrew'],  // some unicode chars aren't assigned
 		['range' => [0xfb50, 0xfdff], 'script' => 'Arabic'],
-		['range' => [0xfe70, 0xfeff], 'script' => 'Arabic'],
+		['range' => [0xfe70, 0xfefc], 'script' => 'Arabic'],
 	];
 
 	/**

--- a/tests/lib/Utf8AnalyzerTest.php
+++ b/tests/lib/Utf8AnalyzerTest.php
@@ -230,6 +230,37 @@ class Utf8AnalyzerTest extends \Test\TestCase {
 					]
 				]
 			],
+			// Include BOM marker at the beginning
+			[
+				'data://text/plain;base64,77u/bGHMiHJsIMOxbwo=',
+				['count', 'details', 'lines'],
+				PHP_INT_MAX,
+				[
+					"count" => [
+						"_unknown" => 2,
+						"Latin" => 6,
+						"Common" => 2,
+					],
+					"details" => [
+						["range" => "0-2", "str" => "﻿", "unicode" => 65279, "unicodeHex" => "feff", "script" => "_unknown"],
+						["range" => "3-3", "str" => "l", "unicode" => 108, "unicodeHex" => "6c", "script" => "Latin"],
+						["range" => "4-4", "str" => "a", "unicode" => 97, "unicodeHex" => "61", "script" => "Latin"],
+						["range" => "5-6", "str" => \mb_chr(776), "unicode" => 776, "unicodeHex" => "308", "script" => "_unknown"],
+						["range" => "7-7", "str" => "r", "unicode" => 114, "unicodeHex" => "72", "script" => "Latin"],
+						["range" => "8-8", "str" => "l", "unicode" => 108, "unicodeHex" => "6c", "script" => "Latin"],
+						["range" => "9-9", "str" => " ", "unicode" => 32, "unicodeHex" => "20", "script" => "Common"],
+						["range" => "10-11", "str" => "ñ", "unicode" => 241, "unicodeHex" => "f1", "script" => "Latin"],
+						["range" => "12-12", "str" => "o", "unicode" => 111, "unicodeHex" => "6f", "script" => "Latin"],
+						["range" => "13-13", "str" => "\n", "unicode" => 10, "unicodeHex" => "a", "script" => "Common"],
+					],
+					"lines" => [
+						"linesNumber" => 2,
+						"lines" => [
+							["﻿", "l", "a", \mb_chr(776), "r", "l", " ", "ñ", "o"],
+						]
+					]
+				],
+			],
 			// with limited chars
 			[
 				'data://text/plain;base64,44Gr56e75YuVCuacnQo=',
@@ -446,6 +477,62 @@ class Utf8AnalyzerTest extends \Test\TestCase {
 						"lines" => [
 							["이", "동"],
 							["아", "침"]
+						]
+					]
+				],
+			],
+			// Include BOM marker at the beginning
+			[
+				"\xef\xbb\xbflat pos",
+				['count'],
+				[
+					"count" => [
+						"_unknown" => 1,
+						"Latin" => 6,
+						"Common" => 1,
+					],
+				],
+			],
+			[
+				"\xef\xbb\xbflat pos",
+				['count', 'lines'],
+				[
+					"count" => [
+						"_unknown" => 1,
+						"Latin" => 6,
+						"Common" => 1,
+					],
+					"lines" => [
+						"linesNumber" => 1,
+						"lines" => [
+							["﻿", "l", "a", "t", " ", "p", "o", "s"],
+						]
+					]
+				],
+			],
+			[
+				"\xef\xbb\xbflat pos",
+				['count', 'details', 'lines'],
+				[
+					"count" => [
+						"_unknown" => 1,
+						"Latin" => 6,
+						"Common" => 1,
+					],
+					"details" => [
+						["range" => "0-2", "str" => "﻿", "unicode" => 65279, "unicodeHex" => "feff", "script" => "_unknown"],
+						["range" => "3-3", "str" => "l", "unicode" => 108, "unicodeHex" => "6c", "script" => "Latin"],
+						["range" => "4-4", "str" => "a", "unicode" => 97, "unicodeHex" => "61", "script" => "Latin"],
+						["range" => "5-5", "str" => "t", "unicode" => 116, "unicodeHex" => "74", "script" => "Latin"],
+						["range" => "6-6", "str" => " ", "unicode" => 32, "unicodeHex" => "20", "script" => "Common"],
+						["range" => "7-7", "str" => "p", "unicode" => 112, "unicodeHex" => "70", "script" => "Latin"],
+						["range" => "8-8", "str" => "o", "unicode" => 111, "unicodeHex" => "6f", "script" => "Latin"],
+						["range" => "9-9", "str" => "s", "unicode" => 115, "unicodeHex" => "73", "script" => "Latin"],
+					],
+					"lines" => [
+						"linesNumber" => 1,
+						"lines" => [
+							["﻿", "l", "a", "t", " ", "p", "o", "s"],
 						]
 					]
 				],


### PR DESCRIPTION
Adjusted range so the BOM isn't detected as an arabic char.
Latin is also added as part of possible fonts, not just if there isn't
any match

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
BOM was detected as arabic char. Alternative fix to https://github.com/owncloud/core/pull/39644

## Related Issue
https://github.com/owncloud/core/issues/39645

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Create a text file containing the BOM and some latin chars
2. Upload the file to ownCloud
3. The preview should show correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
