### PR TITLE
[tests-only][full-ci]Improve then steps usages inside acceptance tests suite apiTrashbin

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -22,10 +22,8 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "<filename2>"
     When user "Alice" empties the trashbin using the trashbin API
     Then the HTTP status code should be "204"
-    And as "Alice" the files with following original paths should not exist in the trashbin
-      | path        |
-      | <filename1> |
-      | <filename2> |
+    And as "Alice" the file with original path "<filename1>" should not exist in the trashbin
+    And as "Alice" the file with original path "<filename2>" should not exist in the trashbin
     Examples:
       | dav-path | filename1     | filename2     |
       | old      | textfile0.txt | textfile1.txt |
@@ -56,19 +54,13 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/child.txt"
     And user "Alice" has deleted file "/PARENT/textfile0.txt"
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
-    When user "Alice" deletes the following files with original path from the trashbin
-      | path                    |
-      | /PARENT/textfile0.txt   |
-      | /PARENT/CHILD/child.txt |
+    When user "Alice" deletes the file with original path "/PARENT/textfile0.txt" from the trashbin using the trashbin API
+    And user "Alice" deletes the file with original path "/PARENT/CHILD/child.txt" from the trashbin using the trashbin API
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the files with following original paths should not exist in the trashbin
-      | path        |
-      | /PARENT/textfile0.txt |
-      | /PARENT/CHILD/child.txt |
-    But as "Alice" the files with following original paths should exist in the trashbin
-      | path              |
-      | textfile0.txt     |
-      | /PARENT/child.txt |
+    And as "Alice" the file with original path "/PARENT/textfile0.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should not exist in the trashbin
+    But as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/child.txt" should exist in the trashbin
 
   @skipOnOcV10.3
   Scenario: User tries to delete another user's trashbin
@@ -79,12 +71,10 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
     When user "Brian" tries to delete the file with original path "textfile1.txt" from the trashbin of user "Alice" using the trashbin API
     Then the HTTP status code should be "401"
-    And as "Alice" the files with following original paths should exist in the trashbin
-      | path                    |
-      | /textfile0.txt          |
-      | /textfile1.txt          |
-      | /PARENT/parent.txt      |
-      | /PARENT/CHILD/child.txt |
+    And as "Alice" the file with original path "/textfile1.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
 
   Scenario: User tries to delete trashbin file using invalid password
     Given user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -20,11 +20,12 @@ Feature: files and folders can be deleted from the trashbin
     And using <dav-path> DAV path
     And user "Alice" has deleted file "<filename1>"
     And user "Alice" has deleted file "<filename2>"
-    And as "Alice" file "<filename1>" should exist in the trashbin
-    And as "Alice" file "<filename2>" should exist in the trashbin
     When user "Alice" empties the trashbin using the trashbin API
-    Then as "Alice" the file with original path "<filename1>" should not exist in the trashbin
-    And as "Alice" the file with original path "<filename2>" should not exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the files with following original paths should not exist in the trashbin
+      | path        |
+      | <filename1> |
+      | <filename2> |
     Examples:
       | dav-path | filename1     | filename2     |
       | old      | textfile0.txt | textfile1.txt |
@@ -55,12 +56,19 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/child.txt"
     And user "Alice" has deleted file "/PARENT/textfile0.txt"
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
-    When user "Alice" deletes the file with original path "/PARENT/textfile0.txt" from the trashbin using the trashbin API
-    And user "Alice" deletes the file with original path "/PARENT/CHILD/child.txt" from the trashbin using the trashbin API
-    Then as "Alice" the file with original path "/PARENT/textfile0.txt" should not exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should not exist in the trashbin
-    But as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/child.txt" should exist in the trashbin
+    When user "Alice" deletes the following files with original path from the trashbin
+      | path                    |
+      | /PARENT/textfile0.txt   |
+      | /PARENT/CHILD/child.txt |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the files with following original paths should not exist in the trashbin
+      | path        |
+      | /PARENT/textfile0.txt |
+      | /PARENT/CHILD/child.txt |
+    But as "Alice" the files with following original paths should exist in the trashbin
+      | path              |
+      | textfile0.txt     |
+      | /PARENT/child.txt |
 
   @skipOnOcV10.3
   Scenario: User tries to delete another user's trashbin
@@ -71,10 +79,12 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
     When user "Brian" tries to delete the file with original path "textfile1.txt" from the trashbin of user "Alice" using the trashbin API
     Then the HTTP status code should be "401"
-    And as "Alice" the file with original path "/textfile1.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    And as "Alice" the files with following original paths should exist in the trashbin
+      | path                    |
+      | /textfile0.txt          |
+      | /textfile1.txt          |
+      | /PARENT/parent.txt      |
+      | /PARENT/CHILD/child.txt |
 
   Scenario: User tries to delete trashbin file using invalid password
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -136,7 +146,8 @@ Feature: files and folders can be deleted from the trashbin
 
 
   Scenario Outline: delete files with special characters from the trashbin
-    Given user "Alice" has uploaded the following files with content "special character file"
+    Given using <dav-path> DAV path
+    And user "Alice" has uploaded the following files with content "special character file"
       | path             |
       | qa&dev.txt       |
       | !@tester$^.txt   |
@@ -168,7 +179,8 @@ Feature: files and folders can be deleted from the trashbin
 
 
   Scenario Outline: delete folders with special characters from the trashbin
-    Given user "Alice" has created the following folders
+    Given using <dav-path> DAV path
+    And user "Alice" has created the following folders
       | path         |
       | qa&dev       |
       | !@tester$^   |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -12,7 +12,8 @@ Feature: files and folders exist in the trashbin after being deleted
   Scenario Outline: deleting a file moves it to trashbin
     Given using <dav-path> DAV path
     When user "Alice" deletes file "/textfile0.txt" using the WebDAV API
-    Then as "Alice" file "/textfile0.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" file "/textfile0.txt" should exist in the trashbin
     But as "Alice" file "/textfile0.txt" should not exist
     Examples:
       | dav-path |
