### PR TITLE
[tests-only][full-ci]Adds spaces tests on `apiWebdavProperties1`

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -24,6 +24,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @smokeTest
   Scenario Outline: Copying and overwriting a file
     Given using <dav_version> DAV path
@@ -34,6 +39,12 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
 
   Scenario Outline: Copying a file when 2 files exist with different case
     Given using <dav_version> DAV path
@@ -46,6 +57,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @files_sharing-app-required
   @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -67,6 +83,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @files_sharing-app-required
   @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
@@ -90,6 +111,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-reva-15
   Scenario Outline: Copying file to a path with extension .part should not be possible
     Given using <dav_version> DAV path
@@ -107,6 +133,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-reva-387
   Scenario Outline: copy a file over the top of an existing folder
     Given using <dav_version> DAV path
@@ -121,6 +152,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-reva-387
   Scenario Outline: copy a folder over the top of an existing file
     Given using <dav_version> DAV path
@@ -133,6 +169,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-reva-387
   Scenario Outline: copy a folder into another folder at different level
@@ -150,6 +191,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-reva-387
   Scenario Outline: copy a file into a folder at different level
@@ -170,6 +216,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-reva-387
   Scenario Outline: copy a file into a file at different level
     Given using <dav_version> DAV path
@@ -187,6 +238,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-reva-387
   Scenario Outline: copy a folder into a file at different level
@@ -207,6 +263,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file over the top of an existing folder received as a user share
     Given using <dav_version> DAV path
@@ -226,6 +287,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder over the top of an existing file received as a user share
     Given using <dav_version> DAV path
@@ -243,6 +309,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into another folder at different level which is received as a user share
@@ -266,6 +337,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a folder at different level received as a user share
@@ -292,6 +368,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a file at different level received as a user share
     Given using <dav_version> DAV path
@@ -315,6 +396,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into a file at different level received as a user share
@@ -340,6 +426,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file over the top of an existing folder received as a group share
     Given using <dav_version> DAV path
@@ -362,6 +453,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder over the top of an existing file received as a group share
     Given using <dav_version> DAV path
@@ -382,6 +478,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into another folder at different level which is received as a group share
@@ -408,6 +509,11 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a folder at different level received as a group share
@@ -437,6 +543,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a file at different level received as a group share
     Given using <dav_version> DAV path
@@ -464,6 +575,11 @@ Feature: copy file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into a file at different level received as a group share
     Given using <dav_version> DAV path
@@ -490,3 +606,8 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature
@@ -31,6 +31,13 @@ Feature: create file or folder named similar to Shares folder
       | new         | /shares     |
       | new         | /Shares1    |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version | folder_name |
+      | spaces      | /Share      |
+      | spaces      | /shares     |
+      | spaces      | /Shares1    |
+
 
   Scenario Outline: create a file with a name similar to Shares
     Given using <dav_version> DAV path
@@ -47,6 +54,13 @@ Feature: create file or folder named similar to Shares folder
       | new         | /shares   |
       | new         | /Shares1  |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version | file_name |
+      | spaces      | /Share    |
+      | spaces      | /shares   |
+      | spaces      | /Shares1  |
+
 
   Scenario Outline: try to create a folder named Shares
     Given using <dav_version> DAV path
@@ -59,6 +73,11 @@ Feature: create file or folder named similar to Shares folder
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
 
   Scenario Outline: try to create a file named Shares
     Given using <dav_version> DAV path
@@ -70,3 +89,8 @@ Feature: create file or folder named similar to Shares folder
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/createFolder.feature
@@ -18,18 +18,28 @@ Feature: create folder
       | old         | /upload         |
       | old         | /strängé folder |
       | old         | /C++ folder.cpp |
-      | old         | /नेपाली         |
+      | old         | /नेपाली           |
       | old         | /folder #2      |
       | old         | /folder ?2      |
       | old         | /😀 🤖          |
       | new         | /upload         |
       | new         | /strängé folder |
       | new         | /C++ folder.cpp |
-      | new         | /नेपाली         |
+      | new         | /नेपाली           |
       | new         | /folder #2      |
       | new         | /folder ?2      |
       | new         | /😀 🤖          |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version | folder_name |
