### PR TITLE
[tests-only] [full-ci] Refactor and fix dav-path-spaces test code

### DIFF
--- a/tests/TestHelpers/MoveCopyHelper.php
+++ b/tests/TestHelpers/MoveCopyHelper.php
@@ -154,8 +154,13 @@ class MoveCopyHelper {
 				'$method has to be "copy" or "move"'
 			);
 		}
+		$spaceId = null;
+		// get space id if testing with spaces dav
+		if ($davPathVersionToUse === WebDavHelper::DAV_VERSION_SPACES) {
+			$spaceId = WebDavHelper::getPersonalSpaceIdForUser($baseUrl, $user, $password, $xRequestId);
+		}
 		$baseUrl = WebDavHelper::sanitizeUrl($baseUrl, true);
-		$davPath = WebDavHelper::getDavPath($user, $davPathVersionToUse);
+		$davPath = WebDavHelper::getDavPath($user, $davPathVersionToUse, "files", $spaceId);
 		$fullDestUrl = WebDavHelper::sanitizeUrl(
 			$baseUrl . $davPath . $toFileName
 		);

--- a/tests/acceptance/features/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/features/bootstrap/ChecksumContext.php
@@ -163,11 +163,6 @@ class ChecksumContext implements Context {
 				<oc:checksums />
 			  </d:prop>
 			</d:propfind>';
-		$url = $this->featureContext->getBaseUrl() . '/' .
-			WebDavHelper::getDavPath(
-				$user,
-				$this->featureContext->getDavPathVersion()
-			) . $path;
 		$password = $this->featureContext->getPasswordForUser($user);
 		$response = WebDavHelper::makeDavRequest(
 			$this->featureContext->getBaseUrl(),

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3097,7 +3097,7 @@ class FeatureContext extends BehatVariablesContext {
 						$this,
 						"getPersonalSpaceIdForUser",
 					],
-					"parameter" => [$user]
+					"parameter" => [$user, true]
 				]
 			);
 		}
@@ -3131,20 +3131,26 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * returns personal space id for user
+	 * returns personal space id for user if the test is using the spaces dav path
+	 * or if alwaysDoIt is set to true,
+	 * otherwise it returns null.
 	 *
 	 * @param string $user
+	 * @param bool $alwaysDoIt default false. Set to true
 	 *
-	 * @return string
+	 * @return string|null
 	 * @throws GuzzleException
 	 */
-	public function getPersonalSpaceIdForUser(string $user):string {
-		return WebDavHelper::getPersonalSpaceIdForUser(
-			$this->getBaseUrl(),
-			$user,
-			$this->getPasswordForUser($user),
-			$this->getStepLineRef()
-		);
+	public function getPersonalSpaceIdForUser(string $user, bool $alwaysDoIt = false): ?string {
+		if ($alwaysDoIt || ($this->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES)) {
+			return WebDavHelper::getPersonalSpaceIdForUser(
+				$this->getBaseUrl(),
+				$user,
+				$this->getPasswordForUser($user),
+				$this->getStepLineRef()
+			);
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
## Description
When running on reva, the personal space id has to be looked up by more tricky ways. That code is coming. But at the moment some test scenarios are failing for new and old dav path because code in TusContext calls `getPersonalSpaceIdForUser` even though the scenario is not actually using the "spaces dav path".

CI has been green in oCIS because the call to ऽgetPersonalSpaceIdForUser` does work on oCIS. The call is wasted, the space id is not actually used, but at least the code runs.

On `cs3org/reva` the space id is not found, because the `/graph/v1.0/me/drives` endpoint does not exist. And those scenarios fail when they should not fail.

https://drone.cernbox.cern.ch/cs3org/reva/5429/15/6
`Notice: Trying to get property 'value' of non-object in /drone/src/tmp/testrunner/tests/TestHelpers/WebDavHelper.php line 401`

This PR does:
1) refactor test code so that the "davPathVersion" magic numbers 1,2,3 are held in constants `DAV_VERSION_OLD` `DAV_VERSION_NEW` `DAV_VERSION_SPACES`. That should make code easier to read, rather than having 1,2,3 mentioned in multiple places.

2) modify `FeatureContext` `getPersonalSpaceIdForUser` so that it only actually tries to get the space id if the scenario is using `DAV_VERSION_SPACES`. If not, then it returns `null`. That will allow it to be called more flexibly.


## How Has This Been Tested?
CI

oCIS PR https://github.com/owncloud/ocis/pull/3105 passes against this branch, so the changes do not break that.

cs3org/reva PR https://github.com/cs3org/reva/pull/2497 passes against this branch, with just sensible line number changes in the expected-failures files.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
