### PR TITLE
[tests-only][full-ci] Improve Then step in apiWebdavLocks2 suite

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
@@ -18,11 +18,9 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
+    And user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
+    Then the HTTP status code of responses on all endpoints should be "423"
     And as "Alice" file "/PARENT/textfile.txt" should not exist
     Examples:
       | dav-path | lock-scope |
@@ -41,11 +39,9 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/parent.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/parent.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/parent.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
+    And user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/parent.txt" using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/parent.txt" using the WebDAV API
+    Then the HTTP status code of responses on all endpoints should be "423"
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
     Examples:
       | dav-path | lock-scope |
@@ -76,15 +72,13 @@ Feature: lock should propagate correctly if a share is reshared
     Given using <dav-path> DAV path
     And user "Alice" has shared folder "PARENT" with user "Brian"
     And user "Brian" has shared folder "PARENT (2)" with user "Carol"
-    When user "Brian" moves folder "/PARENT (2)" to "/PARENT-renamed" using the WebDAV API
-    And user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
+    And user "Brian" has moved folder "/PARENT (2)" to "/PARENT-renamed"
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
-    And user "Carol" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT-renamed/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
+    When user "Carol" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
+    And user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT-renamed/textfile.txt" using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
+    Then the HTTP status code of responses on all endpoints should be "423"
     And as "Alice" file "/PARENT/textfile.txt" should not exist
     Examples:
       | dav-path | lock-scope |
@@ -100,11 +94,9 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Brian" has locked folder "PARENT (2)" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
+    And user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT (2)/textfile.txt" using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
+    Then the HTTP status code of responses on all endpoints should be "423"
     And as "Alice" file "/PARENT/textfile.txt" should not exist
     Examples:
       | dav-path | lock-scope |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -22,11 +22,9 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
+    And user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
+    Then the HTTP status code of responses on all endpoints should be "423"
     And as "Alice" file "/PARENT/textfile.txt" should not exist
     Examples:
       | dav-path | lock-scope |
@@ -54,11 +52,9 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/parent.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/parent.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/parent.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
+    And user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/parent.txt" using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/parent.txt" using the WebDAV API
+    Then the HTTP status code of responses on all endpoints should be "423"
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
     Examples:
       | dav-path | lock-scope |
@@ -100,15 +96,13 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Brian" has accepted share "/PARENT" offered by user "Alice"
     And user "Brian" has shared folder "Shares/PARENT" with user "Carol"
     And user "Carol" has accepted share "/PARENT" offered by user "Brian"
-    When user "Brian" moves folder "/Shares/PARENT" to "/PARENT-renamed" using the WebDAV API
-    And user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
+    And user "Brian" has moved folder "/Shares/PARENT" to "/PARENT-renamed"
+    And user "Alice" has locked folder "PARENT" setting the following properties
       | lockscope | <lock-scope> |
-    And user "Carol" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT-renamed/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
+    When user "Carol" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
+    And user "Brian" uploads file "filesForUpload/textfile.txt" to "/PARENT-renamed/textfile.txt" using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
+    Then the HTTP status code of responses on all endpoints should be "423"
     And as "Alice" file "/PARENT/textfile.txt" should not exist
     Examples:
       | dav-path | lock-scope |
@@ -133,11 +127,9 @@ Feature: lock should propagate correctly if a share is reshared
     And user "Brian" has locked folder "Shares/PARENT" setting the following properties
       | lockscope | <lock-scope> |
     When user "Carol" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
-    When user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
-    Then the HTTP status code should be "423"
+    And user "Brian" uploads file "filesForUpload/textfile.txt" to "/Shares/PARENT/textfile.txt" using the WebDAV API
+    And user "Alice" uploads file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt" using the WebDAV API
+    Then the HTTP status code of responses on all endpoints should be "423"
     And as "Alice" file "/PARENT/textfile.txt" should not exist
     Examples:
       | dav-path | lock-scope |

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -14,18 +14,10 @@ Feature: set timeouts of LOCKS
     And parameter "lock_timeout_max" of app "core" has been set to "<max-timeout>"
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | exclusive |
-    And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response should match "<result>"
+    Then the HTTP status code should be "200"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/CHILD" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/parent.txt" should match "<result>"
     # consider a drift of up to 9 seconds between setting the lock and retrieving it
     Examples:
       | dav-path | default-timeout | max-timeout | result                     |
