### PR TITLE
disable `fr` related api acceptance tests because of #39931

### DIFF
--- a/tests/acceptance/features/apiTranslation/translation.feature
+++ b/tests/acceptance/features/apiTranslation/translation.feature
@@ -21,10 +21,13 @@ Feature: translate messages in api response to preferred language
       | old         | de-DE    |
       | old         | es-ES    |
       | old         | zh-CN    |
-      | old         | fr-FR    |
       | new         | de-DE    |
       | new         | es-ES    |
       | new         | zh-CN    |
+
+    @skipOnOcV10 @issue-39931
+    Examples:
+      | old         | fr-FR    |
       | new         | fr-FR    |
 
     @skipOnOcV10 @personalSpace


### PR DESCRIPTION
## Description
After the recent updates in translations, core API acceptance tests started failing. See the issue in the related section
This PR reverts the latest two transfix commits 848088e781 and e285879a8a. 

The last one e285879a8a directly depends on 848088e781 due to new files created, so had to be removed.


## Related Issue
- https://github.com/owncloud/core/issues/39931

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
