### PR TITLE
Make licenses expire at the end of the expiration date

### DIFF
--- a/changelog/unreleased/39735
+++ b/changelog/unreleased/39735
@@ -1,0 +1,3 @@
+Bugfix: Make licenses expire at the end of the expiration date
+
+https://github.com/owncloud/core/pull/39735

--- a/lib/private/License/BasicLicense.php
+++ b/lib/private/License/BasicLicense.php
@@ -24,7 +24,7 @@ use OCP\License\AbstractLicense;
 class BasicLicense extends AbstractLicense {
 	private $rawLicense;
 	private $org;
-	private $date = 0;  // to ensure an integer as expiration value
+	private $expirationDateTimestamp = 0;  // to ensure an integer as expiration value
 	private $rawCodes;
 	private $codes;
 	private $checksum;
@@ -38,7 +38,7 @@ class BasicLicense extends AbstractLicense {
 			// require 4 parts to initialize the object properly
 			// otherwise the "isValid" will return false, and the "expirationTime" will be 0
 			$this->org = $parts[0];
-			$this->date = \strtotime(\substr($parts[1], 0, 4) . '-' . \substr($parts[1], 4, 2) . '-' . \substr($parts[1], 6));
+			$this->expirationDateTimestamp = \strtotime(\substr($parts[1], 0, 4) . '-' . \substr($parts[1], 4, 2) . '-' . \substr($parts[1], 6));
 			$this->rawCodes = $parts[2];
 			$this->codes = \str_split(\strtoupper($this->rawCodes), 8);
 			$this->checksum = $parts[3];
@@ -56,7 +56,7 @@ class BasicLicense extends AbstractLicense {
 	 * @inheritDoc
 	 */
 	public function isValid(): bool {
-		$dateString = \date('Ymd', $this->date);
+		$dateString = \date('Ymd', $this->expirationDateTimestamp);
 
 		$checksum = \sprintf('%x', \crc32(\strtolower($this->org) . 'zz' . \strtolower($this->rawCodes) . 'zz' . $dateString));
 		$dateCode = \strtoupper(\hash("crc32b", $dateString));
@@ -68,7 +68,9 @@ class BasicLicense extends AbstractLicense {
 	 * @inheritDoc
 	 */
 	public function getExpirationTime(): int {
-		return $this->date;
+		// The license expires at the end of the expiration date.
+		// So add 1 day of seconds to the expiration date timestamp.
+		return $this->expirationDateTimestamp + (24 * 60 * 60);
 	}
 
 	/**

--- a/lib/private/License/MessageService.php
+++ b/lib/private/License/MessageService.php
@@ -130,12 +130,19 @@ class MessageService {
 
 		// licenses valid and about-to-expire
 		if ($info['licenseType'] === ILicense::LICENSE_TYPE_DEMO) {
+			if ($info['daysLeft'] < 2) {
+				$rawMessage = "Evaluation - expires today.";
+				$translatedMessage = $l->t("Evaluation - expires today.");
+			} else {
+				$rawMessage = "Evaluation - expires in {$info['daysLeft']} days.";
+				$translatedMessage = $l->t('Evaluation - expires in %d days.', [$info['daysLeft']]);
+			}
 			return [
 				'raw_message' => [
-					"Evaluation - expires in {$info['daysLeft']} days.",
+					$rawMessage,
 				],
 				'translated_message' => [
-					$l->t('Evaluation - expires in %d days.', [$info['daysLeft']]),
+					$translatedMessage,
 				],
 				'contains_html' => [],
 			];

--- a/tests/lib/License/MessageServiceTest.php
+++ b/tests/lib/License/MessageServiceTest.php
@@ -77,6 +77,12 @@ class MessageServiceTest extends TestCase {
 			'daysLeft' => 15,
 		];
 
+		$demoLicenseExpiresTodayInfo = [
+			'licenseState' => ILicenseManager::LICENSE_STATE_ABOUT_TO_EXPIRE,
+			'licenseType' => ILicense::LICENSE_TYPE_DEMO,
+			'daysLeft' => 1,
+		];
+
 		$licenseAboutToExpireInfo = [
 			'licenseState' => ILicenseManager::LICENSE_STATE_ABOUT_TO_EXPIRE,
 			'licenseType' => ILicense::LICENSE_TYPE_NORMAL,
@@ -172,6 +178,18 @@ class MessageServiceTest extends TestCase {
 					],
 					'translated_message' => [
 						'Evaluation - Expires In 15 Days.',
+					],
+					'contains_html' => [],
+				]
+			],
+			[
+				$demoLicenseExpiresTodayInfo,
+				[
+					'raw_message' => [
+						'Evaluation - expires today.',
+					],
+					'translated_message' => [
+						'Evaluation - Expires Today.',
 					],
 					'contains_html' => [],
 				]


### PR DESCRIPTION
## Description
I noticed that a license that has an expiration date of 2022-01-31 has already expired at 2022-01-31:00:00:00
As a user, I would have thought that the license would work all day up to 2022-01-31:23:59:59 and stop working at 2022-02-01:00:00:00.

This PR makes the license work throughout the day of expiration.

## How Has This Been Tested?
CI and locally observing the license messages for today on a system with a license that expires today, 2022-01-31.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
