### PR TITLE
[tests-only] [full-ci] Check for newline at end of expected-failures file

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -50,6 +50,15 @@ then
 		echo "Check the setting of EXPECTED_FAILURES_FILE environment variable"
 		exit 1
 	fi
+	# If the last line of the expected-failures file ends without a newline character
+	# then that line may not get processed by some of the bash code in this script
+	# So check that the last character in the file is a newline
+	if [ $(tail -c1 "${EXPECTED_FAILURES_FILE}" | wc -l) -eq 0 ]
+	then
+		echo "Expected failures file ${EXPECTED_FAILURES_FILE} must end with a newline"
+		echo "Put a newline at the end of the last line and try again"
+		exit 1
+	fi
 fi
 
 # Default to testing a local system


### PR DESCRIPTION
## Description
See discussion in https://github.com/cs3org/reva/pull/2482

If the last line in an expected-failures file does not have a newline at the end then the test-runner `run.sh` script loop:
```
while read SUITE_SCENARIO
  do
    ...
  done < ${EXPECTED_FAILURES_FILE}
```
does not actually read the last line. That is a "feature" of the definition of what is a "line" in a text file/

So expected-failures files must always end with a newline, to be sure that all lines are processed.
The following check does that:

```
if [ $(tail -c1 "${EXPECTED_FAILURES_FILE}" | wc -l) -eq 0 ]
```

`tail -c1` gets the last character of a file.

If the last character is not a newline (if it is just an ordinary character) then the count of lines `wc -l` returns 0.
If gthe last character is a newline, the `wc -l` returns 1 - a single newline character is a "line".

## How Has This Been Tested?
CI and https://github.com/cs3org/reva/pull/2485 - see my comments in the PR.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: owncloud/docs-server#57
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
