### PR TITLE
Improve session cookie handling

### DIFF
--- a/changelog/unreleased/39916
+++ b/changelog/unreleased/39916
@@ -1,0 +1,20 @@
+Enhancement: Changes regarding cookie handling
+
+The following changes have been implemented:
+* The expiration set for the passphrase cookie will be refreshed each time
+a page is loaded or when the "heartbeat" endpoint is hit
+* If the "session_keepalive" config option is set to true, a periodic request
+to the "heartbeat" endpoint will be made automatically regardless of any
+activity going on. This will extend the session lifetime preventing its
+expiration.
+* If the "session_keepalive" config option is set to false, a "heartbeat" will
+be sent based on activity in order to extend the session lifetime. If we
+don't detect any activity, the session might expire, and the user will need to
+login again.
+* The new "session_forced_logout_timeout" option has been added to the
+config.php. It's disabled by default, and setting a positive (non-zero) value
+will enable the feature. If it's enabled, the passphrase cookie will expire
+after those number of seconds pass, when the tab or the browser closes.
+This will force the user to login again.
+
+https://github.com/owncloud/core/pull/39916

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -246,6 +246,9 @@ $CONFIG = [
  * (having valid access) if the timeout hasn't been reached.
  * The recommended minimum value is 5 or 10 seconds. Using a lower value
  * might cause unwanted logouts for the users.
+ * Also note that this feature works properly if the user uses only one
+ * tab. If a user uses multiple tabs, closing one of them will likely
+ * force the rest to re-authenticate.
  */
 'session_forced_logout_timeout' => 0,
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -220,16 +220,34 @@ $CONFIG = [
 'remember_login_cookie_lifetime' => 60*60*24*15,
 
 /**
- * Define the lifetime of a session after inactivity
+ * Define the lifetime of a session after inactivity.
+ * The web UI might send a "heartbeat" based on the activity happening
+ * in order to extend the session lifetime and keeping it from timing out
+ * prematurely. If there is no activity happening and the lifetime is
+ * reached, you'll have to login again.
  * The default is 20 minutes, expressed in seconds.
  */
 'session_lifetime' => 60 * 20,
 
 /**
  * Enable or disable session keep-alive when a user is logged in to the Web UI
- * Enabling this sends a "heartbeat" to the server to keep it from timing out.
+ * Enabling this sends a "heartbeat" to the server to keep it from
+ * timing out regardless of any activity happening. This heartbeat will
+ * keep extending the session over again, so the user won't be logged out
+ * even if he isn't active in the web UI.
  */
 'session_keepalive' => true,
+
+/**
+ * Force the user to logout when he closes the tab or the browser, after
+ * the specified number of seconds. A negative or 0 value disables this
+ * feature.
+ * Note that the user can still access the page without re-authenticating
+ * (having valid access) if the timeout hasn't been reached.
+ * The recommended minimum value is 5 or 10 seconds. Using a lower value
+ * might cause unwanted logouts for the users.
+ */
+'session_forced_logout_timeout' => 0,
 
 /**
  * Enforce token only authentication for apps and clients connecting to ownCloud

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -185,7 +185,7 @@ $array = [
 	"oc_config" => [
 			'session_lifetime'	=> \min(\OC::$server->getConfig()->getSystemValue('session_lifetime', OC::$server->getIniWrapper()->getNumeric('session.gc_maxlifetime')), OC::$server->getIniWrapper()->getNumeric('session.gc_maxlifetime')),
 			'session_keepalive'	=> \OC::$server->getConfig()->getSystemValue('session_keepalive', true),
-			'session_force_logout_on_exit'	=> \OC::$server->getConfig()->getSystemValue('session_force_logout_on_exit', false),
+			'session_forced_logout_timeout'	=> \OC::$server->getConfig()->getSystemValue('session_forced_logout_timeout', 0),
 			'enable_avatars'	=> \OC::$server->getConfig()->getSystemValue('enable_avatars', true) === true,
 			'lost_password_link'	=> \OC::$server->getConfig()->getSystemValue('lost_password_link', null),
 			'modRewriteWorking'	=> (\getenv('front_controller_active') === 'true'),

--- a/core/js/config.php
+++ b/core/js/config.php
@@ -185,6 +185,7 @@ $array = [
 	"oc_config" => [
 			'session_lifetime'	=> \min(\OC::$server->getConfig()->getSystemValue('session_lifetime', OC::$server->getIniWrapper()->getNumeric('session.gc_maxlifetime')), OC::$server->getIniWrapper()->getNumeric('session.gc_maxlifetime')),
 			'session_keepalive'	=> \OC::$server->getConfig()->getSystemValue('session_keepalive', true),
+			'session_force_logout_on_exit'	=> \OC::$server->getConfig()->getSystemValue('session_force_logout_on_exit', false),
 			'enable_avatars'	=> \OC::$server->getConfig()->getSystemValue('enable_avatars', true) === true,
 			'lost_password_link'	=> \OC::$server->getConfig()->getSystemValue('lost_password_link', null),
 			'modRewriteWorking'	=> (\getenv('front_controller_active') === 'true'),

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1646,6 +1646,17 @@ function initCore() {
 		initMouseTrack();
 	}
 
+	if (oc_config.session_force_logout_on_exit !== undefined && oc_config.session_force_logout_on_exit) {
+		$(window).on('beforeunload', function() {
+			$.ajax({
+				method: 'POST',
+				url: OC.generateUrl('/heartbeat'),
+				data: {t: 10},
+				async: false
+			});
+		});
+	}
+
 	OC.registerMenu($('#expand'), $('#expanddiv'));
 
 	/**

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1570,10 +1570,80 @@ function initCore() {
 		heartBeat();
 	}
 
+	/**
+	 * Check mouse movement to send a heartbeat if the mouse moved
+	 */
+	function initMouseTrack() {
+		var interval = 120;  // 2 minutes
+		if (oc_config.session_lifetime) {
+			interval = Math.floor(oc_config.session_lifetime / 2);
+		}
+		interval = Math.min(Math.max(interval, 60), 3600);  // ensure interval is in [60, 3600]
+
+		var extendableHeartbeat = null;
+		var extendableMouseMoved = false;
+		var mouseMoved = false;
+		var heartbeatTimestamp = 0;
+
+		// If the mouse has moved within this interval, set a timeout to send
+		// a heartbeat request. If the mouse moves again in the next interval,
+		// the timeout will be extended. Note that the heartbeat request might
+		// be delayed indefinitely.
+		setInterval(function() {
+			if (extendableMouseMoved) {
+				clearTimeout(extendableHeartbeat);
+				extendableHeartbeat = setTimeout(function() {
+					if (!extendableMouseMoved) {
+						// if the mouse has moved, either this timeout has been cleared and
+						// a new one is being created, or a new timeout will be created soon
+						// (if this timeout is executed before the setInterval function)
+						var currentTimestamp = Date.now();
+						if (currentTimestamp > heartbeatTimestamp + (30 * 1000)) {
+							// if a heartbeat has been sent recently, don't send a new one
+							console.log('I1 sending heartbeat');
+							$.post(OC.generateUrl('/heartbeat'));
+							heartbeatTimestamp = currentTimestamp;
+						} else {
+							console.log('I1 skipping heartbeat');
+						}
+					} else {
+						console.log('I1 delaying hearbeat because mouse moved.');
+					}
+				}, 30 * 1000);
+			}
+			extendableMouseMoved = false;
+		}, 30 * 1000);
+
+		// If the mouse has been moved within this interval, send a heartbeat
+		// immediately. This will prevent the session to expire.
+		setInterval(function() {
+			if (mouseMoved) {
+				var currentTimestamp = Date.now();
+				if (currentTimestamp > heartbeatTimestamp + (interval * 1000)) {
+					// if a heartbeat has been sent recently, don't send a new one
+					console.log('I2 sending heartbeat');
+					$.post(OC.generateUrl('/heartbeat'));
+					heartbeatTimestamp = currentTimestamp;
+				} else {
+					console.log('I2 skipping heartbeat');
+				}
+			}
+			mouseMoved = false;  // no need to wait for the response
+		}, interval * 1000);
+
+		// set a couple of variables to indicate that the mouse has moved
+		$(window).on('mousemove', function() {
+			mouseMoved = true;
+			extendableMouseMoved = true;
+		});
+	}
+
 	// session heartbeat (defaults to enabled)
 	if (typeof(oc_config.session_keepalive) === 'undefined' || !!oc_config.session_keepalive) {
 
 		initSessionHeartBeat();
+	} else {
+		initMouseTrack();
 	}
 
 	OC.registerMenu($('#expand'), $('#expanddiv'));

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1567,7 +1567,6 @@ function initCore() {
 				$.post(url);
 			}, interval * 1000);
 		};
