### PR TITLE
[tests-only][full-ci]Add spaces tests on `apiAuthWebDav` suites

### DIFF
--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
@@ -21,7 +21,17 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
+      | /remote.php/webdav/PARENT/parent.txt               |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send DELETE requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "DELETE" including body "doesnotmatter" using password "invalid" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   Scenario: send DELETE requests to webDav endpoints as normal user with no password
@@ -31,7 +41,17 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
+      | /remote.php/webdav/PARENT/parent.txt               |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send DELETE requests to webDav endpoints as normal user with no password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "DELETE" including body "doesnotmatter" using password "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @issue-ocis-reva-13
@@ -41,6 +61,15 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "404"
+
+  @issue-ocis-reva-13 @skipOnOcV10 @personalSpace
+  Scenario: send DELETE requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "DELETE" including body "doesnotmatter" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
   @smokeTest
@@ -54,6 +83,15 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnOcV10 @personalSpace
+  Scenario: send DELETE requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
+    When user "usero" requests these endpoints with "DELETE" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   Scenario: send DELETE requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "DELETE" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -62,6 +100,15 @@ Feature: delete file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send DELETE requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "DELETE" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @smokeTest
@@ -74,6 +121,15 @@ Feature: delete file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send DELETE requests to webDav endpoints without any authentication using the spaces WebDAV API
+    When a user requests these endpoints with "DELETE" with body "doesnotmatter" and no authentication about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @issue-ocis-reva-60
@@ -90,6 +146,18 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @issue-ocis-reva-60 @skipOnOcV10 @personalSpace
+  Scenario: send DELETE requests to webDav endpoints using token authentication should not work using the spaces WebDAV API
+    Given token auth has been enforced
+    And a new browser session for "Alice" has been started
+    And the user has generated a new app password named "my-client"
+    When the user requests these endpoints with "DELETE" using the generated app password about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @issue-ocis-reva-60
   Scenario: send DELETE requests to webDav endpoints using app password token as password
     Given token auth has been enforced
@@ -102,4 +170,16 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/FOLDER            |
+    Then the HTTP status code of responses on all endpoints should be "204"
+
+  @issue-ocis-reva-60 @skipOnOcV10 @personalSpace
+  Scenario: send DELETE requests to webDav endpoints using app password token as password using the spaces WebDAV API
+    Given token auth has been enforced
+    And a new browser session for "Alice" has been started
+    And the user has generated a new app password named "my-client"
+    When the user "Alice" requests these endpoints with "DELETE" with body "doesnotmatter" using basic auth and generated app password about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "204"

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -24,6 +24,15 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send LOCK requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "LOCK" including body "doesnotmatter" using password "invalid" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints as normal user with no password
@@ -34,6 +43,15 @@ Feature: LOCK file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send LOCK requests to webDav endpoints as normal user with no password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "LOCK" including body "doesnotmatter" using password "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @issue-ocis-reva-9 @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
@@ -48,6 +66,18 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "409"
 
+  @issue-ocis-reva-9 @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10 @personalSpace
+  Scenario: send LOCK requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
+      | endpoint                                       |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt |
+      | /remote.php/dav/spaces/%spaceid%/PARENT        |
+    Then the HTTP status code of responses on all endpoints should be "403"
+    When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "409"
+
   Scenario: send LOCK requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "LOCK" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -56,6 +86,15 @@ Feature: LOCK file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send LOCK requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
+    When user "usero" requests these endpoints with "LOCK" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   Scenario: send LOCK requests to webDav endpoints using valid password and username of different user
@@ -68,6 +107,15 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @skipOnOcV10 @personalSpace
+  Scenario: send LOCK requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "LOCK" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints without any authentication
@@ -78,6 +126,15 @@ Feature: LOCK file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send LOCK requests to webDav endpoints without any authentication using the spaces WebDAV API
+    When a user requests these endpoints with "LOCK" with body "doesnotmatter" and no authentication about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -20,6 +20,15 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send MKCOL requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "MKCOL" including body "doesnotmatter" using password "invalid" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints as normal user with no password
@@ -30,6 +39,15 @@ Feature: create folder using MKCOL
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnOcV10 @personalSpace @skipOnBruteForceProtection @issue-brute_force_protection-112
+  Scenario: send MKCOL requests to webDav endpoints as normal user with no password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "MKCOL" including body "doesnotmatter" using password "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @issue-ocis-reva-9 @issue-ocis-reva-197
@@ -46,6 +64,20 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "409"
 
