### PR TITLE
replace userid with username in login form

### DIFF
--- a/changelog/unreleased/39870
+++ b/changelog/unreleased/39870
@@ -1,0 +1,7 @@
+Bugfix: replace userid with username in login form
+
+The login form now replaces a user id with the user name.
+
+https://github.com/owncloud/core/pull/39870
+https://github.com/owncloud/oauth2/pull/286
+

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -140,7 +140,7 @@ class LoginController extends Controller {
 
 		$parameters['messages'] = $messages;
 		if ($user !== null && $user !== '') {
-			// if the user exists, replace the userid with the username, eg. for LDAP accounts
+			// if the user exists, replace the userid with the username, e.g. for LDAP accounts
 			// that have the owncloud internal username set to a uuid.
 			$u = $this->userManager->get($user);
 			if ($u !== null) {

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -148,6 +148,7 @@ class LoginController extends Controller {
 			} else {
 				$parameters['loginName'] = $u->getUserName();
 			}
+			$parameters['user_autofocus'] = false;
 		} else {
 			$parameters['loginName'] = '';
 			$parameters['user_autofocus'] = true;

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -143,10 +143,11 @@ class LoginController extends Controller {
 			// if the user exists, replace the userid with the username, eg. for LDAP accounts
 			// that have the owncloud internal username set to a uuid.
 			$u = $this->userManager->get($user);
-			if ($u === null) {
-				$parameters['loginName'] = $user;
-			} else {
+			if ($u !== null) {
 				$parameters['loginName'] = $u->getUserName();
+			}
+			if (!\is_string($parameters['loginName']) || $parameters['loginName'] === '') {
+				$parameters['loginName'] = $user;
 			}
 			$parameters['user_autofocus'] = false;
 		} else {

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -140,8 +140,14 @@ class LoginController extends Controller {
 
 		$parameters['messages'] = $messages;
 		if ($user !== null && $user !== '') {
-			$parameters['loginName'] = $user;
-			$parameters['user_autofocus'] = false;
+			// if the user exists, replace the userid with the username, eg. for LDAP accounts
+			// that have the owncloud internal username set to a uuid.
+			$u = $this->userManager->get($user);
+			if ($u === null) {
+				$parameters['loginName'] = $user;
+			} else {
+				$parameters['loginName'] = $u->getUserName();
+			}
 		} else {
 			$parameters['loginName'] = '';
 			$parameters['user_autofocus'] = true;

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -372,7 +372,7 @@ class LoginControllerTest extends TestCase {
 			->method('canChangePassword')
 			->willReturn($canChangePassword);
 		$this->userManager
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('get')
 			->with('LdapUser')
 			->willReturn($user);
@@ -420,7 +420,7 @@ class LoginControllerTest extends TestCase {
 			->method('canChangePassword')
 			->willReturn(false);
 		$this->userManager
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('get')
 			->with('0')
 			->willReturn($user);


### PR DESCRIPTION
While digging into https://github.com/owncloud/oauth2/issues/326 @kulmann @TheOneRing and I pondered possible solutions to the original problem described in https://github.com/owncloud/oauth2/pull/286

AFAIU the problem is that users may see the LDAP UUID of a user in the login form, which is very confusing. The solution in https://github.com/owncloud/oauth2/pull/286 replaced the user *id* that clients picked up with the user *name*, but that parameter was originally only [intended to be used for mounting windows network drives](https://github.com/owncloud/core/pull/32587).

We tried various combinations of filling the `user` parameter un redirect and logout URLs produced by the oauth2 app and even found a bug where a redirect URL is not urlencoded. That will be followed up as a separate issue.

With this PR a `user` parameter will be replaced with the user name when a user with the given user id is found.

For users without a username this has no sideeffect, as the username falls back to the user id.