@@ -24,7 +25,8 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/tmp"
     When user "Alice" deletes folder "/tmp" using the WebDAV API
-    Then as "Alice" folder "/tmp" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" folder "/tmp" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -35,7 +37,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     When user "Alice" deletes file "/new-folder/new-file.txt" using the WebDAV API
-    Then as "Alice" the file with original path "/new-folder/new-file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "/new-folder/new-file.txt" should exist in the trashbin
     And as "Alice" file "/new-file.txt" should exist in the trashbin
     But as "Alice" file "/new-folder/new-file.txt" should not exist
     Examples:
@@ -51,7 +54,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with user "Brian"
     When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
-    Then as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     And as "Alice" file "/shared_file.txt" should exist in the trashbin
     But as "Alice" file "/shared/shared_file.txt" should not exist
     Examples:
@@ -67,7 +71,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with user "Brian"
     When user "Alice" deletes folder "/shared" using the WebDAV API
-    Then as "Alice" the folder with original path "/shared" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the folder with original path "/shared" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -94,11 +99,13 @@ Feature: files and folders exist in the trashbin after being deleted
       | /folderB/textfile0.txt |
       | /folderC/textfile0.txt |
       | /folderD/textfile0.txt |
-    Then as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the folders with following original paths should exist in the trashbin
+      | path                   |
+      | /folderA/textfile0.txt |
+      | /folderB/textfile0.txt |
+      | /folderC/textfile0.txt |
+      | /textfile0.txt         |
     Examples:
       | dav-path |
       | old      |
@@ -111,12 +118,17 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has created folder "/folderB"
     And user "Alice" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
     And user "Alice" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-    When user "Alice" deletes file "/folderA/textfile0.txt" using the WebDAV API
-    And user "Alice" deletes file "/folderB/textfile0.txt" using the WebDAV API
-    And user "Alice" deletes file "/textfile0.txt" using the WebDAV API
-    Then as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    When user "Alice" deletes the following files
+      | path                   |
+      | /folderA/textfile0.txt |
+      | /folderB/textfile0.txt |
+      | /textfile0.txt         |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the folders with following original paths should exist in the trashbin
+      | path                   |
+      | /folderA/textfile0.txt |
+      | /folderB/textfile0.txt |
+      | /textfile0.txt         |
     Examples:
       | dav-path |
       | old      |
@@ -131,7 +143,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has created folder "/local_storage/tmp"
     And user "Alice" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     When user "Alice" deletes folder "/local_storage/tmp" using the WebDAV API
-    Then as "Alice" the folder with original path "/local_storage/tmp" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the folder with original path "/local_storage/tmp" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -235,7 +248,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "<username>" has uploaded file with content "to delete" to "/textfile0.txt"
     And using <dav-path> DAV path
     When user "<username>" deletes file "/textfile0.txt" using the WebDAV API
-    Then as "<username>" file "/textfile0.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "<username>" file "/textfile0.txt" should exist in the trashbin
     But as "<username>" file "/textfile0.txt" should not exist
     Examples:
       | dav-path | username |
@@ -256,7 +270,8 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "file with comma in filename" to "sample,1.txt"
     When user "Alice" deletes file "sample,1.txt" using the WebDAV API
-    Then as "Alice" file "sample,1.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" file "sample,1.txt" should exist in the trashbin
     But as "Alice" file "sample,1.txt" should not exist
     Examples:
       | dav-path |
@@ -269,7 +284,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/new-folder/new-file.txt"
     When user "Alice" deletes folder "/new-folder" using the WebDAV API
-    Then as "Alice" the file with original path "/new-folder/new-file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "/new-folder/new-file.txt" should exist in the trashbin
     And as "Alice" the folder with original path "/new-folder" should exist in the trashbin
     And as "Alice" file "/new-folder/new-file.txt" should exist in the trashbin
     But as "Alice" file "/new-folder/new-file.txt" should not exist
@@ -284,7 +300,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2018 04:18:13 GMT" using the WebDAV API
     And user "Alice" has deleted file "file.txt"
     When user "Alice" tries to list the trashbin content for user "Alice"
-    Then the deleted file "file.txt" should have the correct deletion mtime in the response
+    Then the HTTP status code should be "207"
+    And the deleted file "file.txt" should have the correct deletion mtime in the response
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -100,12 +100,11 @@ Feature: files and folders exist in the trashbin after being deleted
       | /folderC/textfile0.txt |
       | /folderD/textfile0.txt |
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the folders with following original paths should exist in the trashbin
-      | path                   |
-      | /folderA/textfile0.txt |
-      | /folderB/textfile0.txt |
-      | /folderC/textfile0.txt |
-      | /textfile0.txt         |
+    And as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -118,17 +117,13 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has created folder "/folderB"
     And user "Alice" has copied file "/textfile0.txt" to "/folderA/textfile0.txt"
     And user "Alice" has copied file "/textfile0.txt" to "/folderB/textfile0.txt"
-    When user "Alice" deletes the following files
-      | path                   |
-      | /folderA/textfile0.txt |
-      | /folderB/textfile0.txt |
-      | /textfile0.txt         |
+    When user "Alice" deletes file "/folderA/textfile0.txt" using the WebDAV API
+    And user "Alice" deletes file "/folderB/textfile0.txt" using the WebDAV API
+    And user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the folders with following original paths should exist in the trashbin
-      | path                   |
-      | /folderA/textfile0.txt |
-      | /folderB/textfile0.txt |
-      | /textfile0.txt         |
+    And as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
@@ -30,6 +30,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | /folderB/textfile0.txt |
       | /folderC/textfile0.txt |
       | /folderD/textfile0.txt |
+    Then the HTTP status code of responses on all endpoints should be "204"
     # When issue-23151 is fixed, uncomment these lines. They should pass reliably.
     # These files may or may not exist in the trashbin
 #    Then as "Alice" the folder with original path "/folderA/textfile0.txt" should not exist in the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -14,7 +14,8 @@ Feature: using trashbin together with sharing
     And user "Alice" has shared folder "/shared" with user "Brian"
     And user "Brian" has moved folder "/shared" to "/renamed_shared"
     When user "Brian" deletes folder "/renamed_shared" using the WebDAV API