+  @skipOnOcV10 @personalSpace @issue-ocis-reva-9 @issue-ocis-reva-197
+  Scenario: send MKCOL requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    Given user "Brian" has been created with default attributes and without skeleton files
+    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
+      | endpoint                                        |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt  |
+      | /remote.php/dav/spaces/%spaceid%/PARENT         |
+      | /remote.php/dav/spaces/%spaceid%/does-not-exist |
+    Then the HTTP status code of responses on all endpoints should be "403"
+    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "409"
+
   Scenario: send MKCOL requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "MKCOL" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -54,6 +86,15 @@ Feature: create folder using MKCOL
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send MKCOL requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
+    When user "usero" requests these endpoints with "MKCOL" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   Scenario: send MKCOL requests to webDav endpoints using valid password and username of different user
@@ -67,6 +108,16 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @skipOnOcV10 @personalSpace
+  Scenario: send MKCOL requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
+    Given user "Brian" has been created with default attributes and without skeleton files
+    When user "Brian" requests these endpoints with "MKCOL" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints without any authentication
@@ -77,6 +128,15 @@ Feature: create folder using MKCOL
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send MKCOL requests to webDav endpoints without any authentication using the spaces WebDAV API
+    When a user requests these endpoints with "MKCOL" with body "doesnotmatter" and no authentication about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -23,6 +23,15 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send MOVE requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" using password "invalid" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MOVE requests to webDav endpoints as normal user with no password
@@ -35,6 +44,15 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send MOVE requests to webDav endpoints as normal user with no password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" using password "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @issue-ocis-reva-14
   Scenario: send MOVE requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
@@ -42,6 +60,15 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "403"
+
+  @skipOnOcV10 @personalSpace @issue-ocis-reva-14
+  Scenario: send MOVE requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "403"
 
   Scenario: send MOVE requests to webDav endpoints using invalid username but correct password
@@ -54,6 +81,15 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @skipOnOcV10 @personalSpace
+  Scenario: send MOVE requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
+    When user "usero" requests these endpoints with "MOVE" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   Scenario: send MOVE requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "MOVE" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -62,6 +98,15 @@ Feature: MOVE file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send MOVE requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "MOVE" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @smokeTest
@@ -74,6 +119,15 @@ Feature: MOVE file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send MOVE requests to webDav endpoints without any authentication using the spaces WebDAV API
+    When a user requests these endpoints with "MOVE" with body "doesnotmatter" and no authentication about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -24,6 +24,15 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send POST requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to webDav endpoints as normal user with no password
@@ -36,6 +45,15 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send POST requests to webDav endpoints as normal user with no password  using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @issue-ocis-reva-179
   Scenario: send POST requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" about user "Alice"
@@ -43,6 +61,15 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/textfile1.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "404"
+
+  @skipOnOcV10 @personalSpace @issue-ocis-reva-179
+  Scenario: send POST requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
   Scenario: send POST requests to webDav endpoints using invalid username but correct password
@@ -55,6 +82,15 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @skipOnOcV10 @personalSpace
+  Scenario: send POST requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
+    When user "usero" requests these endpoints with "POST" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   Scenario: send POST requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -63,6 +99,15 @@ Feature: get file info using POST
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send POST requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @smokeTest
@@ -75,6 +120,15 @@ Feature: get file info using POST
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send POST requests to webDav endpoints without any authentication using the spaces WebDAV API
+    When a user requests these endpoints with "POST" with body "doesnotmatter" and no authentication about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -23,6 +23,15 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send PROPFIND requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "PROPFIND" including body "doesnotmatter" using password "invalid" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPFIND requests to webDav endpoints as normal user with no password
@@ -35,6 +44,15 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send PROPFIND requests to webDav endpoints as normal user with no password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "PROPFIND" including body "doesnotmatter" using password "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @issue-ocis-reva-9
   Scenario: send PROPFIND requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PROPFIND" to get property "d:getetag" about user "Alice"
