### PR TITLE
[tests-only][full-ci]added then steps for apiMain suite

### DIFF
--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -39,7 +39,8 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" downloads file "/myChecksumFile.txt" using the WebDAV API
-    Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
+    Then the HTTP status code should be "200"
+    And the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
       | dav_version |
       | old         |
@@ -55,7 +56,8 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
-    Then as user "Alice" the webdav checksum of "/myMovedChecksumFile.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
+    Then the HTTP status code should be "201"
+    And as user "Alice" the webdav checksum of "/myMovedChecksumFile.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
       | dav_version |
       | old         |
@@ -70,9 +72,10 @@ Feature: checksums
   Scenario Outline: Downloading a file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "Alice" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
-    And user "Alice" downloads file "/myMovedChecksumFile.txt" using the WebDAV API
-    Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
+    And user "Alice" has moved file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt"
+    When user "Alice" downloads file "/myMovedChecksumFile.txt" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
       | dav_version |
       | old         |
@@ -90,7 +93,8 @@ Feature: checksums
     And user "Alice" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "Alice" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     When user "Alice" requests the checksum of "/myChecksumFile.txt" via propfind
-    Then the webdav checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
+    Then the HTTP status code should be "207"
+    And the webdav checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8 MD5:45a72715acdd5019c5be30bdbb75233e ADLER32:1ecd03df"
     Examples:
       | dav_version |
       | old         |
@@ -107,7 +111,8 @@ Feature: checksums
     And user "Alice" has uploaded chunk file "2" of "3" with "BBBBB" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     And user "Alice" has uploaded chunk file "3" of "3" with "CCCCC" to "/myChecksumFile.txt" with checksum "MD5:45a72715acdd5019c5be30bdbb75233e"
     When user "Alice" downloads file "/myChecksumFile.txt" using the WebDAV API
-    Then the header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
+    Then the HTTP status code should be "200"
+    And the header checksum should match "SHA1:acfa6b1565f9710d4d497c6035d5c069bd35a8e8"
     Examples:
       | dav_version |
       | old         |
@@ -126,7 +131,8 @@ Feature: checksums
     When user "Alice" downloads file "/local_storage/prueba_cksum.txt" using the WebDAV API
     # Now do a download that is expected to have a checksum with it
     And user "Alice" downloads file "/local_storage/prueba_cksum.txt" using the WebDAV API
-    Then the header checksum should match "SHA1:a35b7605c8f586d735435535c337adc066c2ccb6"
+    Then the HTTP status code should be "200"
+    And the header checksum should match "SHA1:a35b7605c8f586d735435535c337adc066c2ccb6"
     Examples:
       | dav_version |
       | old         |
@@ -138,7 +144,8 @@ Feature: checksums
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" moves file "/myChecksumFile.txt" to "/myMovedChecksumFile.txt" using the WebDAV API
     And user "Alice" downloads file "/myMovedChecksumFile.txt" using the WebDAV API
-    Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
+    Then the HTTP status code should be "200"
+    And the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
       | dav_version |
       | old         |
@@ -154,7 +161,8 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the WebDAV API
-    Then as user "Alice" the webdav checksum of "/myChecksumFileCopy.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
+    Then the HTTP status code should be "201"
+    And as user "Alice" the webdav checksum of "/myChecksumFileCopy.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
       | dav_version |
       | new         |
@@ -169,8 +177,8 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
     When user "Alice" copies file "/myChecksumFile.txt" to "/myChecksumFileCopy.txt" using the WebDAV API
-    And user "Alice" downloads file "/myChecksumFileCopy.txt" using the WebDAV API
-    Then the header checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
+    Then the HTTP status code should be "201"
+    And the header checksum when user "Alice" downloads file "/myChecksumFileCopy.txt" using the WebDAV API should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f"
     Examples:
       | dav_version |
       | new         |
@@ -188,9 +196,9 @@ Feature: checksums
     And using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "Alice" shares file "/myChecksumFile.txt" with user "Brian" using the sharing API
-    And user "Brian" accepts share "/myChecksumFile.txt" offered by user "Alice" using the sharing API
-    And user "Brian" requests the checksum of "/Shares/myChecksumFile.txt" via propfind
+    And user "Alice" has shared file "/myChecksumFile.txt" with user "Brian"
+    And user "Brian" has accepted share "/myChecksumFile.txt" offered by user "Alice"
+    When user "Brian" requests the checksum of "/Shares/myChecksumFile.txt" via propfind
     Then the HTTP status code should be "207"
     And the webdav checksum should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     Examples:
@@ -204,16 +212,17 @@ Feature: checksums
 
   @files_sharing-app-required
   @issue-ocis-reva-196 @skipOnOcV10
-  Scenario Outline: Sharing and modifying a file should return correct checksum in the propfind using new DAV path
+  Scenario Outline: Modifying a shared file should return correct checksum in the propfind using new DAV path
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
     And using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "Alice" shares file "/myChecksumFile.txt" with user "Brian" using the sharing API
