### PR TITLE
[tests-only] [full-ci] Improve createLocalStorageMount test code

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1795,7 +1795,7 @@ def acceptance(ctx):
                                                          "path": "%s/downloads" % dir["server"],
                                                      }],
                                                  }),
-                                             ] + buildGithubCommentForBuildStopped(name, params["earlyFail"]) + githubComment(params["earlyFail"]) + stopBuild(params["earlyFail"]),
+                                             ] + githubComment(params["earlyFail"]) + stopBuild(params["earlyFail"]),
                                     "services": dbServices +
                                                 browserService(browser) +
                                                 emailService(params["emailNeeded"]) +
@@ -1998,27 +1998,6 @@ def stopBuild(earlyFail):
     else:
         return []
 
-def buildGithubCommentForBuildStopped(alternateSuiteName, earlyFail):
-    if (earlyFail):
-        return [{
-            "name": "build-github-comment-buildStop",
-            "image": OC_UBUNTU,
-            "commands": [
-                'echo ":boom: Acceptance tests pipeline <strong>%s</strong> failed. The build has been cancelled.\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}/1\\n" >> %s/comments.file' % (alternateSuiteName, dir["server"]),
-            ],
-            "when": {
-                "status": [
-                    "failure",
-                ],
-                "event": [
-                    "pull_request",
-                ],
-            },
-        }]
-
-    else:
-        return []
-
 def githubComment(earlyFail):
     if (earlyFail):
         return [{
@@ -2026,10 +2005,10 @@ def githubComment(earlyFail):
             "image": THEGEEKLAB_DRONE_GITHUB_COMMENT,
             "pull": "if-not-exists",
             "settings": {
-                "message_file": "%s/comments.file" % dir["server"],
-            },
-            "environment": {
-                "GITHUB_TOKEN": {
+                "message": ":boom: Acceptance tests pipeline <strong>${DRONE_STAGE_NAME}</strong> failed. The build has been cancelled.\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}",
+                "key": "pr-${DRONE_PULL_REQUEST}",
+                "update": "true",
+                "api_key": {
                     "from_secret": "github_token",
                 },
             },

--- a/tests/TestHelpers/SetupHelper.php
+++ b/tests/TestHelpers/SetupHelper.php
@@ -1059,7 +1059,15 @@ class SetupHelper extends \PHPUnit\Framework\Assert {
 		);
 		// stdOut should have a string like "Storage created with id 65"
 		$storageIdWords = \explode(" ", \trim($result['stdOut']));
-		$result['storageId'] = (int)$storageIdWords[4];
+		if (\array_key_exists(4, $storageIdWords)) {
+			$result['storageId'] = (int)$storageIdWords[4];
+		} else {
+			// presumably something went wrong with the files_external:create command
+			// so return "unknown" to the caller. The result array has the command exit
+			// code and stdErr output etc., so the caller can process what it likes
+			// of that information to work out what went wrong.
+			$result['storageId'] = "unknown";
+		}
 		return $result;
 	}
 

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -319,9 +319,14 @@ class OccContext implements Context {
 			$mount,
 			$this->featureContext->getStepLineRef()
 		);
-		$storageId = (int)$result['storageId'];
+		$storageId = $result['storageId'];
+		if (!is_numeric($storageId)) {
+			throw new Exception(
+				__METHOD__ . " storageId '$storageId' is not numeric"
+			);
+		}
 		$this->featureContext->setResultOfOccCommand($result);
-		$this->featureContext->addStorageId($mount, $storageId);
+		$this->featureContext->addStorageId($mount, (int) $storageId);
 	}
 
 	/**


### PR DESCRIPTION
## Description
1) If something goes wrong with the `files_external:create` command in `createLocalStorageMount` then the test fails with:

https://drone.owncloud.com/owncloud/search_elastic/1995/18/14
```
    ┌─ @BeforeScenario @local_storage # FeatureContext::setupLocalStorageBefore()
      │
      ╳  Notice: Undefined offset: 4 in /var/www/owncloud/testrunner/tests/TestHelpers/SetupHelper.php line 1062
```

This happens, for example, if the files_external app is disabled - the `files_external:create` command does not exist.

This PR improves the code so that a more informative error can be emitted.

2) the code for making a GitHub comment when an acceptance test fails was changed to use `thegeeklab/drone-github-comment:1` in PR https://github.com/owncloud/core/pull/39860 but the format of settings needed to use that different docker image was not updated. This commit fixes the format so that the docker images has access to the `github_token` etc.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
