### PR TITLE
[tests-only][full-ci]added then steps for apiProvisioningGroups-v2 suite

### DIFF
--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
@@ -13,7 +13,9 @@ Feature: get groups
     And group "brand-new-group" has been created
     And group "España" has been created
     When the administrator gets all the groups using the provisioning API
-    Then the extra groups returned by the API should be
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the extra groups returned by the API should be
       | España          |
       | brand-new-group |
       | 0               |
@@ -24,7 +26,9 @@ Feature: get groups
     And group "Case-Sensitive-Group" has been created
     And group "CASE-SENSITIVE-GROUP" has been created
     When the administrator gets all the groups using the provisioning API
-    Then the extra groups returned by the API should be
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "200"
+    And the extra groups returned by the API should be
       | case-sensitive-group |
       | Case-Sensitive-Group |
       | CASE-SENSITIVE-GROUP |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -15,11 +15,11 @@ Feature: get subadmin groups
     And user "brand-new-user" has been made a subadmin of group "brand-new-group"
     And user "brand-new-user" has been made a subadmin of group "😅 😆"
     When the administrator gets all the groups where user "brand-new-user" is subadmin using the provisioning API
-    Then the subadmin groups returned by the API should be
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the subadmin groups returned by the API should be
       | brand-new-group |
       | 😅 😆           |
-    And the OCS status code should be "200"
-    And the HTTP status code should be "200"
 
   @skipOnOcV10.5 @skipOnOcV10.6.0
   Scenario: admin tries to get subadmin groups of a user which does not exist

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -24,15 +24,15 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "नेपाली"
     And user "brand-new-user" has been added to group "😅 😆"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the groups returned by the API should be
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
       | brand-new-group      |
       | 0                    |
       | Admin & Finance (NP) |
       | admin:Pokhara@Nepal  |
       | नेपाली               |
       | 😅 😆                |
-    And the OCS status code should be "200"
-    And the HTTP status code should be "200"
 
   @issue-31015 @skipOnOcV10
   Scenario: admin gets groups of an user, including groups containing a slash
@@ -64,10 +64,10 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "brand-new-group"
     And user "brand-new-user" has been added to group "another-new-group"
     When user "subadmin" gets all the groups of user "brand-new-user" using the provisioning API
-    Then the groups returned by the API should include "brand-new-group"
-    And the groups returned by the API should not include "another-new-group"
-    And the OCS status code should be "200"
+    Then the OCS status code should be "200"
     And the HTTP status code should be "200"
+    And the groups returned by the API should include "brand-new-group"
+    And the groups returned by the API should not include "another-new-group"
 
   @issue-31276 @skipOnOcV10
   Scenario: normal user tries to get the groups of another user
@@ -108,7 +108,9 @@ Feature: get user groups
     And user "brand-new-user" has been added to group "नेपाली"
     And user "brand-new-user" has been added to group "😅 😆"
     When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the groups returned by the API should be
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the groups returned by the API should be
       | brand-new-group      |
       | 0                    |
       | Admin & Finance (NP) |
@@ -116,8 +118,6 @@ Feature: get user groups
       | नेपाली               |
       | 😅 😆                |
       | users                |
-    And the OCS status code should be "200"
-    And the HTTP status code should be "200"
 
   @skipOnOcV10
   Scenario: admin gets groups of an user who is not in any groups on ocis


### PR DESCRIPTION
## Description
This PR adds ``` Then ``` steps to existing API test scenarios to better check the results of ``` When ``` steps.

### Suite Covered
- ```apiProvisioningGroups-v2```

## Related Issues
- Part of https://github.com/owncloud/core/issues/39512

## How Has This Been Tested?
- Locally
- CI

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