+      | spaces      | /upload         |
+      | spaces      | /strängé folder |
+      | spaces      | /C++ folder.cpp |
+      | spaces      | /नेपाली           |
+      | spaces      | /folder #2      |
+      | spaces      | /folder ?2      |
+      | spaces      | /😀 🤖          |
 
   @smokeTest
   Scenario Outline: Creating a folder
@@ -44,6 +54,12 @@ Feature: create folder
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
   Scenario Outline: Creating a folder with special chars
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/test_folder:5"
@@ -55,6 +71,11 @@ Feature: create folder
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-reva-15
   Scenario Outline: Creating a directory which contains .part should not be possible
@@ -71,6 +92,11 @@ Feature: create folder
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-reva-168
   Scenario Outline: try to create a folder that already exists
     Given using <dav_version> DAV path
@@ -85,6 +111,11 @@ Feature: create folder
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-reva-168
   Scenario Outline: try to create a folder with a name of an existing file
     Given using <dav_version> DAV path
@@ -98,3 +129,8 @@ Feature: create folder
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/getQuota.feature
@@ -17,6 +17,11 @@ Feature: get quota
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @smokeTest
   Scenario Outline: Retrieving folder quota when quota is set
     Given using <dav_version> DAV path
@@ -26,6 +31,11 @@ Feature: get quota
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @files_sharing-app-required
   Scenario Outline: Retrieving folder quota of shared folder with quota when no quota is set for recipient
@@ -48,6 +58,12 @@ Feature: get quota
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
   Scenario Outline: Retrieving folder quota when quota is set and a file was uploaded
     Given using <dav_version> DAV path
     And the quota of user "Alice" has been set to "1 KB"
@@ -60,6 +76,11 @@ Feature: get quota
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @files_sharing-app-required
   Scenario Outline: Retrieving folder quota when quota is set and a file was received
@@ -76,3 +97,8 @@ Feature: get quota
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
@@ -20,6 +20,11 @@ Feature: set file properties
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcV10.3 @skipOnOcV10.4 @issue-ocis-reva-217
   Scenario Outline: Setting custom complex DAV property and reading it
     Given using <dav_version> DAV path
@@ -31,6 +36,11 @@ Feature: set file properties
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-reva-276
   Scenario Outline: Setting custom DAV property and reading it after the file is renamed
@@ -44,6 +54,11 @@ Feature: set file properties
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @files_sharing-app-required @issue-ocis-reva-217
   Scenario Outline: Setting custom DAV property on a shared file as an owner and reading as a recipient
@@ -63,6 +78,11 @@ Feature: set file properties
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @issue-ocis-reva-276
   Scenario Outline: Setting custom DAV property using one endpoint and reading it with other endpoint
     Given using <action_dav_version> DAV path
@@ -76,11 +96,10 @@ Feature: set file properties
       | old                | new               |
       | new                | old               |
 
-  @issue-ocis-reva-276
-  Scenario: Setting custom DAV property using an old endpoint and reading it using a new endpoint
-    Given using old DAV path
-    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testoldnew.txt"
-    And user "Alice" has set property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testoldnew.txt" to "constant"
-    And using new DAV path
-    When user "Alice" gets a custom property "very-custom-prop" with namespace "x1='http://whatever.org/ns'" of file "/testoldnew.txt"
-    Then the response should contain a custom "very-custom-prop" property with namespace "x1='http://whatever.org/ns'" and value "constant"
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | action_dav_version | other_dav_version |
+      | spaces             | new               |
+      | spaces             | old               |
+      | new                | spaces            |
+      | old                | spaces            |

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -281,7 +281,10 @@ class WebDavPropertiesContext implements Context {
 				$this->featureContext->getUserPassword($user),
 				$path,
 				$properties,
-				$this->featureContext->getStepLineRef()
+				$this->featureContext->getStepLineRef(),
+				"0",
+				"files",
+				$this->featureContext->getDavPathVersion()
 			)
 		);
 	}


### PR DESCRIPTION
## Description
adds spaces DAV path on `apiWebdavProperties1` suite

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/ocis/issues/3042

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require an increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