@@ -46,18 +38,10 @@ Feature: set timeouts of LOCKS
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
-    And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
+    Then the HTTP status code should be "200"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/CHILD" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/parent.txt" should match "<result>"
     Examples:
       | dav-path | timeout         | result          |
       | old      | second-999      | /Second-\d{3}$/ |
@@ -88,18 +72,10 @@ Feature: set timeouts of LOCKS
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
-    And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response should match "<result>"
+    Then the HTTP status code should be "200"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/CHILD" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/parent.txt" should match "<result>"
     Examples:
       | dav-path | timeout      | default-timeout | max-timeout | result                     |
       | old      | second-600   | 120             | 3600        | /Second-(600\|59[1-9])$/   |
@@ -132,18 +108,10 @@ Feature: set timeouts of LOCKS
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
-    And the public gets the following properties of entry "/" in the last created public link using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
-    When the public gets the following properties of entry "/CHILD" in the last created public link using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
-    When the public gets the following properties of entry "/parent.txt" in the last created public link using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
+    Then the HTTP status code should be "200"
+    And as a public the lock discovery property "//d:timeout" of the folder "/" should match "<result>"
+    And as a public the lock discovery property "//d:timeout" of the folder "/CHILD" should match "<result>"
+    And as a public the lock discovery property "//d:timeout" of the folder "/parent.txt" should match "<result>"
     Examples:
       | dav-path | timeout         | result          |
       | old      | second-999      | /Second-\d{3}$/ |

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
@@ -20,18 +20,10 @@ Feature: set timeouts of LOCKS on shares
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
-    And user "Brian" gets the following properties of folder "PARENT (2)" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Brian" should match "<result>"
-    When user "Brian" gets the following properties of folder "PARENT (2)/CHILD" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Brian" should match "<result>"
-    When user "Brian" gets the following properties of folder "PARENT (2)/parent.txt" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Brian" should match "<result>"
+    Then the HTTP status code should be "200"
+    And as user "Brian" the lock discovery property "//d:timeout" of the folder "PARENT (2)" should match "<result>"
+    And as user "Brian" the lock discovery property "//d:timeout" of the folder "PARENT (2)/CHILD" should match "<result>"
+    And as user "Brian" the lock discovery property "//d:timeout" of the folder "PARENT (2)/parent.txt" should match "<result>"
     Examples:
       | dav-path | timeout         | result          |
       | old      | second-999      | /Second-\d{3}$/ |
@@ -52,18 +44,10 @@ Feature: set timeouts of LOCKS on shares
     When user "Brian" locks folder "PARENT (2)" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
-    And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
+    Then the HTTP status code should be "200"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/CHILD" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/parent.txt" should match "<result>"
     Examples:
       | dav-path | timeout         | result          |
       | old      | second-999      | /Second-\d{3}$/ |

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -23,18 +23,10 @@ Feature: set timeouts of LOCKS on shares
     When user "Alice" locks folder "PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
-    And user "Brian" gets the following properties of folder "Shares/PARENT" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Brian" should match "<result>"
-    When user "Brian" gets the following properties of folder "Shares/PARENT/CHILD" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Brian" should match "<result>"
-    When user "Brian" gets the following properties of folder "Shares/PARENT/parent.txt" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Brian" should match "<result>"
+    Then the HTTP status code should be "200"
+    And as user "Brian" the lock discovery property "//d:timeout" of the folder "Shares/PARENT" should match "<result>"
+    And as user "Brian" the lock discovery property "//d:timeout" of the folder "Shares/PARENT/CHILD" should match "<result>"
+    And as user "Brian" the lock discovery property "//d:timeout" of the folder "Shares/PARENT/parent.txt" should match "<result>"
     Examples:
       | dav-path | timeout         | result          |
       | old      | second-999      | /Second-\d{3}$/ |
@@ -65,18 +57,10 @@ Feature: set timeouts of LOCKS on shares
     When user "Brian" locks folder "Shares/PARENT" using the WebDAV API setting the following properties
       | lockscope | shared    |
       | timeout   | <timeout> |
