### PR TITLE
Public-files endpoint won't stream multistatus

### DIFF
--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -224,7 +224,7 @@ class Server {
 			OC::$server->getLazyRootFolder()
 		));
 
-		if ($this->isRequestForSubtree(['files', 'meta', 'trash-bin', 'public-files'])) {
+		if ($this->isRequestForSubtree(['files', 'meta', 'trash-bin'])) {
 			\Sabre\DAV\Server::$streamMultiStatus = true;
 			$this->server->addPlugin(new ViewOnlyPlugin(
 				OC::$server->getLogger()

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -224,8 +224,12 @@ class Server {
 			OC::$server->getLazyRootFolder()
 		));
 
-		if ($this->isRequestForSubtree(['files', 'meta', 'trash-bin'])) {
+		// enable streaming only for the files subtree
+		if ($this->isRequestForSubtree(['files'])) {
 			\Sabre\DAV\Server::$streamMultiStatus = true;
+		}
+
+		if ($this->isRequestForSubtree(['files', 'meta', 'trash-bin', 'public-files'])) {
 			$this->server->addPlugin(new ViewOnlyPlugin(
 				OC::$server->getLogger()
 			));

--- a/changelog/unreleased/39797
+++ b/changelog/unreleased/39797
@@ -1,0 +1,8 @@
+Bugfix: Fix wrong formatted XML in public-files dav endpoint
+
+Previously, trying to perform a PROPFIND over the public-files endpoint
+could cause an exception to be thrown, which would generate a wrong formatted
+XML response. Now, the XML response is properly formatted and can be parsed
+without problems.
+
+https://github.com/owncloud/core/pull/39797

--- a/tests/acceptance/features/webUIUpload/upload.feature
+++ b/tests/acceptance/features/webUIUpload/upload.feature
@@ -133,7 +133,7 @@ Feature: File Upload
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
     And user "Alice" has created a public link share with settings
       | path        | /simple-folder     |
-      | permissions | read,update,create |
+      | permissions | change             |
     When the public accesses the last created public link using the webUI
     And the user uploads overwriting file "lorem.txt" using the webUI and retries if the file is locked
     Then file "lorem.txt" should be listed on the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The public-files endpoint won't stream the result, preventing a malformed XML to be sent in some scenarios where an error happens

## Related Issue
https://github.com/owncloud/core/issues/39707

## Motivation and Context
A malformed XML could cause additional issues

## How Has This Been Tested?
Manually checked with the steps described in the linked issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
