### PR TITLE
[tests-only] Run tests with release-10.9.1

### DIFF
--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -1,5 +1,6 @@
 @api @comments-app-required @issue-ocis-reva-38
 Feature: Comments
+  As a user, I want to run the tests that are in the release-10.9.1 branch
 
   Background:
     Given using new DAV path


### PR DESCRIPTION
This is a test PR to see if the test code plus oC10 server code in release-10.9.1 do actually work nicely together.