### PR TITLE
[tests-only] [full-ci] Add API test coverage for files and folders names like Shares

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature
@@ -1,0 +1,72 @@
+@api
+Feature: create file or folder named similar to Shares folder
+  As a user
+  I want to be able to create files and folders when the Shares folder exists
+  So that I can organise the files in my file system
+
+  Background:
+    Given the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read,update"
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+
+
+  Scenario Outline: create a folder with a name similar to Shares
+    Given using <dav_version> DAV path
+    When user "Brian" creates folder "<folder_name>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Brian" folder "<folder_name>" should exist
+    And as "Brian" folder "/Shares" should exist
+    Examples:
+      | dav_version | folder_name |
+      | old         | /Share      |
+      | old         | /shares     |
+      | old         | /Shares1    |
+      | new         | /Share      |
+      | new         | /shares     |
+      | new         | /Shares1    |
+
+
+  Scenario Outline: create a file with a name similar to Shares
+    Given using <dav_version> DAV path
+    When user "Brian" uploads file with content "some text" to "<file_name>" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "<file_name>" for user "Brian" should be "some text"
+    And as "Brian" folder "/Shares" should exist
+    Examples:
+      | dav_version | file_name |
+      | old         | /Share    |
+      | old         | /shares   |
+      | old         | /Shares1  |
+      | new         | /Share    |
+      | new         | /shares   |
+      | new         | /Shares1  |
+
+
+  Scenario Outline: try to create a folder named Shares
+    Given using <dav_version> DAV path
+    When user "Brian" creates folder "/Shares" using the WebDAV API
+    Then the HTTP status code should be "405"
+    And as "Brian" folder "/Shares" should exist
+    And as "Brian" folder "/Shares/FOLDER" should exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: try to create a file named Shares
+    Given using <dav_version> DAV path
+    When user "Brian" uploads file with content "some text" to "/Shares" using the WebDAV API
+    Then the HTTP status code should be "409"
+    And as "Brian" folder "/Shares" should exist
+    And as "Brian" folder "/Shares/FOLDER" should exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |


### PR DESCRIPTION
## Description
Add API tests for creating files and folders with names similar to "Shares" when the "Shares" folder exists. This demonstrates that oC10 behaves correctly.

## Related Issue
test coverage for oCIS issue https://github.com/owncloud/ocis/issues/3033

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