@@ -42,6 +60,15 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "404"
+
+  @skipOnOcV10 @personalSpace @issue-ocis-reva-9
+  Scenario: send PROPFIND requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "PROPFIND" to get property "d:getetag" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
   Scenario: send PROPFIND requests to webDav endpoints using invalid username but correct password
@@ -54,6 +81,15 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @skipOnOcV10 @personalSpace
+  Scenario: send PROPFIND requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
+    When user "usero" requests these endpoints with "PROPFIND" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   Scenario: send PROPFIND requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "PROPFIND" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -62,6 +98,15 @@ Feature: get file info using PROPFIND
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send PROPFIND requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "PROPFIND" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @smokeTest
@@ -74,6 +119,15 @@ Feature: get file info using PROPFIND
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send PROPFIND requests to webDav endpoints without any authentication using the spaces WebDAV API
+    When a user requests these endpoints with "PROPFIND" with body "doesnotmatter" and no authentication about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -24,6 +24,15 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send PROPPATCH requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using password "invalid" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPPATCH requests to webDav endpoints as normal user with no password
@@ -36,6 +45,15 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send PROPPATCH requests to webDav endpoints as normal user with no password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using password "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send PROPPATCH requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PROPPATCH" to set property "favorite" about user "Alice"
@@ -43,6 +61,15 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "404"
+
+  @issue-ocis-reva-9 @issue-ocis-reva-197 @skipOnOcV10 @personalSpace
+  Scenario: send PROPPATCH requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "PROPPATCH" to set property "favorite" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
   Scenario: send PROPPATCH requests to webDav endpoints using invalid username but correct password
@@ -55,6 +82,15 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @skipOnOcV10 @personalSpace
+  Scenario: send PROPPATCH requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
+    When user "usero" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   Scenario: send PROPPATCH requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -63,6 +99,15 @@ Feature: PROPPATCH file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send PROPPATCH requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @smokeTest
@@ -75,6 +120,15 @@ Feature: PROPPATCH file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send PROPPATCH requests to webDav endpoints without any authentication using the spaces WebDAV API
+    When a user requests these endpoints with "PROPPATCH" with body "doesnotmatter" and no authentication about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -24,6 +24,15 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send PUT requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "invalid" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
   @smokeTest
   @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT requests to webDav endpoints as normal user with no password
@@ -34,6 +43,15 @@ Feature: get file info using PUT
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send PUT requests to webDav endpoints as normal user with no password using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @skipOnOcV10
@@ -48,6 +66,18 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "403"
 
+  @skipOnOcV10 @personalSpace
+  Scenario: send PUT requests to another user's webDav endpoints as normal user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" about user "Alice"
+      | endpoint                                       |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt |
+      | /remote.php/dav/spaces/%spaceid%/PARENT        |
+    Then the HTTP status code of responses on all endpoints should be "403"
+    When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "403"
+
 
   Scenario: send PUT requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "PUT" including body "doesnotmatter" using the password of user "Alice"
@@ -59,7 +89,16 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-    
+  @skipOnOcV10 @personalSpace
+  Scenario: send PUT requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
+    When user "usero" requests these endpoints with "PUT" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+
   Scenario: send PUT requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -68,6 +107,15 @@ Feature: get file info using PUT
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send PUT requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
+    When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" using the password of user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @smokeTest
@@ -80,6 +128,15 @@ Feature: get file info using PUT
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "401"
+
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
+  Scenario: send PUT requests to webDav endpoints without any authentication using the spaces WebDAV API
+    When a user requests these endpoints with "PUT" with body "doesnotmatter" and no authentication about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature
@@ -17,7 +17,17 @@ Feature: make webdav request with special urls
       | //remote.php//dav/files/%username%/textfile1.txt    |
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
-      | //remote.php/dav//files/%username%//FOLDER           |
+      | //remote.php/dav//files/%username%//FOLDER          |
+    Then the HTTP status code of responses on all endpoints should be "204"
+
+  @personalSpace
+  Scenario: send DELETE requests to webDav endpoints with 2 slashes using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "DELETE" including body "doesnotmatter" using password "%regular%" about user "Alice"
+      | endpoint                                             |
+      | //remote.php/dav/spaces/%spaceid%/textfile0.txt      |
+      | /remote.php//dav/spaces/%spaceid%/PARENT             |
+      | //remote.php/dav//spaces/%spaceid%//FOLDER           |
+      | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "204"
 
 
@@ -28,7 +38,17 @@ Feature: make webdav request with special urls
       | //remote.php//dav/files/%username%/textfile1.txt    |
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
-      | //remote.php/dav//files/%username%//FOLDER           |
+      | //remote.php/dav//files/%username%//FOLDER          |
+    Then the HTTP status code of responses on all endpoints should be "200"
+
+  @personalSpace
+  Scenario: send GET requests to webDav endpoints with 2 slashes using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "GET" using password "%regular%" about user "Alice"
+      | endpoint                                             |
+      | //remote.php/dav/spaces/%spaceid%/textfile0.txt      |
+      | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
+      | /remote.php//dav/spaces/%spaceid%/PARENT             |
+      | //remote.php/dav//spaces/%spaceid%//FOLDER           |
     Then the HTTP status code of responses on all endpoints should be "200"
 
 