-    Then as "Brian" the folder with original path "/renamed_shared" should not exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Brian" the folder with original path "/renamed_shared" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -29,7 +30,8 @@ Feature: using trashbin together with sharing
     And user "Alice" has shared folder "/shared" with user "Brian"
     And user "Brian" has moved file "/shared" to "/renamed_shared"
     When user "Brian" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
-    Then as "Brian" the file with original path "/renamed_shared/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Brian" the file with original path "/renamed_shared/shared_file.txt" should exist in the trashbin
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     Examples:
       | dav-path |
@@ -48,7 +50,8 @@ Feature: using trashbin together with sharing
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with group "grp1"
     When user "Brian" deletes file "/shared/shared_file.txt" using the WebDAV API
-    Then as "Brian" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Brian" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     And as "Carol" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
     Examples:
@@ -68,7 +71,8 @@ Feature: using trashbin together with sharing
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared folder "/shared" with group "grp1"
     When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
-    Then as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     And as "Brian" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
     And as "Carol" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
     Examples:
@@ -89,7 +93,8 @@ Feature: using trashbin together with sharing
     And user "Alice" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
     And user "Alice" has shared folder "/shared" with group "grp1"
     When user "Brian" deletes folder "/shared/sub" using the WebDAV API
-    Then as "Brian" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Brian" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
     And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
     And as "Carol" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
@@ -110,7 +115,8 @@ Feature: using trashbin together with sharing
     And user "Alice" has moved file "/textfile0.txt" to "/shared/sub/shared_file.txt"
     And user "Alice" has shared folder "/shared" with group "grp1"
     When user "Alice" deletes folder "/shared/sub" using the WebDAV API
-    Then as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
     And as "Brian" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
     And as "Carol" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -17,7 +17,8 @@ Feature: using trashbin together with sharing
     And user "Brian" has accepted share "/shared" offered by user "Alice"
     And user "Brian" has moved folder "/Shares/shared" to "/Shares/renamed_shared"
     When user "Brian" deletes folder "/Shares/renamed_shared" using the WebDAV API
-    Then as "Brian" the folder with original path "/Shares/renamed_shared" should not exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Brian" the folder with original path "/Shares/renamed_shared" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -33,7 +34,8 @@ Feature: using trashbin together with sharing
     And user "Brian" has accepted share "/shared" offered by user "Alice"
     And user "Brian" has moved file "/Shares/shared" to "/Shares/renamed_shared"
     When user "Brian" deletes file "/Shares/renamed_shared/shared_file.txt" using the WebDAV API
-    Then as "Brian" the file with original path "/Shares/renamed_shared/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Brian" the file with original path "/Shares/renamed_shared/shared_file.txt" should exist in the trashbin
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     Examples:
       | dav-path |
@@ -54,7 +56,8 @@ Feature: using trashbin together with sharing
     And user "Brian" has accepted share "/Shares/shared" offered by user "Alice"
     And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
     When user "Brian" deletes file "/Shares/shared/shared_file.txt" using the WebDAV API
-    Then as "Brian" the file with original path "/Shares/shared/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Brian" the file with original path "/Shares/shared/shared_file.txt" should exist in the trashbin
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
     Examples:
@@ -76,7 +79,8 @@ Feature: using trashbin together with sharing
     And user "Brian" has accepted share "/Shares/shared" offered by user "Alice"
     And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
     When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
-    Then as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     And as "Brian" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
     And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
     Examples:
@@ -99,7 +103,8 @@ Feature: using trashbin together with sharing
     And user "Brian" has accepted share "/Shares/shared" offered by user "Alice"
     And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
     When user "Brian" deletes file "/Shares/shared/sub/shared_file.txt" using the WebDAV API
-    Then as "Brian" the file with original path "/Shares/shared/sub/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Brian" the file with original path "/Shares/shared/sub/shared_file.txt" should exist in the trashbin
     And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
     And as "Carol" the file with original path "/Shares/sub/shared/shared_file.txt" should not exist in the trashbin
     Examples:
@@ -122,7 +127,8 @@ Feature: using trashbin together with sharing
     And user "Brian" has accepted share "/Shares/shared" offered by user "Alice"
     And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
     When user "Alice" deletes file "/shared/sub/shared_file.txt" using the WebDAV API
-    Then as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
     And as "Brian" the file with original path "/Shares/shared/sub/shared_file.txt" should not exist in the trashbin
     And as "Carol" the file with original path "/Shares/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:

--- a/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
@@ -18,13 +18,11 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | php       |
       | go        |
     And using <dav-path> DAV path
-    And user "Alice" has uploaded the following files
-      | path       | content              |
-      | sample.txt | sample delete file 1 |
-      | sample.dat | sample delete file 2 |
-      | sample.php | sample delete file 3 |
-      | sample.go  | sample delete file 4 |
-      | sample.py  | sample delete file 5 |
+    And user "Alice" has uploaded file with content "sample delete file 1" to "sample.txt"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "sample.dat"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "sample.php"
+    And user "Alice" has uploaded file with content "sample delete file 4" to "sample.go"
+    And user "Alice" has uploaded file with content "sample delete file 5" to "sample.py"
     When user "Alice" deletes the following files
       | path       |
       | sample.txt |
@@ -35,11 +33,9 @@ Feature: files and folders can be deleted completely skipping the trashbin
     Then the HTTP status code of responses on all endpoints should be "204"
     And as "Alice" file "sample.txt" should exist in the trashbin
     And as "Alice" file "sample.py" should exist in the trashbin
-    But as "Alice" the files with following original paths should not exist in the trashbin
-      | path       |
-      | sample.dat |
-      | sample.php |
-      | sample.go  |
+    But as "Alice" the file with original path "/sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "/sample.php" should not exist in the trashbin
+    And as "Alice" the file with original path "/sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -53,13 +49,11 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | php       |
       | go        |
     And using <dav-path> DAV path
