### PR TITLE
[tests-only][full-ci]added then steps for apiProvisioningGroups-v1 suite

### DIFF
--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -13,14 +13,14 @@ Feature: add groups
       | groupname   | comment                               |
       | simplegroup | nothing special here                  |
       | España§àôœ€ | special European and other characters |
-      | नेपाली        | Unicode group name                    |
+      | नेपाली      | Unicode group name                    |
     Then the OCS status code of responses on all endpoints should be "100"
     And the HTTP status code of responses on all endpoints should be "200"
     And these groups should exist:
       | groupname   |
       | simplegroup |
       | España§àôœ€ |
-      | नेपाली        |
+      | नेपाली      |
 
   @sqliteDB
   Scenario: admin creates a group with special characters
@@ -60,23 +60,23 @@ Feature: add groups
   @toImplementOnOCIS @issue-product-284
   Scenario: admin creates a group with % and # in name
     When the administrator sends a group creation request for the following groups using the provisioning API
-      | groupname           | comment                                 |
-      | maintenance#123     | Hash sign                               |
-      | 50%pass             | Percent sign (special escaping happens) |
-      | 50%25=0             | %25 literal looks like an escaped "%"   |
-      | 50%2Fix             | %2F literal looks like an escaped slash |
-      | 50%2Eagle           | %2E literal looks like an escaped "."   |
-      | staff?group         | Question mark                           |
+      | groupname       | comment                                 |
+      | maintenance#123 | Hash sign                               |
+      | 50%pass         | Percent sign (special escaping happens) |
+      | 50%25=0         | %25 literal looks like an escaped "%"   |
+      | 50%2Fix         | %2F literal looks like an escaped slash |
+      | 50%2Eagle       | %2E literal looks like an escaped "."   |
+      | staff?group     | Question mark                           |
     Then the OCS status code of responses on all endpoints should be "100"
     And the HTTP status code of responses on all endpoints should be "200"
     And these groups should exist:
-      | groupname           |
-      | maintenance#123     |
-      | 50%pass             |
-      | 50%25=0             |
-      | 50%2Fix             |
-      | 50%2Eagle           |
-      | staff?group         |
+      | groupname       |
+      | maintenance#123 |
+      | 50%pass         |
+      | 50%25=0         |
+      | 50%2Fix         |
+      | 50%2Eagle       |
+      | staff?group     |
 
   @toImplementOnOCIS
   Scenario: group names are case-sensitive, multiple groups can exist with different upper and lower case names

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -15,11 +15,11 @@ Feature: get subadmin groups
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
     And user "brand-new-user" has been made a subadmin of group "😅 😆"
     When the administrator gets all the groups where user "brand-new-user" is subadmin using the provisioning API
-    Then the subadmin groups returned by the API should be
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the subadmin groups returned by the API should be
       | brand-new-group |
       | 😅 😆           |
-    And the OCS status code should be "100"
-    And the HTTP status code should be "200"
 
   @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: admin tries to get subadmin groups of a user which does not exist
@@ -42,7 +42,7 @@ Feature: get subadmin groups
     And the HTTP status code should be "200"
     And the subadmin groups returned by the API should be
       | brand-new-group |
-      | 😅 😆          |
+      | 😅 😆           |
 
   Scenario: subadmin of a group should not be able to get subadmin groups of another subadmin user
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -24,15 +24,15 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "नेपाली"
     And user "brand-new-user" has been added to group "😅 😆"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the groups returned by the API should be
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
       | brand-new-group      |
       | 0                    |
       | Admin & Finance (NP) |
       | admin:Pokhara@Nepal  |
       | नेपाली               |
       | 😅 😆                |
-    And the OCS status code should be "100"
-    And the HTTP status code should be "200"
 
   @issue-31015 @skipOnOcV10
   Scenario: admin gets groups of an user, including groups containing a slash
@@ -45,12 +45,12 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "var/../etc"
     And user "brand-new-user" has been added to group "priv/subadmins/1"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the groups returned by the API should be
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
       | Mgmt/Sydney      |
       | var/../etc       |
       | priv/subadmins/1 |
-    And the OCS status code should be "100"
-    And the HTTP status code should be "200"
 
   @smokeTest @notToImplementOnOCIS
   Scenario: subadmin tries to get other groups of a user in their group
@@ -64,10 +64,10 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "brand-new-group"
     And user "brand-new-user" has been added to group "another-new-group"
     When user "subadmin" gets all the groups of user "brand-new-user" using the provisioning API
-    Then the groups returned by the API should include "brand-new-group"
-    And the groups returned by the API should not include "another-new-group"
-    And the OCS status code should be "100"
+    Then the OCS status code should be "100"
     And the HTTP status code should be "200"
+    And the groups returned by the API should include "brand-new-group"
+    And the groups returned by the API should not include "another-new-group"
 
   Scenario: normal user tries to get the groups of another user
     Given these users have been created with default attributes and without skeleton files:
@@ -107,7 +107,9 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "नेपाली"
     And user "brand-new-user" has been added to group "😅 😆"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the groups returned by the API should be
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
       | brand-new-group      |
       | 0                    |
       | Admin & Finance (NP) |
@@ -115,8 +117,6 @@ Feature: get user groups
       | नेपाली               |
       | 😅 😆                |
       | users                |
-    And the OCS status code should be "100"
-    And the HTTP status code should be "200"
 
   @skipOnOcV10
   Scenario: admin gets groups of an user who is not in any groups on ocis

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroupsOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroupsOc10Issue31015.feature
@@ -22,12 +22,12 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "var/../etc"
     And user "brand-new-user" has been added to group "priv/subadmins/1"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the groups returned by the API should be
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
       | Mgmt/Sydney      |
       | var/../etc       |
       | priv/subadmins/1 |
-    And the OCS status code should be "100"
-    And the HTTP status code should be "200"
     # The following steps are needed so that the groups do get cleaned up.
     # After fixing issue-31015, remove the following steps:
     And the administrator deletes group "Mgmt/Sydney" using the occ command


### PR DESCRIPTION
## Description
This PR adds ``` Then ``` steps to existing API test scenarios to better check the results of ``` When ``` steps.

### Suite Covered
- ```apiProvisioningGroups-v1```

## Related Issues
- Part of https://github.com/owncloud/core/issues/39512

## How Has This Been Tested?
- Locally
- CI

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
