### PR TITLE
[tests-only] update getPersonalSpaceIdForUser to use new oc:id format

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -433,13 +433,31 @@ class WebDavHelper {
 					__METHOD__ . " oc:id not found in webdav propfind for user $user - so the personal space id cannot be discovered"
 				);
 			}
-			// oc:id should be something like:
-			// "7464caf6-1799-103c-9046-c7b74deb5f63!7464caf6-1799-103c-9046-c7b74deb5f63"
-			$ocId = $xmlPart[0]->__toString();
-			$ocIdParts = \explode("!", $ocId);
+			$ocIdRawString = $xmlPart[0]->__toString();
+			$separator = "!";
+			if (\strpos($ocIdRawString, $separator) !== false) {
+				// The string is not base64-encoded, because the exclamation mark is not in the base64 alphabet.
+				// We expect to have a string with 2 parts separated by the exclamation mark.
+				// This is the format introduced in 2022-02
+				// oc:id should be something like:
+				// "7464caf6-1799-103c-9046-c7b74deb5f63!7464caf6-1799-103c-9046-c7b74deb5f63"
+				// There is no encoding to decode.
+				$decodedId = $ocIdRawString;
+			} else {
+				// fall-back to assuming that the oc:id is base64-encoded
+				// That is the format used before and up to 2022-02
+				// This can be removed after both the edge and master branches of cs3org/reva are using the new format.
+				// oc:id should be some base64 encoded string like:
+				// "NzQ2NGNhZjYtMTc5OS0xMDNjLTkwNDYtYzdiNzRkZWI1ZjYzOjc0NjRjYWY2LTE3OTktMTAzYy05MDQ2LWM3Yjc0ZGViNWY2Mw=="
+				// That should decode to something like:
+				// "7464caf6-1799-103c-9046-c7b74deb5f63:7464caf6-1799-103c-9046-c7b74deb5f63"
+				$decodedId = base64_decode($ocIdRawString);
+				$separator = ":";
+			}
+			$ocIdParts = \explode($separator, $decodedId);
 			if (\count($ocIdParts) !== 2) {
 				throw new Exception(
-					__METHOD__ . " the oc:id $ocId for user $user does not have 2 parts separated by an exclamation mark, so the personal space id cannot be discovered"
+					__METHOD__ . " the oc:id $decodedId for user $user does not have 2 parts separated by '$separator', so the personal space id cannot be discovered"
 				);
 			}
 			$personalSpaceId = $ocIdParts[0];

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -433,19 +433,16 @@ class WebDavHelper {
 					__METHOD__ . " oc:id not found in webdav propfind for user $user - so the personal space id cannot be discovered"
 				);
 			}
-			// oc:id should be some base64 encoded string like:
-			// "NzQ2NGNhZjYtMTc5OS0xMDNjLTkwNDYtYzdiNzRkZWI1ZjYzOjc0NjRjYWY2LTE3OTktMTAzYy05MDQ2LWM3Yjc0ZGViNWY2Mw=="
-			$idBase64 = $xmlPart[0]->__toString();
-			// That should decode to something like:
-			// "7464caf6-1799-103c-9046-c7b74deb5f63:7464caf6-1799-103c-9046-c7b74deb5f63"
-			$decodedId = base64_decode($idBase64);
-			$decodedIdParts = \explode(":", $decodedId);
-			if (\count($decodedIdParts) !== 2) {
+			// oc:id should be something like:
+			// "7464caf6-1799-103c-9046-c7b74deb5f63!7464caf6-1799-103c-9046-c7b74deb5f63"
+			$ocId = $xmlPart[0]->__toString();
+			$ocIdParts = \explode("!", $ocId);
+			if (\count($ocIdParts) !== 2) {
 				throw new Exception(
-					__METHOD__ . " the decoded oc:id $decodedId for user $user does not have 2 parts separated by a colon, so the personal space id cannot be discovered"
+					__METHOD__ . " the oc:id $ocId for user $user does not have 2 parts separated by an exclamation mark, so the personal space id cannot be discovered"
 				);
 			}
-			$personalSpaceId = $decodedIdParts[0];
+			$personalSpaceId = $ocIdParts[0];
 		} else {
 			foreach ($json->value as $spaces) {
 				if ($spaces->driveType === "personal") {


### PR DESCRIPTION
## Description
This PR makes the code more flexible in `getPersonalSpaceIdForUser`. It auto-detects if the space id is in base64-encoded format (the current "old" format) or in the proposed new unencoded format. So the tests will run auto-magically against `cs3org/reva` with either the old or proposed new format without needing to do anything special in CI.

This provides a way to transition to the proposed new format without breaking any CI.

## Related Issue
reva PR https://github.com/cs3org/reva/pull/2542

## How Has This Been Tested?
CI
https://github.com/cs3org/reva/pull/2550 - CI passes in reva master branch using the code here in this PR.
https://github.com/cs3org/reva/pull/2551 - CI passes in reva edge branch using the code here in this PR.
https://github.com/cs3org/reva/pull/2552 - CI passes in reva edge with the proposed "remove base64 encoding of ids" code from https://github.com/cs3org/reva/pull/2542

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
