### PR TITLE
[tests-only] [full-ci] getPersonalSpaceIdForUser from webdav propfind

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -443,7 +443,6 @@ class WebDavHelper {
 				);
 			}
 			$personalSpaceId = $decodedIdParts[0];
-			\var_dump($personalSpaceId);
 		} else {
 			foreach ($json->value as $spaces) {
 				if ($spaces->driveType === "personal") {
@@ -454,6 +453,11 @@ class WebDavHelper {
 		}
 
 		if ($personalSpaceId) {
+			// If env var LOG_PERSONAL_SPACE_ID is defined, then output the details of the personal space id.
+			// This is a useful debugging tool to have confidence that the personal space id is found correctly.
+			if (\getenv('LOG_PERSONAL_SPACE_ID') !== false) {
+				echo __METHOD__ . " personal space id of user $user is $personalSpaceId\n";
+			}
 			self::$spacesIdRef[$user] = [];
 			self::$spacesIdRef[$user]["personal"] = $personalSpaceId;
 			return $personalSpaceId;


### PR DESCRIPTION
## Description
See the comments and code for details. When on oCIS, `/graph/v1.0/me/drives` endpoint exists and returns a list of spaces, and the code parses that list like it previously did and finds the personal space id for the user.

If that nice endpoint does not exist, then the code does a PROPFIND on the webdav root of the user. On reva (at least) the response contains `oc:id` which id a base64-encoded value that happens to include the personal space id. See the code for how the personal space id is reconstructed.

This allows us to test using the personal space id to access the files of a user. That allows us to verify what webdav space scenarios pass, or fail, in reva. That will be helpful when fixing stuff - a developer can try to make the tests pass.

Fixed issue #39617 

## How Has This Been Tested?
CI passes here in core
oCIS CI passes in https://github.com/owncloud/ocis/pull/3077 - there is no change there because the test code running there will not use the new webdav propfind way to find the personal space id.

`cs3org/rev` CI passes in https://github.com/cs3org/reva/pull/2505 - that starts running `personalSpace` API tests in reva. It makes use of the new test code in this PR, and it adds the failing `personalSpaces` tests to expected-failures.

After merge this PR, I will switch those oCIS and reva PRs to use the new master commit id, and then we can also merge them.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
