### PR TITLE
[tests-only] Make LDAP based test config more flexible for being able to run with libregraph/idm default config

### DIFF
--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -267,6 +267,13 @@ class OcisHelper {
 	/**
 	 * @return string
 	 */
+	public static function getGroupSchema():string {
+		$schema = \getenv("REVA_LDAP_GROUP_SCHEMA");
+		return $schema ? $schema : "rfc2307";
+	}
+	/**
+	 * @return string
+	 */
 	public static function getHostname():string {
 		$hostname = \getenv("REVA_LDAP_HOSTNAME");
 		return $hostname ? $hostname : "localhost";

--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -251,6 +251,22 @@ class OcisHelper {
 	/**
 	 * @return string
 	 */
+	public static function getGroupsOU():string {
+		$ou = \getenv("REVA_LDAP_GROUPS_OU");
+		return $ou ? $ou : "TestGroups";
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function getUsersOU():string {
+		$ou = \getenv("REVA_LDAP_USERS_OU");
+		return $ou ? $ou : "TestUsers";
+	}
+
+	/**
+	 * @return string
+	 */
 	public static function getHostname():string {
 		$hostname = \getenv("REVA_LDAP_HOSTNAME");
 		return $hostname ? $hostname : "localhost";

--- a/tests/TestHelpers/OcisHelper.php
+++ b/tests/TestHelpers/OcisHelper.php
@@ -232,7 +232,12 @@ class OcisHelper {
 	 * @return bool
 	 */
 	public static function useSsl():bool {
-		return (self::getLdapPort() === 636);
+		$useSsl = \getenv("REVA_LDAP_USESSL");
+		if ($useSsl === false) {
+			return (self::getLdapPort() === 636);
+		} else {
+			return $useSsl === "true";
+		}
 	}
 
 	/**
@@ -257,6 +262,14 @@ class OcisHelper {
 	public static function getBindDN():string {
 		$dn = \getenv("REVA_LDAP_BIND_DN");
 		return $dn ? $dn : "cn=admin,dc=owncloud,dc=com";
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function getBindPassword():string {
+		$pw = \getenv("REVA_LDAP_BIND_PASSWORD");
+		return $pw ? $pw : "";
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -450,6 +450,10 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	private $ldapGroupsOU;
 	/**
+	 * @var string
+	 */
+	private $ldapGroupSchema;
+	/**
 	 * @var bool
 	 */
 	private $skipImportLdif;

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -450,6 +450,10 @@ class FeatureContext extends BehatVariablesContext {
 	 */
 	private $ldapGroupsOU;
 	/**
+	 * @var bool
+	 */
+	private $skipImportLdif;
+	/**
 	 * @var array
 	 */
 	private $toDeleteDNs = [];

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -714,6 +714,7 @@ trait Provisioning {
 		$entry = [];
 		$entry['cn'] = $userId;
 		$entry['sn'] = $userId;
+		$entry['uid'] = $setting["userid"];
 		$entry['homeDirectory'] = '/home/openldap/' . $setting["userid"];
 		$entry['objectclass'][] = 'posixAccount';
 		$entry['objectclass'][] = 'inetOrgPerson';

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -721,6 +721,10 @@ trait Provisioning {
 		$entry['homeDirectory'] = '/home/openldap/' . $setting["userid"];
 		$entry['objectclass'][] = 'posixAccount';
 		$entry['objectclass'][] = 'inetOrgPerson';
+		$entry['objectclass'][] = 'organizationalPerson';
+		$entry['objectclass'][] = 'person';
+		$entry['objectclass'][] = 'top';
+
 		$entry['userPassword'] = $setting["password"];
 		if (isset($setting["displayName"])) {
 			$entry['displayName'] = $setting["displayName"];
@@ -731,14 +735,12 @@ trait Provisioning {
 		$entry['gidNumber'] = 5000;
 		$entry['uidNumber'] = $uidNumber;
 
-		if (OcisHelper::isTestingParallelDeployment()) {
-			$entry['objectclass'][] = 'organizationalPerson';
+		if (OcisHelper::isTestingOnOcis()) {
 			$entry['objectclass'][] = 'ownCloud';
-			$entry['objectclass'][] = 'person';
-			$entry['objectclass'][] = 'top';
-			$entry['uid'] = $setting["userid"];
-			$entry['ownCloudSelector'] = $this->getOCSelector();
 			$entry['ownCloudUUID'] = $this->generateUUIDv4();
+		}
+		if (OcisHelper::isTestingParallelDeployment()) {
+			$entry['ownCloudSelector'] = $this->getOCSelector();
 		}
 
 		if ($this->federatedServerExists()) {

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -45,11 +45,6 @@ trait Provisioning {
 	private $createdUsers = [];
 
 	/**
-	 * @var string
-	 */
-	private $ou = "TestGroups";
-
-	/**
 	 * list of users that were created on the remote server during test runs
 	 * key is the lowercase username, value is an array of user attributes
 	 *
@@ -704,12 +699,12 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function createLdapUser(array $setting):void {
-		$ou = "TestUsers";
+		$ou =  $this->ldapUsersOU ;
 		// Some special characters need to be escaped in LDAP DN and attributes
 		// The special characters allowed in a username (UID) are +_.@-
 		// Of these, only + has to be escaped.
 		$userId = \str_replace('+', '\+', $setting["userid"]);
-		$newDN = 'uid=' . $userId . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
+		$newDN = 'uid=' . $userId . ',ou=' . $ou . ',' . $this->ldapBaseDN;
 
 		//pick a high number as uidnumber to make sure there are no conflicts with existing uidnumbers
 		$uidNumber = \count($this->ldapCreatedUsers) + 30000;
@@ -759,7 +754,7 @@ trait Provisioning {
 	 */
 	public function createLdapGroup(string $group):void {
 		$baseDN = $this->getLdapBaseDN();
-		$newDN = 'cn=' . $group . ',ou=' . $this->ou . ',' . $baseDN;
+		$newDN = 'cn=' . $group . ',ou=' . $this->ldapGroupsOU . ',' . $baseDN;
 		$entry = [];
 		$entry['cn'] = $group;
 		$entry['objectclass'][] = 'posixGroup';
@@ -3258,7 +3253,7 @@ trait Provisioning {
 	 */
 	public function getUsersOfLdapGroup(string $group):array {
 		$ou = $this->getLdapGroupsOU();
-		$entry = 'cn=' . $group . ',ou=' . $ou . ',' . 'dc=owncloud,dc=com';
+		$entry = 'cn=' . $group . ',ou=' . $ou . ',' . $this->ldapBaseDN;
 		$ldapResponse = $this->ldap->getEntry($entry);
 		return $ldapResponse["memberuid"];
 	}
@@ -4221,7 +4216,7 @@ trait Provisioning {
 	public function groupExists(string $group):bool {
 		if ($this->isTestingWithLdap() && OcisHelper::isTestingOnOcisOrReva()) {
 			$baseDN = $this->getLdapBaseDN();
-			$newDN = 'cn=' . $group . ',ou=' . $this->ou . ',' . $baseDN;
+			$newDN = 'cn=' . $group . ',ou=' . $this->ldapGroupsOU . ',' . $baseDN;
 			if ($this->ldap->getEntry($newDN) !== null) {
 				return true;
 			}

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -538,6 +538,7 @@ trait Provisioning {
 			$this->ldapPort = OcisHelper::getLdapPort();
 			$useSsl = OcisHelper::useSsl();
 			$this->ldapAdminUser = OcisHelper::getBindDN();
+			$this->ldapAdminPassword = OcisHelper::getBindPassword();
 			if ($useSsl === true) {
 				\putenv('LDAPTLS_REQCERT=never');
 			}
@@ -569,7 +570,9 @@ trait Provisioning {
 			$this->ldapPort = (int)$ldapConfig['ldapPort'];
 			$this->ldapAdminUser = (string)$ldapConfig['ldapAgentName'];
 		}
-		$this->ldapAdminPassword = (string)$suiteParameters['ldapAdminPassword'];
+		if ($this->ldapAdminPassword === "") {
+			$this->ldapAdminPassword = (string)$suiteParameters['ldapAdminPassword'];
+		}
 		$this->ldapUsersOU = (string)$suiteParameters['ldapUsersOU'];
 		$this->ldapGroupsOU = (string)$suiteParameters['ldapGroupsOU'];
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -534,6 +534,8 @@ trait Provisioning {
 		$useSsl = false;
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$this->ldapBaseDN = OcisHelper::getBaseDN();
+			$this->ldapUsersOU = OcisHelper::getGroupsOU();
+			$this->ldapGroupsOU = OcisHelper::getUsersOU();
 			$this->ldapHost = OcisHelper::getHostname();
 			$this->ldapPort = OcisHelper::getLdapPort();
 			$useSsl = OcisHelper::useSsl();
@@ -570,13 +572,12 @@ trait Provisioning {
 			$this->ldapHost = (string)$ldapConfig['ldapHost'];
 			$this->ldapPort = (int)$ldapConfig['ldapPort'];
 			$this->ldapAdminUser = (string)$ldapConfig['ldapAgentName'];
+			$this->ldapUsersOU = (string)$suiteParameters['ldapUsersOU'];
+			$this->ldapGroupsOU = (string)$suiteParameters['ldapGroupsOU'];
 		}
 		if ($this->ldapAdminPassword === "") {
 			$this->ldapAdminPassword = (string)$suiteParameters['ldapAdminPassword'];
 		}
-		$this->ldapUsersOU = (string)$suiteParameters['ldapUsersOU'];
-		$this->ldapGroupsOU = (string)$suiteParameters['ldapGroupsOU'];
-
 		$options = [
 			'host' => $this->ldapHost,
 			'port' => $this->ldapPort,


### PR DESCRIPTION
## Description
This adds a couple of new LDAP related settings (via enviroment variables) in order to be able to run the LDAP based testsuite against the default libregraph-idm configuration as created by ocis (see: https://github.com/owncloud/ocis/pull/3331). Those settings can also be useful when testing ocis against different LDAP setups.

## Motivation and Context
To provide more flexibility when testing oCIS with and LDAP backend.

## How Has This Been Tested?
- manual run against oCIS

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)