-    And user "Alice" has uploaded the following files
-      | path               | content              |
-      | /PARENT/sample.txt | sample delete file 1 |
-      | /PARENT/sample.dat | sample delete file 2 |
-      | /PARENT/sample.php | sample delete file 3 |
-      | /PARENT/sample.go  | sample delete file 4 |
-      | /PARENT/sample.py  | sample delete file 5 |
+    And user "Alice" has uploaded file with content "sample delete file 1" to "PARENT/sample.txt"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "PARENT/sample.php"
+    And user "Alice" has uploaded file with content "sample delete file 4" to "PARENT/sample.go"
+    And user "Alice" has uploaded file with content "sample delete file 5" to "PARENT/sample.py"
     When user "Alice" deletes the following files
       | path              |
       | PARENT/sample.txt |
@@ -68,15 +62,11 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | PARENT/sample.go  |
       | PARENT/sample.py  |
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the folders with following original paths should exist in the trashbin
-      | path               |
-      | /PARENT/sample.txt |
-      | /PARENT/sample.py  |
-    But as "Alice" the files with following original paths should not exist in the trashbin
-      | path               |
-      | /PARENT/sample.dat |
-      | /PARENT/sample.php |
-      | /PARENT/sample.go  |
+    And as "Alice" the file with original path "/PARENT/sample.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/sample.py" should exist in the trashbin
+    But as "Alice" the file with original path "/PARENT/sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/sample.php" should not exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -90,18 +80,16 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | php       |
       | go        |
     And using <dav-path> DAV path
-    And user "Alice" has uploaded the following files
-      | path       | content              |
-      | sample.txt | sample delete file 1 |
-      | sample.dat | sample delete file 2 |
-      | sample.php | sample delete file 3 |
-      | sample.go  | sample delete file 4 |
-      | sample.py  | sample delete file 5 |
-      | sample.TXT | sample delete file 1 |
-      | sample.DAT | sample delete file 2 |
-      | sample.PHP | sample delete file 3 |
-      | sample.GO  | sample delete file 4 |
-      | sample.PY  | sample delete file 5 |
+    And user "Alice" has uploaded file with content "sample delete file 1" to "sample.TXT"
+    And user "Alice" has uploaded file with content "sample delete file 1" to "sample.txt"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "sample.DAT"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "sample.dat"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "sample.PHP"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "sample.php"
+    And user "Alice" has uploaded file with content "sample delete file 4" to "sample.GO"
+    And user "Alice" has uploaded file with content "sample delete file 4" to "sample.go"
+    And user "Alice" has uploaded file with content "sample delete file 5" to "sample.PY"
+    And user "Alice" has uploaded file with content "sample delete file 5" to "sample.py"
     When user "Alice" deletes the following files
       | path       |
       | sample.TXT |
@@ -115,20 +103,16 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | sample.PY  |
       | sample.py  |
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the files with following original paths should exist in the trashbin
-      | path       |
-      | sample.txt |
-      | sample.TXT |
-      | sample.py  |
-      | sample.PY  |
-    But as "Alice" the files with following original paths should not exist in the trashbin
-      | path       |
-      | sample.dat |
-      | sample.php |
-      | sample.go  |
-      | sample.DAT |
-      | sample.PHP |
-      | sample.GO  |
+    And as "Alice" the file with original path "/sample.TXT" should exist in the trashbin
+    And as "Alice" the file with original path "/sample.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/sample.PY" should exist in the trashbin
+    And as "Alice" the file with original path "/sample.py" should exist in the trashbin
+    But as "Alice" the file with original path "/sample.DAT" should not exist in the trashbin
+    And as "Alice" the file with original path "/sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "/sample.PHP" should not exist in the trashbin
+    And as "Alice" the file with original path "/sample.php" should not exist in the trashbin
+    And as "Alice" the file with original path "/sample.GO" should not exist in the trashbin
+    And as "Alice" the file with original path "/sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -141,22 +125,18 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | php       |
       | go        |
     And using <dav-path> DAV path
-    And user "Alice" has uploaded the following files
-      | path               | content              |
-      | /PARENT/sample.txt | sample delete file 1 |
-      | /PARENT/sample.dat | sample delete file 2 |
-      | /PARENT/sample.php | sample delete file 3 |
-      | /PARENT/sample.go  | sample delete file 4 |
-      | /PARENT/sample.py  | sample delete file 5 |
+    And user "Alice" has uploaded file with content "sample delete file 1" to "PARENT/sample.txt"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "PARENT/sample.php"
+    And user "Alice" has uploaded file with content "sample delete file 4" to "PARENT/sample.go"
+    And user "Alice" has uploaded file with content "sample delete file 5" to "PARENT/sample.py"
     When user "Alice" deletes folder "PARENT" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the folders with following original paths should exist in the trashbin
-      | path               |
-      | /PARENT/sample.txt |
-      | /PARENT/sample.dat |
-      | /PARENT/sample.php |
-      | /PARENT/sample.go  |
-      | /PARENT/sample.py  |
+    And as "Alice" the file with original path "PARENT/sample.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.py" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.dat" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.php" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.go" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -169,13 +149,11 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | PARENT        |
       | simple-folder |
     And using <dav-path> DAV path
-    And user "Alice" has uploaded the following files
-      | path                      | content              |
-      | /sample.txt               | sample delete file 1 |
-      | /PARENT/sample.dat        | sample delete file 2 |
-      | /simple-folder/sample.php | sample delete file 3 |
-      | /simple-folder/sample.go  | sample delete file 4 |
-      | /lorem-folder/sample.py   | sample delete file 5 |
+    And user "Alice" has uploaded file with content "sample delete file 1" to "sample.txt"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "simple-folder/sample.php"
+    And user "Alice" has uploaded file with content "sample delete file 4" to "simple-folder/sample.go"
+    And user "Alice" has uploaded file with content "sample delete file 5" to "lorem-folder/sample.py"
     When user "Alice" deletes the following files
       | path                     |
       | sample.txt               |