-    And user "Alice" gets the following properties of folder "PARENT" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/CHILD" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
-    When user "Alice" gets the following properties of folder "PARENT/parent.txt" using the WebDAV API
-      | propertyName    |
-      | d:lockdiscovery |
-    Then the value of the item "//d:timeout" in the response to user "Alice" should match "<result>"
+    Then the HTTP status code should be "200"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/CHILD" should match "<result>"
+    And as user "Alice" the lock discovery property "//d:timeout" of the folder "PARENT/parent.txt" should match "<result>"
     Examples:
       | dav-path | timeout         | result          |
       | old      | second-999      | /Second-\d{3}$/ |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -3063,6 +3063,8 @@ trait Sharing {
 			200,
 			__METHOD__ . " could not $actionText share $share to $user by $offeredBy"
 		);
+		$this->emptyLastHTTPStatusCodesArray();
+		$this->emptyLastOCSStatusCodesArray();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1897,7 +1897,6 @@ trait WebDav {
 		?array $properties = null,
 		string $type = "files"
 	):ResponseInterface {
-		$user = $this->getActualUsername($user);
 		if ($this->customDavPath !== null) {
 			$path = $this->customDavPath . $path;
 		}
@@ -2056,6 +2055,7 @@ trait WebDav {
 		$this->setResponseXml(
 			HttpRequestHelper::parseResponseAsXml($this->response)
 		);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -2073,6 +2073,7 @@ trait WebDav {
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$source' to '$destination' for user '$user'"
 		);
+		$this->emptyLastHTTPStatusCodesArray();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -313,7 +313,7 @@ class WebDavPropertiesContext implements Context {
 				$path,
 				'0',
 				$properties,
-				"public-files"
+				$this->featureContext->getDavPathVersion() === 1 ? "public-files" : "public-files-new"
 			)
 		);
 	}
@@ -754,6 +754,28 @@ class WebDavPropertiesContext implements Context {
 	}
 
 	/**
+	 * @Then /^as a public the lock discovery property "([^"]*)" of the (?:file|folder|entry) "([^"]*)" should match "([^"]*)"$/
+	 *
+	 * @param string $xpath
+	 * @param string $path
+	 * @param string $pattern
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function publicGetsThePropertiesOfFolderAndAssertValueOfItemInResponseRegExp(string $xpath, string $path, string $pattern):void {
+		$propertiesTable = new TableNode([['propertyName'],['d:lockdiscovery']]);
+		$this->publicGetsThePropertiesOfFolder($path, $propertiesTable);
+
+		$this->featureContext->theHTTPStatusCodeShouldBe('200');
+		$this->assertValueOfItemInResponseToUserRegExp(
+			$xpath,
+			null,
+			$pattern
+		);
+	}
+
+	/**
 	 * @Then there should be an entry with href matching :pattern in the response to user :user
 	 *
 	 * @param string $pattern
@@ -830,6 +852,33 @@ class WebDavPropertiesContext implements Context {
 			$value,
 			"item \"$xpath\" found with value \"$value\", " .
 			"expected to match regex pattern: \"$pattern\""
+		);
+	}
+
+	/**
+	 * @Then /^as user "([^"]*)" the lock discovery property "([^"]*)" of the (?:file|folder|entry) "([^"]*)" should match "([^"]*)"$/
+	 *
+	 * @param string|null $user
+	 * @param string $xpath
+	 * @param string $path
+	 * @param string $pattern
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userGetsPropertiesOfFolderAndAssertValueOfItemInResponseToUserRegExp(string $user, string $xpath, string $path, string $pattern):void {
+		$propertiesTable = new TableNode([['propertyName'],['d:lockdiscovery']]);
+		$this->userGetsPropertiesOfFolder(
+			$user,
+			$path,
+			$propertiesTable
+		);
+
+		$this->featureContext->theHTTPStatusCodeShouldBe('200');
+		$this->assertValueOfItemInResponseToUserRegExp(
+			$xpath,
+			$user,
+			$pattern
 		);
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first to be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adds `Then` steps to existing API test scenarios to better check the results of the `When` steps.
Adds new Then step which get `file/folder` property value and check its content 

**Suites covered:**
- `apiWebdavLocks2`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/core/issues/39512


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
