### PR TITLE
Fix sharing with user-key encryption

### DIFF
--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -235,7 +235,11 @@ class Util {
 		// strip the first 2 directories (expected to be "/<user>/files/path/to/files")
 		// so mountPoint is expected to be "/files/path/to..."
 		$mountPoint = \implode('/', \array_slice($parts, 2));
-		$originalPath = "/{$mountPoint}/{$internalPath}";
+		if ($mountPoint !== '') {
+			$originalPath = "/{$mountPoint}/{$internalPath}";
+		} else {
+			$originalPath = "/{$internalPath}";
+		}
 
 		if ($storage->instanceOfStorage('\OCA\Files_Sharing\ISharedStorage')) {
 			// TODO: Improve sharedStorage detection.


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Having user-key encryption enabled, shares being received by the user might not be properly decrypted.

The cause was a wrong path and a length-base check. Basically a `//files/path/to/file` was used (notice the double `//`) and the check was using a `strlen('/files')`; the resulting path was `s/path/to/file` instead of the expected `/path/to/file`.
When we checked for the shares of the target path (`s/path/to/file`), we didn't find it, so we returned an access list containing only the owner of the file instead of the owner and the sharees. In the end, the key file for the sharee wasn't present in the right place.

## Related Issue
https://github.com/owncloud/encryption/issues/329

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested
1. Setup up user-key encryption
2. user1 shares a file with user2
3. user2 tries to download the file.

With the patch, user2 can preview the file in the file list and he can also download the file without problems

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