@@ -184,15 +162,11 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | simple-folder/sample.go  |
       | lorem-folder/sample.py   |
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the files with following original paths should exist in the trashbin
-      | path       |
-      | sample.txt |
-      | lorem-folder/sample.py |
-    But as "Alice" the files with following original paths should not exist in the trashbin
-      | path                     |
-      | PARENT/sample.dat        |
-      | simple-folder/sample.php |
-      | simple-folder/sample.go  |
+    And as "Alice" the file with original path "sample.txt" should exist in the trashbin
+    And as "Alice" the file with original path "lorem-folder/sample.py" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
+    But as "Alice" the file with original path "simple-folder/sample.php" should not exist in the trashbin
+    And as "Alice" the file with original path "simple-folder/sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -205,20 +179,14 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | simple-folder |
     And using <dav-path> DAV path
     And user "Alice" has created folder "PARENT/simple-folder"
-    And user "Alice" has uploaded the following files
-      | path                          | content              |
-      | /PARENT/p.txt                 | sample delete file 1 |
-      | /PARENT/simple-folder/sub.txt | sample delete file 2 |
-      | /simple-folder/s.txt          | sample delete file 3 |
-    When user "Alice" deletes the following files
-      | path          |
-      | PARENT        |
-      | simple-folder |
+    And user "Alice" has uploaded file with content "sample delete file 1" to "PARENT/p.txt"
+    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/simple-folder/sub.txt"
+    And user "Alice" has uploaded file with content "sample delete file 3" to "simple-folder/s.txt"
+    When user "Alice" deletes folder "PARENT" using the WebDAV API
+    And user "Alice" deletes folder "simple-folder" using the WebDAV API
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the folders with following original paths should exist in the trashbin
-      | path                         |
-      | PARENT/p.txt                 |
-      | PARENT/simple-folder/sub.txt |
+    And as "Alice" the file with original path "PARENT/p.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/simple-folder/sub.txt" should exist in the trashbin
     But as "Alice" the file with original path "simple-folder/s.txt" should not exist in the trashbin
     Examples:
       | dav-path |
@@ -234,10 +202,8 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
     When user "Alice" deletes file "PARENT/sample.dat" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the folders with following original paths should not exist in the trashbin
-      | path              |
-      | PARENT            |
-      | PARENT/sample.dat |
+    And as "Alice" the file with original path "/PARENT" should not exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/sample.dat" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -279,10 +245,8 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And using <dav-path> DAV path
     And user "Alice" has uploaded file with content "sample" to "lorem.txt"
     And user "Alice" has uploaded file with content "sample delete file" to "lorem.dat"
-    When user "Alice" deletes the following files
-      | path      |
-      | lorem.txt |
-      | lorem.dat |
+    When user "Alice" deletes file "/lorem.txt" using the WebDAV API
+    And user "Alice" deletes file "/lorem.dat" using the WebDAV API
     Then the HTTP status code of responses on all endpoints should be "204"
     And as "Alice" the file with original path "lorem.txt" should exist in the trashbin
     But as "Alice" the file with original path "lorem.dat" should not exist in the trashbin
@@ -297,10 +261,8 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And using <dav-path> DAV path
     And user "Alice" has uploaded file with content "sample" to "PARENT/lorem.txt"
     And user "Alice" has uploaded file with content "sample delete file" to "PARENT/lorem.dat"
-    When user "Alice" deletes the following files
-      | path             |
-      | PARENT/lorem.txt |
-      | PARENT/lorem.dat |
+    When user "Alice" deletes file "PARENT/lorem.txt" using the WebDAV API
+    And user "Alice" deletes file "PARENT/lorem.dat" using the WebDAV API
     Then the HTTP status code of responses on all endpoints should be "204"
     And as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
     But as "Alice" the file with original path "PARENT/lorem.dat" should not exist in the trashbin
@@ -317,10 +279,8 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And user "Alice" has uploaded file with content "sample delete file" to "PARENT/lorem.dat"
     When user "Alice" deletes folder "PARENT" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the files with following original paths should exist in the trashbin
-      | path             |
-      | PARENT/lorem.txt |
-      | PARENT/lorem.dat |
+    And as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/lorem.dat" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -361,18 +321,14 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | PARENT/sample.lis        |
       | PARENT/sample.dat        |
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the files with following original paths should exist in the trashbin
-      | path                   |
-      | sample.txt             |
-      | lorem-folder/sample.go |
-    But as "Alice" the files with following original paths should not exist in the trashbin
-      | path                     |
-      | sample.dat               |
-      | lorem-folder/sample.dat  |
-      | PARENT/sample.txt        |
-      | simple-folder/sample.php |
-      | PARENT/sample.lis        |
-      | PARENT/sample.dat        |
+    And as "Alice" the file with original path "sample.txt" should exist in the trashbin
+    And as "Alice" the file with original path "lorem-folder/sample.go" should exist in the trashbin
+    But as "Alice" the file with original path "sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "lorem-folder/sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "simple-folder/sample.php" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.lis" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
@@ -17,12 +17,14 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | dat       |
       | php       |
       | go        |
-    And user "Alice" has uploaded file with content "sample delete file 1" to "sample.txt"
-    And user "Alice" has uploaded file with content "sample delete file 2" to "sample.dat"
-    And user "Alice" has uploaded file with content "sample delete file 3" to "sample.php"
-    And user "Alice" has uploaded file with content "sample delete file 4" to "sample.go"
-    And user "Alice" has uploaded file with content "sample delete file 5" to "sample.py"
     And using <dav-path> DAV path
+    And user "Alice" has uploaded the following files
+      | path       | content              |
+      | sample.txt | sample delete file 1 |
+      | sample.dat | sample delete file 2 |
+      | sample.php | sample delete file 3 |
+      | sample.go  | sample delete file 4 |
+      | sample.py  | sample delete file 5 |
     When user "Alice" deletes the following files
       | path       |
       | sample.txt |
