### PR TITLE
[tests-only][full-ci]Improve then steps in apiShareCreateSpecialToShares1 suite

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
@@ -15,11 +15,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And user "Alice" has created folder "/FOLDER"
     When user "Alice" shares folder "/FOLDER" with user "Brian" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    When user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
+    And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"
+    And the HTTP status code of responses on all endpoints should be "<http_status_code>"
     And the fields of the last response to user "Alice" should include
       | expiration |  |
     And the response when user "Brian" gets the info of the last share should include
@@ -34,18 +32,14 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | /FOLDER    |
       | shareType   | user       |
       | shareWith   | Brian      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
     When user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | user           |
       | file_target | /Shares/FOLDER |
       | uid_owner   | %username%     |
@@ -54,26 +48,22 @@ Feature: a default expiration date can be specified for shares with users or gro
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
+      | ocs_api_version |
+      | 1               |
+      | 2               |
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date not enabled, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | /FOLDER    |
       | shareType   | user       |
       | shareWith   | Brian      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
     When user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" sharing with user "Brian" should include
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | user           |
       | file_target | /Shares/FOLDER |
       | uid_owner   | %username%     |
@@ -82,25 +72,24 @@ Feature: a default expiration date can be specified for shares with users or gro
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
+      | ocs_api_version |
+      | 1               |
+      | 2               |
 
   @skipOnOcV10.3
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | /FOLDER    |
       | shareType   | user       |
       | shareWith   | Brian      |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    And the administrator sets parameter "shareapi_default_expire_date_user_share" of app "core" to "no"
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    When the administrator sets parameter "shareapi_default_expire_date_user_share" of app "core" to "no"
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | user           |
       | file_target | /Shares/FOLDER |
       | uid_owner   | %username%     |
@@ -119,15 +108,14 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | /FOLDER    |
       | shareType   | user       |
       | shareWith   | Brian      |
       | permissions | read,share |
-    And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    And the administrator sets parameter "shareapi_default_expire_date_user_share" of app "core" to "no"
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    When the administrator sets parameter "shareapi_default_expire_date_user_share" of app "core" to "no"
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | user           |
       | file_target | /Shares/FOLDER |
       | uid_owner   | %username%     |
@@ -147,9 +135,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" shares folder "/FOLDER" with group "grp1" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
+    And user "Alice" has shared folder "/FOLDER" with group "grp1"
     When user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
@@ -169,18 +155,14 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | /FOLDER    |
       | shareType   | group      |
       | shareWith   | grp1       |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
     When user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" sharing with group "grp1" should include
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | group          |
       | file_target | /Shares/FOLDER |
       | uid_owner   | %username%     |
@@ -189,9 +171,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
+      | ocs_api_version |
+      | 1               |
+      | 2               |
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
   Scenario Outline: sharing with default expiration date not enabled for groups, user shares with expiration date set
@@ -199,18 +181,14 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | /FOLDER    |
       | shareType   | group      |
       | shareWith   | grp1       |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
     When user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    And the fields of the last response to user "Alice" sharing with group "grp1" should include
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | group          |
       | file_target | /Shares/FOLDER |
       | uid_owner   | %username%     |
@@ -219,9 +197,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +15 days |
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
+      | ocs_api_version |
+      | 1               |
+      | 2               |
 
   @skipOnOcV10.3
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares with expiration date and then disables
@@ -230,16 +208,15 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | /FOLDER    |
       | shareType   | group      |
       | shareWith   | grp1       |
       | permissions | read,share |
       | expireDate  | +15 days   |
-    And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    And the administrator sets parameter "shareapi_default_expire_date_group_share" of app "core" to "no"
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" sharing with group "grp1" should include
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    When the administrator sets parameter "shareapi_default_expire_date_group_share" of app "core" to "no"
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | group          |
       | file_target | /Shares/FOLDER |
       | uid_owner   | %username%     |
@@ -260,16 +237,15 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "/FOLDER"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | /FOLDER    |
       | shareType   | group      |
       | shareWith   | grp1       |
       | permissions | read,share |
       | expireDate  | +3 days    |
