### PR TITLE
[full-ci] Acceptance tests for deep moves and fix 39702

### DIFF
--- a/changelog/unreleased/39703
+++ b/changelog/unreleased/39703
@@ -1,0 +1,6 @@
+Bugfix: Moving a file from one folder into a folder that is a number fails
+
+The issue is fixed by updating sabre/dav from 4.3.0 to 4.3.1
+
+https://github.com/owncloud/core/issues/39702
+https://github.com/owncloud/core/pull/39703

--- a/changelog/unreleased/PHPdependencies20211123onward
+++ b/changelog/unreleased/PHPdependencies20211123onward
@@ -12,7 +12,7 @@ The following have been updated:
 - league/mime-type-detection (1.8.0 to 1.9.0)
 - paragonie/constant_time_encoding (2.4.0 to 2.5.0)
 - phpseclib/phpseclib (3.0.11 => 3.0.12)
-- sabre/dav (4.2.0 to 4.3.0)
+- sabre/dav (4.2.0 to 4.3.1)
 - sabre/vobject (4.4.0 to 4.4.1)
 
 https://github.com/owncloud/core/pull/39526
@@ -20,3 +20,4 @@ https://github.com/owncloud/core/pull/39631
 https://github.com/owncloud/core/pull/39649
 https://github.com/owncloud/core/pull/39693
 https://github.com/owncloud/core/pull/39695
+https://github.com/owncloud/core/pull/39703

--- a/composer.lock
+++ b/composer.lock
@@ -2659,16 +2659,16 @@
         },
         {
             "name": "sabre/dav",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/dav.git",
-                "reference": "1f9bfa733a22e3c1f7526d645dab2cee96eba51a"
+                "reference": "130abb7017f56e0d99b04eb94b041e000a8e9b39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/dav/zipball/1f9bfa733a22e3c1f7526d645dab2cee96eba51a",
-                "reference": "1f9bfa733a22e3c1f7526d645dab2cee96eba51a",
+                "url": "https://api.github.com/repos/sabre-io/dav/zipball/130abb7017f56e0d99b04eb94b041e000a8e9b39",
+                "reference": "130abb7017f56e0d99b04eb94b041e000a8e9b39",
                 "shasum": ""
             },
             "require": {
@@ -2741,7 +2741,7 @@
                 "issues": "https://github.com/sabre-io/dav/issues",
                 "source": "https://github.com/fruux/sabre-dav"
             },
-            "time": "2021-12-14T08:56:03+00:00"
+            "time": "2022-01-20T13:59:29+00:00"
         },
         {
             "name": "sabre/event",

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -404,3 +404,32 @@ Feature: move (rename) file
       | dav_version |
       | old         |
       | new         |
+
+  Scenario Outline: Moving a file (deep moves with various folder and file names)
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "<source_folder>"
+    And user "Alice" has created folder "<target_folder>"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/<source_folder>/<source_file>"
+    When user "Alice" moves file "/<source_folder>/<source_file>" to "/<target_folder>/<target_file>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Alice"
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "/<target_folder>/<target_file>" for user "Alice" should be "ownCloud test text file 0"
+    Examples:
+      | dav_version | source_folder | source_file | target_folder | target_file |
+      | old         | text          | file.txt    | 0             | file.txt    |
+      | old         | text          | file.txt    | 1             | file.txt    |
+      | old         | 0             | file.txt    | text          | file.txt    |
+      | old         | 1             | file.txt    | text          | file.txt    |
+      | old         | texta         | 0           | textb         | file.txt    |
+      | old         | texta         | 1           | textb         | file.txt    |
+      | old         | texta         | file.txt    | textb         | 0           |
+      | old         | texta         | file.txt    | textb         | 1           |
+      | new         | text          | file.txt    | 0             | file.txt    |
+      | new         | text          | file.txt    | 1             | file.txt    |
+      | new         | 0             | file.txt    | text          | file.txt    |
+      | new         | 1             | file.txt    | text          | file.txt    |
+      | new         | texta         | 0           | textb         | file.txt    |
+      | new         | texta         | 1           | textb         | file.txt    |
+      | new         | texta         | file.txt    | textb         | 0           |
+      | new         | texta         | file.txt    | textb         | 1           |

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -433,3 +433,27 @@ Feature: move (rename) file
       | new         | texta         | 1           | textb         | file.txt    |
       | new         | texta         | file.txt    | textb         | 0           |
       | new         | texta         | file.txt    | textb         | 1           |
+
+  Scenario Outline: Moving a file from a folder to the root
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "<source_folder>"
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/<source_folder>/<source_file>"
+    When user "Alice" moves file "/<source_folder>/<source_file>" to "/<target_file>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the following headers should match these regular expressions for user "Alice"
+      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
+    And the content of file "/<target_file>" for user "Alice" should be "ownCloud test text file 0"
+    Examples:
+      | dav_version | source_folder | source_file | target_file |
+      | old         | 0             | file.txt    | file.txt    |
+      | old         | 1             | file.txt    | file.txt    |
+      | old         | texta         | 0           | file.txt    |
+      | old         | texta         | 1           | file.txt    |
+      | old         | texta         | file.txt    | 0           |
+      | old         | texta         | file.txt    | 1           |
+      | new         | 0             | file.txt    | file.txt    |
+      | new         | 1             | file.txt    | file.txt    |
+      | new         | texta         | 0           | file.txt    |
+      | new         | texta         | 1           | file.txt    |
+      | new         | texta         | file.txt    | 0           |
+      | new         | texta         | file.txt    | 1           |


### PR DESCRIPTION
## Description
1) add test scenarios for combinations of moving a file between folders where the folder and/or file names are numeric
2) Update sabre/dav (4.3.0 to 4.3.1), which fixes the issue
3) Add test scenarios for moving file from subfolder to root

