### PR TITLE
[tests-only] allow underscore in repo names

### DIFF
--- a/tests/acceptance/lint-expected-failures.sh
+++ b/tests/acceptance/lint-expected-failures.sh
@@ -36,7 +36,7 @@ then
 			# "The expected failures in this file are from features in the owncloud/ocis repo."
 			# Write a line near the top of the expected-failures file to "declare" this,
 			# overriding the default "owncloud/core"
-			if [[ "${INPUT_LINE}" =~ features[[:blank:]]in[[:blank:]]the[[:blank:]]([a-zA-Z0-9-]+/[a-zA-Z0-9-]+)[[:blank:]]repo ]]; then
+			if [[ "${INPUT_LINE}" =~ features[[:blank:]]in[[:blank:]]the[[:blank:]]([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)[[:blank:]]repo ]]; then
 				FEATURE_FILE_REPO="${BASH_REMATCH[1]}"
 				echo "Features are expected to be in the ${FEATURE_FILE_REPO} repo"
 				continue
@@ -44,7 +44,7 @@ then
 			# Match lines that have [someSuite/someName.feature:n] - the part inside the
 			# brackets is the suite, feature and line number of the expected failure.
 			# Else ignore the line.
-			if [[ "${INPUT_LINE}" =~ \[([a-zA-Z0-9-]+/[a-zA-Z0-9-]+\.feature:[0-9]+)] ]]; then
+			if [[ "${INPUT_LINE}" =~ \[([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+\.feature:[0-9]+)] ]]; then
 				SUITE_SCENARIO_LINE="${BASH_REMATCH[1]}"
 			else
 				continue


### PR DESCRIPTION
## Description
Follow-on from PR #39804 
I missed a few places that should allow on underscore `_` to match in regex of organisation/reponame or suite/featurename when processing an expected-failures file.


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
