### PR TITLE
[tests-only][full-ci]Update `apiWebdavEtagPropagation2` suite for spaces webdav

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -24,6 +24,11 @@ Feature: propagation of etags when copying files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
@@ -44,6 +49,11 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: copying a file from one folder to an other changes the etags of destination
@@ -66,6 +76,11 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: copying a file into a subfolder changes the etags of all parents
@@ -93,6 +108,11 @@ Feature: propagation of etags when copying files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280
   Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
@@ -118,6 +138,11 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
@@ -157,6 +182,11 @@ Feature: propagation of etags when copying files or folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -194,3 +224,8 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
@@ -22,6 +22,11 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
 
   Scenario Outline: creating an invalid folder inside a folder should not change any etags
     Given using <dav_version> DAV path
@@ -40,6 +45,11 @@ Feature: propagation of etags when creating folders
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver creating a folder inside a folder received as a share changes its etag for all collaborators
@@ -66,6 +76,11 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -91,9 +106,15 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario: creating a folder in a publicly shared folder changes its etag for the sharer
-    Given user "Alice" has created folder "/folder"
+  Scenario Outline: creating a folder in a publicly shared folder changes its etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
     And user "Alice" has created a public link share with settings
       | path        | folder |
       | permissions | create |
@@ -104,3 +125,12 @@ Feature: propagation of etags when creating folders
       | user  | path    |
       | Alice | /       |
       | Alice | /folder |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
@@ -23,6 +23,11 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
 
   Scenario Outline: overwriting a file inside a folder changes its etag
     Given using <dav_version> DAV path
@@ -41,6 +46,11 @@ Feature: propagation of etags when uploading data
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver uploading a file inside a received shared folder should update etags for all collaborators
@@ -66,6 +76,11 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer uploading a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -89,6 +104,11 @@ Feature: propagation of etags when uploading data
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver overwriting a file inside a received shared folder should update etags for all collaborators
@@ -115,6 +135,11 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer overwriting a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -140,9 +165,15 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario: uploading a file into a publicly shared folder changes its etag for the sharer
-    Given user "Alice" has created a public link share with settings
+  Scenario Outline: uploading a file into a publicly shared folder changes its etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created a public link share with settings
       | path        | upload |
       | permissions | create |
     And user "Alice" has stored etag of element "/"
@@ -152,3 +183,12 @@ Feature: propagation of etags when uploading data
       | user  | path    |
       | Alice | /       |
       | Alice | /upload |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -1034,7 +1034,7 @@ class WebDavPropertiesContext implements Context {
 		if ($storePath == "") {
 			$storePath = $path;
 		}
-		if ($this->storedETAG[$user][$storePath] === null) {
+		if ($this->storedETAG[$user][$storePath] === null || $this->storedETAG[$user][$path] === "") {
 			throw new Exception("Expected stored etag to be some string but found null!");
 		}
 	}


### PR DESCRIPTION
## Description
adds spaces DAV path on `apiWebDavEtagPropagation2` suite

  - restoreFromTrash.feature (spaces tests not added because trashbin API is not implemented on spaces)
  - restoreVersion.feature (spaces tests not add because file version API is not implemented on spaces)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/ocis/issues/3075

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require an increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
