### PR TITLE
[tests-only][full-ci]Added spaces on `apiWebDavEtagPropagation1` suite

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -26,6 +26,11 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: deleting a folder changes the etags of all parents
     Given using <dav_version> DAV path
@@ -44,6 +49,11 @@ Feature: propagation of etags when deleting a file or folder
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
 
   Scenario Outline: deleting a folder with content changes the etags of all parents
@@ -64,6 +74,11 @@ Feature: propagation of etags when deleting a file or folder
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver deleting a file changes the etags of all parents for all collaborators
@@ -95,6 +110,11 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -124,6 +144,11 @@ Feature: propagation of etags when deleting a file or folder
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver deleting a folder changes the etags of all parents for all collaborators
@@ -157,6 +182,11 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -189,9 +219,15 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario: deleting a file in a publicly shared folder changes its etag for the sharer
-    Given user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+  Scenario Outline: deleting a file in a publicly shared folder changes its etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings
       | path        | upload |
       | permissions | change |
@@ -202,10 +238,20 @@ Feature: propagation of etags when deleting a file or folder
       | user  | path    |
       | Alice | /       |
       | Alice | /upload |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario: deleting a folder in a publicly shared folder changes its etag for the sharer
-    Given user "Alice" has created folder "/upload/sub"
+  Scenario Outline: deleting a folder in a publicly shared folder changes its etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created a public link share with settings
       | path        | upload |
       | permissions | change |
@@ -216,3 +262,12 @@ Feature: propagation of etags when deleting a file or folder
       | user  | path    |
       | Alice | /       |
       | Alice | /upload |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
@@ -21,6 +21,11 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: moving a file from one folder to an other changes the etags of both folders
     Given using <dav_version> DAV path
@@ -40,6 +45,11 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: moving a file into a subfolder changes the etags of all parents
@@ -61,6 +71,11 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
 
   Scenario Outline: renaming a folder inside a folder changes its etag
     Given using <dav_version> DAV path
@@ -77,6 +92,11 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: moving a folder from one folder to an other changes the etags of both folders
@@ -98,6 +118,11 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: moving a folder into a subfolder changes the etags of all parents
     Given using <dav_version> DAV path
@@ -117,6 +142,11 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver renaming a file inside a folder changes its etag for all collaborators
@@ -146,6 +176,11 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -173,6 +208,11 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer moving a file from one folder to an other changes the etags of both folders for all collaborators
@@ -209,6 +249,11 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -243,6 +288,11 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer moving a folder from one folder to an other changes the etags of both folders for all collaborators
@@ -279,6 +329,11 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -314,9 +369,15 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
-  Scenario: renaming a file in a publicly shared folder changes its etag for the sharer
-    Given user "Alice" has created folder "/upload"
+
+  Scenario Outline: renaming a file in a publicly shared folder changes its etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has created a public link share with settings
       | path        | upload |
@@ -328,10 +389,20 @@ Feature: propagation of etags when moving files or folders
       | user  | path    |
       | Alice | /       |
       | Alice | /upload |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
 
-  Scenario: renaming a folder in a publicly shared folder changes its etag for the sharer
-    Given user "Alice" has created folder "/upload"
+  Scenario Outline: renaming a folder in a publicly shared folder changes its etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
     And user "Alice" has created folder "/upload/sub"
     And user "Alice" has created a public link share with settings
       | path        | upload |
@@ -343,3 +414,12 @@ Feature: propagation of etags when moving files or folders
       | user  | path    |
       | Alice | /       |
       | Alice | /upload |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -1054,7 +1054,7 @@ class WebDavPropertiesContext implements Context {
 			$user,
 			$path
 		);
-		if ($this->storedETAG[$user][$path] === null) {
+		if ($this->storedETAG[$user][$path] === "" || $this->storedETAG[$user][$path] === null) {
 			throw new Exception("Expected stored etag to be some string but found null!");
 		}
 	}

--- a/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
+++ b/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
@@ -48,8 +48,8 @@ Feature: poll incoming shares
     And user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/shareFolder/"
     And using server "LOCAL"
-    And user "Brian" has stored etag of element "/"
     And user "Brian" has been created with default attributes and small skeleton files
+    And user "Brian" has stored etag of element "/"
     And user "Alice" from server "REMOTE" has shared "/shareFolder" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"


### PR DESCRIPTION
## Description
adds spaces DAV path on `apiWebDavEtagPropagation1 ` suite

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/ocis/issues/3068

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require an increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
