### PR TITLE
Show only assignable groups to the subadmin

### DIFF
--- a/changelog/unreleased/39752
+++ b/changelog/unreleased/39752
@@ -1,0 +1,7 @@
+Bugfix: Subadmin will be shown only his assignable groups in the users page
+
+Previously, the subadmin could see all groups even if he could only assign
+users to a bunch of them. Now the subadmin will see the groups he can assign
+to the user
+
+https://github.com/owncloud/core/pull/39752

--- a/settings/Controller/GroupsController.php
+++ b/settings/Controller/GroupsController.php
@@ -171,6 +171,7 @@ class GroupsController extends Controller {
 		$removableGroups = [];
 
 		$currentUser = $this->userSession->getUser();
+		/* @phan-suppress-next-line PhanUndeclaredMethod */
 		$subAdmin = $this->groupManager->getSubAdmin();
 
 		if ($this->groupManager->isAdmin($currentUser->getUID())) {


### PR DESCRIPTION
## Description
Subadmins will be shown their own assignable groups, not all the groups available

## Related Issue
Reported in https://central.owncloud.org/t/10-9-1-group-admin-can-see-all-groups-even-the-ones-that-he-is-not-admin-of/36209/2

Fixes #39756 

## Motivation and Context

## How Has This Been Tested?
1. Create some users and groups
2. Assign a user as subadmin of a couple of group
3. Login with that user
4. Go to the user page

The user can assign to the groups he's subadmin. Other groups won't appear.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
