### PR TITLE
Fix issue restoring versions from the trashbin after sharing

### DIFF
--- a/changelog/unreleased/39822
+++ b/changelog/unreleased/39822
@@ -1,0 +1,10 @@
+Bugfix: Fix issue restoring versions from the trashbin after sharing
+
+Previously, having encryption enabled, if a user shared a folder with
+another user, and that new user removed a file inside that shared folder,
+that file ended up in the new user's trashbin along with the file's versions.
+Restoring that file from the trashbin caused the versions of that file
+to get broken due to a bad signature. The file was restored correctly.
+Now, the versions are also restored correctly from the trashbin too.
+
+https://github.com/owncloud/core/pull/39822

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -722,10 +722,13 @@ class Encryption extends Wrapper {
 
 		// in case of a rename we need to manipulate the source cache because
 		// this information will be kept for the new target
-		if ($isRename) {
+		if ($isRename && !($this->isVersion($sourceInternalPath) || $this->isVersion($targetInternalPath))) {
 			/*
 			 * Rename is a process of creating a new file. Here we try to use the
 			 * incremented version of source file, for the destination file.
+			 * Note that if we're renaming or moving a version, the version is copied
+			 * without any change, so the encrypted version mustn't change in order to avoid
+			 * problems with the signature
 			 */
 			$encryptedVersion = $sourceStorage->getCache()->get($sourceInternalPath)['encryptedVersion'];
 			if ($this->encryptionManager->isEnabled() && $isEncrypted) {


### PR DESCRIPTION
A folder contains a file with multiple versions. The folder is shared
with another user. That user deletes the shared file (with the
versions). Then, that user restores the file. At that point, the
versions were broken due to a bad signature.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
According to docs, versions are copied as such, so the signature in the file doesn't change. Since the signature doesn't change, the "encrypted" column shouldn't change neither.
Even if we're moving versions, we won't increase the "encrypted" value for the version in order to not disrupt the signature in the file.

## Related Issue
https://github.com/owncloud/core/issues/39664

## Motivation and Context
Versions of the file were broken after following the steps described in the issue

## How Has This Been Tested?
Manually tested following the steps

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
