### PR TITLE
[tests-only][full-ci] Improve Then step in apiWebdavLocksUnlocks suite

### DIFF
--- a/tests/acceptance/features/apiWebdavLocksUnlock/lockBreakersGroups.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/lockBreakersGroups.feature
@@ -55,7 +55,7 @@ Feature: UNLOCK locked items
       | new      | exclusive  |
 
 
-  Scenario Outline: members of the lock breakers group can unlock a locked folder shared with them and lock it back again
+  Scenario Outline: members of the lock breakers group can lock shared folder that was unlocked by the lock breaker group before
     Given using <dav-path> DAV path
     And group "grp1" has been created
     And user "Brian" has been created with default attributes and without skeleton files
@@ -65,9 +65,7 @@ Feature: UNLOCK locked items
     And user "Alice" has locked folder "FOLDER" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared folder "FOLDER" with user "Brian"
-    When user "Brian" unlocks folder "FOLDER" with the last created lock of folder "FOLDER" of user "Alice" using the WebDAV API
-    Then the HTTP status code should be "204"
-    And 0 locks should be reported for folder "FOLDER" of user "Brian" by the WebDAV API
+    And user "Brian" has unlocked folder "FOLDER" with the last created lock of folder "FOLDER" of user "Alice" using the WebDAV API
     When user "Brian" locks folder "FOLDER" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "200"
@@ -102,7 +100,7 @@ Feature: UNLOCK locked items
       | new      | exclusive  |
 
 
-  Scenario Outline: members of the lock breakers group can unlock a locked file shared with them and lock it back again
+  Scenario Outline: members of the lock breakers group can lock shared file that was unlocked by the lock breaker group before
     Given using <dav-path> DAV path
     And group "grp1" has been created
     And user "Brian" has been created with default attributes and without skeleton files
@@ -112,9 +110,7 @@ Feature: UNLOCK locked items
     And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | <lock-scope> |
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    When user "Brian" unlocks file "textfile0.txt" with the last created lock of file "textfile0.txt" of user "Alice" using the WebDAV API
-    Then the HTTP status code should be "204"
-    And 0 locks should be reported for file "textfile0.txt" of user "Brian" by the WebDAV API
+    And user "Brian" has unlocked file "textfile0.txt" with the last created lock of folder "textfile0.txt" of user "Alice" using the WebDAV API
     When user "Brian" locks file "textfile0.txt" using the WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "200"
@@ -293,19 +289,19 @@ Feature: UNLOCK locked items
     And user "Brian" has been added to group "grp1"
     And user "Brian" has been added to group "grp2"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
-    And user "Alice" has locked file "textfile.txt0" setting the following properties
+    And user "Alice" has locked file "textfile0.txt" setting the following properties
       | lockscope | <lock-scope> |
-    And user "Alice" has shared file "textfile.txt0" with group "grp2"
-    When user "Carol" unlocks file "textfile.txt0" with the last created lock of file "textfile.txt0" of user "Alice" using the WebDAV API
+    And user "Alice" has shared file "textfile0.txt" with group "grp2"
+    When user "Carol" unlocks file "textfile0.txt" with the last created lock of file "textfile0.txt" of user "Alice" using the WebDAV API
     Then the HTTP status code should be "403"
-    And 1 locks should be reported for file "textfile.txt0" of user "Alice" by the WebDAV API
-    And 1 locks should be reported for file "textfile.txt0" of user "Brian" by the WebDAV API
-    And 1 locks should be reported for file "textfile.txt0" of user "Carol" by the WebDAV API
-    When user "Brian" unlocks file "textfile.txt0" with the last created lock of file "textfile.txt0" of user "Alice" using the WebDAV API
+    And 1 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
+    And 1 locks should be reported for file "textfile0.txt" of user "Brian" by the WebDAV API
+    And 1 locks should be reported for file "textfile0.txt" of user "Carol" by the WebDAV API
+    When user "Brian" unlocks file "textfile0.txt" with the last created lock of file "textfile0.txt" of user "Alice" using the WebDAV API
     Then the HTTP status code should be "204"
-    And 0 locks should be reported for file "textfile.txt0" of user "Alice" by the WebDAV API
-    And 0 locks should be reported for file "textfile.txt0" of user "Brian" by the WebDAV API
-    And 0 locks should be reported for file "textfile.txt0" of user "Carol" by the WebDAV API
+    And 0 locks should be reported for file "textfile0.txt" of user "Alice" by the WebDAV API
+    And 0 locks should be reported for file "textfile0.txt" of user "Brian" by the WebDAV API
+    And 0 locks should be reported for file "textfile0.txt" of user "Carol" by the WebDAV API
     Examples:
       | dav-path | lock-scope |
       | old      | shared     |


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first to be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adds `Then` steps to existing API test scenarios to better check the results of the `When` steps.
Adds new Then step datatable which lock `file/folder` 

**Suites covered:**
- `apiWebdavLocksUnlocks`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/core/issues/39512


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