## Related Issue
fixes #39702 

## How Has This Been Tested?
CI

In the first commit: https://drone.owncloud.com/owncloud/core/34371/93/13
```
runsh: Total unexpected failed scenarios throughout the test run:
apiWebdavMove2/moveFile.feature:421
```

In the 3rd commit, locally without tghe fix, I get:
```
  Background:                                                                            # /home/phil/git/owncloud/core/tests/acceptance/features/apiWebdavMove2/moveFile.feature:7
    Given using OCS API version "1"                                                      # FeatureContext::usingOcsApiVersion()
    And user "Alice" has been created with default attributes and without skeleton files # FeatureContext::userHasBeenCreatedWithDefaultAttributesAndWithoutSkeletonFiles()

  Scenario Outline: Moving a file from a folder to the root                                                         # /home/phil/git/owncloud/core/tests/acceptance/features/apiWebdavMove2/moveFile.feature:437
    Given using <dav_version> DAV path                                                                              # FeatureContext::usingOldOrNewDavPath()
    And user "Alice" has created folder "<source_folder>"                                                           # FeatureContext::userHasCreatedFolder()
    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/<source_folder>/<source_file>" # FeatureContext::userHasUploadedAFileWithContentTo()
    When user "Alice" moves file "/<source_folder>/<source_file>" to "/<target_file>" using the WebDAV API          # FeatureContext::userMovesFileUsingTheAPI()
    Then the HTTP status code should be "201"                                                                       # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And the following headers should match these regular expressions for user "Alice"                               # FeatureContext::headersShouldMatchRegularExpressionsForUser()
      | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
    And the content of file "/<target_file>" for user "Alice" should be "ownCloud test text file 0"                 # FeatureContext::contentOfFileForUserShouldBe()

    Examples:
      | dav_version | source_folder | source_file | target_file |
      | old         | 0             | file.txt    | file.txt    |
      | old         | 1             | file.txt    | file.txt    |
      | old         | texta         | 0           | file.txt    |
      | old         | texta         | 1           | file.txt    |
      | old         | texta         | file.txt    | 0           |
      | old         | texta         | file.txt    | 1           |
        HTTP status code 500 is not the expected value 201
        Failed asserting that 500 matches expected '201'.
      | new         | 0             | file.txt    | file.txt    |
      | new         | 1             | file.txt    | file.txt    |
      | new         | texta         | 0           | file.txt    |
      | new         | texta         | 1           | file.txt    |
      | new         | texta         | file.txt    | 0           |
      | new         | texta         | file.txt    | 1           |

--- Failed scenarios:

    /home/phil/git/owncloud/core/tests/acceptance/features/apiWebdavMove2/moveFile.feature:453

12 scenarios (11 passed, 1 failed)
108 steps (105 passed, 1 failed, 2 skipped)
1m51.32s (18.36Mb)
```

The fails happened when the target of the move was a path that starts with a non-zero number
For example, moving a file up to the root and calling it "1".
Or moving a file to a folder called "1".

Somehow the cases where the target path starts with a "0" did not fail.

CI passes with the 2nd commit, and 3rd commit.

Also, everything was OK with the "new" dav_version. Only "old" dav_version failed. That seems strange, but I guess there must be different ways that those make use of `sabre/dav`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
