### PR TITLE
[tests-only][full-ci]Improve Then steps in `apiShareCreateSpecialToRoot2` suite

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
@@ -10,12 +10,12 @@ Feature: shares are received in the default folder for received shares
     And user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "<share_folder>"
     And user "Alice" has created folder "FOLDER"
-    When user "Alice" shares folder "/FOLDER" with user "Brian" using the sharing API
-    And user "Brian" unshares folder "ReceivedShares/FOLDER" using the WebDAV API
-    And user "Brian" shares folder "/ReceivedShares" with user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
+    And user "Alice" has shared folder "/FOLDER" with user "Brian"
+    And user "Brian" has unshared folder "ReceivedShares/FOLDER"
+    When user "Brian" shares folder "/ReceivedShares" with user "Alice" using the sharing API
+    Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code | share_folder    |
-      | 1               | 404             | 200              | /ReceivedShares |
-      | 2               | 404             | 404              | /ReceivedShares |
+      | ocs_api_version | http_status_code | share_folder    |
+      | 1               | 200              | /ReceivedShares |
+      | 2               | 404              | /ReceivedShares |

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupCaseSensitive.feature
@@ -22,16 +22,12 @@ Feature: share with groups, group names are case-sensitive
     And user "Carol" has been added to group "<group_id2>"
     And user "David" has been added to group "<group_id3>"
     When user "Alice" shares file "textfile1.txt" with group "<group_id1>" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
+    And user "Alice" shares file "textfile2.txt" with group "<group_id2>" using the sharing API
+    And user "Alice" shares file "textfile3.txt" with group "<group_id3>" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"
+    And the HTTP status code of responses on all endpoints should be "200"
     And the content of file "textfile1.txt" for user "Brian" should be "ownCloud test text file 1"
-    When user "Alice" shares folder "textfile2.txt" with group "<group_id2>" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
     And the content of file "textfile2.txt" for user "Carol" should be "ownCloud test text file 2"
-    When user "Alice" shares folder "textfile3.txt" with group "<group_id3>" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
     And the content of file "textfile3.txt" for user "David" should be "ownCloud test text file 3"
     Examples:
       | ocs_api_version | group_id1            | group_id2            | group_id3            | ocs_status_code |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1573,6 +1573,7 @@ trait Sharing {
 			$group,
 			$permissions
 		);
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds ``` Then ``` steps to existing API test scenarios to better check the results of ``` When ``` steps.

### Suite Covered
- ```apiShareCreateSpecialToRoot2```

## Related Issues
- Part of https://github.com/owncloud/core/issues/39512

## How Has This Been Tested?
- Locally
- CI

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
