### PR TITLE
Add wnd.listen.reconnectAfterTime config sample

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -545,7 +545,7 @@ $CONFIG = [
  * The timeout (in ms) for all the operations against the backend.
  * The same timeout will be applied for all the connections.
  *
- * Increase it if requests to the server sometimes time out. This can happen when SMB3 
+ * Increase it if requests to the server sometimes time out. This can happen when SMB3
  * encryption is selected and smbclient is overwhelming the server with requests.
  */
 'wnd.connector.opts.timeout' => 20000,  // 20 seconds

--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -544,6 +544,9 @@ $CONFIG = [
 /**
  * The timeout (in ms) for all the operations against the backend.
  * The same timeout will be applied for all the connections.
+ *
+ * Increase it if requests to the server sometimes time out. This can happen when SMB3 
+ * encryption is selected and smbclient is overwhelming the server with requests.
  */
 'wnd.connector.opts.timeout' => 20000,  // 20 seconds
 

--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -428,6 +428,8 @@ $CONFIG = [
  *
  * Possible keys: `wnd.groupmembership.checkUserFirst` BOOL
  *
+ * Possible keys: `wnd.connector.opts.timeout` INTEGER
+ *
  * *Note* With WND 2.1.0, key `wnd.storage.testForHiddenMount` is obsolete and has been removed completely.
  */
 
@@ -538,6 +540,12 @@ $CONFIG = [
  * recommended to enable this option only if there are a high number of ACLs targeting users.
  */
 'wnd.groupmembership.checkUserFirst' => false,
+
+/**
+ * The timeout (in ms) for all the operations against the backend.
+ * The same timeout will be applied for all the connections.
+ */
+'wnd.connector.opts.timeout' => 20000,  // 20 seconds
 
 /**
  * App: Workflow / Tagging


### PR DESCRIPTION
## Description
Adding a config.apps.sample for wnd.
Necessary to do a `config-to-docs` run.

**DO NOT MERGE** before the referenced PR gets merged.

## Related Issue
- References: https://github.com/owncloud/windows_network_drive/pull/391 (Add config option to set the connection timeout)
- Use-Case: https://github.com/owncloud/windows_network_drive/pull/392 
## Motivation and Context
A config key has been added in WND

## How Has This Been Tested?
Not necessary

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs/issues/4685
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

@pmaier1 FYI