### PR TITLE
[tests-only] skip changed pollinterval tests on old oC10

### DIFF
--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -18,11 +18,13 @@ Feature: capabilities
     When the administrator sets parameter "shareapi_enabled" of app "core" to "no"
     Then the capabilities setting of "files_sharing" path "api_enabled" should be ""
 
+
   Scenario: Check that group sharing can be enabled
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be ""
     When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "yes"
     Then the capabilities setting of "files_sharing" path "group_sharing" should be "1"
+
 
   Scenario: Check that group sharing can be disabled
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "yes"
@@ -30,11 +32,12 @@ Feature: capabilities
     When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no"
     Then the capabilities setting of "files_sharing" path "group_sharing" should be ""
 
+
   Scenario: Check that search_min_length can be changed
     When the administrator updates system config key "user.search_min_length" with value "4" using the occ command
     Then the capabilities setting of "files_sharing" path "search_min_length" should be "4"
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -159,6 +162,7 @@ Feature: capabilities
       | capability | path_to_element | value |
       | files      | versioning      | 1     |
 
+
   Scenario: getting default_permissions capability with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -166,6 +170,7 @@ Feature: capabilities
     And the capabilities should contain
       | capability    | path_to_element     | value |
       | files_sharing | default_permissions | 31    |
+
 
   Scenario: default_permissions capability can be changed
     Given parameter "shareapi_default_permissions" of app "core" has been set to "7"
@@ -176,6 +181,7 @@ Feature: capabilities
       | capability    | path_to_element     | value |
       | files_sharing | default_permissions | 7     |
 
+
   Scenario: .htaccess is reported as a blacklisted file by default
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -183,6 +189,7 @@ Feature: capabilities
     And the capabilities should contain
       | capability | path_to_element                | value     |
       | files      | blacklisted_files@@@element[0] | .htaccess |
+
 
   Scenario: multiple files can be reported as blacklisted
     When the administrator updates system config key "blacklisted_files" with value '["test.txt",".htaccess"]' and type "json" using the occ command
@@ -280,6 +287,7 @@ Feature: capabilities
       | capability    | path_to_element | value |
       | files_sharing | can_share       | 1     |
 
+
   #feature added in #32414 released in 10.0.10
   Scenario: getting async capabilities when async operations are enabled
     Given the administrator has enabled async operations
@@ -290,6 +298,7 @@ Feature: capabilities
       | capability | path_to_element | value |
       | async      |                 | 1.0   |
 
+
   Scenario: getting async capabilities when async operations are disabled
     Given the administrator has disabled async operations
     When the administrator retrieves the capabilities using the capabilities API
@@ -297,6 +306,7 @@ Feature: capabilities
       | capability | path_to_element | value |
       | async      |                 | EMPTY |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing public upload
     Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -322,6 +332,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Disabling share api
     Given parameter "shareapi_enabled" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -341,6 +352,7 @@ Feature: capabilities
       | files_sharing | federation@@@incoming | 1                 |
       | files         | bigfilechunking       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Disabling public links
     Given parameter "shareapi_allow_links" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -364,6 +376,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing resharing
     Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -388,6 +401,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing federation outgoing
     Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -412,6 +426,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing federation incoming
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -436,6 +451,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing "password enforced for read-only public link shares"
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -463,6 +479,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing "password enforced for read-write public link shares"
     Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -490,6 +507,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing "password enforced for write-only public link shares"
     Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -517,6 +535,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing public notifications
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -541,6 +560,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing public social share
     Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -565,6 +585,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing expire date
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -590,6 +611,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing expire date enforcing
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
@@ -617,6 +639,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing group sharing allowed
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -641,6 +664,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing only share with group member
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -665,6 +689,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing only share with membership groups
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -690,6 +715,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing auto accept share
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -716,6 +742,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing allow share dialog user enumeration
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -739,6 +766,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled    | EMPTY             |
       | files         | bigfilechunking               | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing allow share dialog user enumeration for group members only
     Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -763,6 +791,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | 1                 |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing allow mail notification
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -788,6 +817,7 @@ Feature: capabilities
       | files_sharing | user@@@send_mail                      | 1                 |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Changing exclude groups from sharing
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And group "group1" has been created
@@ -816,6 +846,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: When in a group that is excluded from sharing, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "Alice" has been created with default attributes and without skeleton files
@@ -847,6 +878,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: When not in any group that is excluded from sharing, can_share is on
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "Alice" has been created with default attributes and without skeleton files
@@ -878,6 +910,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: When in a group that is excluded from sharing and in another group, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "Alice" has been created with default attributes and without skeleton files
@@ -912,7 +945,7 @@ Feature: capabilities
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   # This is a new capability in 10.9
-  Scenario: blacklisted_files_regex is reported in capabilites
+  Scenario: blacklisted_files_regex is reported in capabilities
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
@@ -7,7 +7,7 @@ Feature: default capabilities for normal user
 
   # adjust this scenario after fixing tagged issues as its just created to show difference
   # in the response items in different environment (core & ocis-reva)
-  @issue-ocis-reva-175 @issue-ocis-reva-176
+  @issue-ocis-reva-175 @issue-ocis-reva-176 @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: getting default capabilities with normal user
     When user "Alice" retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"


### PR DESCRIPTION
## Description
PR #39143 was merged last Friday. The `pollinterval` capability is now different in `master` then in the "old" releases. Skip those tests when running against an older oC10.

And I spaced-out the scenarios. The line numbers all change anyway, so I took the chance to fix the spacing.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
