### PR TITLE
[tests-only][full-ci]added then steps for apiProvisioning-v2 suite

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -75,3 +75,14 @@ Feature: access user provisioning API using app password
     When the user requests "/ocs/v2.php/cloud/users/another-new-user" with "GET" using the generated app password
     Then the HTTP status code should be "401"
     And the API should not return any data
+
+  Scenario: normal user gets his own resources using the app password
+    Given these users have been created with small skeleton files:
+      | username       | password  | displayname | email                    |
+      | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
+    And a new browser session for "brand-new-user" has been started
+    And the user has generated a new app password named "my-client"
+    When the user "brand-new-user" requests these endpoints with "PROPFIND" to get property "d:getetag" using basic auth and generated app password about user "brand-new-user"
+      | endpoint                                       |
+      | /remote.php/dav/files/%username%/textfile0.txt |
+    Then the HTTP status code should be "207"

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -96,7 +96,9 @@ Feature: edit users
     When user "subadmin" changes the quota of user "brand-new-user" to "12MB" using the provisioning API
     And user "subadmin" changes the email of user "brand-new-user" to "brand-new-user@example.com" using the provisioning API
     And user "subadmin" changes the display of user "brand-new-user" to "Anne Brown" using the provisioning API
-    Then the display name of user "brand-new-user" should be "Anne Brown"
+    Then the OCS status code of responses on all endpoints should be "200"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And the display name of user "brand-new-user" should be "Anne Brown"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
     And the quota definition of user "brand-new-user" should be "12 MB"
 
@@ -143,7 +145,9 @@ Feature: edit users
     When user "another-admin" changes the quota of user "another-admin" to "12MB" using the provisioning API
     And user "another-admin" changes the email of user "another-admin" to "another-admin@example.com" using the provisioning API
     And user "another-admin" changes the display of user "another-admin" to "Anne Brown" using the provisioning API
-    Then the display name of user "another-admin" should be "Anne Brown"
+    Then the OCS status code of responses on all endpoints should be "200"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And the display name of user "another-admin" should be "Anne Brown"
     And the email address of user "another-admin" should be "another-admin@example.com"
     And the quota definition of user "another-admin" should be "12 MB"
 
@@ -160,7 +164,9 @@ Feature: edit users
     When user "subadmin" changes the quota of user "another-subadmin" to "12MB" using the provisioning API
     And user "subadmin" changes the email of user "another-subadmin" to "brand-new-user@example.com" using the provisioning API
     And user "subadmin" changes the display of user "another-subadmin" to "Anne Brown" using the provisioning API
-    Then the display name of user "another-subadmin" should be "Anne Brown"
+    Then the OCS status code of responses on all endpoints should be "200"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And the display name of user "another-subadmin" should be "Anne Brown"
     And the email address of user "another-subadmin" should be "brand-new-user@example.com"
     And the quota definition of user "another-subadmin" should be "12 MB"
 
@@ -174,14 +180,10 @@ Feature: edit users
     And user "another-subadmin" has been made a subadmin of group "new-group"
     And user "subadmin" has been made a subadmin of group "new-group"
     When user "subadmin" changes the quota of user "another-subadmin" to "12MB" using the provisioning API
-    Then the OCS status code should be "997"
-    And the HTTP status code should be "401"
-    When user "subadmin" changes the email of user "another-subadmin" to "brand-new-user@example.com" using the provisioning API
-    Then the OCS status code should be "997"
-    And the HTTP status code should be "401"
-    When user "subadmin" changes the display of user "another-subadmin" to "Anne Brown" using the provisioning API
-    Then the OCS status code should be "997"
-    And the HTTP status code should be "401"
+    And user "subadmin" changes the email of user "another-subadmin" to "brand-new-user@example.com" using the provisioning API
+    And user "subadmin" changes the display of user "another-subadmin" to "Anne Brown" using the provisioning API
+    Then the OCS status code of responses on all endpoints should be "997"
+    And the HTTP status code of responses on all endpoints should be "401"
     And the display name of user "another-subadmin" should be "Regular User"
     And the email address of user "another-subadmin" should be "another-subadmin@owncloud.com"
     And the quota definition of user "another-subadmin" should be "default"
