### PR TITLE
[tests-only] [do-not-merge] Test scenarios 10.9.1

### DIFF
--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -917,10 +917,12 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		$resultXml = \simplexml_load_string($contents);
 
 		if ($resultXml === false) {
+			$status = $result->getStatusCode();
 			throw new Exception(
 				"Response is not valid XML after executing 'occ $argsString'. " .
+				"HTTP status was $status. " .
 				$isTestingAppEnabledText .
-				$contents
+				"Response contents were '$contents'"
 			);
 		}
 

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -885,7 +885,8 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		}
 
 		$body = [];
-		$body['command'] = \implode(' ', $args);
+		$argsString = \implode(' ', $args);
+		$body['command'] = $argsString;
 
 		if ($envVariables !== null) {
 			$body['env_variables'] = $envVariables;
@@ -917,7 +918,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 
 		if ($resultXml === false) {
 			throw new Exception(
-				"Response is not valid XML after executing 'occ $args'. " .
+				"Response is not valid XML after executing 'occ $argsString'. " .
 				$isTestingAppEnabledText .
 				$contents
 			);
@@ -929,7 +930,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 
 		if (!isset($return['code'][0])) {
 			throw new Exception(
-				"Return code not found after executing 'occ $args'. " .
+				"Return code not found after executing 'occ $argsString'. " .
 				$isTestingAppEnabledText .
 				$contents
 			);
@@ -937,7 +938,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 
 		if (!isset($return['stdOut'][0])) {
 			throw new Exception(
-				"Return stdOut not found after executing 'occ $args'. " .
+				"Return stdOut not found after executing 'occ $argsString'. " .
 				$isTestingAppEnabledText .
 				$contents
 			);
@@ -945,7 +946,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 
 		if (!isset($return['stdErr'][0])) {
 			throw new Exception(
-				"Return stdErr not found after executing 'occ $args'. " .
+				"Return stdErr not found after executing 'occ $argsString'. " .
 				$isTestingAppEnabledText .
 				$contents
 			);
@@ -953,7 +954,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 
 		if (!\is_a($return['code'][0], "SimpleXMLElement")) {
 			throw new Exception(
-				"Return code is not a SimpleXMLElement after executing 'occ $args'. " .
+				"Return code is not a SimpleXMLElement after executing 'occ $argsString'. " .
 				$isTestingAppEnabledText .
 				$contents
 			);
@@ -961,7 +962,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 
 		if (!\is_a($return['stdOut'][0], "SimpleXMLElement")) {
 			throw new Exception(
-				"Return stdOut is not a SimpleXMLElement after executing 'occ $args'. " .
+				"Return stdOut is not a SimpleXMLElement after executing 'occ $argsString'. " .
 				$isTestingAppEnabledText .
 				$contents
 			);
@@ -969,7 +970,7 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 
 		if (!\is_a($return['stdErr'][0], "SimpleXMLElement")) {
 			throw new Exception(
-				"Return stdErr is not a SimpleXMLElement after executing 'occ $args'. " .
+				"Return stdErr is not a SimpleXMLElement after executing 'occ $argsString'. " .
 				$isTestingAppEnabledText .
 				$contents
 			);

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -866,6 +866,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 					SetupHelper::setSystemConfig(
 						'enable_previews',
 						$this->oldPreviewSetting[$server],
+						$this->featureContext->getStepLineRef(),
 						'boolean'
 					);
 				}

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -91,7 +91,7 @@ Feature: add users
       | guiusr1  | simple user-name      |
       | a@-+_.'b | complicated user-name |
 
-  @smokeTest @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: user sets his own password after being created with an Email address only and invitation link resend
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator resends the invitation email for user "<username>" using the webUI

--- a/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/changeOwnEmailAddress.feature
@@ -9,7 +9,7 @@ Feature: Change own email address on the personal settings page
     And user "Alice" has logged in using the webUI
     And the user has browsed to the personal general settings page
 
-  @smokeTest @skipOnLDAP
+  @skipOnLDAP
   @skipOnFIREFOX
   Scenario: Change email address
     When the user changes the email address to "new-address@owncloud.com" using the webUI


### PR DESCRIPTION
This branch adjusts some test code that is in the `release-10.9.1` branch:

1) SetupHelper - fixes some "array to string" conversion errors that can happen if a test is failing and some error reporting code gets run. That was fixed in core master after the 10.9.1 branch point.

2) WebUIGenralContext - a call to ऽSetupHelper::setSystemConfig had out-of-date parameters. The problem was only noticeable if the scenario tear-down needed to reset `enable_previews`, so it was an edge case that depended on exactly what system-under-test was being tested.

3) `addUsers.feature` and `changeOwnEmailAddress.feature` - take these out of the smoke tests. They are causing some problems with some systems-under-test. It needs investigation to see if there is some environment/setup problem in the system-under-test, or if there is some real edge case being found.

This PR has been made to expose the diffs of this branch. It is not intended to merge it anywhere! The branch will be used for any systems-under-test that are running release 10.9.1 and need the acceptance tests to be run.