-    And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    And the administrator sets parameter "shareapi_default_expire_date_group_share" of app "core" to "no"
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" sharing with group "grp1" should include
+    And user "Brian" has accepted share "/FOLDER" offered by user "Alice"
+    When the administrator sets parameter "shareapi_default_expire_date_group_share" of app "core" to "no"
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | group          |
       | file_target | /Shares/FOLDER |
       | uid_owner   | %username%     |
@@ -288,9 +264,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | user                  |
       | file_target | /Shares/textfile0.txt |
       | uid_owner   | %username%            |
@@ -332,9 +308,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" shares file "textfile0.txt" with user "Brian" using the sharing API
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    Then the fields of the last response to user "Alice" sharing with user "Brian" should include
+    And user "Alice" has shared file "/textfile0.txt" with user "Brian"
+    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | user                  |
       | file_target | /Shares/textfile0.txt |
       | uid_owner   | %username%            |
@@ -377,11 +353,10 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" shares file "textfile0.txt" with user "Brian" with permissions "read,share" using the sharing API
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    And the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "40"
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    And user "Alice" has shared file "textfile0.txt" with user "Brian" with permissions "read,share"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "40"
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | expiration | +30 days |
     Examples:
       | ocs_api_version |
@@ -395,11 +370,10 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "30"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" shares file "textfile0.txt" with user "Brian" with permissions "read,share" using the sharing API
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    And the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "15"
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    And user "Alice" has shared file "textfile0.txt" with user "Brian" with permissions "read,share"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When the administrator sets parameter "shareapi_expire_after_n_days_user_share" of app "core" to "15"
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | expiration | +30 days |
     Examples:
       | ocs_api_version |
@@ -414,9 +388,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    Then the fields of the last response to user "Alice" sharing with group "grp1" should include
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | group                 |
       | file_target | /Shares/textfile0.txt |
       | uid_owner   | %username%            |
@@ -462,9 +436,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" shares file "textfile0.txt" with group "grp1" using the sharing API
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    Then the fields of the last response to user "Alice" sharing with group "grp1" should include
+    And user "Alice" has shared file "textfile0.txt" with group "grp1"
+    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | share_type  | group                 |
       | file_target | /Shares/textfile0.txt |
       | uid_owner   | %username%            |
@@ -511,11 +485,10 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" shares file "textfile0.txt" with group "grp1" with permissions "read,share" using the sharing API
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    And the administrator sets parameter "shareapi_expire_after_n_days_group_share" of app "core" to "40"
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    And user "Alice" has shared file "textfile0.txt" with group "grp1" with permissions "read,share"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When the administrator sets parameter "shareapi_expire_after_n_days_group_share" of app "core" to "40"
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | expiration | +30 days |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +30 days |
@@ -533,11 +506,10 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" shares file "textfile0.txt" with group "grp1" with permissions "read,share" using the sharing API
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    And the administrator sets parameter "shareapi_expire_after_n_days_group_share" of app "core" to "15"
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    And user "Alice" has shared file "textfile0.txt" with group "grp1" with permissions "read,share"
+    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
+    When the administrator sets parameter "shareapi_expire_after_n_days_group_share" of app "core" to "15"
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | expiration | +30 days |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | +30 days |
@@ -554,10 +526,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And group "grp1" has been created
     And user "Brian" has been added to group "grp1"
     And user "Alice" has created folder "FOLDER"
-    When user "Alice" shares file "FOLDER" with group "grp1" with permissions "read,share" using the sharing API
-    And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    And user "Alice" has shared folder "FOLDER" with group "grp1" with permissions "read,share"
+    When user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | expiration |  |
     And the response when user "Brian" gets the info of the last share should include
       | expiration |  |
@@ -572,10 +543,9 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
     And user "Alice" has created folder "FOLDER"
-    When user "Alice" shares folder "/FOLDER" with user "Brian" with permissions "read,share" using the sharing API
-    And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
-    And user "Alice" gets the info of the last share using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    And user "Alice" has shared folder "/FOLDER" with user "Brian" with permissions "read,share"
+    When user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
+    Then the info about the last share by user "Alice" with user "Brian" should include
       | expiration |  |
     And the response when user "Brian" gets the info of the last share should include
       | expiration |  |
