### PR TITLE
[tests-only] [full-ci] Added Then steps to improve checks in tests for apiWebdavLocks suite

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -153,7 +153,8 @@ Feature: lock folders
     When user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
       | propertyName    |
       | d:lockdiscovery |
-    Then the value of the item "//d:lockroot/d:href" in the response to user "Alice" should match "<lock-root>"
+    Then the HTTP status code should be "200"
+    And the value of the item "//d:lockroot/d:href" in the response to user "Alice" should match "<lock-root>"
     And the value of the item "//d:locktoken/d:href" in the response to user "Alice" should match "/^opaquelocktoken:[a-z0-9-]+$/"
     Examples:
       | dav-path | lock-scope | lock-root                                                  |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -13,10 +13,11 @@ Feature: persistent-locking in case of a public link
     Given using <dav-path> DAV path
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share of folder "FOLDER" with change permission
-    When user "Alice" locks folder "FOLDER" using the WebDAV API setting the following properties
+    And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
-    Then uploading a file should not work using the <webdav_api_version> public WebDAV API
-    And the HTTP status code should be "423"
+    When the public uploads file "/test.txt" with content "test" using the <webdav_api_version> public WebDAV API
+    Then the HTTP status code should be "423"
+    And as "Alice" file "/FOLDER/test.txt" should not exist
 
     @notToImplementOnOCIS @issue-ocis-2079
     Examples:
@@ -49,8 +50,8 @@ Feature: persistent-locking in case of a public link
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
-    And the public uploads file "CHILD/test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    And the public has uploaded file "test.txt" with content "test"
+    When the public uploads file "CHILD/test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
     And as "Alice" file "/PARENT/CHILD/test.txt" should not exist
     But the content of file "/PARENT/test.txt" for user "Alice" should be "test"
@@ -82,8 +83,8 @@ Feature: persistent-locking in case of a public link
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
       | lockscope | <lock-scope> |
-    When the public uploads file "parent.txt" with content "changed text" using the <public-webdav-api-version> public WebDAV API
-    And the public uploads file "CHILD/child.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
+    And the public has uploaded file "parent.txt" with content "changed text"
+    When the public uploads file "CHILD/child.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "changed text"
     But the content of file "/PARENT/CHILD/child.txt" for user "Alice" should be:

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -14,7 +14,8 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/" in the last created public link using the WebDAV API
       | propertyName    |
       | d:lockdiscovery |
-    Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
+    Then the HTTP status code should be "200"
+    And the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
@@ -29,7 +30,8 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | propertyName    |
       | d:lockdiscovery |
-    Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
+    Then the HTTP status code should be "200"
+    And the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
@@ -44,7 +46,8 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
       | propertyName    |
       | d:lockdiscovery |
-    Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
+    Then the HTTP status code should be "200"
+    And the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
     And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
@@ -59,7 +62,8 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | propertyName    |
       | d:lockdiscovery |
-    Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
+    Then the HTTP status code should be "200"
+    And the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD$/"
     And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
@@ -74,7 +78,8 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | propertyName    |
       | d:lockdiscovery |
-    Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
+    Then the HTTP status code should be "200"
+    And the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
@@ -89,7 +94,8 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/CHILD/child.txt" in the last created public link using the WebDAV API
       | propertyName    |
       | d:lockdiscovery |
-    Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD\/child.txt$/"
+    Then the HTTP status code should be "200"
+    And the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/CHILD\/child.txt$/"
     And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:
@@ -104,7 +110,8 @@ Feature: LOCKDISCOVERY for public links
     When the public gets the following properties of entry "/child.txt" in the last created public link using the WebDAV API
       | propertyName    |
       | d:lockdiscovery |
-    Then the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
+    Then the HTTP status code should be "200"
+    And the value of the item "//d:lockroot/d:href" in the response should match "/%base_path%\/public.php\/webdav\/$/"
     And the item "//d:locktoken/d:href" in the response should not exist
     And the value of the item "//d:timeout" in the response should match "/Second-\d+/"
     Examples:


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adds `Then` steps to existing API test scenarios to better check the results of `When` steps.

**Suites covered:**
- [x] `apiWebdavLocks`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/core/issues/39512


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)