### PR TITLE
[tests-only] [full-ci] Bump postgres to 10.20 in tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -43,7 +43,7 @@ config = {
                 "mysql:5.7",
                 "mysql:8.0",
                 "postgres:9.4",
-                "postgres:10.3",
+                "postgres:10.20",
             ],
         },
         "slowDatabases": {
@@ -234,7 +234,7 @@ config = {
             "dbServices": [
                 "sqlite",
                 "mysql:8.0",
-                "postgres:10.3",
+                "postgres:10.20",
             ],
         },
         "cliExternalStorage": {
@@ -1265,7 +1265,7 @@ def phpTests(ctx, testType, withCoverage):
             "mysql:5.7",
             "mysql:8.0",
             "postgres:9.4",
-            "postgres:10.3",
+            "postgres:10.20",
             "oracle",
         ],
         "coverage": True,


### PR DESCRIPTION
## Description
https://www.postgresql.org/support/versioning/

The latest minor release of pgsql 10 is 10.20. Use that in CI.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
