### PR TITLE
Sftp key handling

### DIFF
--- a/apps/files_external/appinfo/Migrations/Version20220329110116.php
+++ b/apps/files_external/appinfo/Migrations/Version20220329110116.php
@@ -1,0 +1,105 @@
+<?php
+namespace OCA\files_external\Migrations;
+
+use OCA\Files_External\Lib\Backend\SFTP;
+use OCA\Files_External\Lib\Auth\PublicKey\RSA;
+use OCA\Files_External\Lib\RSAStore;
+use OCP\Migration\ISimpleMigration;
+use OCP\Migration\IOutput;
+use OCP\Files\External\Service\IGlobalStoragesService;
+use OCP\Files\External\IStorageConfig;
+use OCP\ILogger;
+use OCP\IConfig;
+use phpseclib3\Crypt\RSA as RSACrypt;
+use phpseclib3\Crypt\RSA\PrivateKey;
+
+class Version20220329110116 implements ISimpleMigration {
+	/** @var IGlobalStoragesService */
+	private $storageService;
+	/** @var ILogger */
+	private $logger;
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IGlobalStoragesService $storageService, ILogger $logger, IConfig $config) {
+		$this->storageService = $storageService;
+		$this->logger = $logger;
+		$this->config = $config;
+	}
+	/**
+	 * @param IOutput $out
+	 */
+	public function run(IOutput $out) {
+		if (!$this->config->getSystemValue('installed', false)) {
+			// Skip the migration for new installations -> nothing to migrate
+			return;
+		}
+
+		$this->loadFSApps();
+		\OC_Util::setupFS();  // this should load additional backends and auth mechanisms
+		$storageConfigs = $this->storageService->getStorageForAllUsers();
+		$pass = $this->config->getSystemValue('secret', '');
+
+		$rsaStore = RSAStore::getGlobalInstance();
+		foreach ($storageConfigs as $storageConfig) {
+			if ($storageConfig->getBackend() instanceof SFTP && $storageConfig->getAuthMechanism() instanceof RSA) {
+				$encPubKey = $storageConfig->getBackendOption('public_key');
+				$encPrivKey = $storageConfig->getBackendOption('private_key');
+
+				$pubKey = \base64_decode($encPubKey, true);
+				$privKey = \base64_decode($encPrivKey, true);
+
+				$configId = $storageConfig->getId();
+				if ($pubKey === false || $privKey === false) {
+					$out->warning("Storage configuration with id = {$configId}: Cannot decode either public or private key, skipping");
+					continue;
+				}
+
+				try {
+					$rsaKey = RSACrypt::load($privKey, $pass)->withHash('sha1');
+				} catch (\phpseclib3\Exception\NoKeyLoadedException $e) {
+					$out->warning("Storage configuration with id = {$configId}: Cannot load private key, skipping");
+					continue;
+				}
+
+				$targetUserId = '';
+				if ($storageConfig->getType() === IStorageConfig::MOUNT_TYPE_PERSONAl) {
+					$applicableUsers = $storageConfig->getApplicableUsers();
+					$targetUserId = $applicableUsers[0];  // it must have one user.
+				}
+
+				$token = $rsaStore->storeData($rsaKey, $targetUserId);
+				$storageConfig->setBackendOption('public_key', $pubKey);
+				$storageConfig->setBackendOption('private_key', $token);
+
+				$this->storageService->updateStorage($storageConfig);
+				$out->info("Storage configuration with id = {$configId}: keys migrated successfully");
+			}
+		}
+	}
+
+	/**
+	 * Load the FS apps. This is required because the FS apps might not be loaded during the
+	 * migration.
+	 */
+	private function loadFSApps() {
+		$enabledApps = \OC_App::getEnabledApps();
+		foreach ($enabledApps as $enabledApp) {
+			if ($enabledApp !== 'files_external' && \OC_App::isType($enabledApp, ['filesystem'])) {
+				try {
+					\OC_App::loadApp($enabledApp);
+				} catch (NeedsUpdateException $ex) {
+					if (\OC_App::updateApp($enabledApp)) {
+						// update successful.
+						// We can load the app without checking if the should upgrade or not.
+						\OC_App::loadApp($enabledApp, false);
+					} else {
+						$this->logger->error("Error during files_external migration. $enabledApp couldn't be loaded nor updated.", ['app' => 'files_external']);
+						$this->logger->logException($ex, ['app' => 'files_external']);
+						$this->logger->error("Mount points using $enabledApp might not be migrated properly. You might need to re-enter the passwords for those mount points", ['app' => 'files_external']);
+					}
+				}
+			}
+		}
+	}
+}

