### PR TITLE
Fix files:checksums:verify for a single file

### DIFF
--- a/apps/files/lib/Command/VerifyChecksums.php
+++ b/apps/files/lib/Command/VerifyChecksums.php
@@ -115,7 +115,7 @@ class VerifyChecksums extends Command {
 					$this->exitStatus = self::EXIT_INVALID_ARGS;
 					return $this->exitStatus;
 				}
-				if ($node === FileInfo::TYPE_FILE) {
+				if ($node->getType() === FileInfo::TYPE_FILE) {
 					$this->verifyChecksumsForFile($node, $input, $output);
 				} else {
 					$this->verifyChecksumsForFolder($node, $input, $output);

--- a/apps/files/tests/Command/VerifyChecksumsTest.php
+++ b/apps/files/tests/Command/VerifyChecksumsTest.php
@@ -117,7 +117,7 @@ class VerifyChecksumsTest extends TestCase {
 	 * @return bool|IUser
 	 */
 	private function createRandomUser($number) {
-		$userName = $this->getUniqueID("$number-verifycheksums");
+		$userName = $this->getUniqueID("$number-verifychecksums");
 		$user = $this->createUser($userName);
 		$this->loginAsUser($userName);
 
@@ -269,6 +269,32 @@ class VerifyChecksumsTest extends TestCase {
 		]);
 
 		$this->assertEquals(self::BROKEN_CHECKSUM_STRING, $file4->getChecksum());
+	}
+
+	/**
+	 * @depends testBrokenFilesAreRepairedWithRepairArgument
+	 */
+	public function testSingleFileInGivenPathArgumentIsRepaired() {
+
+		/** @var File $file1 */
+		$file1 = $this->testFiles[0]['file'];
+		/** @var File $file2 */
+		$file2 = $this->testFiles[1]['file'];
+
+		$this->breakChecksum($file1);
+		$this->breakChecksum($file2);
+
+		$this->cmd->execute([
+			'-r' => null,
+			'-u' => $this->user1,
+			'-p' => "dir/nested/somefile.txt"
+		]);
+
+		$this->assertChecksumsAreCorrect([
+			$this->testFiles[0],
+		]);
+
+		$this->assertEquals(self::BROKEN_CHECKSUM_STRING, $file2->getChecksum());
 	}
 
 	public function testOnlyFilesOfAGivenUserAreRepaired() {

--- a/changelog/unreleased/39683
+++ b/changelog/unreleased/39683
@@ -1,0 +1,5 @@
+Bugfix: Fix files:checksums:verify for a single file
+
+Fixed an issue where running files:checksums:verify for a single file would fail.
+
+https://github.com/owncloud/core/pull/39683


### PR DESCRIPTION
## Description
`files:checksums:verify` fails if run against just a single file (specify -u someuser -p somefile.ext)

I added a unit test that does this, and it fails as follows:

```
/home/phil/git/owncloud/core/lib/composer/phpunit/phpunit/phpunit --configuration phpunit-autotest.xml --log-junit autotest-results-sqlite.xml ../apps/files/tests/Command/VerifyChecksumsTest.php 
PHPUnit 9.5.11 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.27
Configuration: phpunit-autotest.xml

......E.....                                                      12 / 12 (100%)

Time: 00:00.709, Memory: 28.00 MB

There was 1 error:

1) OCA\Files\Tests\Command\VerifyChecksumsTest::testSingleFileInGivenPathArgumentIsRepaired
Error: Call to undefined method OC\Files\Node\File::getDirectoryListing()

/home/phil/git/owncloud/core/apps/files/lib/Command/VerifyChecksums.php:214
/home/phil/git/owncloud/core/apps/files/lib/Command/VerifyChecksums.php:121
/home/phil/git/owncloud/core/lib/composer/symfony/console/Command/Command.php:255
/home/phil/git/owncloud/core/lib/composer/symfony/console/Tester/CommandTester.php:76
/home/phil/git/owncloud/core/apps/files/tests/Command/VerifyChecksumsTest.php:290

ERRORS!
Tests: 12, Assertions: 47, Errors: 1.
make: *** [Makefile:195: test-php-unit] Error 2
```

The test passes with the fixed code.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4946

## How Has This Been Tested?
Added a unit test that fails without the fix, and passes with the fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
