### PR TITLE
[tests-only][full-ci]Fix ocis problem due to core cc8e53a4 merged commit

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -558,7 +558,7 @@ class WebDavHelper {
 			return "remote.php/dav/";
 		}
 		if ($davPathVersionToUse === 3) {
-			return "remote.php/dav/spaces/" . $spaceId . '/';
+			return "dav/spaces/" . $spaceId . '/';
 		} else {
 			if ($davPathVersionToUse === 1) {
 				$path = "remote.php/webdav/";

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -39,17 +39,17 @@ Feature: get file properties
     And user "Alice" has uploaded file with content "uploaded content" to "<file_name>"
     When user "Alice" gets the properties of file "<file_name>" using the WebDAV API
     Then the properties response should contain an etag
-    And the value of the item "//d:response/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>/"
+    And the value of the item "//d:response/d:href" in the response to user "Alice" should match "/<expected_href>/"
     Examples:
-      | dav_version | file_name     | expected_href                                     |
-      | old         | /C++ file.cpp | webdav\/C%2[bB]%2[bB]%20file\.cpp                 |
-      | old         | /file #2.txt  | webdav\/file%20%232\.txt                          |
-      | old         | /file ?2.txt  | webdav\/file%20%3[fF]2\.txt                       |
-      | old         | /file &2.txt  | webdav\/file%20%262\.txt                          |
-      | new         | /C++ file.cpp | dav\/files\/%username%\/C%2[bB]%2[bB]%20file\.cpp |
-      | new         | /file #2.txt  | dav\/files\/%username%\/file%20%232\.txt          |
-      | new         | /file ?2.txt  | dav\/files\/%username%\/file%20%3[fF]2\.txt       |
-      | new         | /file &2.txt  | dav\/files\/%username%\/file%20%262\.txt          |
+      | dav_version | file_name     | expected_href                                                  |
+      | old         | /C++ file.cpp | remote\.php\/webdav\/C%2[bB]%2[bB]%20file\.cpp                 |
+      | old         | /file #2.txt  | remote\.php\/webdav\/file%20%232\.txt                          |
+      | old         | /file ?2.txt  | remote\.php\/webdav\/file%20%3[fF]2\.txt                       |
+      | old         | /file &2.txt  | remote\.php\/webdav\/file%20%262\.txt                          |
+      | new         | /C++ file.cpp | remote\.php\/dav\/files\/%username%\/C%2[bB]%2[bB]%20file\.cpp |
+      | new         | /file #2.txt  | remote\.php\/dav\/files\/%username%\/file%20%232\.txt          |
+      | new         | /file ?2.txt  | remote\.php\/dav\/files\/%username%\/file%20%3[fF]2\.txt       |
+      | new         | /file &2.txt  | remote\.php\/dav\/files\/%username%\/file%20%262\.txt          |
 
     @skipOnOcV10 @personalSpace
     Examples:
@@ -66,25 +66,25 @@ Feature: get file properties
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file1.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file2.txt"
     When user "Alice" gets the properties of folder "<folder_name>" with depth 1 using the WebDAV API
-    Then there should be an entry with href matching "/remote\.php\/<expected_href>\//" in the response to user "Alice"
-    And there should be an entry with href matching "/remote\.php\/<expected_href>\/file1.txt/" in the response to user "Alice"
-    And there should be an entry with href matching "/remote\.php\/<expected_href>\/file2.txt/" in the response to user "Alice"
+    Then there should be an entry with href matching "/<expected_href>\//" in the response to user "Alice"
+    And there should be an entry with href matching "/<expected_href>\/file1.txt/" in the response to user "Alice"
+    And there should be an entry with href matching "/<expected_href>\/file2.txt/" in the response to user "Alice"
     Examples:
       | dav_version | folder_name     | expected_href                                                                                                            |
-      | old         | /upload         | webdav\/upload                                                                                                           |
-      | old         | /strängé folder | webdav\/str%[cC]3%[aA]4ng%[cC]3%[aA]9%20folder                                                                           |
-      | old         | /C++ folder     | webdav\/C%2[bB]%2[bB]%20folder                                                                                           |
-      | old         | /नेपाली           | webdav\/%[eE]0%[aA]4%[aA]8%[eE]0%[aA]5%87%[eE]0%[aA]4%[aA]a%[eE]0%[aA]4%be%[eE]0%[aA]4%b2%[eE]0%[aA]5%80                 |
-      | old         | /folder #2.txt  | webdav\/folder%20%232\.txt                                                                                               |
-      | old         | /folder ?2.txt  | webdav\/folder%20%3[fF]2\.txt                                                                                            |
-      | old         | /folder &2.txt  | webdav\/folder%20%262\.txt                                                                                               |
-      | new         | /upload         | dav\/files\/%username%\/upload                                                                                           |
-      | new         | /strängé folder | dav\/files\/%username%\/str%[cC]3%[aA]4ng%[cC]3%[aA]9%20folder                                                           |
-      | new         | /C++ folder     | dav\/files\/%username%\/C%2[bB]%2[bB]%20folder                                                                           |
-      | new         | /नेपाली           | dav\/files\/%username%\/%[eE]0%[aA]4%[aA]8%[eE]0%[aA]5%87%[eE]0%[aA]4%[aA]a%[eE]0%[aA]4%be%[eE]0%[aA]4%b2%[eE]0%[aA]5%80 |
-      | new         | /folder #2.txt  | dav\/files\/%username%\/folder%20%232\.txt                                                                               |
-      | new         | /folder ?2.txt  | dav\/files\/%username%\/folder%20%3[fF]2\.txt                                                                            |
-      | new         | /folder &2.txt  | dav\/files\/%username%\/folder%20%262\.txt                                                                               |
+      | old         | /upload         | remote\.php\/webdav\/upload                                                                                                           |
+      | old         | /strängé folder | remote\.php\/webdav\/str%[cC]3%[aA]4ng%[cC]3%[aA]9%20folder                                                                           |
+      | old         | /C++ folder     | remote\.php\/webdav\/C%2[bB]%2[bB]%20folder                                                                                           |
+      | old         | /नेपाली           | remote\.php\/webdav\/%[eE]0%[aA]4%[aA]8%[eE]0%[aA]5%87%[eE]0%[aA]4%[aA]a%[eE]0%[aA]4%be%[eE]0%[aA]4%b2%[eE]0%[aA]5%80                 |
+      | old         | /folder #2.txt  | remote\.php\/webdav\/folder%20%232\.txt                                                                                               |
+      | old         | /folder ?2.txt  | remote\.php\/webdav\/folder%20%3[fF]2\.txt                                                                                            |
+      | old         | /folder &2.txt  | remote\.php\/webdav\/folder%20%262\.txt                                                                                               |
+      | new         | /upload         | remote\.php\/dav\/files\/%username%\/upload                                                                                           |
+      | new         | /strängé folder | remote\.php\/dav\/files\/%username%\/str%[cC]3%[aA]4ng%[cC]3%[aA]9%20folder                                                           |
+      | new         | /C++ folder     | remote\.php\/dav\/files\/%username%\/C%2[bB]%2[bB]%20folder                                                                           |
+      | new         | /नेपाली           | remote\.php\/dav\/files\/%username%\/%[eE]0%[aA]4%[aA]8%[eE]0%[aA]5%87%[eE]0%[aA]4%[aA]a%[eE]0%[aA]4%be%[eE]0%[aA]4%b2%[eE]0%[aA]5%80 |
+      | new         | /folder #2.txt  | remote\.php\/dav\/files\/%username%\/folder%20%232\.txt                                                                               |
+      | new         | /folder ?2.txt  | remote\.php\/dav\/files\/%username%\/folder%20%3[fF]2\.txt                                                                            |
+      | new         | /folder &2.txt  | remote\.php\/dav\/files\/%username%\/folder%20%262\.txt                                                                               |
 
     @skipOnOcV10 @personalSpace
     Examples:


### PR DESCRIPTION
## Description
Fixes ocis test failing problem on apiFavorites/favorites.feature and apiShareOperationsToShares2/getWebDAVSharePermissions.feature due to changes on core commit **`cc8e53a4`**

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/core/pull/39720

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

