### PR TITLE
Add product to version in capabilities response

### DIFF
--- a/changelog/unreleased/39851
+++ b/changelog/unreleased/39851
@@ -1,0 +1,3 @@
+Enhancement: Add product to version in capabilities response
+
+https://github.com/owncloud/core/pull/39851

--- a/core/Controller/CloudController.php
+++ b/core/Controller/CloudController.php
@@ -41,6 +41,7 @@ class CloudController extends OCSController {
 	 */
 	public function getCapabilities() {
 		$result = [];
+		$defaults = new \OCP\Defaults();
 		list($major, $minor, $micro) = \OCP\Util::getVersion();
 		$result['version'] = [
 			'major' => $major,
@@ -48,6 +49,7 @@ class CloudController extends OCSController {
 			'micro' => $micro,
 			'string' => \OC_Util::getVersionString(),
 			'edition' => \OC_Util::getEditionString(),
+			'product' => $defaults->getName(),
 		];
 
 		$result['capabilities'] = \OC::$server->getCapabilitiesManager()->getCapabilities();

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -74,7 +74,7 @@ class Util {
 	public static function getVersion() {
 		return(\OC_Util::getVersion());
 	}
-	
+
 	/**
 	 * Set current update channel
 	 * @param string $channel
@@ -85,7 +85,7 @@ class Util {
 		\OC::$server->getSession()->set('OC_Version_Timestamp', 0);
 		\OC::$server->getAppConfig()->setValue('core', 'OC_Channel', $channel);
 	}
-	
+
 	/**
 	 * Get current update channel
 	 * @return string
@@ -760,7 +760,8 @@ class Util {
 			'version' => '',
 			'versionstring' => '',
 			'edition' => '',
-			'productname' => ''];
+			'productname' => '', // deprecated
+			'product' => ''];
 
 		// expose version and servername details
 		if ($includeVersion || (bool) $systemConfig->getValue('version.hide', false) === false) {
@@ -768,6 +769,7 @@ class Util {
 			$values['versionstring'] = \OC_Util::getVersionString();
 			$values['edition'] = \OC_Util::getEditionString();
 			$values['productname'] = $defaults->getName();
+			$values['product'] = $defaults->getName();
 			// expose the servername only if allowed via version, but never when called via status.php
 			if ($serverHide === false) {
 				$hostname = \gethostname();

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -970,3 +970,4 @@ Feature: capabilities
       | string  | %versionstring%   |
       | edition | %edition%         |
       | product | %productname%     |
+    And the major-minor-micro version data in the response should match the version string

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -965,3 +965,8 @@ Feature: capabilities
       | core          | status@@@productname                      | %productname%     |
       | core          | status@@@version                          | %version%         |
       | core          | status@@@versionstring                    | %versionstring%   |
+    And the version data in the response should contain
+      | name    | value             |
+      | string  | %versionstring%   |
+      | edition | %edition%         |
+      | product | %productname%     |

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -953,3 +953,15 @@ Feature: capabilities
       | capability | path_to_element         | value    |
       | files      | blacklisted_files_regex | \.(part\|filepart)$ |
 
+  @smokeTest
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  # This is a new capability after 10.9.1
+  Scenario: getting default capabilities with admin user
+    When the administrator retrieves the capabilities using the capabilities API
+    Then the capabilities should contain
+      | capability    | path_to_element                           | value             |
+      | core          | status@@@edition                          | %edition%         |
+      | core          | status@@@product                          | %productname%     |
+      | core          | status@@@productname                      | %productname%     |
+      | core          | status@@@version                          | %version%         |
+      | core          | status@@@versionstring                    | %versionstring%   |

--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -1,10 +1,10 @@
 @api @issue-ocis-reva-65 @issue-ocis-reva-97
 Feature: Status
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Status.php is correct
     When the administrator requests status.php
     Then the status.php response should match with
       """
-      {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"$EDITION","productname":"$PRODUCTNAME"}
+      {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"$EDITION","product":"$PRODUCT","productname":"$PRODUCTNAME"}
       """

--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -6,5 +6,5 @@ Feature: Status
     When the administrator requests status.php
     Then the status.php response should match with
       """
-      {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"$EDITION","product":"$PRODUCT","productname":"$PRODUCTNAME"}
+      {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"$EDITION","productname":"$PRODUCTNAME","product":"$PRODUCT"}
       """

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -213,6 +213,18 @@ class AppConfigurationContext implements Context {
 	}
 
 	/**
+	 * @param string $exceptionText text to put at the front of exception messages
+	 *
+	 * @return SimpleXMLElement latest retrieved version data in XML format
+	 */
+	public function getVersionXml(string $exceptionText = ''): SimpleXMLElement {
+		if ($exceptionText === '') {
+			$exceptionText = __METHOD__;
+		}
+		return $this->featureContext->getResponseXml(null, $exceptionText)->data->version;
+	}
+
+	/**
 	 * @param SimpleXMLElement $xml of the capabilities
 	 * @param string $capabilitiesApp the "app" name in the capabilities response
 	 * @param string $capabilitiesPath the path to the element

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -91,7 +91,6 @@ class CapabilitiesContext implements Context {
 		foreach ($formData->getHash() as $row) {
 			$row['value'] = $this->featureContext->substituteInLineCodes($row['value']);
 			$actualValue = $versionXML->{$row['name']};
-			\var_dump($actualValue);
 
 			Assert::assertEquals(
 				$row['value'] === "EMPTY" ? '' : $row['value'],
@@ -104,6 +103,47 @@ class CapabilitiesContext implements Context {
 		Assert::assertTrue(
 			$assertedSomething,
 			'there was nothing in the table of expected version data'
+		);
+	}
+
+	/**
+	 * @Then the major-minor-micro version data in the response should match the version string
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function checkVersionMajorMinorMicroResponse():void {
+		$versionXML = $this->featureContext->appConfigurationContext->getVersionXml(__METHOD__);
+		$versionString = (string) $versionXML->string;
+		// We expect that versionString will be in a format like "10.9.2 beta" or "10.9.2-alpha" or "10.9.2"
+		$result = \preg_match('/^[0-9]+\.[0-9]+\.[0-9]+/', $versionString, $matches);
+		Assert::assertSame(
+			1,
+			$result,
+			__METHOD__ . " version string '$versionString' does not start with a semver version"
+		);
+		// semVerParts should have an array with the 3 semver components of the version, e.g. "1", "9" and "2".
+		$semVerParts = \explode('.', $matches[0]);
+		$expectedMajor = $semVerParts[0];
+		$expectedMinor = $semVerParts[1];
+		$expectedMicro = $semVerParts[2];
+		$actualMajor = (string) $versionXML->major;
+		$actualMinor = (string) $versionXML->minor;
+		$actualMicro = (string) $versionXML->micro;
+		Assert::assertSame(
+			$expectedMajor,
+			$actualMajor,
+			__METHOD__ . "'major' data item does not match with major version in string '$versionString'"
+		);
+		Assert::assertSame(
+			$expectedMinor,
+			$actualMinor,
+			__METHOD__ . "'minor' data item does not match with minor version in string '$versionString'"
+		);
+		Assert::assertSame(
+			$expectedMicro,
+			$actualMicro,
+			__METHOD__ . "'micro' data item does not match with micro (patch) version in string '$versionString'"
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -75,6 +75,39 @@ class CapabilitiesContext implements Context {
 	}
 
 	/**
+	 * @Then the version data in the response should contain
+	 *
+	 * @param TableNode|null $formData
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function checkVersionResponse(TableNode $formData):void {
+		$versionXML = $this->featureContext->appConfigurationContext->getVersionXml(__METHOD__);
+		$assertedSomething = false;
+
+		$this->featureContext->verifyTableNodeColumns($formData, ['name', 'value']);
+
+		foreach ($formData->getHash() as $row) {
+			$row['value'] = $this->featureContext->substituteInLineCodes($row['value']);
+			$actualValue = $versionXML->{$row['name']};
+			\var_dump($actualValue);
+
+			Assert::assertEquals(
+				$row['value'] === "EMPTY" ? '' : $row['value'],
+				$actualValue,
+				"Failed field {$row['name']}"
+			);
+			$assertedSomething = true;
+		}
+
+		Assert::assertTrue(
+			$assertedSomething,
+			'there was nothing in the table of expected version data'
+		);
+	}
+
+	/**
 	 * @Then the :pathToElement capability of files sharing app should be :value
 	 *
 	 * @param string $pathToElement

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2640,6 +2640,7 @@ class FeatureContext extends BehatVariablesContext {
 		}
 
 		$jsonExpectedDecoded['edition'] = $edition;
+		$jsonExpectedDecoded['product'] = $productName;
 		$jsonExpectedDecoded['productname'] = $productName;
 
 		if (OcisHelper::isTestingOnOc10()) {


### PR DESCRIPTION
## Description
Add product to version in capabilities response

This has been introduced by oCIS recently to announce oCIS with a proper
product name. The web ui (as just another API client) defaults to
"ownCloud" if the property is not set. With this enhancement we show the
product name for ownCloud Server as well so that clients don't have to
guess a sane default.

## Motivation and Context
Handle all clients equally.

## How Has This Been Tested?
... manually with a capabilities request 👀 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
