### PR TITLE
[tests-only] skip test because of encryption issue 321

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersionAuthor.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionAuthor.feature
@@ -71,7 +71,7 @@ Feature: file versions remember the author of each version
       | 1     | Brian  |
       | 2     | Alice  |
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @skipOnEncryption @issue-encryption-321
   Scenario: enable file versioning and check the history of changes from multiple users while moving file in/out of a subfolder
     Given user "Alice" has created folder "/test"
     And group "grp1" has been created


### PR DESCRIPTION
## Description
This core version-author scenario fails in encryption because of encryption issue https://github.com/owncloud/encryption/issues/321

Skip it in that case, so that the rest of encryption CI will pass.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
