### PR TITLE
throw ShareNotFound when share id is not an integer

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -723,6 +723,15 @@ class FederatedShareProvider implements IShareProvider {
 	 * @inheritdoc
 	 */
 	public function getShareById($id, $recipientId = null) {
+		if (!ctype_digit($id)) {
+			// share id is defined as a field of type integer
+			// if someone calls the API asking for a share id like "abc" or "42.1"
+			// then there is no point trying to query the database,
+			// and, depending on the database, the query may throw an exception
+			// with a message like "invalid input syntax for type integer"
+			// So throw ShareNotFound now.
+			throw new ShareNotFound();
+		}
 		$qb = $this->dbConnection->getQueryBuilder();
 
 		$qb->select('*')

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -130,6 +130,26 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		parent::tearDown();
 	}
 
+	public function getShareByIdNotExistProvider() {
+		return [
+			[1],
+			[0],
+			[-1],
+			[42.42],
+			["text"],
+			["123text"],
+		];
+	}
+
+	/**
+	 * @dataProvider getShareByIdNotExistProvider
+	 */
+	public function testGetShareByIdNotExist($shareId) {
+		$this->expectException(\OCP\Share\Exceptions\ShareNotFound::class);
+
+		$this->provider->getShareById($shareId);
+	}
+
 	public function testCreate() {
 		$share = $this->shareManager->newShare();
 		$share->setSharedWith('user@server.com')
@@ -510,7 +530,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider datatTestUpdate
+	 * @dataProvider dataTestUpdate
 	 * @param string $owner
 	 * @param string $sharedBy
 	 * @param bool $isOwnerLocal
@@ -598,7 +618,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->assertEquals($expirationDate->getTimestamp(), $share->getExpirationDate()->getTimestamp());
 	}
 
-	public function datatTestUpdate() {
+	public function dataTestUpdate() {
 		return [
 			// IRL it is not possible to get both true and false from userManager->userExists for the same uid
 			// so these cases are skipped
@@ -831,7 +851,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		return [
 			['a', 'b', 'c', 'a', true],
 			['a', 'b', 'c', 'b', false],
-			// The recipient is non local.
+			// The recipient is non-local.
 			['a', 'b', 'c', 'c', false],
 			['a', 'b', 'c', 'd', false],
 		];

--- a/changelog/unreleased/39873
+++ b/changelog/unreleased/39873
@@ -1,0 +1,7 @@
+Bugfix: Fix issue with requesting an invalid share id
+
+When using the pgsql database and requesting an invalid share id, a 500 error status
+could be returned. This has been fixed. A 404 "not found" is now returned.
+
+https://github.com/owncloud/core/issues/39868
+https://github.com/owncloud/core/pull/39873

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -551,6 +551,15 @@ class DefaultShareProvider implements IShareProvider {
 	 * @inheritdoc
 	 */
 	public function getShareById($id, $recipientId = null) {
+		if (!ctype_digit($id)) {
+			// share id is defined as a field of type integer
+			// if someone calls the API asking for a share id like "abc"
+			// then there is no point trying to query the database,
+			// and, depending on the database, the query may throw an exception
+			// with a message like "invalid input syntax for type integer"
+			// So throw ShareNotFound now.
+			throw new ShareNotFound();
+		}
 		$qb = $this->dbConn->getQueryBuilder();
 
 		$qb->select('*')

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -160,12 +160,24 @@ class DefaultShareProviderTest extends TestCase {
 		return$qb->getLastInsertId();
 	}
 
+	public function getShareByIdNotExistProvider() {
+		return [
+			[1],
+			[0],
+			[-1],
+			[42.42],
+			["text"],
+			["123text"],
+		];
+	}
+
 	/**
+	 * @dataProvider getShareByIdNotExistProvider
 	 */
-	public function testGetShareByIdNotExist() {
+	public function testGetShareByIdNotExist($shareId) {
 		$this->expectException(\OCP\Share\Exceptions\ShareNotFound::class);
 
-		$this->provider->getShareById(1);
+		$this->provider->getShareById($shareId);
 	}
 
 	public function testGetShareByIdUserShare() {


### PR DESCRIPTION
## Description
Throw ShareNotFound early when share id is not an integer, rather than attempting to query the database.

Both share-providers only work with integer share-ids. I added the check to both of them, rather than to some higher-level common code, because it is possible that another future share provider could implement share-ids with a different format.

## Related Issue
- Fixes #39868 

## How Has This Been Tested?
CI - see PR #39872 - that runs acceptance tests with pgsql and demonstrates the fails before the code fix, and that it passes after the code fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
