### PR TITLE
Fix getting the file owner for share recipients

### DIFF
--- a/apps/files_versions/lib/MetaStorage.php
+++ b/apps/files_versions/lib/MetaStorage.php
@@ -103,12 +103,14 @@ class MetaStorage {
 			return false;
 		}
 
-		$userPath = "/files_versions$currentFileName" . MetaStorage::CURRENT_FILE_EXT;
-		$owner = Filesystem::getOwner($currentFileName);
+		list($owner, $fileName) = Storage::getUidAndFilename($currentFileName);
+
+		$userPath = "/files_versions$fileName" . MetaStorage::CURRENT_FILE_EXT;
+
 		$author = \OC_User::getUser();
 		$absPathOnDisk = $this->pathToAbsDiskPath($owner, $userPath);
 		$userView = $this->fileHelper->getUserView($owner);
-		$this->fileHelper->createMissingDirectories($userView, $currentFileName);
+		$this->fileHelper->createMissingDirectories($userView, $fileName);
 
 		return $this->writeMetaFile($author, $absPathOnDisk) !== false;
 	}
@@ -121,9 +123,9 @@ class MetaStorage {
 	 *
 	 * @param string $currentFileName
 	 * @param FileInfo $versionFile
+	 * @param string $uid
 	 */
-	public function moveCurrentToVersion(string $currentFileName, FileInfo $versionFile) {
-		$uid = Filesystem::getOwner($currentFileName);
+	public function moveCurrentToVersion(string $currentFileName, FileInfo $versionFile, string $uid) {
 		$currentMetaFile = $this->pathToAbsDiskPath($uid, "/files_versions/$currentFileName" . self::CURRENT_FILE_EXT);
 		$targetMetaFile = $this->dataDir . $versionFile->getPath() . self::VERSION_FILE_EXT;
 

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -229,7 +229,7 @@ class Storage {
 				]);
 
 				if (self::metaEnabled()) {
-					self::$metaData->moveCurrentToVersion($filename, $fileInfo);
+					self::$metaData->moveCurrentToVersion($filename, $fileInfo, $uid);
 				}
 			}
 		}

--- a/changelog/10.9.1_2021-12-28/39670
+++ b/changelog/10.9.1_2021-12-28/39670
@@ -1,0 +1,8 @@
+Bugfix: Getting the file owner for share recipients
+
+Fixed a bug where a wrong file owner was retrieved when saving version authors.
+This scenario happened for share recipients if they had a file with the same
+name as the shared file.
+
+https://github.com/owncloud/core/pull/39670
+https://github.com/owncloud/core/issues/39662


### PR DESCRIPTION
## Description

Fixed a bug where a wrong file owner was retrieved when saving version authors. This scenario happened for share recipients if they had a file with the same name as the shared one.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39662

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
