### PR TITLE
[tests-only] enhance theWebdavChecksumShouldMatch test

### DIFF
--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -191,7 +191,8 @@ Feature: checksums
     When user "Alice" shares file "/myChecksumFile.txt" with user "Brian" using the sharing API
     And user "Brian" accepts share "/myChecksumFile.txt" offered by user "Alice" using the sharing API
     And user "Brian" requests the checksum of "/Shares/myChecksumFile.txt" via propfind
-    Then the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
+    Then the HTTP status code should be "207"
+    And the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
       | dav_version |
       | new         |

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -405,6 +405,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Moving a file (deep moves with various folder and file names)
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<source_folder>"
@@ -434,6 +435,7 @@ Feature: move (rename) file
       | new         | texta         | file.txt    | textb         | 0           |
       | new         | texta         | file.txt    | textb         | 1           |
 
+  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Moving a file from a folder to the root
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<source_folder>"

--- a/tests/acceptance/features/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/features/bootstrap/ChecksumContext.php
@@ -184,56 +184,125 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @Then the webdav checksum should match :checksum
+	 * @Then the webdav checksum should match :expectedChecksum
 	 *
-	 * @param string $checksum
+	 * @param string $expectedChecksum
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theWebdavChecksumShouldMatch(string $checksum):void {
+	public function theWebdavChecksumShouldMatch(string $expectedChecksum):void {
 		$service = new Sabre\Xml\Service();
-		$parsed = $service->parse(
-			$this->featureContext->getResponse()->getBody()->getContents()
-		);
+		$bodyContents = $this->featureContext->getResponse()->getBody()->getContents();
+		$parsed = $service->parse($bodyContents);
 
 		/*
 		 * Fetch the checksum array
-		 * Maybe we want to do this a bit cleaner ;)
+		 * The checksums are way down in the array:
+		 * $checksums = $parsed[0]['value'][1]['value'][0]['value'][0];
+		 * And inside is the actual checksum string:
+		 * $checksums['value'][0]['value']
+		 * The Asserts below check the existence of the expected key at every level
+		 * of the nested array. This helps to see what happened if a test fails
+		 * because the response structure is not as expected.
 		 */
-		$checksums = $parsed[0]['value'][1]['value'][0]['value'][0];
+
+		Assert::assertIsArray(
+			$parsed,
+			__METHOD__ . " could not parse response as XML: " . $bodyContents
+		);
+		Assert::assertArrayHasKey(
+			0,
+			$parsed,
+			__METHOD__ . " parsed XML does not have key 0"
+		);
+		$parsed0 = $parsed[0];
+		Assert::assertArrayHasKey(
+			'value',
+			$parsed0,
+			__METHOD__ . " parsed XML parsed0 does not have key value"
+		);
+		$parsed0Value = $parsed0['value'];
+		Assert::assertArrayHasKey(
+			1,
+			$parsed0Value,
+			__METHOD__ . " parsed XML parsed0Value does not have key 1"
+		);
+		$parsed0Value1 = $parsed0Value[1];
+		Assert::assertArrayHasKey(
+			'value',
+			$parsed0Value1,
+			__METHOD__ . " parsed XML parsed0Value1 does not have key value after key 1"
+		);
+		$parsed0Value1Value = $parsed0Value1['value'];
+		Assert::assertArrayHasKey(
+			0,
+			$parsed0Value1Value,
+			__METHOD__ . " parsed XML parsed0Value1Value does not have key 0"
+		);
+		$parsed0Value1Value0 = $parsed0Value1Value[0];
+		Assert::assertArrayHasKey(
+			'value',
+			$parsed0Value1Value0,
+			__METHOD__ . " parsed XML parsed0Value1Value0 does not have key value"
+		);
+		$parsed0Value1Value0Value = $parsed0Value1Value0['value'];
+		Assert::assertArrayHasKey(
+			0,
+			$parsed0Value1Value0Value,
+			__METHOD__ . " parsed XML parsed0Value1Value0Value does not have key 0"
+		);
+		$checksums = $parsed0Value1Value0Value[0];
+		Assert::assertArrayHasKey(
+			'value',
+			$checksums,
+			__METHOD__ . " parsed XML checksums does not have key value"
+		);
+		$checksumsValue = $checksums['value'];
+		Assert::assertArrayHasKey(
+			0,
+			$checksumsValue,
+			__METHOD__ . " parsed XML checksumsValue does not have key 0"
+		);
+		$checksumsValue0 = $checksumsValue[0];
+		Assert::assertArrayHasKey(
+			'value',
+			$checksumsValue0,
+			__METHOD__ . " parsed XML checksumsValue0 does not have key value"
+		);
+		$actualChecksum = $checksumsValue0['value'];
 		Assert::assertEquals(
-			$checksum,
-			$checksums['value'][0]['value'],
-			"Expected: webDav checksum should be {$checksum} but got {$checksums['value'][0]['value']}"
+			$expectedChecksum,
+			$actualChecksum,
+			"Expected: webDav checksum should be {$expectedChecksum} but got {$actualChecksum}"
 		);
 	}
 
 	/**
-	 * @Then as user :user the webdav checksum of :path via propfind should match :checksum
+	 * @Then as user :user the webdav checksum of :path via propfind should match :expectedChecksum
 	 *
 	 * @param string $user
 	 * @param string $path
-	 * @param string $checksum
+	 * @param string $expectedChecksum
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theWebdavChecksumOfViaPropfindShouldMatch(string $user, string $path, string $checksum):void {
+	public function theWebdavChecksumOfViaPropfindShouldMatch(string $user, string $path, string $expectedChecksum):void {
 		$user = $this->featureContext->getActualUsername($user);
 		$this->userRequestsTheChecksumOfViaPropfind($user, $path);
-		$this->theWebdavChecksumShouldMatch($checksum);
+		$this->theWebdavChecksumShouldMatch($expectedChecksum);
 	}
 
 	/**
-	 * @Then the header checksum should match :checksum
+	 * @Then the header checksum should match :expectedChecksum
 	 *
-	 * @param string $checksum
+	 * @param string $expectedChecksum
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theHeaderChecksumShouldMatch(string $checksum):void {
+	public function theHeaderChecksumShouldMatch(string $expectedChecksum):void {
 		$headerChecksums
 			= $this->featureContext->getResponse()->getHeader('OC-Checksum');
 
@@ -257,9 +326,9 @@ class ChecksumContext implements Context {
 		$headerChecksum
 			= $headerChecksums[0];
 		Assert::assertEquals(
-			$checksum,
+			$expectedChecksum,
 			$headerChecksum,
-			"Expected: header checksum should match {$checksum} but got {$headerChecksum}"
+			"Expected: header checksum should match {$expectedChecksum} but got {$headerChecksum}"
 		);
 	}
 
@@ -304,14 +373,14 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @When user :user uploads chunk file :num of :total with :data to :destination with checksum :checksum using the WebDAV API
+	 * @When user :user uploads chunk file :num of :total with :data to :destination with checksum :expectedChecksum using the WebDAV API
 	 *
 	 * @param string $user
 	 * @param int $num
 	 * @param int $total
 	 * @param string $data
 	 * @param string $destination
-	 * @param string $checksum
+	 * @param string $expectedChecksum
 	 *
 	 * @return void
 	 */
@@ -321,7 +390,7 @@ class ChecksumContext implements Context {
 		int $total,
 		string $data,
 		string $destination,
-		string $checksum
+		string $expectedChecksum
 	):void {
 		$user = $this->featureContext->getActualUsername($user);
 		$num -= 1;
@@ -330,7 +399,7 @@ class ChecksumContext implements Context {
 			$user,
 			'PUT',
 			$file,
-			['OC-Checksum' => $checksum, 'OC-Chunked' => '1'],
+			['OC-Checksum' => $expectedChecksum, 'OC-Chunked' => '1'],
 			$data,
 			"files"
 		);
@@ -338,14 +407,14 @@ class ChecksumContext implements Context {
 	}
 
 	/**
-	 * @Given user :user has uploaded chunk file :num of :total with :data to :destination with checksum :checksum
+	 * @Given user :user has uploaded chunk file :num of :total with :data to :destination with checksum :expectedChecksum
 	 *
 	 * @param string $user
 	 * @param int $num
 	 * @param int $total
 	 * @param string $data
 	 * @param string $destination
-	 * @param string $checksum
+	 * @param string $expectedChecksum
 	 *
 	 * @return void
 	 */
@@ -355,7 +424,7 @@ class ChecksumContext implements Context {
 		int $total,
 		string $data,
 		string $destination,
-		string $checksum
+		string $expectedChecksum
 	):void {
 		$this->userUploadsChunkFileOfWithToWithChecksum(
 			$user,
@@ -363,7 +432,7 @@ class ChecksumContext implements Context {
 			$total,
 			$data,
 			$destination,
-			$checksum
+			$expectedChecksum
 		);
 		$this->featureContext->theHTTPStatusCodeShouldBeOr(201, 206);
 	}


### PR DESCRIPTION
## Description
https://drone.owncloud.com/owncloud/ocis/8908/23/6 fails with:
`Warning: Illegal string offset 'value' in /srv/app/testrunner/tests/acceptance/features/bootstrap/ChecksumContext.php line 204`

1) The PROPFIND response does not have the expected structure. The test code assumes that the deep array structure of the PROPFIND will all exist, and that it will be able to directly find the checksum.

This PR enhances the test code so that it checks at every level of the expected structure and fails with a message as soon as it discovers part of the nested structure does not exist.

2) some tests were added to core for "deep move" in PR #39705 - those need to be skipped when testing against an "old" oC10, because the fix is only in master, not in 10.9.1 release or earlier.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
