### PR TITLE
[tests-only] skip changed createPublicLinkShare test scenarios on old oC10

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -323,7 +323,7 @@ Feature: create a public link share
       | 1               | 403             |
       | 2               | 403             |
 
-
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Updating a public link share with read+create permissions is forbidden when public upload is disabled globally
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -342,7 +342,7 @@ Feature: create a public link share
       | 2               | 403             |
 
 
-  @issue-ocis-reva-41
+  @issue-ocis-reva-41 @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Creating a link share with read+update+create permissions is forbidden when public upload is disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"


### PR DESCRIPTION
## Description
PR #39194 adjusted API status responses for some cases of public link permissions. The relevant tests were also adjusted. The PR was merged in core master a few days ago. The behavior changes are not in release 10.9.1 or any of the older releases. So skip the changed test scenarios when testing against those releases.

https://drone.owncloud.com/owncloud/encryption/2311/80/18
```
runsh: Total unexpected failed scenarios throughout the test run:
apiSharePublicLink1/createPublicLinkShare.feature:341
apiSharePublicLink1/createPublicLinkShare.feature:342
apiSharePublicLink1/createPublicLinkShare.feature:358
apiSharePublicLink1/createPublicLinkShare.feature:359
```

And the same in https://drone.owncloud.com/owncloud/user_ldap/3772/109/18

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
