### PR TITLE
[tests-only] allow underscore in expected-failures links

### DIFF
--- a/tests/acceptance/lint-expected-failures.sh
+++ b/tests/acceptance/lint-expected-failures.sh
@@ -50,7 +50,7 @@ then
 				continue
 			fi
 			# Find the link in round-brackets that should be after the SUITE_SCENARIO_LINE
-			if [[ "${INPUT_LINE}" =~ \(([a-zA-Z0-9:/.#-]+)\) ]]; then
+			if [[ "${INPUT_LINE}" =~ \(([a-zA-Z0-9:/.#_-]+)\) ]]; then
 				ACTUAL_LINK="${BASH_REMATCH[1]}"
 			else
 				echo "Link not found in ${INPUT_LINE}"


### PR DESCRIPTION
## Description
A lint checker for expected-failures files was added to CI in PR #39782 
One of the checks is to find and validate the link that should be in `()` after an expected-failures feature file mention.
Links can contain an underscore character, e.g.:
```
-   [apiFilesSpaces/filesSpaces.feature:114](https://github.com/owncloud/files_spaces/blob/master/tests/acceptance/features/apiFilesSpaces/filesSpaces.feature#L114)
```

The repo is `files_spaces`.

This PR adds the `_` to the allowed characters used to find matches of links.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
