### PR TITLE
[tests-only] [full-ci] Run all cliExternalStorage tests in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -289,9 +289,11 @@ config = {
             "suites": [
                 "cliExternalStorage",
             ],
-            "filterTags": "~@local_storage&&~@files_external-app-required",
             "federatedServerNeeded": True,
             "federatedServerVersions": ["git", "latest", "10.8.0"],
+            "extraApps": {
+                "files_external": "",
+            },
         },
         "webUI": {
             "suites": {

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1657,17 +1657,17 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @Then /^the HTTP response message should be "([^"]*)"$/
 	 *
-	 * @param string $responseMessage
+	 * @param string $expectedMessage
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theHttpResponseMessageShouldBe(string $responseMessage):void {
-		$expectedMessage = $this->responseXml['value'][1]['value'];
+	public function theHttpResponseMessageShouldBe(string $expectedMessage):void {
+		$actualMessage = $this->responseXml['value'][1]['value'];
 		Assert::assertEquals(
-			$responseMessage,
 			$expectedMessage,
-			"Expected $expectedMessage HTTP response message but got $responseMessage"
+			$actualMessage,
+			"Expected $expectedMessage HTTP response message but got $actualMessage"
 		);
 	}
 

--- a/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
+++ b/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
@@ -258,10 +258,11 @@ Feature: using files external service with storage as webdav_owncloud
       | storage_backend        | owncloud           |
       | mount_point            | TestMountPoint     |
       | authentication_backend | password::password |
-    And user "Alice" has created folder "testFolder"
-    When user "Alice" moves folder "testFolder" to "TestMountPoint/testFolder" using the WebDAV API
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "testFolder"
+    When user "Brian" moves folder "testFolder" to "TestMountPoint/testFolder" using the WebDAV API
     Then the HTTP status code should be "201"
-    And as "Alice" folder "TestMountPoint/testFolder" should exist
+    And as "Brian" folder "TestMountPoint/testFolder" should exist
     And using server "REMOTE"
     And as "Alice" folder "TestMnt/testFolder" should exist
 
@@ -276,10 +277,11 @@ Feature: using files external service with storage as webdav_owncloud
       | storage_backend        | owncloud           |
       | mount_point            | TestMountPoint     |
       | authentication_backend | password::password |
-    And user "Alice" has uploaded file with content "Test content for moving file." to "test.txt"
-    When user "Alice" moves file "/test.txt" to "TestMountPoint/test.txt" using the WebDAV API
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has uploaded file with content "Test content for moving file." to "test.txt"
+    When user "Brian" moves file "/test.txt" to "TestMountPoint/test.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And as "Alice" file "TestMountPoint/test.txt" should exist
+    And as "Brian" file "TestMountPoint/test.txt" should exist
     And using server "REMOTE"
     And as "Alice" file "TestMnt/test.txt" should exist
     And the content of file "TestMnt/test.txt" for user "Alice" should be "Test content for moving file."
@@ -295,12 +297,13 @@ Feature: using files external service with storage as webdav_owncloud
       | storage_backend        | owncloud           |
       | mount_point            | TestMountPoint     |
       | authentication_backend | password::password |
+    And user "Brian" has been created with default attributes and without skeleton files
     And using server "REMOTE"
     And user "Alice" has created folder "TestMnt/testFolder"
     And using server "LOCAL"
-    When user "Alice" moves folder "TestMountPoint/testFolder" to "/testFolder" using the WebDAV API
+    When user "Brian" moves folder "TestMountPoint/testFolder" to "/testFolder" using the WebDAV API
     Then the HTTP status code should be "201"
-    And as "Alice" folder "testFolder" should exist
+    And as "Brian" folder "testFolder" should exist
 
 
   Scenario: user moves a file out of external storage to their own storage
@@ -313,13 +316,14 @@ Feature: using files external service with storage as webdav_owncloud
       | storage_backend        | owncloud           |
       | mount_point            | TestMountPoint     |
       | authentication_backend | password::password |
+    And user "Brian" has been created with default attributes and without skeleton files
     And using server "REMOTE"
     And user "Alice" has uploaded file with content "Test content for moving file." to "TestMnt/test.txt"
     And using server "LOCAL"
-    When user "Alice" moves file "TestMountPoint/test.txt" to "/test.txt" using the WebDAV API
+    When user "Brian" moves file "TestMountPoint/test.txt" to "/test.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And as "Alice" file "/test.txt" should exist
-    And the content of file "/test.txt" for user "Alice" should be "Test content for moving file."
+    And as "Brian" file "/test.txt" should exist
+    And the content of file "/test.txt" for user "Brian" should be "Test content for moving file."
 
   @issue-39550
   Scenario: user tries to move a folder that they have shared to someone, to external storage
@@ -332,18 +336,19 @@ Feature: using files external service with storage as webdav_owncloud
       | storage_backend        | owncloud           |
       | mount_point            | TestMountPoint     |
       | authentication_backend | password::password |
-    And user "Alice" has created folder "testFolder"
     And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has shared folder "/testFolder" with user "Brian"
-    When user "Alice" moves folder "testFolder" to "TestMountPoint/testFolder" using the WebDAV API
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "testFolder"
+    And user "Brian" has shared folder "/testFolder" with user "Carol"
+    When user "Brian" moves folder "testFolder" to "TestMountPoint/testFolder" using the WebDAV API
     # Remove the following lines after the issue has been fixed
     Then the HTTP status code should be "500"
-    And the HTTP response message should be "You are not allowed to share /Alice/files/TestMountPoint/testFolder"
+    And the HTTP response message should be "You are not allowed to share /Brian/files/TestMountPoint/testFolder"
     # Uncomment the following lines after the issue has been fixed
     # Then the HTTP status code should be "403"
     # And the HTTP response message should be "It is not allowed to move one mount point into another one"
-    # Folder should not be move but here the folder is moved to mount storage
-    But as "Alice" folder "TestMountPoint/testFolder" should exist
+    # Folder should not be moved but here the folder is moved to mount storage
+    But as "Brian" folder "TestMountPoint/testFolder" should exist
 
   @issue-39550
   Scenario: user tries to move a file that they have shared to someone, to external storage
@@ -356,18 +361,19 @@ Feature: using files external service with storage as webdav_owncloud
       | storage_backend        | owncloud           |
       | mount_point            | TestMountPoint     |
       | authentication_backend | password::password |
-    And user "Alice" has uploaded file with content "Test content for moving file." to "test.txt"
     And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has shared file "test.txt" with user "Brian"
-    When user "Alice" moves file "/test.txt" to "TestMountPoint/test.txt" using the WebDAV API
+    And user "Carol" has been created with default attributes and without skeleton files
+    And user "Brian" has uploaded file with content "Test content for moving file." to "test.txt"
+    And user "Brian" has shared file "test.txt" with user "Carol"
+    When user "Brian" moves file "/test.txt" to "TestMountPoint/test.txt" using the WebDAV API
     # Remove the following lines after the issue has been fixed
     Then the HTTP status code should be "500"
-    And the HTTP response message should be "You are not allowed to share /Alice/files/TestMountPoint/test.txt"
+    And the HTTP response message should be "You are not allowed to share /Brian/files/TestMountPoint/test.txt"
     # Uncomment the following lines after the issue has been fixed
     # Then the HTTP status code should be "403"
     # And the HTTP response message should be "It is not allowed to move one mount point into another one"
-    # File should not be move but here the file is moved to mount storage
-    But as "Alice" file "TestMountPoint/test.txt" should exist
+    # File should not be moved but here the file is moved to mount storage
+    But as "Brian" file "TestMountPoint/test.txt" should exist
 
   @issue-39550
   Scenario: share receiver tries to move a folder that they have received from someone, to external storage
@@ -381,12 +387,15 @@ Feature: using files external service with storage as webdav_owncloud
       | mount_point            | TestMountPoint     |
       | authentication_backend | password::password |
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "testFolder"
-    And user "Brian" has shared folder "/testFolder" with user "Alice"
-    When user "Alice" moves folder "/testFolder" to "TestMountPoint/testFolder" using the WebDAV API
-    Then the HTTP status code should be "403"
+    And user "Brian" has shared folder "/testFolder" with user "Carol"
+    When user "Brian" moves folder "/testFolder" to "TestMountPoint/testFolder" using the WebDAV API
+    Then the HTTP status code should be "500"
+    # Uncomment the following line after the issue has been fixed
+    # Then the HTTP status code should be "403"
     # Remove the following line after the issue has been fixed
-    And the HTTP response message should be "There was an error while renaming the file or directory"
+    And the HTTP response message should be "You are not allowed to share /Brian/files/TestMountPoint/testFolder"
     # Uncomment the following line after the issue has been fixed
     # And the HTTP response message should be "It is not allowed to move one mount point into another one"
 
@@ -402,11 +411,14 @@ Feature: using files external service with storage as webdav_owncloud
       | mount_point            | TestMountPoint     |
       | authentication_backend | password::password |
     And user "Brian" has been created with default attributes and without skeleton files
+    And user "Carol" has been created with default attributes and without skeleton files
     And user "Brian" has uploaded file with content "Test content for moving file." to "test.txt"
-    And user "Brian" has shared file "test.txt" with user "Alice"
-    When user "Alice" moves file "/test.txt" to "TestMountPoint/test.txt" using the WebDAV API
-    Then the HTTP status code should be "403"
+    And user "Brian" has shared file "test.txt" with user "Carol"
+    When user "Brian" moves file "/test.txt" to "TestMountPoint/test.txt" using the WebDAV API
+    Then the HTTP status code should be "500"
+    # Uncomment the following line after the issue has been fixed
+    # Then the HTTP status code should be "403"
     # Remove the following line after the issue has been fixed
-    And the HTTP response message should be "There was an error while renaming the file or directory"
+    And the HTTP response message should be "You are not allowed to share /Brian/files/TestMountPoint/test.txt"
     # Uncomment the following line after the issue has been fixed
     # And the HTTP response message should be "It is not allowed to move one mount point into another one"


### PR DESCRIPTION
## Description
1) Run all cliExternalStorage tests in CI with `files_external` enabled. Those were accidentally disabled in CI at about the same time as new test scenarios were added. So the new (and many existing) test scenarios were not running. There were PRs that changed files_external and the PR that added the test scenarios both happening at similar times.

Now we see what fails: https://drone.owncloud.com/owncloud/core/35000/124/18
```
runsh: Total unexpected failed scenarios throughout the test run:
cliExternalStorage/filesExternalWebdavOwncloud.feature:251
cliExternalStorage/filesExternalWebdavOwncloud.feature:269
cliExternalStorage/filesExternalWebdavOwncloud.feature:288
cliExternalStorage/filesExternalWebdavOwncloud.feature:306
cliExternalStorage/filesExternalWebdavOwncloud.feature:325
cliExternalStorage/filesExternalWebdavOwncloud.feature:349
cliExternalStorage/filesExternalWebdavOwncloud.feature:373
cliExternalStorage/filesExternalWebdavOwncloud.feature:394
```
The tests mention user "Alice" (who exists on the federated server) in the context of the local system, and that fails.

2) Refactor those scenarios so that Brian (and Carol when needed) are created on the local server and used correctly in the test scenarios.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
