### PR TITLE
[tests-only] Add test step 'the user count of group should not be displayed

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -924,6 +924,22 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then /^the user count of group "([^"]*)" should not be displayed on the webUI$/
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 */
+	public function theUserCountOfGroupShouldNotBeDisplayedOnTheWebUI(string $group):void {
+		Assert::assertFalse(
+			$this->usersPage->groupUserCountElementExists($group),
+			__METHOD__
+			. " The user count of group '$group' is not expected to be displayed on the webUI, "
+			. "but it is displayed."
+		);
+	}
+
+	/**
 	 * @Then /^the user count of group "([^"]*)" should display (\d+) users on the webUI$/
 	 *
 	 * @param string $group

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -955,19 +955,40 @@ class UsersPage extends OwncloudPage {
 	/**
 	 * @param string $group
 	 *
+	 * @return NodeElement|null
+	 */
+	public function getGroupUserCountElement(string $group): ?NodeElement {
+		$groupUserCountXpath = \sprintf($this->groupUserCountXpath, $group);
+		return $this->find('xpath', $groupUserCountXpath);
+	}
+
+	/**
+	 * @param string $group
+	 *
+	 * @return bool
+	 */
+	public function groupUserCountElementExists(string $group): bool {
+		if ($this->getGroupUserCountElement($group) === null) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * @param string $group
+	 *
 	 * @return int|null
 	 * @throws ElementNotFoundException
 	 */
 	public function getUserCountOfGroup(string $group): ?int {
-		$groupUserCountXpath = \sprintf($this->groupUserCountXpath, $group);
-		$groupUserCount = $this->find('xpath', $groupUserCountXpath);
+		$groupUserCountElement = $this->getGroupUserCountElement($group);
 		$this->assertElementNotNull(
-			$groupUserCount,
+			$groupUserCountElement,
 			__METHOD__ .
-			" xpath $groupUserCountXpath " .
+			" xpath $this->groupUserCountXpath " .
 			"could not find user count for group $group"
 		);
-		$groupUserCount = \trim($groupUserCount->getText());
+		$groupUserCount = \trim($groupUserCountElement->getText());
 		if ($groupUserCount === "") {
 			return null;
 		}


### PR DESCRIPTION
## Description
PR #39721 changed the behavior of the groups on the user management page. If the group is an LDAP group, or for whatever reason the group member count is zero or not available, then the count is not displayed at all.

As a result, some existing tests in `user_ldap` are failing and need to be adjusted. The group member count is no longer displayed.

To help adjust the scenarios mention in the related issue, this PR adds a test step to core:
```
@Then /^the user count of group "([^"]*)" should not be displayed on the webUI$/
```

That step can be used in user_ldap test scenarios, or anywhere that it is appropriate.

## Related Issue
https://github.com/owncloud/user_ldap/issues/716

## How Has This Been Tested?
CI

I have tried the step locally and it works. After this PR is merged to core, I will make a PR to user_ldap that adjusts the user_ldap test scenarios.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
