### PR TITLE
Fix issue with wrong version authors being saved

### DIFF
--- a/apps/files_versions/lib/MetaStorage.php
+++ b/apps/files_versions/lib/MetaStorage.php
@@ -137,15 +137,16 @@ class MetaStorage {
 	 * metadata.
 	 *
 	 * @param string $authorUid
+	 * @param string $fileOwner
 	 * @param FileInfo $version
 	 */
-	public function createForVersion(string $authorUid, FileInfo $version) {
-		$path = self::pathToAbsDiskPath($authorUid, $version->getInternalPath()) . self::VERSION_FILE_EXT;
+	public function createForVersion(string $authorUid, string $fileOwner, FileInfo $version) {
+		$path = self::pathToAbsDiskPath($fileOwner, $version->getInternalPath()) . self::VERSION_FILE_EXT;
 		self::writeMetaFile($authorUid, $path);
 	}
 
 	/**
-	 *  Retrieve the uid of the user that has authored a given version.
+	 * Retrieve the uid of the user that has authored a given version.
 	 *
 	 * @param FileInfo $versionFile
 	 * @return string|null null if no metadata is available
@@ -153,11 +154,39 @@ class MetaStorage {
 	public function getAuthorUid(FileInfo $versionFile) : ?string {
 		$metaDataFilePath = $this->dataDir . '/' . $versionFile->getPath() . MetaStorage::VERSION_FILE_EXT;
 		if (\file_exists($metaDataFilePath)) {
-			$json = \file_get_contents($metaDataFilePath);
-			if ($decoded = \json_decode($json, true)) {
-				if (isset($decoded[MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME])) {
-					return $decoded[MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME];
-				}
+			return $this->getVersionAuthorByPath($metaDataFilePath);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Retrieve the uid of the user that has authored the current version.
+	 *
+	 * @param string $uid
+	 * @param string $filename
+	 * @return string|null null if no metadata is available
+	 */
+	public function getCurrentVersionAuthorUid(string $uid, string $filename) : ?string {
+		$metaDataFilePath = $this->pathToAbsDiskPath($uid, "files_versions$filename" . self::CURRENT_FILE_EXT);
+		if (\file_exists($metaDataFilePath)) {
+			return $this->getVersionAuthorByPath($metaDataFilePath);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Retrieve the uid of a given version file path. Presumes that the file exists.
+	 *
+	 * @param string $path
+	 * @return string|null
+	 */
+	protected function getVersionAuthorByPath(string $path) : ?string {
+		$json = \file_get_contents($path);
+		if ($decoded = \json_decode($json, true)) {
+			if (isset($decoded[MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME])) {
+				return $decoded[MetaPlugin::VERSION_EDITED_BY_PROPERTYNAME];
 			}
 		}
 
@@ -190,13 +219,12 @@ class MetaStorage {
 	}
 
 	/**
-	 *
 	 * After a version is restored, the version's metadata is also restored
 	 * and becomes the current metadata of the file.
 	 *
-	 * @param $uid
-	 * @param $fileToRestore
-	 * @param $target
+	 * @param string $uid
+	 * @param string $fileToRestore
+	 * @param string $target
 	 */
 	public function restore(string $uid, string $fileToRestore, string $target) {
 		$restoreDirName = \dirname($fileToRestore);
@@ -207,6 +235,9 @@ class MetaStorage {
 
 		if (\file_exists($src)) {
 			\rename($src, $dst);
+		} elseif (\file_exists($dst)) {
+			// Remove current author file in case there is no author to restore
+			\unlink($dst);
 		}
 	}
 

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -404,7 +404,10 @@ class Storage {
 			if (self::metaEnabled()) {
 				$versionFileInfo = $users_view->getFileInfo($version);
 				if ($versionFileInfo && !$versionFileInfo->getStorage()->instanceOfStorage(ObjectStoreStorage::class)) {
-					self::$metaData->createForVersion($uid, $versionFileInfo);
+					$versionAuthor = self::$metaData->getCurrentVersionAuthorUid($uid, $filename);
+					if ($versionAuthor) {
+						self::$metaData->createForVersion($versionAuthor, $uid, $versionFileInfo);
+					}
 				}
 			}
 		}

--- a/changelog/10.9.1_2021-12-28/39673
+++ b/changelog/10.9.1_2021-12-28/39673
@@ -1,0 +1,7 @@
+Bugfix: Prevent version author from being overwritten with wrong uid
+
+Fixed an issue where restoring a previous version could lead to a wrong
+version author being saved, basically overwriting the correct author.
+
+https://github.com/owncloud/core/pull/39673
+https://github.com/owncloud/core/issues/39672


### PR DESCRIPTION
## Description

Fixed issues where restoring a previous version could lead to a wrong version author being saved:

* Rolling back a previous version as share recipient now rolls back the correct author as well. Previously, the rolled back version "received" the file owner as author, not the actual author (see https://github.com/owncloud/core/issues/39672#issue-1097953642).
* When restoring a version which has no author information, the current author file is being deleted because the restored version has no author. In the past, the current author stayed the same, compromising the author history (see https://github.com/owncloud/core/issues/39672#issuecomment-1009796367).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39672

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
