### PR TITLE
[tests-only] Fix ldapAdminPassword in tests

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -440,7 +440,7 @@ class FeatureContext extends BehatVariablesContext {
 	/**
 	 * @var string
 	 */
-	private $ldapAdminPassword;
+	private $ldapAdminPassword = "";
 	/**
 	 * @var string
 	 */


### PR DESCRIPTION
## Description
Set the "default" `ldapAdminPassword` to the empty string.

That will help this code to work from Provisioning.php `connectToLdap()` function:
```
		if ($this->ldapAdminPassword === "") {
			$this->ldapAdminPassword = (string)$suiteParameters['ldapAdminPassword'];
		}
```

Without the default set to the empty string, the variable has the value NULL and the password never gets set.

## Related Issue
- Fixes https://github.com/owncloud/user_ldap/issues/729

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