@@ -39,7 +59,17 @@ Feature: make webdav request with special urls
       | //remote.php//dav/files/%username%/textfile1.txt    |
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
-      | //remote.php/dav//files/%username%//FOLDER           |
+      | //remote.php/dav//files/%username%//FOLDER          |
+    Then the HTTP status code of responses on all endpoints should be "200"
+
+  @personalSpace
+  Scenario: send LOCK requests to webDav endpoints with 2 slashes using the spaces WebDAV API
+    When the user "Alice" requests these endpoints with "LOCK" to get property "d:shared" with password "%regular%" about user "Alice"
+      | endpoint                                             |
+      | //remote.php/dav/spaces/%spaceid%/textfile0.txt      |
+      | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
+      | /remote.php//dav/spaces/%spaceid%/PARENT             |
+      | //remote.php/dav//spaces/%spaceid%//FOLDER           |
     Then the HTTP status code of responses on all endpoints should be "200"
 
 
@@ -54,6 +84,18 @@ Feature: make webdav request with special urls
       | /remote.php/dav//files/%username%/PARENT6  |
     Then the HTTP status code of responses on all endpoints should be "201"
 
+  @personalSpace
+  Scenario: send MKCOL requests to webDav endpoints with 2 slashes using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "MKCOL" using password "%regular%" about user "Alice"
+      | endpoint                                   |
+      | //remote.php/dav/spaces/%spaceid%/PARENT1  |
+      | /remote.php//dav/spaces/%spaceid%/PARENT2  |
+      | //remote.php//dav/spaces/%spaceid%/PARENT3 |
+      | //remote.php/dav//spaces/%spaceid%/PARENT4 |
+      | /remote.php/dav/spaces/%spaceid%//PARENT5  |
+      | /remote.php/dav//spaces/%spaceid%/PARENT6  |
+    Then the HTTP status code of responses on all endpoints should be "201"
+
 
   Scenario: send MOVE requests to webDav endpoints with 2 slashes
     When user "Alice" requests these endpoints with "MOVE" using password "%regular%" about user "Alice"
@@ -65,6 +107,16 @@ Feature: make webdav request with special urls
       | /remote.php/dav//files/%username%/PARENT2/parent.txt | /remote.php/dav/files/%username%/PARENT2/parent1.txt |
     Then the HTTP status code of responses on all endpoints should be "201"
 
