### PR TITLE
[tests-only] Revert "Do not run unit tests against fsweb.test.owncloud.com"

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -77,6 +77,7 @@ config = {
             ],
             "externalTypes": [
                 "samba",
+                "windows",
             ],
             "coverage": True,
             "extraCommandsBeforeTestRun": [


### PR DESCRIPTION
## Description
This reverts commit a68b8bb7ff35b7a8dabc5c0d177158b7ab1db6a9.

The unit test pipelines that are run with windows back-end storage were removed yesterday because the test server was not responding. This PR puts those unit test pipelines back.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