-		$(document).ajaxComplete(heartBeat);
 		heartBeat();
 	}
 

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1632,7 +1632,7 @@ function initCore() {
 		}, interval * 1000);
 
 		// set a couple of variables to indicate that the mouse has moved
-		$(window).on('mousemove', function() {
+		$(window).on('mousemove.sessiontrack', function() {
 			mouseMoved = true;
 			extendableMouseMoved = true;
 		});
@@ -1646,12 +1646,12 @@ function initCore() {
 		initMouseTrack();
 	}
 
-	if (oc_config.session_force_logout_on_exit !== undefined && oc_config.session_force_logout_on_exit) {
-		$(window).on('beforeunload', function() {
+	if (oc_config.session_forced_logout_timeout !== undefined && oc_config.session_forced_logout_timeout > 0) {
+		$(window).on('beforeunload.sessiontrack', function() {
 			$.ajax({
 				method: 'POST',
 				url: OC.generateUrl('/heartbeat'),
-				data: {t: 10},
+				data: {t: oc_config.session_forced_logout_timeout},
 				async: false
 			});
 		});

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1658,9 +1658,13 @@ function initCore() {
 				credentials: 'same-origin',
 				keepalive: true
 			};
-			var r = new Request(OC.generateUrl('/heartbeat'), requestData);
-			if (r.keepalive === undefined) {
-				// firefox doesn't support keepalive (checked 4th Apr 2022)
+			var r = undefined;
+			if (typeof Request !== "undefined") {
+				// IE 11 doesn't have support "Request", so we'll fallback to ajax
+				r = new Request(OC.generateUrl('/heartbeat'), requestData);
+			}
+			if (r === undefined || r.keepalive === undefined) {
+				// firefox doesn't support keepalive (checked 11th Apr 2022)
 				// try a sync ajax call instead
 				$.ajax({
 					method: 'POST',

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1648,12 +1648,29 @@ function initCore() {
 
 	if (oc_config.session_forced_logout_timeout !== undefined && oc_config.session_forced_logout_timeout > 0) {
 		$(window).on('beforeunload.sessiontrack', function() {
-			$.ajax({
+			var requestData = {
 				method: 'POST',
-				url: OC.generateUrl('/heartbeat'),
-				data: {t: oc_config.session_forced_logout_timeout},
-				async: false
-			});
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Requested-With': 'XMLHttpRequest'
+				},
+				body: JSON.stringify({t: oc_config.session_forced_logout_timeout}),
+				credentials: 'same-origin',
+				keepalive: true
+			};
+			var r = new Request(OC.generateUrl('/heartbeat'), requestData);
+			if (r.keepalive === undefined) {
+				// firefox doesn't support keepalive (checked 4th Apr 2022)
+				// try a sync ajax call instead
+				$.ajax({
+					method: 'POST',
+					url: OC.generateUrl('/heartbeat'),
+					data: {t: oc_config.session_forced_logout_timeout},
+					async: false
+				});
+			} else {
+				fetch(r);
+			}
 		});
 	}
 

--- a/core/routes.php
+++ b/core/routes.php
@@ -144,7 +144,8 @@ $this->create('files_sharing.sharecontroller.downloadShare', '/s/{token}/downloa
 
 // used for heartbeat
 $this->create('heartbeat', '/heartbeat')->action(function () {
-	\OC::$server->getSessionCryptoWrapper()->refreshCookie(\OC::$server->getConfig());
+	$expire = \OC::$server->getRequest()->getParam('t');
+	\OC::$server->getSessionCryptoWrapper()->refreshCookie(\OC::$server->getConfig(), $expire);
 });
 
 /**

--- a/core/routes.php
+++ b/core/routes.php
@@ -144,7 +144,7 @@ $this->create('files_sharing.sharecontroller.downloadShare', '/s/{token}/downloa
 
 // used for heartbeat
 $this->create('heartbeat', '/heartbeat')->action(function () {
-	// do nothing
+	\OC::$server->getSessionCryptoWrapper()->refreshCookie(\OC::$server->getConfig());
 });
 
 /**

--- a/lib/base.php
+++ b/lib/base.php
@@ -434,6 +434,7 @@ class OC {
 			}
 
 			$cryptoWrapper = \OC::$server->getSessionCryptoWrapper();
+			$cryptoWrapper->sendCookie(self::$server->getConfig());
 			$session = $cryptoWrapper->wrapSession($session);
 			self::$server->setSession($session);
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -809,7 +809,6 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 			);
 
 			return new CryptoWrapper(
-				$c->getConfig(),
 				$c->getCrypto(),
 				$c->getSecureRandom(),
 				$request,

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -154,7 +154,7 @@ class CryptoWrapper {
 			$webRoot = '/';
 		}
 
-		$sessionLifetime = $config->getSystemValue('session_lifetime',  60 * 20);
+		$sessionLifetime = $config->getSystemValue('session_lifetime', 60 * 20);
 		if ($sessionLifetime > 0) {
 			$sessionLifetime += $this->timeFactory->getTime();
 		} else {

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -118,7 +118,7 @@ class CryptoWrapper {
 	/**
 	 * Refresh the cookie expiration time
 	 */
-	public function refreshCookie(IConfig $config) {
+	public function refreshCookie(IConfig $config, $expire = null) {
 		if ($this->request->getCookie(self::COOKIE_NAME) === null) {
 			return;
 		}
@@ -127,6 +127,9 @@ class CryptoWrapper {
 		// FIXME: Required for CI
 		if (!\defined('PHPUNIT_RUN')) {
 			$options = $this->prepareOptions($config);
+			if ($expire !== null) {
+				$options['expires'] = $this->timeFactory->getTime() + $expire;
+			}
 			$this->sendCookieToBrowser($this->passphrase, $options);
 		}
 	}

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -76,7 +76,6 @@ class CryptoWrapper {
 	 * @param ITimeFactory $timeFactory
 	 */
 	public function __construct(
-		IConfig $config,
 		ICrypto $crypto,
 		ISecureRandom $random,
 		IRequest $request,
@@ -165,7 +164,7 @@ class CryptoWrapper {
 		}
 
 		$samesite = $config->getSystemValue('http.cookie.samesite', 'Strict');
-		$options = [
+		return [
 			'expires' => $sessionLifetime,
 			'path' => $webRoot,
 			'domain' => '',
@@ -173,7 +172,6 @@ class CryptoWrapper {
 			'httponly' => true,
 			'samesite' => $samesite,
 		];
-		return $options;
 	}
 
 	private function sendCookieToBrowser($value, $options) {

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -154,7 +154,7 @@ class CryptoWrapper {
 			$webRoot = '/';
 		}
 
-		$sessionLifetime = $config->getSystemValue('session_lifetime', 0);
+		$sessionLifetime = $config->getSystemValue('session_lifetime',  60 * 20);
 		if ($sessionLifetime > 0) {
 			$sessionLifetime += $this->timeFactory->getTime();
 		} else {

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -136,15 +136,18 @@ class CryptoWrapper {
 	 * Try to delete the cookie
 	 */
 	public function deleteCookie() {
-		$options = [
-			'expires' => \time() - 3600,
-			'path' => '',
-			'domain' => '',
-			'secure' => false,
-			'httponly' => false,
-			'samesite' => 'None',
-		];
-		$this->sendCookieToBrowser('', $options);
+		// FIXME: Required for CI
+		if (!\defined('PHPUNIT_RUN')) {
+			$options = [
+				'expires' => \time() - 3600,
+				'path' => '',
+				'domain' => '',
+				'secure' => false,
+				'httponly' => false,
+				'samesite' => 'None',
+			];
+			$this->sendCookieToBrowser('', $options);
+		}
 	}
 
 	private function prepareOptions(IConfig $config) {

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -62,6 +62,9 @@ class CryptoWrapper {
 	/** @var string  */
 	private $passphrase;
 
+	/** @var IRequest  */
+	private $request;
+
 	/** @var ITimeFactory */
 	private $timeFactory;
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -1119,6 +1119,7 @@ class Session implements IUserSession, Emitter {
 			$this->setUser(null);
 			$this->setLoginName(null);
 			$this->unsetMagicInCookie();
+			OC::$server->getSessionCryptoWrapper()->deleteCookie();
 			$this->session->clear();
 			$this->manager->emit('\OC\User', 'postLogout');
 			return true;


### PR DESCRIPTION
The oc_sessionPassphrase cookie will always be sent for all the non-ajax
requests in order to update the expiration time accordingly. The
expiration time will match the one set in the 'session_lifetime'
configuration in config.php. If the 'session_lifetime' isn't set, the
expiration for the cookie will be set to "session" time.

If the 'session_keepalive' isn't set as false, a periodic "heartbeat"
request will be performed to prevent the browser session from being
expired. The "/heartbeat" will always update the expiration time for the
oc_sessionPassphrase cookie.

Login out will cause the cookie to be deleted.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Usually, an auth cookie is sent without explicit expiration, so it will last for the whole browsing session.
If `session_lifetime` is explicitly set, the cookie will have the corresponding expiration time. Once the cookie expires, the browser will stop sending the cookie, which will cause the user to be kicked out and he'll have to login again.
(Minimum expiration time for the cookie is 60 secs. Setting the `session_lifetime` to an equal or lower value will likely cause problems)

Loading pages will cause the cookie expiration to be refreshed. This will allow extending the period where the user can perform actions in ownCloud. Note that this doesn't apply to ajax requests. In particular, browsing through the files page won't prevent the user from being kicked out.

Unless the `session_keepalive` is explicitly set to false, a periodic heartbeat request will be sent to the server. The "/heartbeat" endpoint will always refresh the cookie's expiration time. The "heartbeat" request is expected to happen every `session_lifetime / 2` secs. This will help preventing the cookie from being expired.

Login out will remove the cookie. A new one will be generated.

Note that this have been only tested with basic auth. Other authentication mechanisms haven't been tested yet, so there could be problems with those.
Also note that the behavior is mostly related to the browser. In order to refresh the expiration time for the cookie, we have to send a cookie to overwrite the old one, otherwise the browser won't send the cookie if it's expired.

**NOTE**: Additional features described in https://github.com/owncloud/core/pull/39916#issuecomment-1091237328 have been added

## Related Issue
https://github.com/owncloud/enterprise/issues/5067

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested with basic auth
1. Setup `session_lifetime = 120` and `session_keepalive = false`
2. Login with user
3. Browse through ownCloud from more than 5 minutes
4. Check you haven't logged out automatically
5. Don't do anything for more than 2 minutes (*)
6. Check you get log out.

(*) After those 2 minutes, you have to perform any request to the server. If you have the notifications app enabled, a request is performed automatically each 30 secs, so worst case, you are logged out after 2 minutes and a half. If you don't have the notifications app enabled, you'll have to perform any request by yourself.

1. Setup `session_lifetime = 120` (`session_keepalive` is unset)
2. Login with user
3. Wait for more than 3 minutes without doing anything
4. Check that you're still logged in

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