@@ -611,14 +581,12 @@ Feature: a default expiration date can be specified for shares with users or gro
     Given using OCS API version "2"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path               | textfile0.txt |
       | shareType          | user          |
       | shareWith          | Brian         |
       | permissions        | read,share    |
       | expireDateAsString | <date>        |
-    Then the HTTP status code should be "200"
-    And the OCS status code should be "200"
     When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "200"
@@ -640,13 +608,13 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "<enforce>"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path               | textfile0.txt     |
       | shareType          | user              |
       | shareWith          | Brian             |
       | permissions        | read,share        |
       | expireDateAsString | <expiration_date> |
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
     Then the fields of the last response to user "Alice" should include
       | expiration | <expiration_date> |
     And the response when user "Brian" gets the info of the last share should include
@@ -747,20 +715,22 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "0"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | textfile0.txt |
       | shareType   | user          |
       | shareWith   | Brian         |
       | permissions | read,share    |
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And the fields of the last response to user "Alice" should include
       | expiration | today |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | today |
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   @skipOnOcV10.3
   Scenario Outline: sharing with default expiration date enforced for users, max expire date is 1, user shares without specifying expiration date
@@ -769,17 +739,19 @@ Feature: a default expiration date can be specified for shares with users or gro
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "1"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    When user "Alice" creates a share using the sharing API with settings
+    And user "Alice" has created a share with settings
       | path        | textfile0.txt |
       | shareType   | user          |
       | shareWith   | Brian         |
       | permissions | read,share    |
-    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    Then the fields of the last response to user "Alice" should include
+    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And the fields of the last response to user "Alice" should include
       | expiration | tomorrow |
     And the response when user "Brian" gets the info of the last share should include
       | expiration | tomorrow |
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedInMultipleWays.feature
@@ -578,9 +578,9 @@ Feature: share resources where the sharee receives the share in multiple ways
       | permissions | all     |
     And user "Carol" has created a share with settings
       | path        | /parent/child1 |
-      | shareType   | group           |
-      | shareWith   | grp2            |
-      | permissions | read            |
+      | shareType   | group          |
+      | shareWith   | grp2           |
+      | permissions | read           |
     When user "Alice" accepts share "/parent" offered by user "Carol" using the sharing API
     And user "Brian" accepts share "<path>" offered by user "Carol" using the sharing API
     Then the HTTP status code of responses on all endpoints should be "200"

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedMultipleWaysIssue39347.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareReceivedMultipleWaysIssue39347.feature
@@ -20,18 +20,25 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Alice" has created folder "parent"
     And user "Alice" has created folder "parent/child"
     And user "Alice" has uploaded file with content "Share content" to "parent/child/lorem.txt"
-    When user "Alice" shares folder "parent" with group "grp" with permissions "read" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
-    And user "Brian" moves folder "/Shares/parent" to "/Shares/sharedParent" using the WebDAV API
-    And user "Alice" shares folder "parent" with user "Brian" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
-    Then as "Brian" folder "Shares/parent" should exist
+    And user "Alice" has created a share with settings
+      | path        | parent |
+      | shareType   | group  |
+      | shareWith   | grp    |
+      | permissions | read   |
+    When user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And user "Brian" should be able to rename folder "/Shares/parent" to "/Shares/sharedParent"
+    And user "Alice" should be able to share folder "parent" with user "Brian" with permissions "read" using the sharing API
+    And user "Brian" should be able to accept pending share "/parent" offered by user "Alice"
+    And as "Brian" folder "Shares/parent" should exist
     And as "Brian" folder "Shares/sharedParent" should not exist
     And as "Brian" file "Shares/sharedParent/child/lorem.txt" should not exist
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
 
   # Note: after fixing the bug, this scenario is no longer relevant.
   #       Brian should not get a chance to decline (or accept) the 2nd share of the resource from Alice
@@ -43,18 +50,24 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Alice" has created folder "parent"
     And user "Alice" has created folder "parent/child"
     And user "Alice" has uploaded file with content "Share content" to "parent/child/lorem.txt"
