### PR TITLE
[tests-only] Make deleteLdapUsersAndGroups backward-compatible for oC10 user_ldap testing

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -853,19 +853,25 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function deleteLdapUsersAndGroups():void {
+		// pdd
+		$isOcisOrReva = OcisHelper::isTestingOnOcisOrReva();
 		foreach ($this->ldapCreatedUsers as $user) {
-			$this->ldap->delete(
-				"uid=" . ldap_escape($user, "", LDAP_ESCAPE_DN) . ",ou=" . $this->ldapUsersOU . "," . $this->ldapBaseDN,
-			);
+			if ($isOcisOrReva) {
+				$this->ldap->delete(
+					"uid=" . ldap_escape($user, "", LDAP_ESCAPE_DN) . ",ou=" . $this->ldapUsersOU . "," . $this->ldapBaseDN,
+				);
+			}
 			$this->rememberThatUserIsNotExpectedToExist($user);
 		}
 		foreach ($this->ldapCreatedGroups as $group) {
-			$this->ldap->delete(
-				"cn=" . ldap_escape($group, "", LDAP_ESCAPE_DN) . ",ou=" . $this->ldapGroupsOU . "," . $this->ldapBaseDN,
-			);
+			if ($isOcisOrReva) {
+				$this->ldap->delete(
+					"cn=" . ldap_escape($group, "", LDAP_ESCAPE_DN) . ",ou=" . $this->ldapGroupsOU . "," . $this->ldapBaseDN,
+				);
+			}
 			$this->rememberThatGroupIsNotExpectedToExist($group);
 		}
-		if (!$this->skipImportLdif) {
+		if (!$isOcisOrReva || !$this->skipImportLdif) {
 			//delete ou from LDIF import
 			$this->ldap->delete(
 				"ou=" . $this->ldapUsersOU . "," . $this->ldapBaseDN,


### PR DESCRIPTION
## Description
The new code in #39893 tries to delete each user and group one-by-one from the LDAP server. It was not done that way previously - we used to just delete the whole user and group "ou".

Put "if" checks around the new code so that we do not do it when testing oC10. That gets the oC10 tests passing.
(We could investigate in more detail about exactly why deleting one-by-one does not work, but for now just put back the original behavior and get CI passing)

## Related Issue
- Fixes https://github.com/owncloud/user_ldap/issues/729

## How Has This Been Tested?
user_ldap PR https://github.com/owncloud/user_ldap/pull/731 passes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
