### PR TITLE
[tests-only] Smaller fixes for LDAP based tests on oCIS

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -734,6 +734,8 @@ trait Provisioning {
 		}
 		if (isset($setting["email"])) {
 			$entry['mail'] = $setting["email"];
+		} elseif (OcisHelper::isTestingOnOcis()) {
+			$entry['mail'] = $userId . '@owncloud.com';
 		}
 		$entry['gidNumber'] = 5000;
 		$entry['uidNumber'] = $uidNumber;

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -534,8 +534,8 @@ trait Provisioning {
 		$useSsl = false;
 		if (OcisHelper::isTestingOnOcisOrReva()) {
 			$this->ldapBaseDN = OcisHelper::getBaseDN();
-			$this->ldapUsersOU = OcisHelper::getGroupsOU();
-			$this->ldapGroupsOU = OcisHelper::getUsersOU();
+			$this->ldapUsersOU = OcisHelper::getUsersOU();
+			$this->ldapGroupsOU = OcisHelper::getGroupsOU();
 			$this->ldapGroupSchema = OcisHelper::getGroupSchema();
 			$this->ldapHost = OcisHelper::getHostname();
 			$this->ldapPort = OcisHelper::getLdapPort();


### PR DESCRIPTION
## Description

The OUs for group where mixed up. This went unnoticed since the reva configuration was using the top of the LDAP tree as the search base for users and groups.

This also includes a small change for creating LDAP user when testing against oCIS. Current the default configuration for oCIS requires the mail attribute to be present on the user object. We make sure to add it. (Similar to what is done for the non-LDAP case)

## Motivation and Context
Being able to run the LDAP based test-suite against ocis

