### PR TITLE
[tests-only] Adjust tests for issue-39347

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
@@ -544,29 +544,10 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
     And user "Brian" moves folder "/Shares/parent" to "/Shares/sharedParent" using the WebDAV API
     And user "Alice" shares folder "parent" with user "Brian" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
-    Then as "Brian" folder "Shares/parent" should not exist
-    And as "Brian" folder "Shares/sharedParent" should exist
-    And as "Brian" file "Shares/sharedParent/child/lorem.txt" should exist
-    Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
-
-  @skipOnOcV10 @issue-39347
-  Scenario Outline: Share receiver renames the received group share and declines another share of same folder through user share again
-    Given using OCS API version "<ocs_api_version>"
-    And group "grp" has been created
-    And user "Brian" has been added to group "grp"
-    And user "Alice" has been added to group "grp"
-    And user "Alice" has created folder "parent"
-    And user "Alice" has created folder "parent/child"
-    And user "Alice" has uploaded file with content "Share content" to "parent/child/lorem.txt"
-    When user "Alice" shares folder "parent" with group "grp" with permissions "read" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
-    And user "Brian" moves folder "/Shares/parent" to "/Shares/sharedParent" using the WebDAV API
-    And user "Alice" shares folder "parent" with user "Brian" using the sharing API
-    And user "Brian" declines share "/parent" offered by user "Alice" using the sharing API
+    # Note: Brian has already accepted the share of this resource as a member of "grp".
+    #       Now he has also received the same resource shared directly to "Brian".
+    #       The server should effectively "auto-accept" this new "copy" of the resource
+    #       and present to Brian only the single resource "Shares/sharedParent"
     Then as "Brian" folder "Shares/parent" should not exist
     And as "Brian" folder "Shares/sharedParent" should exist
     And as "Brian" file "Shares/sharedParent/child/lorem.txt" should exist
@@ -588,7 +569,10 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
     And user "Brian" moves folder "/Shares/parent" to "/Shares/sharedParent" using the WebDAV API
     And user "Alice" shares folder "parent" with user "Brian" with permissions "all" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
+    # Note: Brian has already accepted the share of this resource as a member of "grp".
+    #       Now he has also received the same resource shared directly to "Brian".
+    #       The server should effectively "auto-accept" this new "copy" of the resource
+    #       and present to Brian only the single resource "Shares/sharedParent"
     Then as "Brian" folder "Shares/parent" should not exist
     And as "Brian" folder "Shares/sharedParent" should exist
     And as "Brian" file "Shares/sharedParent/child/lorem.txt" should exist
@@ -611,7 +595,10 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
     And user "Brian" moves folder "/Shares/parent" to "/Shares/sharedParent" using the WebDAV API
     And user "Alice" shares folder "parent" with user "Brian" with permissions "read" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
+    # Note: Brian has already accepted the share of this resource as a member of "grp".
+    #       Now he has also received the same resource shared directly to "Brian".
+    #       The server should effectively "auto-accept" this new "copy" of the resource
+    #       and present to Brian only the single resource "Shares/sharedParent"
     Then as "Brian" folder "Shares/parent" should not exist
     And as "Brian" folder "Shares/sharedParent" should exist
     And as "Brian" file "Shares/sharedParent/child/lorem.txt" should exist

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedMultipleWaysIssue39347.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedMultipleWaysIssue39347.feature
@@ -33,7 +33,8 @@ Feature: share resources where the sharee receives the share in multiple ways
       | 1               |
       | 2               |
 
-
+  # Note: after fixing the bug, this scenario is no longer relevant.
+  #       Brian should not get a chance to decline (or accept) the 2nd share of the resource from Alice
   Scenario Outline: Share receiver renames the received group share and declines another share of same folder through user share again
     Given using OCS API version "<ocs_api_version>"
     And group "grp" has been created
@@ -80,7 +81,7 @@ Feature: share resources where the sharee receives the share in multiple ways
       | 2               |
 
 
-  Scenario Outline:Share receiver renames a group share and receives same resource through user share with additional permissions
+  Scenario Outline: Share receiver renames a group share and receives same resource through user share with less permissions
     Given using OCS API version "<ocs_api_version> "
     And group "grp" has been created
     And user "Brian" has been added to group "grp"


### PR DESCRIPTION
## Description
See comment https://github.com/owncloud/ocis/issues/2711#issuecomment-1076444442 

When the same resource is received by the same user, for example, because they are a member of a group and also the share has been personally shared with them, then there should not be any need for the user to accept the 2nd share of the resource - they have already accepted the resource. The new received share should be "auto-merged" into the existing received share/resource. (So the user might get higher level access to the resource, but will still see he resource only once.)

The test scenarios have been adjusted to reflect the desired behavior.

oCIS and oC10 behavior can be adjusted to match the expectation of these test scenarios.

## Related Issue
#39347 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
