### PR TITLE
Fix encryption when the file is moved out of a share

### DIFF
--- a/changelog/unreleased/39829
+++ b/changelog/unreleased/39829
@@ -1,0 +1,10 @@
+Bugfix: Fix issue when encryption is enabled and a file is moved out of the share
+
+When encryption was used, moving a file out of a shared folder caused the
+versions of the file to get broken. The file was moved correctly though. This
+happened due to the key file not being copied to the new location and a new
+key file being generated for the file.
+Now, the key file is properly copied to the new location, so the versions can
+be decrypted properly.
+
+https://github.com/owncloud/core/pull/39829


### PR DESCRIPTION
## Description
Having encryption enabled, moving out a file out of a shared folder was breaking the encryption

Also see small fix in #39842 

## Related Issue
https://github.com/owncloud/encryption/issues/321

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested based on the steps described in the linked issue
Checked with:
* Shared folder in the root
* Shared folder in a folder (not root)
* Renamed shared folder for the user (Brian in the issue steps)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