-    When user "Alice" shares folder "parent" with group "grp" with permissions "read" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
-    And user "Brian" moves folder "/Shares/parent" to "/Shares/sharedParent" using the WebDAV API
-    And user "Alice" shares folder "parent" with user "Brian" using the sharing API
-    And user "Brian" declines share "/parent" offered by user "Alice" using the sharing API
-    Then as "Brian" folder "Shares/parent" should not exist
+    And user "Alice" has created a share with settings
+      | path        | parent |
+      | shareType   | group  |
+      | shareWith   | grp    |
+      | permissions | read   |
+    When user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And user "Brian" should be able to rename folder "/Shares/parent" to "/Shares/sharedParent"
+    And user "Alice" should be able to share folder "parent" with user "Brian" with permissions "read" using the sharing API
+    And user "Brian" should be able to decline pending share "/parent" offered by user "Alice"
+    And as "Brian" folder "Shares/parent" should not exist
     And as "Brian" folder "Shares/sharedParent" should not exist
     And as "Brian" file "Shares/sharedParent/child/lorem.txt" should not exist
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Share receiver renames a group share and receives same resource through user share with additional permissions
@@ -65,20 +78,26 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Alice" has created folder "parent"
     And user "Alice" has created folder "parent/child"
     And user "Alice" has uploaded file with content "Share content" to "parent/child/lorem.txt"
-    When user "Alice" shares folder "parent" with group "grp" with permissions "read" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
-    And user "Brian" moves folder "/Shares/parent" to "/Shares/sharedParent" using the WebDAV API
-    And user "Alice" shares folder "parent" with user "Brian" with permissions "all" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
-    Then as "Brian" folder "Shares/parent" should exist
+    And user "Alice" has created a share with settings
+      | path        | parent |
+      | shareType   | group  |
+      | shareWith   | grp    |
+      | permissions | read   |
+    When user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And user "Brian" should be able to rename folder "/Shares/parent" to "/Shares/sharedParent"
+    And user "Alice" should be able to share folder "parent" with user "Brian" with permissions "all" using the sharing API
+    And user "Brian" should be able to accept pending share "/parent" offered by user "Alice"
+    And as "Brian" folder "Shares/parent" should exist
     And as "Brian" folder "Shares/sharedParent" should not exist
     And as "Brian" file "Shares/sharedParent/child/lorem.txt" should not exist
     And as "Brian" file "Shares/parent/child/lorem.txt" should exist
     And user "Brian" should be able to delete file "Shares/parent/child/lorem.txt"
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Share receiver renames a group share and receives same resource through user share with less permissions
@@ -89,17 +108,23 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Alice" has created folder "parent"
     And user "Alice" has created folder "parent/child"
     And user "Alice" has uploaded file with content "Share content" to "parent/child/lorem.txt"
-    When user "Alice" shares folder "parent" with group "grp" with permissions "all" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
-    And user "Brian" moves folder "/Shares/parent" to "/Shares/sharedParent" using the WebDAV API
-    And user "Alice" shares folder "parent" with user "Brian" with permissions "read" using the sharing API
-    And user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
-    Then as "Brian" folder "Shares/parent" should exist
+    And user "Alice" has created a share with settings
+      | path        | parent |
+      | shareType   | group  |
+      | shareWith   | grp    |
+      | permissions | all    |
+    When user "Brian" accepts share "/parent" offered by user "Alice" using the sharing API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs_status_code>"
+    And user "Brian" should be able to rename folder "/Shares/parent" to "/Shares/sharedParent"
+    And user "Alice" should be able to share folder "parent" with user "Brian" with permissions "read" using the sharing API
+    And user "Brian" should be able to accept pending share "/parent" offered by user "Alice"
+    And as "Brian" folder "Shares/parent" should exist
     And as "Brian" folder "Shares/sharedParent" should not exist
     And as "Brian" file "Shares/sharedParent/child/lorem.txt" should not exist
     And as "Brian" file "Shares/parent/child/lorem.txt" should exist
     And user "Brian" should be able to delete file "Shares/parent/child/lorem.txt"
     Examples:
-      | ocs_api_version |
-      | 1               |
-      | 2               |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
@@ -40,8 +40,10 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /TEXTFILE.txt     |
       | /TEXT_FILE.txt    |
       | /123TEXTFILE.txt  |
-      | /TEXTFILE.xyz.txt  |
-    Then as "Brian" the following files should exist
+      | /TEXTFILE.xyz.txt |
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And as "Brian" the following files should exist
       | path                     |
       | /Shares/textfile.txt     |
       | /Shares/text_file.txt    |
