### PR TITLE
[tests-only] [full-ci] adjust moveShareInsideAnotherShare tests for oCIS

### DIFF
--- a/tests/acceptance/features/apiShareManagementToShares/moveShareInsideAnotherShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveShareInsideAnotherShare.feature
@@ -41,7 +41,7 @@ Feature: moving a share inside another share
     And as "Brian" file "/Shares/folderA/folderB/fileB.txt" should exist
     And as "Brian" file "/Shares/folderB/fileB.txt" should exist
 
-
+  @notToImplementOnOCIS
   Scenario: share receiver moves a whole share inside a local folder
     Given user "Brian" has created folder "localFolder"
     And user "Brian" has uploaded file with content "local text" to "/localFolder/localFile.txt"
@@ -52,7 +52,7 @@ Feature: moving a share inside another share
     And as "Brian" file "/localFolder/localFile.txt" should exist
     But as "Brian" file "/Shares/folderB/fileB.txt" should not exist
 
-
+  @notToImplementOnOCIS
   Scenario: share receiver moves a whole share inside a local folder then moves the local folder inside a received share
     Given user "Brian" has created folder "localFolder"
     And user "Brian" has uploaded file with content "local text" to "/localFolder/localFile.txt"
@@ -69,7 +69,7 @@ Feature: moving a share inside another share
     But as "Alice" folder "/folderA/localFolder/folderB" should not exist
     And as "Brian" folder "/Shares/folderA/localFolder/folderB" should not exist
 
-
+  @notToImplementOnOCIS
   Scenario: share receiver moves a whole share inside a local folder then tries to move the share inside a received share
     Given user "Brian" has created folder "localFolder"
     And user "Brian" has uploaded file with content "local text" to "/localFolder/localFile.txt"
@@ -81,3 +81,27 @@ Feature: moving a share inside another share
     And as "Brian" file "/localFolder/folderB/fileB.txt" should exist
     But as "Alice" folder "/folderA/folderB" should not exist
     And as "Brian" folder "/Shares/folderA/folderB" should not exist
+
+
+  Scenario: share receiver moves a local folder inside a received share (local folder does not have a share in it)
+    Given user "Brian" has created folder "localFolder"
+    Given user "Brian" has created folder "localFolder/subFolder"
+    And user "Brian" has uploaded file with content "local text" to "/localFolder/localFile.txt"
+    And user "Brian" moves folder "localFolder" to "Shares/folderA/localFolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" folder "/folderA/localFolder" should exist
+    And as "Brian" folder "/Shares/folderA/localFolder" should exist
+    And as "Alice" folder "/folderA/localFolder/subFolder" should exist
+    And as "Brian" folder "/Shares/folderA/localFolder/subFolder" should exist
+    And as "Alice" file "/folderA/localFolder/localFile.txt" should exist
+    And as "Brian" file "/Shares/folderA/localFolder/localFile.txt" should exist
+
+  @skipOnOcV10
+  Scenario: share receiver tries to move a whole share inside a local folder
+    Given user "Brian" has created folder "localFolder"
+    And user "Brian" has uploaded file with content "local text" to "/localFolder/localFile.txt"
+    # On oCIS you cannot move received shares out of the "Shares" folder
+    When user "Brian" moves folder "Shares/folderB" to "localFolder/folderB" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And as "Alice" file "/folderB/fileB.txt" should exist
+    And as "Brian" file "/Shares/folderB/fileB.txt" should exist


### PR DESCRIPTION
## Description
PR #39724 added test scenarios for issue #39000 but some of those try to move received shares out of the `Shares` folder. oCIS implements a sort-of "jail" for received shares - they have to stay in the `Shares` folder. So some of the new test scenarios are not relevant for oCIS. See the linked oCIS issue for more details.

This PR adds `@notToImplementOnOCIS` for those tests that are not relevant to oCIS, and adds 2 new scenarios to help demonstrate what should happen on oCIS. 

## Related Issue
https://github.com/owncloud/ocis/issues/3047

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
