### PR TITLE
fix: fr_FR has not enough translated strings

### DIFF
--- a/l10n/Makefile
+++ b/l10n/Makefile
@@ -9,6 +9,7 @@ l10n-push:
 .PHONY: l10n-pull
 l10n-pull:
 	tx -d pull -a --skip
+	rm -r fr_FR
 
 .PHONY: l10n-clean
 l10n-clean:


### PR DESCRIPTION
## Description
fr_FR holds too little translations

## Related Issue
- Fixes #39931 

## How Has This Been Tested?
- cd l10n
- make l10n-pull
- no l10n/fr_FR available

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
