### PR TITLE
[tests-only] [full-ci] Run files_external acceptance tests in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -188,6 +188,17 @@ config = {
             ],
             "filterTags": "~@local_storage&&~@files_external-app-required",
         },
+        "apiFilesExternal": {
+            "suites": {
+                "apiFilesExternal": "apiFilesExt",
+            },
+            "filterTags": "@files_external-app-required",
+            "runAllSuites": True,
+            "numberOfParts": 1,
+            "extraApps": {
+                "files_external": "",
+            },
+        },
         "apiNotifications": {
             "suites": [
                 "apiSharingNotificationsToRoot",
@@ -217,6 +228,17 @@ config = {
             ],
             "filterTags": "~@local_storage&&~@files_external-app-required",
             "emailNeeded": True,
+        },
+        "cliFilesExternal": {
+            "suites": {
+                "cliFilesExternal": "cliFilesExt",
+            },
+            "filterTags": "@files_external-app-required",
+            "runAllSuites": True,
+            "numberOfParts": 1,
+            "extraApps": {
+                "files_external": "",
+            },
         },
         "cliAppManagement": {
             "suites": [
@@ -307,6 +329,17 @@ config = {
             "emailNeeded": True,
             "useHttps": False,
             "selUserNeeded": True,
+        },
+        "webUIFilesExternal": {
+            "suites": {
+                "webUIFilesExternal": "webUIFilesExt",
+            },
+            "filterTags": "@files_external-app-required",
+            "runAllSuites": True,
+            "numberOfParts": 1,
+            "extraApps": {
+                "files_external": "",
+            },
         },
         "webUINotifications": {
             "suites": {

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -122,7 +122,7 @@ Feature: checksums
       | dav_version |
       | spaces      |
 
-  @local_storage @notToImplementOnOCIS
+  @local_storage @files_external-app-required @notToImplementOnOCIS
   Scenario Outline: Downloading a file from local storage has correct checksum
     Given using <dav_version> DAV path
     # Create the file directly in local storage, bypassing ownCloud
@@ -354,7 +354,7 @@ Feature: checksums
       | dav_version |
       | spaces      |
 
-  @local_storage @notToImplementOnOCIS @skipOnEncryptionType:user-keys @encryption-issue-42
+  @local_storage @files_external-app-required @notToImplementOnOCIS @skipOnEncryptionType:user-keys @encryption-issue-42
   Scenario Outline: Uploaded file to external storage should have the same checksum when downloaded
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -1,4 +1,4 @@
-@api @local_storage @notToImplementOnOCIS
+@api @local_storage @files_external-app-required @notToImplementOnOCIS
 Feature: external-storage
 
   Background:

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareFromLocalStorageToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareFromLocalStorageToRootFolder.feature
@@ -1,4 +1,4 @@
-@api @local_storage @files_sharing-app-required @notToImplementOnOCIS
+@api @local_storage @files_external-app-required @files_sharing-app-required @notToImplementOnOCIS
 Feature: local-storage
 
   Background:

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @local_storage @notToImplementOnOCIS @files_sharing-app-required
+@api @local_storage @files_external-app-required @notToImplementOnOCIS @files_sharing-app-required
 Feature: local-storage
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareFromLocalStorage.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareFromLocalStorage.feature
@@ -1,4 +1,4 @@
-@api @local_storage @notToImplementOnOCIS
+@api @local_storage @files_external-app-required @notToImplementOnOCIS
 Feature: local-storage
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
@@ -1,4 +1,4 @@
-@api @local_storage @notToImplementOnOCIS
+@api @local_storage @files_external-app-required @notToImplementOnOCIS
 Feature: local-storage
 
   Background:

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -122,7 +122,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | old      |
       | new      |
 
-  @local_storage
+  @local_storage @files_external-app-required
   @skipOnEncryptionType:user-keys @encryption-issue-42
   @skip_on_objectstore
   Scenario Outline: Deleting a folder into external storage moves it to the trashbin

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -130,7 +130,7 @@ Feature: Restore deleted files/folders
       | old      |
       | new      |
 
-  @local_storage
+  @local_storage @files_external-app-required
   @skipOnEncryptionType:user-keys @encryption-issue-42
   @skip_on_objectstore
   Scenario Outline: Deleting a file into external storage moves it to the trashbin and can be restored
@@ -155,7 +155,7 @@ Feature: Restore deleted files/folders
       | old      |
       | new      |
 
-  @local_storage
+  @local_storage @files_external-app-required
   @skipOnEncryptionType:user-keys @encryption-issue-42
   @skip_on_objectstore
   Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored
@@ -171,7 +171,7 @@ Feature: Restore deleted files/folders
     And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the content of file "/local_storage/tmp/textfile0.txt" for user "Alice" should be "AA"
 
-  @local_storage
+  @local_storage @files_external-app-required
   @skipOnEncryptionType:user-keys @encryption-issue-42
   @skip_on_objectstore @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored with new chunking

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -182,12 +182,32 @@ class AppConfigurationContext implements Context {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function getAdminUsernameForCapabilitiesCheck():string {
+		if (\TestHelpers\OcisHelper::isTestingOnReva()) {
+			// When testing on reva we don't have a user called "admin" to use
+			// to access the capabilities. So create an ordinary user on-the-fly
+			// with a default password. That user should be able to get a
+			// capabilities response that the test can process.
+			$adminUsername = "PseudoAdminForRevaTest";
+			$createdUsers = $this->featureContext->getCreatedUsers();
+			if (!\array_key_exists($adminUsername, $createdUsers)) {
+				$this->featureContext->createUser($adminUsername);
+			}
+		} else {
+			$adminUsername = $this->featureContext->getAdminUsername();
+		}
+		return $adminUsername;
+	}
+
+	/**
 	 * @When the administrator retrieves the capabilities using the capabilities API
 	 *
 	 * @return void
 	 */
 	public function theAdministratorGetsCapabilities():void {
-		$this->userGetsCapabilities($this->featureContext->getAdminUsername());
+		$this->userGetsCapabilities($this->getAdminUsernameForCapabilitiesCheck());
 	}
 
 	/**
@@ -197,7 +217,7 @@ class AppConfigurationContext implements Context {
 	 * @throws Exception
 	 */
 	public function theAdministratorGetsCapabilitiesCheckResponse():void {
-		$this->userGetsCapabilitiesCheckResponse($this->featureContext->getAdminUsername());
+		$this->userGetsCapabilitiesCheckResponse($this->getAdminUsernameForCapabilitiesCheck());
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -83,7 +83,7 @@ class FeatureContext extends BehatVariablesContext {
 	/**
 	 * An array of values of replacement values of user attributes.
 	 * These are only referenced when creating a user. After that, the
-	 * run-time values are maintained and referenced in the $createUsers array.
+	 * run-time values are maintained and referenced in the $createdUsers array.
 	 *
 	 * Key is the username, value is an array of user attributes
 	 *

--- a/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
+++ b/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
@@ -249,8 +249,7 @@ Feature: using files external service with storage as webdav_owncloud
 
 
   Scenario: user moves their own folder to the external storage
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
+    Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |
@@ -268,8 +267,7 @@ Feature: using files external service with storage as webdav_owncloud
 
 
   Scenario: user moves their own file to the external storage
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
+    Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |
@@ -288,8 +286,7 @@ Feature: using files external service with storage as webdav_owncloud
 
 
   Scenario: user moves a folder out of external storage to their own storage
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
+    Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |
@@ -307,8 +304,7 @@ Feature: using files external service with storage as webdav_owncloud
 
 
   Scenario: user moves a file out of external storage to their own storage
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
+    Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |
@@ -327,8 +323,7 @@ Feature: using files external service with storage as webdav_owncloud
 
   @issue-39550
   Scenario: user tries to move a folder that they have shared to someone, to external storage
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
+    Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |
@@ -352,8 +347,7 @@ Feature: using files external service with storage as webdav_owncloud
 
   @issue-39550
   Scenario: user tries to move a file that they have shared to someone, to external storage
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
+    Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |
@@ -377,8 +371,7 @@ Feature: using files external service with storage as webdav_owncloud
 
   @issue-39550
   Scenario: share receiver tries to move a folder that they have received from someone, to external storage
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
+    Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |
@@ -399,8 +392,7 @@ Feature: using files external service with storage as webdav_owncloud
 
   @issue-39550
   Scenario: share receiver tries to move a file that they have received from someone, to external storage
-    Given user "Alice" has been created with default attributes and without skeleton files
-    And the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
+    Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
       | root                   | TestMnt            |
       | secure                 | false              |

--- a/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
+++ b/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
@@ -189,7 +189,7 @@ Feature: using files external service with storage as webdav_owncloud
     Then the command should have been successful
     And the command should output configuration for local storage mount "TestMountPoint"
 
-  @local_storage
+  @local_storage @files_external-app-required
   Scenario: importing config to create a webdav_owncloud external storage
     Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: create local storage from the command line
   As an admin
   I want to create local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroups.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: create local storage from the command line
   As an admin
   I want to create local storage available to a specific group(s) from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroupsAndUsers.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForGroupsAndUsers.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: create local storage from the command line
   As an admin
   I want to create local storage available to a specific user(s) group(s) from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageForUsers.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: create local storage from the command line
   As an admin
   I want to create local storage available to a specific user(s) from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageOc10Issue36713.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageOc10Issue36713.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: create local storage from the command line
   As an admin
   I want to create local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageOc10Issue36719.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageOc10Issue36719.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP @issue-36719 @notToImplementOnOCIS
+@cli @local_storage @files_external-app-required @skipOnLDAP @issue-36719 @notToImplementOnOCIS
 Feature: create local storage from the command line
   As an admin
   I want to create local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnly.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: create read-only local storage from the command line
   As an admin
   I want to create read-only local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnlyAndShare.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadOnlyAndShare.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: create local storage and enable read-only and sharing from the command line
   As an admin
   I want to create read-only local storage and enable sharing from the command line

--- a/tests/acceptance/features/cliLocalStorage/createLocalStorageReadWriteAndShare.feature
+++ b/tests/acceptance/features/cliLocalStorage/createLocalStorageReadWriteAndShare.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: create local storage and enable sharing from the command line
   As an admin
   I want to create read-write local storage and enable sharing from the command line

--- a/tests/acceptance/features/cliLocalStorage/deleteLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/deleteLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: delete local storage from the command line
   As an admin
   I want to delete local storage

--- a/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/exportLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: export created local storage mounts from the command line
   As an admin
   I want to export all created local storage mounts from the command line

--- a/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: import exported local storage mounts from the command line
   As an admin
   I want to import exported local storage mounts from the command line

--- a/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/listLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: list created local storage from the command line
   As an admin
   I want to list all created local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/manageBackendConfig.feature
+++ b/tests/acceptance/features/cliLocalStorage/manageBackendConfig.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: manage backend configuration for a mount using occ command
   As an admin
   I want to configure a local storage mount

--- a/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/manageOptionsForLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: manage options for a mount using occ command
   As an admin
   I want to add options for a local storage mount

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@cli @local_storage @files_external-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: get file info using PROPFIND
 
   Background:

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@cli @local_storage @files_external-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
 Feature: get file info using PROPFIND
 
   Background:

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage
+@cli @local_storage @files_external-app-required
 Feature: Scanning files on local storage
   As an admin
   I want to be able to control the scanning of local storage for changes

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorageOc10Issue33670.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorageOc10Issue33670.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @issue-33670 @notToImplementOnOCIS
+@cli @local_storage @files_external-app-required @issue-33670 @notToImplementOnOCIS
 Feature: Scanning files on local storage
   As an admin
   I want to be able to control the scanning of local storage for changes

--- a/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
+++ b/tests/acceptance/features/cliLocalStorage/showBackendsForMount.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: show available backends using occ command
   As an admin
   I want to list backends

--- a/tests/acceptance/features/cliLocalStorage/verifyMountConfiguration.feature
+++ b/tests/acceptance/features/cliLocalStorage/verifyMountConfiguration.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @skipOnLDAP
+@cli @local_storage @files_external-app-required @skipOnLDAP
 Feature: verify mount configuration using occ command
   As an admin
   I want to verify mount configuration for created local storage

--- a/tests/acceptance/features/cliMain/maintenance.feature
+++ b/tests/acceptance/features/cliMain/maintenance.feature
@@ -1,4 +1,4 @@
-@cli @local_storage
+@cli @local_storage @files_external-app-required
 Feature: Maintenance command
 
   As an admin

--- a/tests/acceptance/features/cliMain/transferOwnership.feature
+++ b/tests/acceptance/features/cliMain/transferOwnership.feature
@@ -115,7 +115,7 @@ Feature: transfer-ownership
     And as "Carol" folder "/testByAlice" should exist
     And as "Carol" folder "/testByBrian" should exist
 
-  @local_storage @skipOnEncryptionType:user-keys
+  @local_storage @files_external-app-required @skipOnEncryptionType:user-keys
   Scenario: transferring ownership does not transfer external storage
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and small skeleton files
@@ -282,7 +282,7 @@ Feature: transfer-ownership
     Then the command should have been successful
     And as "Alice" folder "/test" should not exist
 
-  @local_storage
+  @local_storage @files_external-app-required
   Scenario: transferring ownership of a folder does not transfer external storage
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and small skeleton files

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @skipOnOcV10.6 @skipOnOcV10.7
+@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @files_external-app-required @skipOnOcV10.6 @skipOnOcV10.7
 Feature: admin storage settings
   As an admin
   I want to be able to manage external storages on the ownCloud server

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7
+@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @files_external-app-required @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7
 Feature: admin storage settings
   As an admin
   I want to be able to manage external storages on the ownCloud server

--- a/tests/acceptance/features/webUIFiles/externalStorage.feature
+++ b/tests/acceptance/features/webUIFiles/externalStorage.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @local_storage @disablePreviews
+@webUI @insulated @local_storage @files_external-app-required @disablePreviews
 Feature: external-storage
 
   Scenario: the external section shows a filtered view with just the external storage folders


### PR DESCRIPTION
## Description
PR #39856 allowed the files_external app to be disabled. In current CI we are running acceptance tests with the files_external app disabled, and we skip the tests that require the files_external app.

This PR adds 3 test pipelines that run the API, CLI and webUI test scenarios that require files_external. In those pipelines, the files_external app is explicitly enabled.

Various related scenarios were tagged either `@local_storage` or `@files_external-app-required`. All `@local_storage` scenarios have had the `@files_external-app-required` tag also added. That makes it easy to run all test scenarios for the files_external app by specifying filter tag `@files_external-app-required`.

There were some new scenarios that were introduced in PR #39772 that had the creation of user "Alice" duplicated. The problem was not noticed because they were not being run. Now they are being run. I removed the duplication.

## Related Issue


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
