### PR TITLE
Autoprovisioning update in config.apps.sample

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -342,7 +342,14 @@ $CONFIG = [
 		  // defines the claim which holds the picture of the user - must be a URL
 		'picture-claim' => 'picture',
 		  // defines a list of groups to which the newly created user will be added automatically
-		'groups' => ['admin', 'guests', 'employees']
+		'groups' => ['admin', 'guests', 'employees'],
+		  // sets a claim which is defined at the IDP. the IDP will return a single value or an array like:
+		  // "allowed_applications": ["erp", "owncloud"],
+		'provisioning-claim' => 'allowed_applications',
+		  // defines the matching case for the provisioning. the attribute can only be a single value
+		  // in case no match is found against the IDP response, no provisioning will be made,
+		  // "User not found" will be returned
+		'provisioning-attribute' => 'owncloud'
 	],
 	  // `mode` and `search-attribute` will be used to create a unique user in ownCloud
 	'mode' => 'email',


### PR DESCRIPTION
## Description
Adding the following to the config.apps.sample documentation
```
'provisioning-attribute' => 'my_group',
'provisioning-claim' => 'groups'
```

Note post merging this PR, a `config-to-docs` run will be made to integrate this into the server documentation.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/openidconnect/issues/202 (provisioning-claim and provisioning-attribute not documented)

## Motivation and Context
Add missing config parameters to the config.apps.sample file

## How Has This Been Tested?
no tests necessary

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: [<link>](https://github.com/owncloud/docs/issues/3502 ([OIDC] AutoProvisioning based on a Provisioning Claim)) 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
