### PR TITLE
[tests-only] Test moving a folder into a sub-folder of itself

### DIFF
--- a/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
@@ -93,3 +93,19 @@ Feature: move (rename) folder
       | new         | /upload...1.. |
       | new         | /...          |
       | new         | /..upload     |
+
+
+  Scenario Outline: Moving a folder into a sub-folder of itself
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file with content "parent text" to "/PARENT/parent.txt"
+    And user "Alice" has uploaded file with content "child text" to "/PARENT/CHILD/child.txt"
+    When user "Alice" moves folder "/PARENT" to "/PARENT/CHILD/PARENT" using the WebDAV API
+    Then the HTTP status code should be "409"
+    And the content of file "/PARENT/parent.txt" for user "Alice" should be "parent text"
+    And the content of file "/PARENT/CHILD/child.txt" for user "Alice" should be "child text"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |


### PR DESCRIPTION
## Description
This scenario is not currently in the acceptance tests, so add it. It was mentioned today that it seems to be a problem when this type of API move request is done on oCIS. It works correctly on oC10 - gives a 409 "conflict" response.

## How Has This Been Tested?
Local run of test scenario.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