@@ -30,11 +32,14 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | sample.php |
       | sample.go  |
       | sample.py  |
-    Then as "Alice" file "sample.txt" should exist in the trashbin
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" file "sample.txt" should exist in the trashbin
     And as "Alice" file "sample.py" should exist in the trashbin
-    But as "Alice" the file with original path "/sample.dat" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.php" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.go" should not exist in the trashbin
+    But as "Alice" the files with following original paths should not exist in the trashbin
+      | path       |
+      | sample.dat |
+      | sample.php |
+      | sample.go  |
     Examples:
       | dav-path |
       | old      |
@@ -47,12 +52,14 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | dat       |
       | php       |
       | go        |
-    And user "Alice" has uploaded file with content "sample delete file 1" to "PARENT/sample.txt"
-    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
-    And user "Alice" has uploaded file with content "sample delete file 3" to "PARENT/sample.php"
-    And user "Alice" has uploaded file with content "sample delete file 4" to "PARENT/sample.go"
-    And user "Alice" has uploaded file with content "sample delete file 5" to "PARENT/sample.py"
     And using <dav-path> DAV path
+    And user "Alice" has uploaded the following files
+      | path               | content              |
+      | /PARENT/sample.txt | sample delete file 1 |
+      | /PARENT/sample.dat | sample delete file 2 |
+      | /PARENT/sample.php | sample delete file 3 |
+      | /PARENT/sample.go  | sample delete file 4 |
+      | /PARENT/sample.py  | sample delete file 5 |
     When user "Alice" deletes the following files
       | path              |
       | PARENT/sample.txt |
@@ -60,11 +67,16 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | PARENT/sample.php |
       | PARENT/sample.go  |
       | PARENT/sample.py  |
-    Then as "Alice" the file with original path "/PARENT/sample.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/sample.py" should exist in the trashbin
-    But as "Alice" the file with original path "/PARENT/sample.dat" should not exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/sample.php" should not exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/sample.go" should not exist in the trashbin
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the folders with following original paths should exist in the trashbin
+      | path               |
+      | /PARENT/sample.txt |
+      | /PARENT/sample.py  |
+    But as "Alice" the files with following original paths should not exist in the trashbin
+      | path               |
+      | /PARENT/sample.dat |
+      | /PARENT/sample.php |
+      | /PARENT/sample.go  |
     Examples:
       | dav-path |
       | old      |
@@ -77,17 +89,19 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | dat       |
       | php       |
       | go        |
-    And user "Alice" has uploaded file with content "sample delete file 1" to "sample.TXT"
-    And user "Alice" has uploaded file with content "sample delete file 1" to "sample.txt"
-    And user "Alice" has uploaded file with content "sample delete file 2" to "sample.DAT"
-    And user "Alice" has uploaded file with content "sample delete file 2" to "sample.dat"
-    And user "Alice" has uploaded file with content "sample delete file 3" to "sample.PHP"
-    And user "Alice" has uploaded file with content "sample delete file 3" to "sample.php"
-    And user "Alice" has uploaded file with content "sample delete file 4" to "sample.GO"
-    And user "Alice" has uploaded file with content "sample delete file 4" to "sample.go"
-    And user "Alice" has uploaded file with content "sample delete file 5" to "sample.PY"
-    And user "Alice" has uploaded file with content "sample delete file 5" to "sample.py"
     And using <dav-path> DAV path
+    And user "Alice" has uploaded the following files
+      | path       | content              |
+      | sample.txt | sample delete file 1 |
+      | sample.dat | sample delete file 2 |
+      | sample.php | sample delete file 3 |
+      | sample.go  | sample delete file 4 |
+      | sample.py  | sample delete file 5 |
+      | sample.TXT | sample delete file 1 |
+      | sample.DAT | sample delete file 2 |
+      | sample.PHP | sample delete file 3 |
+      | sample.GO  | sample delete file 4 |
+      | sample.PY  | sample delete file 5 |
     When user "Alice" deletes the following files
       | path       |
       | sample.TXT |
@@ -100,16 +114,21 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | sample.go  |
       | sample.PY  |
       | sample.py  |
-    Then as "Alice" the file with original path "/sample.TXT" should exist in the trashbin
-    And as "Alice" the file with original path "/sample.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/sample.PY" should exist in the trashbin
-    And as "Alice" the file with original path "/sample.py" should exist in the trashbin
-    But as "Alice" the file with original path "/sample.DAT" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.dat" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.PHP" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.php" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.GO" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.go" should not exist in the trashbin
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the files with following original paths should exist in the trashbin
+      | path       |
+      | sample.txt |
+      | sample.TXT |
+      | sample.py  |
+      | sample.PY  |
+    But as "Alice" the files with following original paths should not exist in the trashbin
+      | path       |
+      | sample.dat |
+      | sample.php |
+      | sample.go  |
+      | sample.DAT |
+      | sample.PHP |
+      | sample.GO  |
     Examples:
       | dav-path |
       | old      |
@@ -121,18 +140,23 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | dat       |
       | php       |
       | go        |
-    And user "Alice" has uploaded file with content "sample delete file 1" to "PARENT/sample.txt"
-    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
-    And user "Alice" has uploaded file with content "sample delete file 3" to "PARENT/sample.php"
-    And user "Alice" has uploaded file with content "sample delete file 4" to "PARENT/sample.go"
-    And user "Alice" has uploaded file with content "sample delete file 5" to "PARENT/sample.py"
     And using <dav-path> DAV path
+    And user "Alice" has uploaded the following files
+      | path               | content              |
+      | /PARENT/sample.txt | sample delete file 1 |
+      | /PARENT/sample.dat | sample delete file 2 |
+      | /PARENT/sample.php | sample delete file 3 |
+      | /PARENT/sample.go  | sample delete file 4 |
+      | /PARENT/sample.py  | sample delete file 5 |
     When user "Alice" deletes folder "PARENT" using the WebDAV API
