### PR TITLE
[tests-only] use spaces dav path in `apiAuth` suite

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -385,8 +385,8 @@ class WebDavHelper {
 		if (\array_key_exists($user, self::$spacesIdRef) && \array_key_exists("personal", self::$spacesIdRef[$user])) {
 			return self::$spacesIdRef[$user]["personal"];
 		}
-		$drivesPath = 'graph/v1.0/me/drives';
-		$fullUrl = $baseUrl . $drivesPath;
+		$drivesPath = '/graph/v1.0/me/drives';
+		$fullUrl = \trim($baseUrl, "/") . $drivesPath;
 		$response = HttpRequestHelper::get(
 			$fullUrl,
 			$xRequestId,

--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -9,10 +9,23 @@ Feature: auth
     When a user requests "/remote.php/webdav" with "PROPFIND" and no authentication
     Then the HTTP status code should be "401"
 
+  @smokeTest @skipOnOcV10 @personalSpace
+  Scenario: using spaces WebDAV anonymously
+    When user "Alice" requests "/dav/spaces/%spaceid%" with "PROPFIND" and no authentication
+    Then the HTTP status code should be "401"
+
   @smokeTest
-  Scenario: using WebDAV with basic auth
-    When user "Alice" requests "/remote.php/webdav" with "PROPFIND" using basic auth
+  Scenario Outline: using WebDAV with basic auth
+    When user "Alice" requests "<dav_path>" with "PROPFIND" using basic auth
     Then the HTTP status code should be "207"
+    Examples:
+      | dav_path           |
+      | /remote.php/webdav |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_path              |
+      | /dav/spaces/%spaceid% |
 
   @smokeTest @notToImplementOnOCIS @issue-ocis-reva-28
   Scenario: using WebDAV with token auth

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -134,6 +134,22 @@ class AuthContext implements Context {
 	}
 
 	/**
+	 * @When user :user requests :url with :method and no authentication
+	 *
+	 * @param string $user
+	 * @param string $url
+	 * @param string $method
+	 *
+	 * @return void
+	 * @throws JsonException
+	 */
+	public function userRequestsURLWithNoAuth(string $user, string $url, string $method):void {
+		$userRenamed = $this->featureContext->getActualUsername($user);
+		$url = $this->featureContext->substituteInLineCodes($url, $userRenamed);
+		$this->sendRequest($url, $method);
+	}
+
+	/**
 	 * @Given a user has requested :url with :method and no authentication
 	 *
 	 * @param string $url

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3090,6 +3090,14 @@ class FeatureContext extends BehatVariablesContext {
 						"getEmailAddressForUser"
 					],
 					"parameter" => [$user]
+				],
+				[
+					"code" => "%spaceid%",
+					"function" => [
+						$this,
+						"getPersonalSpaceIdForUser",
+					],
+					"parameter" => [$user]
 				]
 			);
 		}
@@ -3120,6 +3128,23 @@ class FeatureContext extends BehatVariablesContext {
 			);
 		}
 		return $value;
+	}
+
+	/**
+	 * returns personal space id for user
+	 *
+	 * @param string $user
+	 *
+	 * @return string
+	 * @throws GuzzleException
+	 */
+	public function getPersonalSpaceIdForUser(string $user):string {
+		return WebDavHelper::getPersonalSpaceIdForUser(
+			$this->getBaseUrl(),
+			$user,
+			$this->getPasswordForUser($user),
+			$this->getStepLineRef()
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
use spaces DAV path in `apiAuth` suite

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/ocis/issues/3022

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 
- https://github.com/owncloud/ocis/pull/3025

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