-    And user "Brian" accepts share "/myChecksumFile.txt" offered by user "Alice" using the sharing API
-    And user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/Shares/myChecksumFile.txt" using the WebDAV API
-    Then as user "Alice" the webdav checksum of "/myChecksumFile.txt" via propfind should match "<checksum>"
+    And user "Alice" has shared file "/myChecksumFile.txt" with user "Brian"
+    And user "Brian" has accepted share "/myChecksumFile.txt" offered by user "Alice"
+    When user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/Shares/myChecksumFile.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as user "Alice" the webdav checksum of "/myChecksumFile.txt" via propfind should match "<checksum>"
     Examples:
       | dav_version | checksum                                                                                            |
       | new         | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 MD5:56e57920c3c8c727bfe7a5288cdf61c4 ADLER32:1048035a |
@@ -226,20 +235,21 @@ Feature: checksums
   @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file where checksum matches
     Given using new DAV path
-    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Alice" has created a new chunking upload with id "chunking-42"
+    When user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "Alice" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
-    Then the HTTP status code should be "201"
+    Then the HTTP status code of responses on all endpoints should be "201"
+
 
   @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file where checksum does not match
     Given using new DAV path
-    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Alice" has created a new chunking upload with id "chunking-42"
+    When user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "Alice" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:f005ba11" using the WebDAV API
-    Then the HTTP status code should be "400"
+    Then the HTTP status code of responses on each endpoint should be "201, 201, 400" respectively
     And user "Alice" should not see the following elements
       | /myChunkedFile.txt |
 
@@ -247,11 +257,11 @@ Feature: checksums
   Scenario: Upload new DAV chunked file using async MOVE where checksum matches
     Given using new DAV path
     And the administrator has enabled async operations
-    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Alice" has created a new chunking upload with id "chunking-42"
+    When user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "Alice" moves new chunk file with id "chunking-42" asynchronously to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
-    Then the HTTP status code should be "202"
+    Then the HTTP status code of responses on each endpoint should be "201, 201, 202" respectively
     And the following headers should match these regular expressions for user "Alice"
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/%username%\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "Alice" should match these regular expressions
@@ -263,11 +273,11 @@ Feature: checksums
   Scenario: Upload new DAV chunked file using async MOVE where checksum does not match
     Given using new DAV path
     And the administrator has enabled async operations
-    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Alice" has created a new chunking upload with id "chunking-42"
+    When user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "Alice" moves new chunk file with id "chunking-42" asynchronously to "/myChunkedFile.txt" with checksum "SHA1:f005ba11" using the WebDAV API
-    Then the HTTP status code should be "202"
+    Then the HTTP status code of responses on each endpoint should be "201, 201, 202" respectively
     And the following headers should match these regular expressions for user "Alice"
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/%username%\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "Alice" should match these regular expressions
@@ -281,12 +291,12 @@ Feature: checksums
   Scenario: Upload new DAV chunked file using async MOVE where checksum does not match - retry with correct checksum
     Given using new DAV path
     And the administrator has enabled async operations
-    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Alice" has created a new chunking upload with id "chunking-42"
+    When user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "Alice" moves new chunk file with id "chunking-42" asynchronously to "/myChunkedFile.txt" with checksum "SHA1:f005ba11" using the WebDAV API
     And user "Alice" moves new chunk file with id "chunking-42" asynchronously to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
-    Then the HTTP status code should be "202"
+    Then the HTTP status code of responses on each endpoint should be "201, 201, 202, 202" respectively
     And the following headers should match these regular expressions for user "Alice"
       | OC-JobStatus-Location | /%base_path%\/remote\.php\/dav\/job-status\/%username%\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ |
     And the oc job status values of last request for user "Alice" should match these regular expressions
@@ -330,7 +340,8 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/chksumtst.txt"
     When user "Alice" downloads file "/chksumtst.txt" using the WebDAV API
-    Then the following headers should be set
+    Then the HTTP status code should be "200"
+    And the following headers should be set
       | header      | value                                         |
       | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
     Examples:
@@ -348,7 +359,8 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"
     When user "Alice" downloads file "/local_storage/chksumtst.txt" using the WebDAV API
-    Then the following headers should be set
+    Then the HTTP status code should be "200"
+    And the following headers should be set
       | header      | value                                         |
       | OC-Checksum | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 |
     Examples:
@@ -379,7 +391,8 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "some data" to "textfile0.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a" using the WebDAV API
-    Then as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
+    Then the HTTP status code should be "204"
+    And as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     And the content of file "/textfile0.txt" for user "Alice" should be:
       """
       This is a testfile.
@@ -401,7 +414,8 @@ Feature: checksums
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "some data" to "textfile0.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f" using the WebDAV API
-    Then as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
+    Then the HTTP status code should be "204"
+    And as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960"
     And the content of file "/textfile0.txt" for user "Alice" should be:
       """
       This is a testfile.