-    Then as "Alice" the file with original path "PARENT/sample.txt" should exist in the trashbin
-    And as "Alice" the file with original path "PARENT/sample.py" should exist in the trashbin
-    And as "Alice" the file with original path "PARENT/sample.dat" should exist in the trashbin
-    And as "Alice" the file with original path "PARENT/sample.php" should exist in the trashbin
-    And as "Alice" the file with original path "PARENT/sample.go" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the folders with following original paths should exist in the trashbin
+      | path               |
+      | /PARENT/sample.txt |
+      | /PARENT/sample.dat |
+      | /PARENT/sample.php |
+      | /PARENT/sample.go  |
+      | /PARENT/sample.py  |
     Examples:
       | dav-path |
       | old      |
@@ -145,11 +169,13 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | PARENT        |
       | simple-folder |
     And using <dav-path> DAV path
-    And user "Alice" has uploaded file with content "sample delete file 1" to "sample.txt"
-    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
-    And user "Alice" has uploaded file with content "sample delete file 3" to "simple-folder/sample.php"
-    And user "Alice" has uploaded file with content "sample delete file 4" to "simple-folder/sample.go"
-    And user "Alice" has uploaded file with content "sample delete file 5" to "lorem-folder/sample.py"
+    And user "Alice" has uploaded the following files
+      | path                      | content              |
+      | /sample.txt               | sample delete file 1 |
+      | /PARENT/sample.dat        | sample delete file 2 |
+      | /simple-folder/sample.php | sample delete file 3 |
+      | /simple-folder/sample.go  | sample delete file 4 |
+      | /lorem-folder/sample.py   | sample delete file 5 |
     When user "Alice" deletes the following files
       | path                     |
       | sample.txt               |
@@ -157,11 +183,16 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | simple-folder/sample.php |
       | simple-folder/sample.go  |
       | lorem-folder/sample.py   |
-    Then as "Alice" the file with original path "sample.txt" should exist in the trashbin
-    And as "Alice" the file with original path "lorem-folder/sample.py" should exist in the trashbin
-    And as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
-    But as "Alice" the file with original path "simple-folder/sample.php" should not exist in the trashbin
-    And as "Alice" the file with original path "simple-folder/sample.go" should not exist in the trashbin
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the files with following original paths should exist in the trashbin
+      | path       |
+      | sample.txt |
+      | lorem-folder/sample.py |
+    But as "Alice" the files with following original paths should not exist in the trashbin
+      | path                     |
+      | PARENT/sample.dat        |
+      | simple-folder/sample.php |
+      | simple-folder/sample.go  |
     Examples:
       | dav-path |
       | old      |
@@ -174,13 +205,20 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | simple-folder |
     And using <dav-path> DAV path
     And user "Alice" has created folder "PARENT/simple-folder"
-    And user "Alice" has uploaded file with content "sample delete file 1" to "PARENT/p.txt"
-    And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/simple-folder/sub.txt"
-    And user "Alice" has uploaded file with content "sample delete file 3" to "simple-folder/s.txt"
-    When user "Alice" deletes folder "PARENT" using the WebDAV API
-    And user "Alice" deletes folder "simple-folder" using the WebDAV API
-    Then as "Alice" the file with original path "PARENT/p.txt" should exist in the trashbin
-    And as "Alice" the file with original path "PARENT/simple-folder/sub.txt" should exist in the trashbin
+    And user "Alice" has uploaded the following files
+      | path                          | content              |
+      | /PARENT/p.txt                 | sample delete file 1 |
+      | /PARENT/simple-folder/sub.txt | sample delete file 2 |
+      | /simple-folder/s.txt          | sample delete file 3 |
+    When user "Alice" deletes the following files
+      | path          |
+      | PARENT        |
+      | simple-folder |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the folders with following original paths should exist in the trashbin
+      | path                         |
+      | PARENT/p.txt                 |
+      | PARENT/simple-folder/sub.txt |
     But as "Alice" the file with original path "simple-folder/s.txt" should not exist in the trashbin
     Examples:
       | dav-path |
@@ -195,8 +233,11 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And using <dav-path> DAV path
     And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
     When user "Alice" deletes file "PARENT/sample.dat" using the WebDAV API
-    Then as "Alice" the file with original path "PARENT" should not exist in the trashbin
-    And as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the folders with following original paths should not exist in the trashbin
+      | path              |
+      | PARENT            |
+      | PARENT/sample.dat |
     Examples:
       | dav-path |
       | old      |
@@ -210,7 +251,8 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And using <dav-path> DAV path
     And user "Alice" has uploaded file with content "sample delete file 2" to "skipFile"
     When user "Alice" deletes file "skipFile" using the WebDAV API
-    Then as "Alice" the file with original path "skipFile" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "skipFile" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -224,7 +266,8 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And using <dav-path> DAV path
     And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/lorem.txt"
     When user "Alice" deletes file "PARENT/lorem.txt" using the WebDAV API
-    Then as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -236,9 +279,12 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And using <dav-path> DAV path
     And user "Alice" has uploaded file with content "sample" to "lorem.txt"
     And user "Alice" has uploaded file with content "sample delete file" to "lorem.dat"
-    When user "Alice" deletes file "lorem.txt" using the WebDAV API
-    And user "Alice" deletes file "lorem.dat" using the WebDAV API
-    Then as "Alice" the file with original path "lorem.txt" should exist in the trashbin
+    When user "Alice" deletes the following files
+      | path      |
+      | lorem.txt |
+      | lorem.dat |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the file with original path "lorem.txt" should exist in the trashbin
     But as "Alice" the file with original path "lorem.dat" should not exist in the trashbin
     Examples:
       | dav-path |
@@ -251,9 +297,12 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And using <dav-path> DAV path
     And user "Alice" has uploaded file with content "sample" to "PARENT/lorem.txt"
     And user "Alice" has uploaded file with content "sample delete file" to "PARENT/lorem.dat"
