### PR TITLE
Use memcache and avoid loading the whole mimetypes table in memory

### DIFF
--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -34,6 +34,8 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
  * @package OC\Files\Type
  */
 class Loader implements IMimeTypeLoader {
+	public const CACHE_PREFIX_FOR_ID = ':id:';
+	public const CACHE_PREFIX_FOR_MIME = ':mime:';
 
 	/** @var IDBConnection */
 	private $dbConnection;
@@ -76,9 +78,8 @@ class Loader implements IMimeTypeLoader {
 		}
 
 		// Check the DB. Local vars and memcache will be updated if needed
-		$mimetype = $this->getMimetypeFromDB($id);
 		// if the id doesn't exists, null will be returned
-		return $mimetype;
+		return $this->getMimetypeFromDB($id);
 	}
 
 	/**
@@ -124,8 +125,7 @@ class Loader implements IMimeTypeLoader {
 		}
 
 		// Check the DB. Local vars and memcache will be updated if needed
-		$id = $this->getIdFromDB($mimetype);
-		return $id;
+		return $this->getIdFromDB($mimetype);
 	}
 
 	/**
@@ -167,8 +167,8 @@ class Loader implements IMimeTypeLoader {
 		$row = $fetch->execute()->fetch();
 
 		// update cache
-		$this->memcache->set(':id:' . $row['id'], $mimetype);
-		$this->memcache->set(':mime:' . $mimetype, $row['id']);
+		$this->memcache->set(self::CACHE_PREFIX_FOR_ID . $row['id'], $mimetype);
+		$this->memcache->set(self::CACHE_PREFIX_FOR_MIME . $mimetype, $row['id']);
 
 		// update local vars
 		$this->mimetypes[$row['id']] = $mimetype;
@@ -183,7 +183,7 @@ class Loader implements IMimeTypeLoader {
 	 * @return int|null the id for the mimetype or null if it isn't found in the memcache
 	 */
 	private function getIdFromMemcache($mimetype) {
-		$id = $this->memcache->get(':mime:' . $mimetype);
+		$id = $this->memcache->get(self::CACHE_PREFIX_FOR_MIME . $mimetype);
 		if ($id !== null) {
 			$this->mimetypes[$id] = $mimetype;
 			$this->mimetypeIds[$mimetype] = $id;
@@ -198,7 +198,7 @@ class Loader implements IMimeTypeLoader {
 	 * @return string|null the mimetype for the id or null if it isn't found in the memcache
 	 */
 	private function getMimetypeFromMemcache($id) {
-		$mimetype = $this->memcache->get(':id:' . $id);
+		$mimetype = $this->memcache->get(self::CACHE_PREFIX_FOR_ID . $id);
 		if ($mimetype !== null) {
 			$this->mimetypes[$id] = $mimetype;
 			$this->mimetypeIds[$mimetype] = $id;
@@ -228,8 +228,8 @@ class Loader implements IMimeTypeLoader {
 			$id = $row['id'];
 
 			// update cache
-			$this->memcache->set(':id:' . $row['id'], $row['mimetype']);
-			$this->memcache->set(':mime:' . $row['mimetype'], $row['id']);
+			$this->memcache->set(self::CACHE_PREFIX_FOR_ID . $row['id'], $row['mimetype']);
+			$this->memcache->set(self::CACHE_PREFIX_FOR_MIME . $row['mimetype'], $row['id']);
 
 			// update local vars
 			$this->mimetypes[$row['id']] = $row['mimetype'];
@@ -262,8 +262,8 @@ class Loader implements IMimeTypeLoader {
 			$mimetype = $row['mimetype'];
 
 			// update cache
-			$this->memcache->set(':id:' . $row['id'], $row['mimetype']);
-			$this->memcache->set(':mime:' . $row['mimetype'], $row['id']);
+			$this->memcache->set(self::CACHE_PREFIX_FOR_ID . $row['id'], $row['mimetype']);
+			$this->memcache->set(self::CACHE_PREFIX_FOR_MIME . $row['mimetype'], $row['id']);
 
 			// update local vars
 			$this->mimetypes[$row['id']] = $row['mimetype'];

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -765,7 +765,8 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 		});
 		$this->registerService('MimeTypeLoader', function (Server $c) {
 			return new \OC\Files\Type\Loader(
-				$c->getDatabaseConnection()
+				$c->getDatabaseConnection(),
+				$c->getMemCacheFactory()
 			);
 		});
 		$this->registerAlias('OCP\Files\IMimeTypeLoader', 'MimeTypeLoader');

--- a/tests/lib/Files/Type/LoaderTest.php
+++ b/tests/lib/Files/Type/LoaderTest.php
@@ -23,16 +23,26 @@ namespace Test\Files\Type;
 
 use OC\Files\Type\Loader;
 use OCP\IDBConnection;
+use OCP\ICacheFactory;
+use OCP\ICache;
 
 class LoaderTest extends \Test\TestCase {
 	/** @var IDBConnection */
 	protected $db;
 	/** @var Loader */
 	protected $loader;
+	/** @var ICache */
+	protected $memcache;
 
 	protected function setUp(): void {
+		$this->memcache = $this->createMock(ICache::class);
+		$cacheFactoryMock = $this->createMock(ICacheFactory::class);
+		$cacheFactoryMock->expects($this->once())
+			->method('create')
+			->willReturn($this->memcache);
+
 		$this->db = \OC::$server->getDatabaseConnection();
-		$this->loader = new Loader($this->db);
+		$this->loader = new Loader($this->db, $cacheFactoryMock);
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Use a memory cache to prevent hitting the DB too many times for the mimetypes. The information will be loaded from the DB on demand, avoiding loading the whole mimetypes tables.

## Related Issue
https://github.com/owncloud/enterprise/issues/5044

## Motivation and Context
optimizations for oracle

## How Has This Been Tested?
Checked with redis as distributed cache. Just uploading some files and checking the information is loaded in redis.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