@@ -420,11 +434,12 @@ Feature: checksums
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
   @issue-ocis-reva-196
- Scenario Outline: Uploading a file with invalid SHA1 checksum overwriting an existing file
+  Scenario Outline: Uploading a file with invalid SHA1 checksum overwriting an existing file
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/textfile0.txt" with checksum "SHA1:f005ba11f005ba11f005ba11f005ba11f005ba11" using the WebDAV API
-    Then as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:2052377dec0724bda0d57aeab67fa819278b7f74 MD5:096e350e9ff1339a997a14145f9fc4b9 ADLER32:7d5a0921"
+    Then the HTTP status code should be "400"
+    And as user "Alice" the webdav checksum of "/textfile0.txt" via propfind should match "SHA1:2052377dec0724bda0d57aeab67fa819278b7f74 MD5:096e350e9ff1339a997a14145f9fc4b9 ADLER32:7d5a0921"
     And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
     Examples:
       | dav_version |
@@ -440,11 +455,11 @@ Feature: checksums
   Scenario: Upload overwriting a file with new chunking and correct checksum
     Given using new DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
-    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Alice" has created a new chunking upload with id "chunking-42"
+    When user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "Alice" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
-    Then the HTTP status code should be "204"
+    Then the HTTP status code of responses on each endpoint should be "201, 201, 204" respectively
     And the content of file "/textfile0.txt" for user "Alice" should be "BBBBBCCCCC"
 
   @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
@@ -452,11 +467,11 @@ Feature: checksums
   Scenario: Upload overwriting a file with new chunking and invalid checksum
     Given using new DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
-    When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
-    And user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
+    And user "Alice" has created a new chunking upload with id "chunking-42"
+    When user "Alice" uploads new chunk file "2" with "BBBBB" to id "chunking-42" using the WebDAV API
     And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "Alice" moves new chunk file with id "chunking-42" to "/textfile0.txt" with checksum "SHA1:f005ba11" using the WebDAV API
-    Then the HTTP status code should be "400"
+    Then the HTTP status code of responses on each endpoint should be "201, 201, 400" respectively
     And the content of file "/textfile0.txt" for user "Alice" should be "ownCloud test text file 0"
 
   @issue-ocis-reva-214

--- a/tests/acceptance/features/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/features/bootstrap/ChecksumContext.php
@@ -328,6 +328,21 @@ class ChecksumContext implements Context {
 	}
 
 	/**
+	 * @Then the header checksum when user :arg1 downloads file :arg2 using the WebDAV API should match :arg3
+	 *
+	 * @param string $user
+	 * @param string $fileName
+	 * @param string $expectedChecksum
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theHeaderChecksumWhenUserDownloadsFileUsingTheWebdavApiShouldMatch(string $user, string $fileName, string $expectedChecksum):void {
+		$this->featureContext->userDownloadsFileUsingTheAPI($user, $fileName);
+		$this->theHeaderChecksumShouldMatch($expectedChecksum);
+	}
+
+	/**
 	 * @Then the webdav checksum should be empty
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -2455,6 +2455,33 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then the HTTP status code of responses on each endpoint should be :statusCode respectively
+	 *
+	 * @param string $statusCodes
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theHTTPStatusCodeOfResponsesOnEachEndpointShouldBe(string $statusCodes):void {
+		$statusCodes = \explode(',', $statusCodes);
+		$count = \count($statusCodes);
+		if ($count === \count($this->lastHttpStatusCodesArray)) {
+			for ($i = 0; $i < $count; $i++) {
+				Assert::assertSame(
+					(int)\trim($statusCodes[$i]),
+					(int)$this->lastHttpStatusCodesArray[$i],
+					'Responses did not return expected http status code'
+				);
+			}
+		} else {
+			throw new Exception(
+				'Expected status codes: "' . \implode(',', $statusCodes) .
+				'". Found status codes: "' . \implode(',', $this->lastHttpStatusCodesArray) . '"'
+			);
+		}
+	}
+
+	/**
 	 * @Then the HTTP status code of responses on all endpoints should be :statusCode1 or :statusCode2
 	 *
 	 * @param string $statusCode1
@@ -3974,6 +4001,7 @@ trait WebDav {
 			$data,
 			"uploads"
 		);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -4093,6 +4121,7 @@ trait WebDav {
 			$dest,
 			$headers
 		);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -4151,6 +4180,7 @@ trait WebDav {
 			$dest,
 			$headers
 		);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds ``` Then ``` steps to existing API test scenarios to better check the results of ``` When ``` steps.

### Suite Covered
- ``` apiMain ```

## Related Issues
- Part of https://github.com/owncloud/core/issues/39512

## How Has This Been Tested?
- Locally
- CI

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