@@ -193,11 +195,9 @@ Feature: edit users
       | Alice    |
       | Brian    |
     When user "Alice" tries to change the display name of user "Brian" to "New Brian" using the provisioning API
-    Then the OCS status code should be "997"
-    And the HTTP status code should be "401"
-    When user "Alice" tries to change the email of user "Brian" to "brian-new-email@example.com" using the provisioning API
-    Then the OCS status code should be "997"
-    And the HTTP status code should be "401"
+    And user "Alice" tries to change the email of user "Brian" to "brian-new-email@example.com" using the provisioning API
+    Then the OCS status code of responses on all endpoints should be "997"
+    And the HTTP status code of responses on all endpoints should be "401"
     And the display name of user "Brian" should not have changed
     And the email address of user "Brian" should not have changed
 

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -64,6 +64,8 @@ Feature: enable user
     And user "another-admin" has been added to group "admin"
     And user "another-admin" has been disabled
     When user "another-admin" tries to enable user "another-admin" using the provisioning API
+    Then the OCS status code should be "997"
+    And the HTTP status code should be "401"
     Then user "another-admin" should be disabled
 
   @issue-31276 @skipOnOcV10

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -13,10 +13,11 @@ Feature: get subadmins
     And group "brand-new-group" has been created
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
     When the administrator gets all the subadmins of group "brand-new-group" using the provisioning API
-    Then the subadmin users returned by the API should be
-      | brand-new-user |
-    And the OCS status code should be "200"
+    Then the OCS status code should be "200"
     And the HTTP status code should be "200"
+    And the subadmin users returned by the API should be
+      | brand-new-user |
+
 
   Scenario: admin tries to get subadmin users of a group which does not exist
     Given user "brand-new-user" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -35,10 +35,10 @@ Feature: get users
     And user "brand-new-user" has been added to group "brand-new-group"
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
     When user "brand-new-user" gets the list of all users using the provisioning API
-    Then the users returned by the API should be
-      | brand-new-user |
-    And the OCS status code should be "200"
+    Then the OCS status code should be "200"
     And the HTTP status code should be "200"
+    And the users returned by the API should be
+      | brand-new-user |
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get other users

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -147,14 +147,9 @@ Feature: reset user password
       | brand-new-user | %regular% | New user    | brand.new.user@oc.com.np |
     And a new browser session for "brand-new-user" has been started
     And the user has generated a new app password named "my-client"
+    And user "brand-new-user" has reset the password of user "brand-new-user" to "%alt1%"
     When the user "brand-new-user" requests these endpoints with "PROPFIND" to get property "d:getetag" using basic auth and generated app password about user "brand-new-user"
-      | endpoint                                           |
-      | /remote.php/dav/files/%username%/textfile0.txt     |
-    Then the HTTP status code of responses on all endpoints should be "207"
-    When user "brand-new-user" resets the password of user "brand-new-user" to "%alt1%" using the provisioning API
-    Then the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
-    When the user "brand-new-user" requests these endpoints with "PROPFIND" to get property "d:getetag" using basic auth and generated app password about user "brand-new-user"
-      | endpoint                                           |
-      | /remote.php/dav/files/%username%/textfile0.txt     |
-    Then the HTTP status code of responses on all endpoints should be "207"
+      | endpoint                                       |
+      | /remote.php/dav/files/%username%/textfile0.txt |
+    Then the HTTP status code should be "207"
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1998,6 +1998,7 @@ trait Provisioning {
 		);
 		$targetUser = $this->getActualUsername($targetUser);
 		$this->rememberUserEmailAddress($targetUser, $email);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -2234,6 +2235,7 @@ trait Provisioning {
 			'displayname',
 			$displayName
 		);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -2266,6 +2268,7 @@ trait Provisioning {
 			$displayName
 		);
 		$this->rememberUserDisplayName($targetUser, $displayName);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -2414,6 +2417,7 @@ trait Provisioning {
 			$targetUser,
 			$quota
 		);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds ``` Then ``` steps to existing API test scenarios to better check the results of ``` When ``` steps.

### Suite Covered
- ``` apiProvisioning-v2```

## Related Issues
- Part of https://github.com/owncloud/core/issues/39512

## How Has This Been Tested?
- Locally
- CI

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