+  @personalSpace
+  Scenario: send MOVE requests to webDav endpoints with 2 slashes using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "MOVE" using password "%regular%" about user "Alice"
+      | endpoint                                             | destination                                          |
+      | /remote.php//dav/spaces/%spaceid%/textfile1.txt      | /remote.php/dav/spaces/%spaceid%/textfileOne.txt     |
+      | /remote.php/dav//spaces/%spaceid%/PARENT             | /remote.php/dav/spaces/%spaceid%/PARENT1             |
+      | //remote.php/dav/spaces/%spaceid%//PARENT1           | /remote.php/dav/spaces/%spaceid%/PARENT2             |
+      | //remote.php/dav/spaces/%spaceid%/PARENT2/parent.txt | /remote.php/dav/spaces/%spaceid%/PARENT2/parent1.txt |
+    Then the HTTP status code of responses on all endpoints should be "201"
+
 
   Scenario: send POST requests to webDav endpoints with 2 slashes
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "%regular%" about user "Alice"
@@ -73,7 +125,17 @@ Feature: make webdav request with special urls
       | //remote.php//dav/files/%username%/textfile1.txt    |
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
-      | //remote.php/dav//files/%username%//FOLDER           |
+      | //remote.php/dav//files/%username%//FOLDER          |
+    Then the HTTP status code of responses on all endpoints should be "500" or "501"
+
+  @personalSpace
+  Scenario: send POST requests to webDav endpoints with 2 slashes using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "%regular%" about user "Alice"
+      | endpoint                                            |
+      | //remote.php//dav/spaces/%spaceid%/textfile1.txt    |
+      | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
+      | /remote.php//dav/spaces/%spaceid%/PARENT            |
+      | //remote.php/dav//spaces/%spaceid%//FOLDER          |
     Then the HTTP status code of responses on all endpoints should be "500" or "501"
 
 
@@ -87,6 +149,16 @@ Feature: make webdav request with special urls
       | //remote.php/dav//files/%username%//FOLDER           |
     Then the HTTP status code of responses on all endpoints should be "207"
 
+  @personalSpace
+  Scenario: send PROPFIND requests to webDav endpoints with 2 slashes using the spaces WebDAV API
+    When the user "Alice" requests these endpoints with "PROPFIND" to get property "d:href" with password "%regular%" about user "Alice"
+      | endpoint                                            |
+      | //remote.php//dav/spaces/%spaceid%/textfile1.txt    |
+      | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
+      | /remote.php//dav/spaces/%spaceid%/PARENT            |
+      | //remote.php/dav//spaces/%spaceid%//FOLDER          |
+    Then the HTTP status code of responses on all endpoints should be "207"
+
 
   Scenario: send PROPPATCH requests to webDav endpoints with 2 slashes
     When the user "Alice" requests these endpoints with "PROPPATCH" to set property "d:getlastmodified" with password "%regular%" about user "Alice"
@@ -98,6 +170,16 @@ Feature: make webdav request with special urls
       | //remote.php/dav//files/%username%//FOLDER           |
     Then the HTTP status code of responses on all endpoints should be "207"
 
+  @personalSpace
+  Scenario: send PROPPATCH requests to webDav endpoints with 2 slashes using the spaces WebDAV API
+    When the user "Alice" requests these endpoints with "PROPPATCH" to set property "d:getlastmodified" with password "%regular%" about user "Alice"
+      | endpoint                                            |
+      | //remote.php//dav/spaces/%spaceid%/textfile1.txt    |
+      | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
+      | /remote.php//dav/spaces/%spaceid%/PARENT            |
+      | //remote.php/dav//spaces/%spaceid%//FOLDER          |
+    Then the HTTP status code of responses on all endpoints should be "207"
+
 
   Scenario: send PUT requests to webDav endpoints with 2 slashes
     When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "%regular%" about user "Alice"
@@ -107,4 +189,15 @@ Feature: make webdav request with special urls
       | //remote.php//dav/files/%username%/textfile1.txt     |
       | /remote.php/dav/files/%username%/textfile7.txt       |
       | //remote.php/dav/files/%username%/PARENT//parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "204" or "201"
+
+  @personalSpace
+  Scenario: send PUT requests to webDav endpoints with 2 slashes using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "%regular%" about user "Alice"
+      | endpoint                                             |
+      | //remote.php/dav/spaces/%spaceid%/textfile0.txt      |
+      | /remote.php//dav/spaces/%spaceid%/textfile1.txt      |
+      | //remote.php//dav/spaces/%spaceid%/textfile1.txt     |
+      | /remote.php/dav/spaces/%spaceid%/textfile7.txt       |
+      | //remote.php/dav/spaces/%spaceid%/PARENT//parent.txt |
     Then the HTTP status code of responses on all endpoints should be "204" or "201"


### PR DESCRIPTION
## Description
use spaces DAV path in `apiAuthWebDav` suite

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/ocis/issues/3029

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI
- https://github.com/owncloud/ocis/pull/3030

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