-    When user "Alice" deletes file "PARENT/lorem.txt" using the WebDAV API
-    And user "Alice" deletes file "PARENT/lorem.dat" using the WebDAV API
-    Then as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
+    When user "Alice" deletes the following files
+      | path             |
+      | PARENT/lorem.txt |
+      | PARENT/lorem.dat |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
     But as "Alice" the file with original path "PARENT/lorem.dat" should not exist in the trashbin
     Examples:
       | dav-path |
@@ -267,8 +316,11 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And user "Alice" has uploaded file with content "sample" to "PARENT/lorem.txt"
     And user "Alice" has uploaded file with content "sample delete file" to "PARENT/lorem.dat"
     When user "Alice" deletes folder "PARENT" using the WebDAV API
-    Then as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
-    And as "Alice" the file with original path "PARENT/lorem.dat" should exist in the trashbin
+    Then the HTTP status code should be "204"
+    And as "Alice" the files with following original paths should exist in the trashbin
+      | path             |
+      | PARENT/lorem.txt |
+      | PARENT/lorem.dat |
     Examples:
       | dav-path |
       | old      |
@@ -308,14 +360,19 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | simple-folder/sample.php |
       | PARENT/sample.lis        |
       | PARENT/sample.dat        |
-    Then as "Alice" the file with original path "sample.txt" should exist in the trashbin
-    And as "Alice" the file with original path "lorem-folder/sample.go" should exist in the trashbin
-    But as "Alice" the file with original path "sample.dat" should not exist in the trashbin
-    And as "Alice" the file with original path "lorem-folder/sample.dat" should not exist in the trashbin
-    And as "Alice" the file with original path "PARENT/sample.txt" should not exist in the trashbin
-    And as "Alice" the file with original path "simple-folder/sample.php" should not exist in the trashbin
-    And as "Alice" the file with original path "PARENT/sample.lis" should not exist in the trashbin
-    And as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
+    Then the HTTP status code of responses on all endpoints should be "204"
+    And as "Alice" the files with following original paths should exist in the trashbin
+      | path                   |
+      | sample.txt             |
+      | lorem-folder/sample.go |
+    But as "Alice" the files with following original paths should not exist in the trashbin
+      | path                     |
+      | sample.dat               |
+      | lorem-folder/sample.dat  |
+      | PARENT/sample.txt        |
+      | simple-folder/sample.php |
+      | PARENT/sample.lis        |
+      | PARENT/sample.dat        |
     Examples:
       | dav-path |
       | old      |

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -552,6 +552,7 @@ class TrashbinContext implements Context {
 			$numItemsDeleted,
 			"Expected to delete exactly one item from the trashbin but $numItemsDeleted were deleted"
 		);
+		$this->featureContext->pushToLastStatusCodesArrays();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -918,6 +918,7 @@ trait WebDav {
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to copy file '$fileSource' to '$fileDestination' for user '$user'"
 		);
+		$this->emptyLastHTTPStatusCodesArray();
 	}
 
 	/**
@@ -3138,6 +3139,7 @@ trait WebDav {
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to upload file '$destination' for user '$user'"
 		);
+		$this->emptyLastHTTPStatusCodesArray();
 		return $fileId;
 	}
 
@@ -3187,7 +3189,7 @@ trait WebDav {
 	 * @return array
 	 * @throws Exception
 	 */
-	public function userHasUploadedFollowingFiles(
+	public function userHasUploadedFollowingFilesWithContent(
 		string $user,
 		?string $content,
 		TableNode $table
@@ -3202,6 +3204,27 @@ trait WebDav {
 		}
 
 		return $fileIds;
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has uploaded the following files$/
+	 *
+	 * @param string $user
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userHasUploadedFollowingFiles(
+		string $user,
+		TableNode $table
+	):void {
+		$this->verifyTableNodeColumns($table, ["path", "content"]);
+		$files = $table->getHash();
+		foreach ($files as $destination) {
+			$this->userHasUploadedAFileWithContentTo($user, $destination["content"], $destination["path"])[0];
+		}
+		$this->emptyLastHTTPStatusCodesArray();
 	}
 
 	/**
@@ -3404,6 +3427,7 @@ trait WebDav {
 			["204"],
 			"HTTP status code was not 204 while trying to $deleteText $fileOrFolder '$entry' for user '$user'"
 		);
+		$this->emptyLastHTTPStatusCodesArray();
 	}
 
 	/**
@@ -3424,6 +3448,7 @@ trait WebDav {
 		foreach ($paths as $file) {
 			$this->userHasDeletedFile($user, $deletedOrUnshared, $fileOrFolder, $file["path"]);
 		}
+		$this->emptyLastHTTPStatusCodesArray();
 	}
 
 	/**
@@ -3485,6 +3510,7 @@ trait WebDav {
 		foreach ($table->getTable() as $entry) {
 			$entryName = $entry[0];
 			$this->response = $this->makeDavRequest($user, 'DELETE', $entryName, []);
+			$this->pushToLastStatusCodesArrays();
 		}
 		$this->lastUploadDeleteTime = \time();
 	}

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3207,27 +3207,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given /^user "([^"]*)" has uploaded the following files$/
-	 *
-	 * @param string $user
-	 * @param TableNode $table
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function userHasUploadedFollowingFiles(
-		string $user,
-		TableNode $table
-	):void {
-		$this->verifyTableNodeColumns($table, ["path", "content"]);
-		$files = $table->getHash();
-		foreach ($files as $destination) {
-			$this->userHasUploadedAFileWithContentTo($user, $destination["content"], $destination["path"])[0];
-		}
-		$this->emptyLastHTTPStatusCodesArray();
-	}
-
-	/**
 	 * @When /^user "([^"]*)" downloads the following files using the WebDAV API$/
 	 *
 	 * @param string $user
@@ -3396,6 +3375,7 @@ trait WebDav {
 		$this->pauseUploadDelete();
 		$this->response = $this->makeDavRequest($user, 'DELETE', $file, []);
 		$this->lastUploadDeleteTime = \time();
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adds `Then` steps to existing API test scenarios to better check the results of `When` steps.

**Suites covered:**
- `apiTrashbin`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/core/issues/39512


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
