### PR TITLE
Improve FileDrop view

### DIFF
--- a/apps/files_sharing/css/upload.css
+++ b/apps/files_sharing/css/upload.css
@@ -2,16 +2,37 @@
 	margin-top: 20px;
 }
 
+.public-upload-view>div>h2 {
+	font-weight: 600;
+}
+
+.public-upload-view--completed>h3 {
+	font-weight: 600;
+	font-size: 1.3em;
+}
+
+.public-upload-view--completed>ul {
+	width: 90%;
+	padding: 5px;
+	margin: auto;
+	background: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(238,238,238,1) 50%, rgba(255,255,255,0) 100%);
+
+}
+
+.public-upload-view--completed>ul>li {
+	font-size: 1.2em;
+}
+
 .public-upload-view--dropzone {
-	border: 3px dashed #888888;
-	line-height: 150px;
+	border: 3px dotted #888888;
+	border-radius: 20px;
+	padding: 80px 20px;
 	margin-top: 20px;
 	margin-bottom: 20px;
-	margin-left: auto;
-	margin-right: auto;
-	width: 75%;
+	margin-left: 15%;
+	margin-right: 15%;
 	cursor: pointer;
-	font-size: 18px; 
+	font-size: 18px;
 	color: #000000;
 	opacity: 0.5;
 	-webkit-transition: opacity 200ms;
@@ -43,4 +64,3 @@
 .public-upload-view--upload-button {
 	margin-top: 20px;
 }
-

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -56,7 +56,7 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 <header>
 	<div id="header" class="<?php p((isset($_['folder']) ? 'share-folder' : 'share-file')) ?>" data-protected="<?php p($_['protected']) ?>"
 		 data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
-		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud">
+		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud-public">
 			<h1 class="logo-icon">
 				<?php p($theme->getName()); ?>
 			</h1>

--- a/changelog/unreleased/39900
+++ b/changelog/unreleased/39900
@@ -1,0 +1,10 @@
+Enhancement: Improve FileDrop view
+
+Small change in the design and behavior of the FileDrop view of Public Links.
+
+- The font is bigger and thicker
+- Background color was added to the list of files
+- The text in the "Dropbox" is wrapped properly, line-height was removed
+- Don't hide the logo on small resolutions
+
+https://github.com/owncloud/core/pull/39900

--- a/core/css/header.css
+++ b/core/css/header.css
@@ -46,7 +46,8 @@
 
 /* LOGO and APP NAME -------------------------------------------------------- */
 
-#owncloud {
+#owncloud,
+#owncloud-public {
 	position: absolute;
 	top: 0;
 	left: 50%;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Small change in the design and behavior of the FileDrop view of Public Links.

- The font is bigger and thicker
- Background color was added to the list of files
- The text in the "Dropbox" is wrapped properly, line-height was removed
- Don't hide the logo on small resolutions

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39899

## Motivation and Context
You should see immediately that something has changed in the UI after the first file is completely uploaded so that you are not tempted to upload files twice.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested in Chrome and Firefox
- ...

## Screenshots:
Before:

<img width="600" alt="Screenshot 2022-03-18 at 13 41 54" src="https://user-images.githubusercontent.com/33026403/159018836-3d611f12-1073-4d39-ad66-8b3dcab63205.png">

After:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/33026403/159102467-b1f090ae-f964-4a68-a392-3e726b4ebfb0.png">

On small resolution:

<img width="362" alt="image" src="https://user-images.githubusercontent.com/33026403/159102607-f665e54f-8c0b-43b7-953c-5bdcf9b7b3c9.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
