### PR TITLE
Avoid sending passwords in the API

### DIFF
--- a/apps/files_external/lib/Controller/GlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/GlobalStoragesController.php
@@ -118,6 +118,9 @@ class GlobalStoragesController extends StoragesController {
 
 		$this->updateStorageStatus($newStorage);
 
+		// replace the password to prevent leaking it
+		$this->replacePasswords($newStorage);
+
 		return new DataResponse(
 			$newStorage,
 			Http::STATUS_CREATED
@@ -184,6 +187,9 @@ class GlobalStoragesController extends StoragesController {
 		}
 
 		$this->updateStorageStatus($storage, $testOnly);
+
+		// replace the password to prevent leaking it
+		$this->replacePasswords($storage);
 
 		return new DataResponse(
 			$storage,

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -282,6 +282,11 @@ abstract class StoragesController extends Controller {
 	public function index() {
 		$storages = $this->service->getStorages();
 
+		\array_map(function ($storage) {
+			$this->replacePasswords($storage);
+			return $storage;
+		}, $storages);
+
 		return new DataResponse(
 			$storages,
 			Http::STATUS_OK
@@ -310,6 +315,8 @@ abstract class StoragesController extends Controller {
 			);
 		}
 
+		$this->replacePasswords($storage);
+
 		return new DataResponse(
 			$storage,
 			Http::STATUS_OK
@@ -336,5 +343,19 @@ abstract class StoragesController extends Controller {
 		}
 
 		return new DataResponse([], Http::STATUS_NO_CONTENT);
+	}
+
+	/**
+	 * Replace the passwords found with a custom string in order to avoid leaking
+	 * the password
+	 */
+	protected function replacePasswords(IStorageConfig $storage) {
+		$opts = $storage->getBackendOptions();
+		foreach ($opts as $key => $value) {
+			if (\strpos($key, 'password') !== false && \is_string($value) && $value !== '') {
+				$opts[$key] = IStoragesService::REDACTED_PASSWORD;
+			}
+		}
+		$storage->setBackendOptions($opts);
 	}
 }

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -352,7 +352,10 @@ abstract class StoragesController extends Controller {
 	protected function replacePasswords(IStorageConfig $storage) {
 		$opts = $storage->getBackendOptions();
 		foreach ($opts as $key => $value) {
-			if (\strpos($key, 'password') !== false && \is_string($value) && $value !== '') {
+			if (
+				(\strpos($key, 'password') !== false && \is_string($value) && $value !== '') ||  // key contains "password"
+				($key === 'secret')  // key is "secret"
+			) {
 				$opts[$key] = IStoragesService::REDACTED_PASSWORD;
 			}
 		}

--- a/apps/files_external/lib/Controller/UserGlobalStoragesController.php
+++ b/apps/files_external/lib/Controller/UserGlobalStoragesController.php
@@ -90,6 +90,7 @@ class UserGlobalStoragesController extends StoragesController {
 		// remove configuration data, this must be kept private
 		foreach ($storages as $storage) {
 			$this->sanitizeStorage($storage);
+			$this->replacePasswords($storage);
 		}
 
 		return new DataResponse(
@@ -131,6 +132,7 @@ class UserGlobalStoragesController extends StoragesController {
 		}
 
 		$this->sanitizeStorage($storage);
+		$this->replacePasswords($storage);
 
 		return new DataResponse(
 			$storage,
@@ -181,6 +183,9 @@ class UserGlobalStoragesController extends StoragesController {
 
 		$this->updateStorageStatus($storage, $testOnly);
 		$this->sanitizeStorage($storage);
+
+		// replace the password just before sending the response.
+		$this->replacePasswords($storage);
 
 		return new DataResponse(
 			$storage,

--- a/apps/files_external/lib/Controller/UserStoragesController.php
+++ b/apps/files_external/lib/Controller/UserStoragesController.php
@@ -153,6 +153,9 @@ class UserStoragesController extends StoragesController {
 		$newStorage = $this->service->addStorage($newStorage);
 		$this->updateStorageStatus($newStorage);
 
+		// replace the password to prevent leaking it
+		$this->replacePasswords($newStorage);
+
 		return new DataResponse(
 			$newStorage,
 			Http::STATUS_CREATED
@@ -212,6 +215,9 @@ class UserStoragesController extends StoragesController {
 		}
 
 		$this->updateStorageStatus($storage, $testOnly);
+
+		// replace the password to prevent leaking it
+		$this->replacePasswords($storage);
 
 		return new DataResponse(
 			$storage,

--- a/apps/files_external/tests/Controller/UserStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/UserStoragesControllerTest.php
@@ -28,6 +28,9 @@ use OC\Files\External\StorageConfig;
 use OCA\Files_External\Controller\UserStoragesController;
 use OCP\AppFramework\Http;
 use OCP\Files\External\IStoragesBackendService;
+use OCP\Files\External\IStorageConfig;
+use OCP\Files\External\Service\IStoragesService;
+use OCP\Files\StorageNotAvailableException;
 
 class UserStoragesControllerTest extends StoragesControllerTest {
 
@@ -100,5 +103,131 @@ class UserStoragesControllerTest extends StoragesControllerTest {
 		);
 
 		$this->assertEquals(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+	}
+
+	public function testCreate() {
+		$mount = 'randomMount';
+		$backend = 'identifier:\This\Doesnt\Exist';
+		$auth = 'identifier:\Random\Missing\Auth\Class';
+		$backendOpts = [
+			'host' => 'host001',
+			'user' => 'user001',
+			'password' => 'password001',
+			'service-password' => '001password',
+			'keystore_password' => 'wordpass',
+		];
+		$priority = 3;
+
+		$storageConfig = $this->getNewStorageConfigMock([
+			'id' => 30,
+			'backendClass' => '\This\Doesnt\Exist',
+			'backendStorageClass' => '\This\Doesnt\Exist\Storage',
+			'authClass' => '\Random\Missing\Auth\Class',
+			'mountPoint' => $mount,
+			'backendOpts' => $backendOpts,
+			'priority' => $priority,
+			'type' => IStorageConfig::MOUNT_TYPE_ADMIN,
+		]);
+
+		$backendMock = $storageConfig->getBackend();
+		$backendMock->method('isVisibleFor')->willReturn(true);
+		$backendMock->method('validateStorage')->willReturn(true);
+
+		$authMock = $storageConfig->getAuthMechanism();
+		$authMock->method('isVisibleFor')->willReturn(true);
+		$authMock->method('validateStorage')->willReturn(true);
+
+		$this->service->expects($this->once())
+		->method('createStorage')
+		->willReturn($storageConfig);
+		$this->service->expects($this->once())
+		->method('addStorage')
+		->will($this->returnArgument(0));
+
+		$expectedStorage = [
+			'id' => 30,
+			'mountPoint' => '/randomMount',
+			'backend' => 'identifier:\This\Doesnt\Exist',
+			'authMechanism' => 'identifier:\Random\Missing\Auth\Class',
+			'backendOptions' => [
+				'host' => 'host001',
+				'user' => 'user001',
+				'password' => IStoragesService::REDACTED_PASSWORD,
+				'service-password' => IStoragesService::REDACTED_PASSWORD,
+				'keystore_password' => IStoragesService::REDACTED_PASSWORD,
+			],
+			'priority' => 3,
+			'userProvided' => false,
+			'type' => 'system',
+			'status' => StorageNotAvailableException::STATUS_SUCCESS, // status check for the storage is skipped and always returns this value
+		];
+
+		$result = $this->controller->create($mount, $backend, $auth, $backendOpts, [], [], [], $priority);
+		$actual = $result->getData()->jsonSerialize();
+		$this->assertEquals(Http::STATUS_CREATED, $result->getStatus());
+		$this->assertEquals($expectedStorage, $actual);
+	}
+
+	public function testUpdate() {
+		$mount = 'randomMount';
+		$backend = 'identifier:\This\Doesnt\Exist';
+		$auth = 'identifier:\Random\Missing\Auth\Class';
+		$backendOpts = [
+			'host' => 'host001',
+			'user' => 'user001',
+			'password' => 'password001',
+			'service-password' => '001password',
+			'keystore_password' => 'wordpass',
+		];
+		$priority = 3;
+
+		$storageConfig = $this->getNewStorageConfigMock([
+			'id' => 30,
+			'backendClass' => '\This\Doesnt\Exist',
+			'backendStorageClass' => '\This\Doesnt\Exist\Storage',
+			'authClass' => '\Random\Missing\Auth\Class',
+			'mountPoint' => $mount,
+			'backendOpts' => $backendOpts,
+			'priority' => $priority,
+			'type' => IStorageConfig::MOUNT_TYPE_ADMIN,
+		]);
+
+		$backendMock = $storageConfig->getBackend();
+		$backendMock->method('isVisibleFor')->willReturn(true);
+		$backendMock->method('validateStorage')->willReturn(true);
+
+		$authMock = $storageConfig->getAuthMechanism();
+		$authMock->method('isVisibleFor')->willReturn(true);
+		$authMock->method('validateStorage')->willReturn(true);
+
+		$this->service->expects($this->once())
+		->method('createStorage')
+		->willReturn($storageConfig);
+		$this->service->expects($this->once())
+		->method('updateStorage')
+		->will($this->returnArgument(0));
+
+		$expectedStorage = [
+			'id' => 30,
+			'mountPoint' => '/randomMount',
+			'backend' => 'identifier:\This\Doesnt\Exist',
+			'authMechanism' => 'identifier:\Random\Missing\Auth\Class',
+			'backendOptions' => [
+				'host' => 'host001',
+				'user' => 'user001',
+				'password' => IStoragesService::REDACTED_PASSWORD,
+				'service-password' => IStoragesService::REDACTED_PASSWORD,
+				'keystore_password' => IStoragesService::REDACTED_PASSWORD,
+			],
+			'priority' => 3,
+			'userProvided' => false,
+			'type' => 'system',
+			'status' => StorageNotAvailableException::STATUS_SUCCESS, // status check for the storage is skipped and always returns this value
+		];
+
+		$result = $this->controller->update(30, $mount, $backend, $auth, $backendOpts, [], [], [], $priority);
+		$actual = $result->getData()->jsonSerialize();
+		$this->assertEquals(Http::STATUS_OK, $result->getStatus());
+		$this->assertEquals($expectedStorage, $actual);
 	}
 }

--- a/changelog/unreleased/39841
+++ b/changelog/unreleased/39841
@@ -1,0 +1,7 @@
+Bugfix: Avoid sending unneeded passwords in the files_external app
+
+Some passwords were being sent to the web UI in the external storage
+configuration. These passwords aren't required and they're now replaced
+in the web UI in order not to leak the actual password
+
+https://github.com/owncloud/core/pull/39841

--- a/lib/private/Files/External/Service/StoragesService.php
+++ b/lib/private/Files/External/Service/StoragesService.php
@@ -457,7 +457,7 @@ abstract class StoragesService implements IStoragesService {
 
 		$backend = $updatedStorage->getBackend();
 		foreach ($changedConfig as $key => $value) {
-			if (\strpos($key, 'password') === false || $value !== IStoragesService::REDACTED_PASSWORD) {
+			if ((\strpos($key, 'password') === false && $key !== 'secret') || $value !== IStoragesService::REDACTED_PASSWORD) {
 				// check if we should change the password.
 				// Note that the key MUST contain "password", so some other keys that could be hidden in
 				// the UI such as the oAuth2 secret or private / public keys won't be affected

--- a/lib/private/Files/External/Service/StoragesService.php
+++ b/lib/private/Files/External/Service/StoragesService.php
@@ -457,8 +457,13 @@ abstract class StoragesService implements IStoragesService {
 
 		$backend = $updatedStorage->getBackend();
 		foreach ($changedConfig as $key => $value) {
-			$value = $this->encryptIfPassword($backend, $updatedStorage->getAuthMechanism(), $key, $value);
-			$this->dbConfig->setConfig($id, $key, $value);
+			if (\strpos($key, 'password') === false || $value !== IStoragesService::REDACTED_PASSWORD) {
+				// check if we should change the password.
+				// Note that the key MUST contain "password", so some other keys that could be hidden in
+				// the UI such as the oAuth2 secret or private / public keys won't be affected
+				$value = $this->encryptIfPassword($backend, $updatedStorage->getAuthMechanism(), $key, $value);
+				$this->dbConfig->setConfig($id, $key, $value);
+			}
 		}
 		foreach ($changedOptions as $key => $value) {
 			$this->dbConfig->setOption($id, $key, $value);

--- a/lib/public/Files/External/Service/IStoragesService.php
+++ b/lib/public/Files/External/Service/IStoragesService.php
@@ -31,6 +31,14 @@ use OCP\Files\External\NotFoundException;
  */
 interface IStoragesService {
 	/**
+	 * The password to be used when we don't want the storage service to change
+	 * the actual password stored.
+	 * When a storage configuration uses this password with any field containing
+	 * the name "password", the storage service is expected to ignore the field
+	 * to prevent overwriting the stored password
+	 */
+	public const REDACTED_PASSWORD = '**PASSWORD SET**';
+	/**
 	 * Get a storage with status
 	 *
 	 * @param int $id storage mount numeric id

--- a/tests/lib/Files/External/Service/UserGlobalStoragesServiceTest.php
+++ b/tests/lib/Files/External/Service/UserGlobalStoragesServiceTest.php
@@ -372,6 +372,11 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		$this->assertTrue(true);
 	}
 
+	public function testUpdateStorageMountPointRedactedPassword() {
+		// we don't test this here
+		$this->assertTrue(true);
+	}
+
 	public function testCannotEditInvalidBackend() {
 		// we don't test this here
 		$this->assertTrue(true);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Passwords could be seen in several requests made by ownCloud

## Related Issue
https://github.com/owncloud/enterprise/issues/5036

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually checked with some external storages and some operations on them.
* Create a new storage
* Update a storage config without changing the password
* Reload the web page (password should be replaced)
* Check with additional WND authentication methods
  * WND Collaborative
  * User-entered authentication
* Personal mounts

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
