### PR TITLE
[tests-only] [full-ci] Fix call to setSystemConfig in WebUIGeneralContext

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -917,10 +917,12 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		$resultXml = \simplexml_load_string($contents);
 
 		if ($resultXml === false) {
+			$status = $result->getStatusCode();
 			throw new Exception(
 				"Response is not valid XML after executing 'occ $argsString'. " .
+				"HTTP status was $status. " .
 				$isTestingAppEnabledText .
-				$contents
+				"Response contents were '$contents'"
 			);
 		}
 

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -866,6 +866,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 					SetupHelper::setSystemConfig(
 						'enable_previews',
 						$this->oldPreviewSetting[$server],
+						$this->featureContext->getStepLineRef(),
 						'boolean'
 					);
 				}


### PR DESCRIPTION
## Description
1) Report more information in SetupHelper - if something goes wrong with `runOcc`  then the Exception message that was generated was not very helpful. For example, in one case, the contents of the response was empty, and it was not clear in he Exception message that the contents were really empty. The message has been enahncced to show the HTTP status and to put the contents in quotes.

2) fix setSystemConfig call in `tearDownSuite()`. The `type` parameter `boolean` was in the wrong place. It had been missed in a previous refactoring. This code was only run when `enable_previews` needed to be reset at the end of a scenario, so it was not noticed in regular core CI. The problem was noticed in other CI where the test suite is used against a system that has `enable_previews` on by default.

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
