### PR TITLE
[tests-only][full-ci]Add spaces tests for apiWebdavMove2 suite

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -54,6 +54,7 @@ class WebDavHelper {
 	 * @param string|null $password
 	 * @param string|null $path
 	 * @param string|null $xRequestId
+	 * @param int|null $davPathVersionToUse
 	 *
 	 * @return string
 	 * @throws Exception
@@ -63,15 +64,16 @@ class WebDavHelper {
 		?string $user,
 		?string $password,
 		?string $path,
-		?string $xRequestId = ''
+		?string $xRequestId = '',
+		?int $davPathVersionToUse = self::DAV_VERSION_NEW
 	): string {
 		$body
 			= '<?xml version="1.0"?>
-<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
-  <d:prop>
-    <oc:fileid />
-  </d:prop>
-</d:propfind>';
+				<d:propfind  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+ 					<d:prop>
+    					<oc:fileid />
+  					</d:prop>
+				</d:propfind>';
 		$response = self::makeDavRequest(
 			$baseUrl,
 			$user,
@@ -80,7 +82,8 @@ class WebDavHelper {
 			$path,
 			null,
 			$xRequestId,
-			$body
+			$body,
+			$davPathVersionToUse
 		);
 		\preg_match(
 			'/\<oc:fileid\>([^\<]*)\<\/oc:fileid\>/',

--- a/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
@@ -151,3 +151,51 @@ Feature: move (rename) folder
     Examples:
       | dav_version |
       | spaces      |
+
+  @files_sharing-app-required @skipOnOcis
+  Scenario Outline: Moving a folder out of a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created folder "/testshare/testsubfolder"
+    And user "Brian" has uploaded file with content "test data" to "/testshare/testsubfolder/testfile.txt"
+    And user "Brian" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | Alice     |
+    When user "<mover>" moves folder "/testshare/testsubfolder" to "/testsubfolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testsubfolder/testfile.txt" for user "<mover>" should be "test data"
+    And as "Alice" folder "/testshare/testsubfolder" should not exist
+    And as "Brian" folder "/testshare/testsubfolder" should not exist
+    Examples:
+      | dav_version | mover |
+      | old         | Alice |
+      | new         | Alice |
+      | old         | Brian |
+      | new         | Brian |
+
+  @files_sharing-app-required @skipOnOcis
+  Scenario Outline: Moving a folder into a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | Alice     |
+    And user "<mover>" has created folder "/testsubfolder"
+    And user "<mover>" has uploaded file with content "test data" to "/testsubfolder/testfile.txt"
+    When user "<mover>" moves folder "/testsubfolder" to "/testshare/testsubfolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testshare/testsubfolder/testfile.txt" for user "Alice" should be "test data"
+    And the content of file "/testshare/testsubfolder/testfile.txt" for user "Brian" should be "test data"
+    And as "<mover>" file "/testsubfolder" should not exist
+    Examples:
+      | dav_version | mover |
+      | old         | Alice |
+      | new         | Alice |
+      | old         | Brian |
+      | new         | Brian |

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-14
+@api
 Feature: move (rename) file
   As a user
   I want to be able to move and rename files
@@ -23,6 +23,11 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @smokeTest
   Scenario Outline: Moving and overwriting a file
     Given using <dav_version> DAV path
@@ -38,6 +43,12 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
   Scenario Outline: Moving (renaming) a file to be only different case
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
@@ -49,6 +60,11 @@ Feature: move (rename) file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @smokeTest
   Scenario Outline: Moving (renaming) a file to a file with only different case to an existing file
@@ -64,6 +80,12 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
   Scenario Outline: Moving (renaming) a file to a file in a folder with only different case to an existing file
     Given using <dav_version> DAV path
     And user "Alice" has created folder "PARENT"
@@ -78,7 +100,12 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @files_sharing-app-required
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @files_sharing-app-required @skipOnOcis
   Scenario Outline: Moving a file into a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -101,7 +128,7 @@ Feature: move (rename) file
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required
+  @files_sharing-app-required @skipOnOcis
   Scenario Outline: Moving a file out of a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -124,55 +151,7 @@ Feature: move (rename) file
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required
-  Scenario Outline: Moving a folder into a shared folder as the sharee and as the sharer
-    Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Brian" has created folder "/testshare"
-    And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
-    And user "<mover>" has created folder "/testsubfolder"
-    And user "<mover>" has uploaded file with content "test data" to "/testsubfolder/testfile.txt"
-    When user "<mover>" moves folder "/testsubfolder" to "/testshare/testsubfolder" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And the content of file "/testshare/testsubfolder/testfile.txt" for user "Alice" should be "test data"
-    And the content of file "/testshare/testsubfolder/testfile.txt" for user "Brian" should be "test data"
-    And as "<mover>" file "/testsubfolder" should not exist
-    Examples:
-      | dav_version | mover |
-      | old         | Alice |
-      | new         | Alice |
-      | old         | Brian |
-      | new         | Brian |
-
-  @files_sharing-app-required
-  Scenario Outline: Moving a folder out of a shared folder as the sharee and as the sharer
-    Given using <dav_version> DAV path
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Brian" has created folder "/testshare"
-    And user "Brian" has created folder "/testshare/testsubfolder"
-    And user "Brian" has uploaded file with content "test data" to "/testshare/testsubfolder/testfile.txt"
-    And user "Brian" has created a share with settings
-      | path        | testshare |
-      | shareType   | user      |
-      | permissions | change    |
-      | shareWith   | Alice     |
-    When user "<mover>" moves folder "/testshare/testsubfolder" to "/testsubfolder" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And the content of file "/testsubfolder/testfile.txt" for user "<mover>" should be "test data"
-    And as "Alice" folder "/testshare/testsubfolder" should not exist
-    And as "Brian" folder "/testshare/testsubfolder" should not exist
-    Examples:
-      | dav_version | mover |
-      | old         | Alice |
-      | new         | Alice |
-      | old         | Brian |
-      | new         | Brian |
-
-  @files_sharing-app-required
+  @files_sharing-app-required @skipOnOcis
   Scenario Outline: Moving a file to a shared folder with no permissions
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -192,7 +171,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @files_sharing-app-required
+  @files_sharing-app-required @skipOnOcis
   Scenario Outline: Moving a file to overwrite a file in a shared folder with no permissions
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
@@ -213,6 +192,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+
   Scenario Outline: move file into a not-existing folder
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToMove.txt"
@@ -222,6 +202,11 @@ Feature: move (rename) file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-reva-211
   Scenario Outline: rename a file into an invalid filename
@@ -233,6 +218,12 @@ Feature: move (rename) file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
 
   Scenario Outline: Checking file id after a move
     Given using <dav_version> DAV path
@@ -248,7 +239,12 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @files_sharing-app-required
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @files_sharing-app-required @skipOnOcis
   Scenario Outline: Checking file id after a move between received shares
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -257,7 +253,7 @@ Feature: move (rename) file
     And user "Alice" has shared folder "/folderA" with user "Brian"
     And user "Alice" has shared folder "/folderB" with user "Brian"
     And user "Brian" has created folder "/folderA/ONE"
-    And user "Brian" has stored id of file "/folderA/ONE"
+    And user "Brian" has stored id of folder "/folderA/ONE"
     And user "Brian" has created folder "/folderA/ONE/TWO"
     When user "Brian" moves folder "/folderA/ONE" to "/folderB/ONE" using the WebDAV API
     Then as "Brian" folder "/folderA" should exist
@@ -266,7 +262,7 @@ Feature: move (rename) file
     And as "Brian" folder "/folderA/ONE/TWO" should not exist
     And as "Brian" folder "/folderB/ONE" should exist
     And as "Brian" folder "/folderB/ONE/TWO" should exist
-    And user "Brian" file "/folderB/ONE" should have the previously stored id
+    And user "Brian" folder "/folderB/ONE" should have the previously stored id
     Examples:
       | dav_version |
       | old         |
@@ -290,9 +286,15 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @sqliteDB
-  Scenario: renaming to a file with special characters
-    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+  Scenario Outline: renaming to a file with special characters
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 1" to "textfile1.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 2" to "textfile2.txt"
     And user "Alice" has uploaded file with content "ownCloud test text file 3" to "textfile3.txt"
@@ -307,17 +309,34 @@ Feature: move (rename) file
     And the content of file "1 2 3##.##" for user "Alice" should be "ownCloud test text file 1"
     And the content of file "file[2]" for user "Alice" should be "ownCloud test text file 2"
     And the content of file "file [ 3 ]" for user "Alice" should be "ownCloud test text file 3"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @issue-ocis-reva-265
   #after fixing the issues merge this Scenario into the one above
   Scenario Outline: renaming to a file with question mark in its name
-    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     When user "Alice" moves file "/textfile0.txt" to "/<renamed_file>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/<renamed_file>" for user "Alice" should be "ownCloud test text file 0"
     Examples:
-      | renamed_file  |
-      | #oc ab?cd=ef# |
+      | dav_version | renamed_file  |
+      | old         | #oc ab?cd=ef# |
+      | new         | #oc ab?cd=ef# |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version | renamed_file  |
+      | spaces      | #oc ab?cd=ef# |
+
 
   Scenario Outline: renaming file with dots in the path
     Given using <dav_version> DAV path
@@ -341,6 +360,16 @@ Feature: move (rename) file
       | new         | /...          | ...         |
       | new         | /..upload     | ..abc       |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version | folder_name   | file_name   |
+      | spaces      | /upload.      | abc.        |
+      | spaces      | /upload.      | abc .       |
+      | spaces      | /upload.1     | abc         |
+      | spaces      | /upload...1.. | abc...txt.. |
+      | spaces      | /...          | abcd.txt    |
+      | spaces      | /...          | ...         |
+
   @smokeTest
   Scenario Outline: user tries to move a file that doesnt exist into a folder
     Given using <dav_version> DAV path
@@ -353,6 +382,11 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
   @smokeTest
   Scenario Outline: user tries to rename a file that doesnt exist
     Given using <dav_version> DAV path
@@ -363,6 +397,12 @@ Feature: move (rename) file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
 
   Scenario Outline: Moving a hidden file
     Given using <dav_version> DAV path
@@ -385,6 +425,12 @@ Feature: move (rename) file
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
   Scenario Outline: Renaming to/from a hidden file
     Given using <dav_version> DAV path
     And user "Alice" has uploaded the following files with content "hidden file"
@@ -404,6 +450,11 @@ Feature: move (rename) file
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Moving a file (deep moves with various folder and file names)
@@ -435,6 +486,18 @@ Feature: move (rename) file
       | new         | texta         | file.txt    | textb         | 0           |
       | new         | texta         | file.txt    | textb         | 1           |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version | source_folder | source_file | target_folder | target_file |
+      | spaces      | text          | file.txt    | 0             | file.txt    |
+      | spaces      | text          | file.txt    | 1             | file.txt    |
+      | spaces      | 0             | file.txt    | text          | file.txt    |
+      | spaces      | 1             | file.txt    | text          | file.txt    |
+      | spaces      | texta         | 0           | textb         | file.txt    |
+      | spaces      | texta         | 1           | textb         | file.txt    |
+      | spaces      | texta         | file.txt    | textb         | 0           |
+      | spaces      | texta         | file.txt    | textb         | 1           |
+
   @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Moving a file from a folder to the root
     Given using <dav_version> DAV path
@@ -458,4 +521,14 @@ Feature: move (rename) file
       | new         | texta         | 0           | file.txt    |
       | new         | texta         | 1           | file.txt    |
       | new         | texta         | file.txt    | 0           |
-      | new         | texta         | file.txt    | 1           |
+      | new         | texta         | file.txt    | 0           |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version | source_folder | source_file | target_file |
+      | spaces      | 0             | file.txt    | file.txt    |
+      | spaces      | 1             | file.txt    | file.txt    |
+      | spaces      | texta         | 0           | file.txt    |
+      | spaces      | texta         | 1           | file.txt    |
+      | spaces      | texta         | file.txt    | 0           |
+      | spaces      | texta         | file.txt    | 0           |

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-14
+@api
 Feature: users cannot move (rename) a file to a blacklisted name
   As an administrator
   I want to be able to prevent users from moving (renaming) files to specified file names
@@ -19,6 +19,11 @@ Feature: users cannot move (rename) a file to a blacklisted name
       | old         |
       | new         |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
 
   Scenario Outline: rename a file to a banned filename
     Given using <dav_version> DAV path
@@ -29,6 +34,11 @@ Feature: users cannot move (rename) a file to a blacklisted name
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcV10.3
   Scenario Outline: rename a file to a filename that matches (or not) blacklisted_files_regex
@@ -63,3 +73,8 @@ Feature: users cannot move (rename) a file to a blacklisted name
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
@@ -9,6 +9,7 @@ Feature: users cannot move (rename) a file to or into an excluded directory
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
 
+
   Scenario Outline: rename a file to an excluded directory name
     Given using <dav_version> DAV path
     When the administrator updates system config key "excluded_directories" with value '[".github"]' and type "json" using the occ command
@@ -18,6 +19,12 @@ Feature: users cannot move (rename) a file to or into an excluded directory
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+      
 
   Scenario Outline: rename a file to an excluded directory name inside a parent directory
     Given using <dav_version> DAV path
@@ -29,6 +36,11 @@ Feature: users cannot move (rename) a file to or into an excluded directory
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
 
   @skipOnOcV10.3
   Scenario Outline: rename a file to a filename that matches (or not) excluded_directories_regex
@@ -65,3 +77,8 @@ Feature: users cannot move (rename) a file to or into an excluded directory
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavMove2/moveShareOnOcis.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveShareOnOcis.feature
@@ -1,0 +1,216 @@
+@api @files_sharing-app-required @skipOnOcV10
+Feature: move (rename) file
+  As a user
+  I want to be able to move and rename files
+  So that I can manage my file system
+
+  Background:
+    Given using OCS API version "1"
+    And user "Alice" has been created with default attributes and without skeleton files
+
+
+  Scenario Outline: Moving a file into a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | Alice     |
+    And user "<mover>" has uploaded file with content "test data" to "/testfile.txt"
+    When user "Alice" accepts share "/testshare" offered by user "Brian" using the sharing API
+    And user "<mover>" moves file "/testfile.txt" to "<destination_folder>/testfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/Shares/testshare/testfile.txt" for user "Alice" should be "test data"
+    And the content of file "/testshare/testfile.txt" for user "Brian" should be "test data"
+    And as "<mover>" file "/testfile.txt" should not exist
+    Examples:
+      | dav_version | mover | destination_folder |
+      | old         | Alice | /Shares/testshare  |
+      | new         | Alice | /Shares/testshare  |
+      | old         | Brian | /testshare         |
+      | new         | Brian | /testshare         |
+
+    @personalSpace
+    Examples:
+      | dav_version | mover | destination_folder |
+      | spaces      | Alice | /Shares/testshare  |
+      | spaces      | Brian | /testshare         |
+
+
+  Scenario Outline: Moving a file out of a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has uploaded file with content "test data" to "/testshare/testfile.txt"
+    And user "Brian" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | Alice     |
+    When user "Alice" accepts share "/testshare" offered by user "Brian" using the sharing API
+    And user "<mover>" moves file "<source_folder>/testfile.txt" to "/testfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testfile.txt" for user "<mover>" should be "test data"
+    And as "Alice" file "/Shares/testfile.txt" should not exist
+    And as "Brian" file "/testshare/testfile.txt" should not exist
+    Examples:
+      | dav_version | mover | source_folder     |
+      | old         | Alice | /Shares/testshare |
+      | new         | Alice | /Shares/testshare |
+      | old         | Brian | /testshare        |
+      | new         | Brian | /testshare        |
+
+    @personalSpace
+    Examples:
+      | dav_version | mover | source_folder     |
+      | spaces      | Alice | /Shares/testshare |
+      | spaces      | Brian | /testshare        |
+
+
+  Scenario Outline: Moving a folder into a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | Alice     |
+    And user "<mover>" has created folder "/testsubfolder"
+    And user "<mover>" has uploaded file with content "test data" to "/testsubfolder/testfile.txt"
+    When user "Alice" accepts share "/testshare" offered by user "Brian" using the sharing API
+    And user "<mover>" moves folder "/testsubfolder" to "<destination_folder>/testsubfolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/Shares/testshare/testsubfolder/testfile.txt" for user "Alice" should be "test data"
+    And the content of file "/testshare/testsubfolder/testfile.txt" for user "Brian" should be "test data"
+    And as "<mover>" file "/testsubfolder" should not exist
+    Examples:
+      | dav_version | mover | destination_folder |
+      | old         | Alice | /Shares/testshare  |
+      | new         | Alice | /Shares/testshare  |
+      | old         | Brian | /testshare         |
+      | new         | Brian | /testshare         |
+
+    @personalSpace
+    Examples:
+      | dav_version | mover | destination_folder |
+      | spaces      | Alice | /Shares/testshare  |
+      | spaces      | Brian | /testshare         |
+
+
+  Scenario Outline: Moving a folder out of a shared folder as the sharee and as the sharer
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created folder "/testshare/testsubfolder"
+    And user "Brian" has uploaded file with content "test data" to "/testshare/testsubfolder/testfile.txt"
+    And user "Brian" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | Alice     |
+    When user "Alice" accepts share "/testshare" offered by user "Brian" using the sharing API
+    And user "<mover>" moves folder "<source_folder>/testsubfolder" to "/testsubfolder" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testsubfolder/testfile.txt" for user "<mover>" should be "test data"
+    And as "Alice" folder "<source_folder>/testsubfolder" should not exist
+    And as "Brian" folder "/testshare/testsubfolder" should not exist
+    Examples:
+      | dav_version | mover | source_folder     |
+      | old         | Alice | /Shares/testshare |
+      | new         | Alice | /Shares/testshare |
+      | old         | Brian | /testshare        |
+      | new         | Brian | /testshare        |
+
+    @personalSpace
+    Examples:
+      | dav_version | mover | source_folder     |
+      | spaces      | Alice | /Shares/testshare |
+      | spaces      | Brian | /testshare        |
+
+
+  Scenario Outline: Moving a file to a shared folder with no permissions
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | read      |
+      | shareWith   | Alice     |
+    When user "Alice" accepts share "/testshare" offered by user "Brian" using the sharing API
+    And user "Alice" moves file "/textfile0.txt" to "/Shares/testshare/textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+    When user "Alice" downloads file "/Shares/testshare/textfile0.txt" using the WebDAV API
+    Then the HTTP status code should be "404"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
+  Scenario Outline: Moving a file to overwrite a file in a shared folder with no permissions
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has uploaded file with content "Welcome to ownCloud" to "fileToCopy.txt"
+    And user "Brian" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | read      |
+      | shareWith   | Alice     |
+    And user "Brian" has copied file "/fileToCopy.txt" to "/testshare/overwritethis.txt"
+    When user "Alice" accepts share "/testshare" offered by user "Brian" using the sharing API
+    And user "Alice" moves file "/textfile0.txt" to "/Shares/testshare/overwritethis.txt" using the WebDAV API
+    Then the HTTP status code should be "403"
+    And the content of file "/Shares/testshare/overwritethis.txt" for user "Alice" should be "Welcome to ownCloud"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
+  Scenario Outline: Checking file id after a move between received shares
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/folderA"
+    And user "Alice" has created folder "/folderB"
+    And user "Alice" has shared folder "/folderA" with user "Brian"
+    And user "Alice" has shared folder "/folderB" with user "Brian"
+    When user "Brian" accepts the following shares offered by user "Alice" using the sharing API
+      | path        |
+      | /folderA    |
+      | /folderB    |
+    And user "Brian" creates folder "/Shares/folderA/ONE" using the WebDAV API
+    And user "Brian" stores id of folder "/Shares/folderA/ONE"
+    And user "Brian" creates folder "/Shares/folderA/ONE/TWO" using the WebDAV API
+    And user "Brian" moves folder "/Shares/folderA/ONE" to "/Shares/folderB/ONE" using the WebDAV API
+    Then as "Brian" folder "/Shares/folderA" should exist
+    And as "Brian" folder "/Shares/folderA/ONE" should not exist
+    And as "Brian" folder "/Shares/folderA/ONE/TWO" should not exist
+    And as "Brian" folder "/Shares/folderB/ONE" should exist
+    And as "Brian" folder "/Shares/folderB/ONE/TWO" should exist
+    And user "Brian" folder "/Shares/folderB/ONE" should have the previously stored id
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -4572,7 +4572,8 @@ trait WebDav {
 				$user,
 				$this->getPasswordForUser($user),
 				$path,
-				$this->getStepLineRef()
+				$this->getStepLineRef(),
+				$this->getDavPathVersion()
 			);
 		} catch (Exception $e) {
 			return null;
@@ -4580,33 +4581,36 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has stored id of file "([^"]*)"$/
+	 * @Given /^user "([^"]*)" has stored id of (file|folder) "([^"]*)"$/
+	 * @When /^user "([^"]*)" stores id of (file|folder) "([^"]*)"$/
 	 *
 	 * @param string $user
+	 * @param string $fileOrFolder
 	 * @param string $path
 	 *
 	 * @return void
 	 */
-	public function userStoresFileIdForPath(string $user, string $path):void {
+	public function userStoresFileIdForPath(string $user, string $fileOrFolder, string $path):void {
 		$this->storedFileID = $this->getFileIdForPath($user, $path);
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" file "([^"]*)" should have the previously stored id$/
+	 * @Then /^user "([^"]*)" (file|folder) "([^"]*)" should have the previously stored id$/
 	 *
 	 * @param string $user
+	 * @param string $fileOrFolder
 	 * @param string $path
 	 *
 	 * @return void
 	 */
-	public function userFileShouldHaveStoredId(string $user, string $path):void {
+	public function userFileShouldHaveStoredId(string $user, string $fileOrFolder, string $path):void {
 		$user = $this->getActualUsername($user);
 		$currentFileID = $this->getFileIdForPath($user, $path);
 		Assert::assertEquals(
 			$currentFileID,
 			$this->storedFileID,
 			__METHOD__
-			. " User '$user' file '$path' does not have the previously stored id '{$this->storedFileID}', but has '$currentFileID'."
+			. " User '$user' $fileOrFolder '$path' does not have the previously stored id '{$this->storedFileID}', but has '$currentFileID'."
 		);
 	}
 


### PR DESCRIPTION
## Description
adds spaces DAV path on `apiWebdavMove2 ` suite
- moves two test scenario related to moving folder from `apiWebdavMove2/moveFile.feature` to  `apiWebdavMove1/moveFolder.feature`
- adds new feature file` moveShareOnOcisfile` for testing Share related test only on ocis 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fixes https://github.com/owncloud/ocis/issues/3107

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require an increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
