### PR TITLE
Add composer allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
         "classmap-authoritative": false,
         "platform": {
             "php": "7.3"
+        },
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true,
+            "dg/composer-cleaner": true
         }
     },
     "autoload" : {


### PR DESCRIPTION
## Description
I updated my local system to the latest `composer` 2.2.6. When I do `composer update` it now asks me if I trust the composer plugins that we use. After answering "yes" it adds that "trust" to `composer.json`

https://getcomposer.org/doc/06-config.md#allow-plugins
"As of Composer 2.2.0, the allow-plugins option adds a layer of security allowing you to restrict which Composer plugins are able to execute code during a Composer run."

This PR commits the `allow-plugins` section for `composer.json` so that it is there for anyone who updates to composer 2.2

This is a tool change, no changelog is required.

## Related Issue
Part of https://github.com/owncloud/QA/issues/723

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
