### PR TITLE
introduce a static fileid->(storage, path) cache

### DIFF
--- a/changelog/unreleased/39847
+++ b/changelog/unreleased/39847
@@ -1,0 +1,6 @@
+Enhancement: Cache some data in memory from the filecache
+
+Some data from the filecache will be cached from the DB after accessing.
+This will improve the performance a bit.
+
+https://github.com/owncloud/core/pull/39847

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -83,7 +83,7 @@ class Cache implements ICache {
 	protected $connection;
 
 	/**
-	 * we use a static cache for the path lookup by id because to filecache already knows about all storages
+	 * we use a static cache for the path lookup by id because the filecache already knows about all storages
 	 * and a single trip to the db is sufficient to answer subsequent calls.
 	 * Each entry will contain a storage and a path, such as:
 	 *


### PR DESCRIPTION
This PR significantly reduces the number of queries for `Cache::pathById()` lookups. This is less intrusive than a [full cache implementation](https://github.com/owncloud/core/pull/28165) but it can at least cache and invalidate the id -> path lookup per request.

Before:
```json
{
  "type": "SUMMARY",
  "reqId": "Yh-dLiX1gfglyR5qoetJZwAAAIw",
  "time": "2022-03-02T21:10:07+00:00",
  "remoteAddr": "172.20.0.11",
  "user": "jfd",
  "method": "GET",
  "url": "/ocs/v1.php/apps/files_sharing/api/v1/shares?format=json&include_tags=true",
  "diagnostics": {
    "totalSQLQueries": 2872,
    "totalSQLDurationmsec": 357.25855827331543,
    "totalSQLParams": 3430,
    "totalEvents": 32,
    "totalEventsDurationmsec": 445.83773612976074
  }
}
```

After:
```json
{
  "type": "SUMMARY",
  "reqId": "Yh-dsiX1gfglyR5qoetJfQAAAIY",
  "time": "2022-03-02T21:12:19+00:00",
  "remoteAddr": "172.20.0.11",
  "user": "jfd",
  "method": "GET",
  "url": "/ocs/v1.php/apps/files_sharing/api/v1/shares?format=json&include_tags=true",
  "diagnostics": {
    "totalSQLQueries": 637,
    "totalSQLDurationmsec": 135.25128364562988,
    "totalSQLParams": 1195,
    "totalEvents": 32,
    "totalEventsDurationmsec": 207.22270011901855
  }
}
```