### PR TITLE
[tests-only][full-ci]added then steps for apiMain suite

### DIFF
--- a/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
+++ b/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
@@ -13,8 +13,9 @@ Feature: checksums
     And using new DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myChecksumFile.txt" with checksum "MD5:d70b40f177b14b470d1756a3c12b963a"
-    When user "Alice" shares file "/myChecksumFile.txt" with user "Brian" using the sharing API
-    And user "Brian" accepts share "/myChecksumFile.txt" offered by user "Alice" using the sharing API
-    And user "Brian" uploads file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/Shares/myChecksumFile.txt" using the WebDAV API
-    And user "Brian" requests the checksum of "/Shares/myChecksumFile.txt" via propfind
-    Then the webdav checksum should be empty
+    And user "Alice" has shared file "/myChecksumFile.txt" with user "Brian"
+    And user "Brian" has accepted share "/myChecksumFile.txt" offered by user "Alice"
+    And user "Brian" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/Shares/myChecksumFile.txt"
+    When user "Brian" requests the checksum of "/Shares/myChecksumFile.txt" via propfind
+    Then the HTTP status code should be "207"
+    And the webdav checksum should be empty

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -31,7 +31,8 @@ Feature: external-storage
       | Brian    |
     And user "Alice" has created folder "/local_storage/foo1"
     When user "Alice" moves file "/textfile0.txt" to "/local_storage/foo1/textfile0.txt" using the WebDAV API
-    Then as "Brian" file "/local_storage/foo1/textfile0.txt" should exist
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/local_storage/foo1/textfile0.txt" should exist
     And as "Alice" file "/local_storage/foo1/textfile0.txt" should exist
 
   Scenario: Move a file out of storage
@@ -42,7 +43,8 @@ Feature: external-storage
     And user "Alice" has created folder "/local_storage/foo2"
     And user "Alice" has moved file "/textfile0.txt" to "/local_storage/foo2/textfile0.txt"
     When user "Brian" moves file "/local_storage/foo2/textfile0.txt" to "/local.txt" using the WebDAV API
-    Then as "Brian" file "/local_storage/foo2/textfile0.txt" should not exist
+    Then the HTTP status code should be "201"
+    And as "Brian" file "/local_storage/foo2/textfile0.txt" should not exist
     And as "Alice" file "/local_storage/foo2/textfile0.txt" should not exist
     And as "Brian" file "/local.txt" should exist
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1388,6 +1388,7 @@ trait Sharing {
 			$user2,
 			$permissions
 		);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -2977,6 +2978,7 @@ trait Sharing {
 			$url,
 			null
 		);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3230,6 +3230,7 @@ trait WebDav {
 			$content
 		);
 		$this->lastUploadDeleteTime = \time();
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds ``` Then ``` steps to existing API test scenarios to better check the results of ``` When ``` steps.

### Suite Covered
- ``` apiMain ```

## Related Issues
- Part of https://github.com/owncloud/core/issues/39512

## How Has This Been Tested?
- Locally
- CI

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