@@ -84,7 +86,9 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /f_o    |
       | /123fo  |
       | /fo.xyz |
-    Then as "Brian" the following folders should exist
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And as "Brian" the following folders should exist
       | path           |
       | /Shares/FO     |
       | /Shares/F_O    |
@@ -131,7 +135,9 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /CASE_SENSITIVE        |
       | /123case_sensitive     |
       | /CASESENSITIVE.xyz     |
-    Then as "Brian" the following files should exist
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And as "Brian" the following files should exist
       | path                          |
       | /Shares/casesensitive.txt     |
       | /Shares/case_sensitive.txt    |
@@ -177,8 +183,10 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /TEXTFILE.txt     |
       | /TEXT_FILE.txt    |
       | /123TEXTFILE.txt  |
-      | /TEXTFILE.xyz.txt  |
-    Then as "Brian" the following files should exist
+      | /TEXTFILE.xyz.txt |
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And as "Brian" the following files should exist
       | path                     |
       | /Shares/textfile.txt     |
       | /Shares/text_file.txt    |
@@ -223,7 +231,9 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /f_o    |
       | /123fo  |
       | /fo.xyz |
-    Then as "Brian" the following folders should exist
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And as "Brian" the following folders should exist
       | path           |
       | /Shares/FO     |
       | /Shares/F_O    |
@@ -272,7 +282,9 @@ Feature: Sharing resources with different case names with the sharee and checkin
       | /CASE_SENSITIVE        |
       | /123case_sensitive     |
       | /CASESENSITIVE.xyz     |
-    Then as "Brian" the following files should exist
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And as "Brian" the following files should exist
       | path                          |
       | /Shares/casesensitive.txt     |
       | /Shares/case_sensitive.txt    |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
@@ -19,6 +19,8 @@ Feature: resources shared with the same name are received with unique names
     And user "Carol" accepts share "/foo" offered by user "Alice" using the sharing API
     And user "Brian" shares folder "/foo" with user "Carol" using the sharing API
     And user "Carol" accepts share "/foo" offered by user "Brian" using the sharing API
-    Then user "Carol" should see the following elements
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And user "Carol" should see the following elements
       | /Shares/foo/       |
       | /Shares/foo (2)/ |

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1423,6 +1423,7 @@ trait Sharing {
 				$permissions
 			);
 		}
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -3056,6 +3057,7 @@ trait Sharing {
 				$offeredBy
 			);
 		}
+		$this->pushToLastStatusCodesArrays();
 	}
 
 	/**
@@ -3132,7 +3134,6 @@ trait Sharing {
 
 	/**
 	 * @Given /^user "([^"]*)" has accepted the (?:first|next|) pending share "([^"]*)" offered by user "([^"]*)"$/
-	 * @Then /^user "([^"]*)" should be able to accept pending share "([^"]*)" offered by user "([^"]*)"$/
 	 *
 	 * @param string $user
 	 * @param string $share
@@ -3148,6 +3149,30 @@ trait Sharing {
 			__METHOD__ . " could not accept the pending share $share to $user by $offeredBy"
 		);
 		$this->ocsContext->assertOCSResponseIndicatesSuccess();
+	}
+
+	/**
+	 * @Then /^user "([^"]*)" should be able to (decline|accept) pending share "([^"]*)" offered by user "([^"]*)"$/
+	 *
+	 * @param string $user
+	 * @param string $action
+	 * @param string $share
+	 * @param string $offeredBy
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userShouldBeAbleToAcceptShareOfferedBy(
+		string $user,
+		string $action,
+		string $share,
+		string $offeredBy
+	) {
+		if ($action === 'accept') {
+			$this->userHasAcceptedThePendingShareOfferedBy($user, $share, $offeredBy);
+		} elseif ($action === 'decline') {
+			$this->userHasReactedToShareOfferedBy($user, 'declined', $share, $offeredBy);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds ``` Then ``` steps to existing API test scenarios to better check the results of ``` When ``` steps.

### Suite Covered
- ```apiShareCreateSpecialToShare1```

## Related Issues
- Part of https://github.com/owncloud/core/issues/39512

## How Has This Been Tested?
- Locally
- CI

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