--- a/apps/files_external/appinfo/Migrations/Version20220329110116.php
+++ b/apps/files_external/appinfo/Migrations/Version20220329110116.php
@@ -1,6 +1,7 @@
 <?php
 namespace OCA\files_external\Migrations;
 
+use OC\NeedsUpdateException;
 use OCA\Files_External\Lib\Backend\SFTP;
 use OCA\Files_External\Lib\Auth\PublicKey\RSA;
 use OCA\Files_External\Lib\RSAStore;

--- a/apps/files_external/appinfo/info.xml
+++ b/apps/files_external/appinfo/info.xml
@@ -13,7 +13,7 @@
 		<admin>admin-external-storage</admin>
 	</documentation>
 	<rememberlogin>false</rememberlogin>
-	<version>0.8.0</version>
+	<version>0.9.0</version>
 	<types>
 		<filesystem/>
 	</types>

--- a/apps/files_external/js/public_key.js
+++ b/apps/files_external/js/public_key.js
@@ -3,11 +3,14 @@ $(document).ready(function() {
 	OCA.External.Settings.mountConfig.whenSelectAuthMechanism(function($tr, authMechanism, scheme, onCompletion) {
 		if (scheme === 'publickey') {
 			var config = $tr.find('.configuration');
-			if ($(config).find('[name="public_key_generate"]').length === 0) {
+			if (config.find('[name="public_key_generate"]').length === 0) {
 				setupTableRow($tr, config);
 				onCompletion.then(function() {
 					// If there's no private key, build one
-					if (0 === $(config).find('[data-parameter="private_key"]').val().length) {
+					var $privateKeyElem = config.find('[data-parameter="private_key"]');
+					if ($privateKeyElem.length !== 0 && $privateKeyElem.val().length === 0) {
+						// the private_key element might be removed in some scenarios such as
+						// global mount showing in the personal mounts
 						generateKeys($tr);
 					}
 				});
@@ -33,7 +36,16 @@ $(document).ready(function() {
 	function generateKeys(tr) {
 		var config = $(tr).find('.configuration');
 
-		$.post(OC.filePath('files_external', 'ajax', 'public_key.php'), {}, function(result) {
+		var $table = $(tr).parentsUntil('#files_external', '#externalStorage');
+		var isAdmin = $table.data('admin');
+
+		var postData = {};
+		if (!isAdmin) {
+			postData = {
+				'userId': OC.currentUser
+			};
+		}
+		$.post(OC.filePath('files_external', 'ajax', 'public_key.php'), postData, function(result) {
 			if (result && result.status === 'success') {
 				$(config).find('[data-parameter="public_key"]').val(result.data.public_key).keyup();
 				$(config).find('[data-parameter="private_key"]').val(result.data.private_key);

--- a/apps/files_external/lib/Controller/AjaxController.php
+++ b/apps/files_external/lib/Controller/AjaxController.php
@@ -39,8 +39,8 @@ class AjaxController extends Controller {
 		$this->rsaMechanism = $rsaMechanism;
 	}
 
-	private function generateSshKeys() {
-		$key = $this->rsaMechanism->createKey();
+	private function generateSshKeys($userId) {
+		$key = $this->rsaMechanism->createKey($userId);
 		// Replace the placeholder label with a more meaningful one
 		$key['publickey'] = \str_replace('phpseclib-generated-key', \gethostname(), $key['publickey']);
 
@@ -49,11 +49,11 @@ class AjaxController extends Controller {
 
 	/**
 	 * Generates an SSH public/private key pair.
-	 *
+	 * @param string $userId
 	 * @NoAdminRequired
 	 */
-	public function getSshKeys() {
-		$key = $this->generateSshKeys();
+	public function getSshKeys($userId = '') {
+		$key = $this->generateSshKeys($userId);
 		return new JSONResponse(
 			['data' => [
 				'private_key' => $key['privatekey'],

--- a/apps/files_external/lib/Lib/RSAStore.php
+++ b/apps/files_external/lib/Lib/RSAStore.php
@@ -57,7 +57,7 @@ class RSAStore {
 	 * instance was there.
 	 * This shouldn't be needed outside of unit tests
 	 */
-	public static function setGlobalInstance(RSAStore $rsaStore) {
+	public static function setGlobalInstance(?RSAStore $rsaStore) {
 		self::$rsaStore = $rsaStore;
 	}
 

--- a/apps/files_external/lib/Lib/RSAStore.php
+++ b/apps/files_external/lib/Lib/RSAStore.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez Ramos <jvillafanez@owncloud.com>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Lib;
+
+use OCP\Security\ICredentialsManager;
+use OCP\IConfig;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\RSA\PrivateKey;
+
+/**
+ * Store and retrieve phpseclib3 RSA private keys
+ */
+class RSAStore {
+	private static $rsaStore = null;
+
+	/** @var ICredentialsManager */
+	private $credentialsManager;
+	/** @var IConfig */
+	private $config;
+
+	/**
+	 * Get the global instance of the RSAStore. If no one is set yet, a new
+	 * one will be created using real server components.
+	 * @return RSAStore
+	 */
+	public static function getGlobalInstance(): RSAStore {
+		if (self::$rsaStore === null) {
+			self::$rsaStore = new RSAStore(
+				\OC::$server->getCredentialsManager(),
+				\OC::$server->getConfig()
+			);
+		}
+		return self::$rsaStore;
+	}
+
+	/**
+	 * Set a new RSAStore instance as a global instance overwriting whatever
+	 * instance was there.
+	 * This shouldn't be needed outside of unit tests
+	 */
+	public static function setGlobalInstance(RSAStore $rsaStore) {
+		self::$rsaStore = $rsaStore;
+	}
+
+	/**
+	 * @param ICredentialsManager $credentialsManager
+	 * @param IConfig $config
+	 */
+	public function __construct(ICredentialsManager $credentialsManager, IConfig $config) {
+		$this->credentialsManager = $credentialsManager;
+		$this->config = $config;
+	}
+
+	/**
+	 * Store the $rsaKey inside the $userId's space. A token will be returned
+	 * in order to retrieve the stored key
+	 * @param PrivateKey $rsaKey the private key to be stored
+	 * @param string $userId the user under which the token will be stored
+	 * @return string an opaque token to be used to retrieve the stored key later
+	 */
+	public function storeData(PrivateKey $rsaKey, string $userId): string {
+		$password = $this->config->getSystemValue('secret', '');
+		$privatekey = $rsaKey->withPassword($password)->toString('PKCS1');
+
+		$keyId = \uniqid('rsaid:', true);
+
+		$this->credentialsManager->store($userId, $keyId, $privatekey);
+
+		$keyData = [
+			'rsaId' => $keyId,
+			'userId' => $userId,
+		];
+		return \base64_encode(\json_encode($keyData));
+	}
+
+	/**
+	 * Retrieve a previously stored private key using the token that was returned
+	 * when the key was stored
+	 * @param string $token the token returned previously by the "storeData"
+	 * method when the key was stored.
+	 * @return PrivateKey the stored private key
+	 */
+	public function retrieveData(string $token): PrivateKey {
+		$keyData = \json_decode(\base64_decode($token), true);
+		$privateKey = $this->credentialsManager->retrieve($keyData['userId'], $keyData['rsaId']);
+		$password = $this->config->getSystemValue('secret', '');
+
+		return RSA::load($privateKey, $password)->withHash('sha1');
+	}
+}

--- a/apps/files_external/lib/Lib/RSAStore.php
+++ b/apps/files_external/lib/Lib/RSAStore.php
@@ -56,6 +56,9 @@ class RSAStore {
 	 * Set a new RSAStore instance as a global instance overwriting whatever
 	 * instance was there.
 	 * This shouldn't be needed outside of unit tests
+	 * @param RSAStore|null The RSAStore to be set as global instance, or null
+	 * to destroy the global instance (destroying the global instance will allow
+	 * getting the default one again)
 	 */
 	public static function setGlobalInstance(?RSAStore $rsaStore) {
 		self::$rsaStore = $rsaStore;

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -35,6 +35,7 @@ namespace OCA\Files_External\Lib\Storage;
 use Icewind\Streams\IteratorDirectory;
 use Icewind\Streams\RetryWrapper;
 use phpseclib3\Net\SFTP\Stream;
+use OCA\Files_External\Lib\RSAStore;
 
 /**
 * Uses phpseclib's Net\SFTP class and the Net\SFTP\Stream stream wrapper to
@@ -92,8 +93,9 @@ class SFTP extends \OCP\Files\Storage\StorageAdapter {
 		}
 		$this->user = $params['user'];
 
-		if (isset($params['public_key_auth'])) {
-			$this->auth = $params['public_key_auth'];
+		if (isset($params['private_key'])) {
+			$rsaStore = RSAStore::getGlobalInstance();
+			$this->auth = $rsaStore->retrieveData($params['private_key']);
 		} elseif (isset($params['password'])) {
 			$this->auth = $params['password'];
 		} else {

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -94,6 +94,8 @@ class SFTP extends \OCP\Files\Storage\StorageAdapter {
 		$this->user = $params['user'];
 
 		if (isset($params['private_key'])) {
+			// The $params['private_key'] contains the token to get the private key, not the key.
+			// The actual private key is fetched from the RSAStore using that token.
 			$rsaStore = RSAStore::getGlobalInstance();
 			$this->auth = $rsaStore->retrieveData($params['private_key']);
 		} elseif (isset($params['password'])) {

--- a/apps/files_external/tests/RSAStoreTest.php
+++ b/apps/files_external/tests/RSAStoreTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @author Juan Pablo Villafáñez Ramos <jvillafanez@owncloud.com>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files_External\Tests;
+
+use OCP\Security\ICredentialsManager;
+use OCP\IConfig;
+use OCA\Files_External\Lib\RSAStore;
+use phpseclib3\Crypt\RSA;
+
+class RSAStoreTest extends \Test\TestCase {
+	/** @var ICredentialsManager */
+	private $credentialsManager;
+	/** @var IConfig */
+	private $config;
+	/** @var RSAStore */
+	private $rsaStore;
+
+	protected function setUp(): void {
+		$this->credentialsManager = $this->createMock(ICredentialsManager::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->rsaStore = new RSAStore($this->credentialsManager, $this->config);
+	}
+
+	protected function tearDown(): void {
+		RSAStore::setGlobalInstance(null);  // reset global instance
+	}
+
+	public function testGlobalInstanceNotMocked() {
+		$this->assertNotSame($this->rsaStore, RSAStore::getGlobalInstance());
+	}
+
+	public function testGlobalInstance() {
+		RSAStore::setGlobalInstance($this->rsaStore);
+		$this->assertSame($this->rsaStore, RSAStore::getGlobalInstance());
+	}
+
+	public function testStoreAndRetrieve() {
+		$credentialsHolder = [];
+
+		$userId = '';
+		$this->config->method('getSystemValue')
+		->will($this->returnValueMap([
+			'secret', '', 'itsASecret',
+		]));
+
+		$this->credentialsManager->expects($this->once())
+			->method('store')
+			->with($userId, $this->anything(), $this->anything())
+			->will($this->returnCallback(function ($uid, $key, $value) use (&$credentialsHolder) {
+				if (!isset($credentialsHolder[$uid])) {
+					$credentialsHolder[$uid] = [];
+				}
+				$credentialsHolder[$uid][$key] = $value;
+			}));
+
+		$this->credentialsManager->expects($this->once())
+			->method('retrieve')
+			->with($userId, $this->anything())
+			->will($this->returnCallback(function ($uid, $key) use (&$credentialsHolder) {
+				return $credentialsHolder[$uid][$key];
+			}));
+		$privKey = RSA::createKey();
+
+		$token = $this->rsaStore->storeData($privKey, $userId);
+		$this->assertEquals($privKey->toString('PKCS1'), $this->rsaStore->retrieveData($token)->toString('PKCS1'));
+	}
+}

--- a/changelog/unreleased/39935
+++ b/changelog/unreleased/39935
@@ -1,0 +1,17 @@
+Change: Private keys for SFTP storage will be stored in credentials table
+
+Previously, both private and public keys were part of the configuration of
+the SFTP mount point. Although encrypted, there were some scenarios where
+the private key could be visible.
+
+The following changes have been implemented:
+* The private key will never leave the ownCloud server.
+* The private key will be stored encrypted inside the oc_credentials table.
+* A random token will be created to refer to the private key. This token
+will be part of the SFTP mount point configuration.
+* The public key will be treated as a normal configuration parameter. This
+means that it won't be neither encrypted nor encoded in any way.
+
+The overall behavior remains the same. ownCloud will generate a key pair, whose public key will need to be placed in the SFTP server.
+
+https://github.com/owncloud/core/pull/39935

--- a/lib/private/Files/External/FrontendDefinitionTrait.php
+++ b/lib/private/Files/External/FrontendDefinitionTrait.php
@@ -141,11 +141,7 @@ trait FrontendDefinitionTrait {
 				if (!$parameter->validateValue($value)) {
 					return false;
 				}
-				if (($name === 'public_key') || ($name === 'private_key')) {
-					$storage->setBackendOption($name, \base64_encode($value));
-				} else {
-					$storage->setBackendOption($name, $value);
-				}
+				$storage->setBackendOption($name, $value);
 			}
 		}
 		return true;

--- a/lib/private/Files/External/StorageConfig.php
+++ b/lib/private/Files/External/StorageConfig.php
@@ -221,15 +221,6 @@ class StorageConfig implements IStorageConfig {
 					}
 					$backendOptions[$key] = $value;
 				}
-				if (\is_string($backendOptions[$key])) {
-					if (($key === 'public_key') || ($key === 'private_key')) {
-						if (\base64_decode($backendOptions[$key], true) === false) {
-							$backendOptions[$key] = \base64_encode($backendOptions[$key]);
-						}
-					}
-
-					$backendOptions[$key] = \str_replace(["\n", "\r"], "", $backendOptions[$key]);
-				}
 			}
 		}
 
@@ -242,13 +233,6 @@ class StorageConfig implements IStorageConfig {
 	 */
 	public function getBackendOption($key) {
 		if (isset($this->backendOptions[$key])) {
-			if (($key === 'private_key') || ($key === 'public_key')) {
-				$decodedString = \base64_decode($this->backendOptions[$key], true);
-				if ($decodedString !== false) {
-					return $decodedString;
-				}
-			}
-
 			return $this->backendOptions[$key];
 		}
 		return null;

--- a/tests/lib/Files/External/StorageConfigTest.php
+++ b/tests/lib/Files/External/StorageConfigTest.php
@@ -55,7 +55,7 @@ class StorageConfigTest extends \Test\TestCase {
 		$storageConfig->setMountPoint('test');
 		$storageConfig->setBackend($backend);
 		$storageConfig->setAuthMechanism($authMech);
-		$storageConfig->setBackendOptions(['user' => 'test', 'password' => 'password123', 'secure' => true, 'key' => "12345\r\n"]);
+		$storageConfig->setBackendOptions(['user' => 'test', 'password' => 'password123', 'secure' => true, 'key' => "12345"]);
 		$storageConfig->setPriority(128);
 		$storageConfig->setApplicableUsers(['user1', 'user2']);
 		$storageConfig->setApplicableGroups(['group1', 'group2']);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Modify public/private key behavior for SFTP storage in order to avoid exposing the private key.

The keys will always be generated in the server. The user won't be able to provide his own keys.
The public key will be handled as any "public" parameter, so no encryption or encoding will be applied to this parameter.
For the private key, an opaque token will be sent instead of the actual key. For the user's perspective, this token needs to be sent as private key. The actual private key will be kept in ownCloud and it will be encrypted.

Since the parameters for the storage are different, a migration is provided to convert the old parameters to the new format.

## Related Issue
https://github.com/owncloud/enterprise/issues/5036

## Motivation and Context
Private key shouldn't be exposed in any way.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
