### PR TITLE
[tests-only] decode href value before assertions

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -41,25 +41,25 @@ Feature: get file properties
     When user "Alice" gets the properties of file "<file_name>" using the WebDAV API
     Then the HTTP status code should be "201"
     And the properties response should contain an etag
-    And the value of the item "//d:response/d:href" in the response to user "Alice" should match "/<expected_href>/"
+    And there should be an entry with href containing "<expected_href>" in the response to user "Alice"
     Examples:
-      | dav_version | file_name     | expected_href                                                  |
-      | old         | /C++ file.cpp | remote\.php\/webdav\/C%2[bB]%2[bB]%20file\.cpp                 |
-      | old         | /file #2.txt  | remote\.php\/webdav\/file%20%232\.txt                          |
-      | old         | /file ?2.txt  | remote\.php\/webdav\/file%20%3[fF]2\.txt                       |
-      | old         | /file &2.txt  | remote\.php\/webdav\/file%20%262\.txt                          |
-      | new         | /C++ file.cpp | remote\.php\/dav\/files\/%username%\/C%2[bB]%2[bB]%20file\.cpp |
-      | new         | /file #2.txt  | remote\.php\/dav\/files\/%username%\/file%20%232\.txt          |
-      | new         | /file ?2.txt  | remote\.php\/dav\/files\/%username%\/file%20%3[fF]2\.txt       |
-      | new         | /file &2.txt  | remote\.php\/dav\/files\/%username%\/file%20%262\.txt          |
+      | dav_version | file_name     | expected_href                                 |
+      | old         | /C++ file.cpp | remote.php/webdav/C++ file.cpp                |
+      | old         | /file #2.txt  | remote.php/webdav/file #2.txt                 |
+      | old         | /file ?2.txt  | remote.php/webdav/file ?2.txt                 |
+      | old         | /file &2.txt  | remote.php/webdav/file &2.txt                 |
+      | new         | /C++ file.cpp | remote.php/dav/files/%username%/C++ file.cpp  |
+      | new         | /file #2.txt  | remote.php/dav/files/%username%/file #2.txt   |
+      | new         | /file ?2.txt  | remote.php/dav/files/%username%/file ?2.txt   |
+      | new         | /file &2.txt  | remote.php/dav/files/%username%/file &2.txt   |
 
     @skipOnOcV10 @personalSpace
     Examples:
-      | dav_version | file_name     | expected_href                                     |
-      | spaces      | /C++ file.cpp | dav\/spaces\/%spaceid%\/C%2[bB]%2[bB]%20file\.cpp |
-      | spaces      | /file #2.txt  | dav\/spaces\/%spaceid%\/file%20%232\.txt          |
-      | spaces      | /file ?2.txt  | dav\/spaces\/%spaceid%\/file%20%3[fF]2\.txt       |
-      | spaces      | /file &2.txt  | dav\/spaces\/%spaceid%\/file%20%262\.txt          |
+      | dav_version | file_name     | expected_href                     |
+      | spaces      | /C++ file.cpp | dav/spaces/%spaceid%/C++ file.cpp |
+      | spaces      | /file #2.txt  | dav/spaces/%spaceid%/file #2.txt  |
+      | spaces      | /file ?2.txt  | dav/spaces/%spaceid%/file ?2.txt  |
+      | spaces      | /file &2.txt  | dav/spaces/%spaceid%/file &2.txt  |
 
   @issue-ocis-reva-214
   Scenario Outline: Do a PROPFIND of various folder names
@@ -69,36 +69,36 @@ Feature: get file properties
     And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file2.txt"
     When user "Alice" gets the properties of folder "<folder_name>" with depth 1 using the WebDAV API
     Then the HTTP status code should be "201"
-    And there should be an entry with href matching "/<expected_href>\//" in the response to user "Alice"
-    And there should be an entry with href matching "/<expected_href>\/file1.txt/" in the response to user "Alice"
-    And there should be an entry with href matching "/<expected_href>\/file2.txt/" in the response to user "Alice"
+    And there should be an entry with href containing "<expected_href>/" in the response to user "Alice"
+    And there should be an entry with href containing "<expected_href>/file1.txt" in the response to user "Alice"
+    And there should be an entry with href containing "<expected_href>/file2.txt" in the response to user "Alice"
     Examples:
-      | dav_version | folder_name     | expected_href                                                                                                            |
-      | old         | /upload         | remote\.php\/webdav\/upload                                                                                                           |
-      | old         | /strängé folder | remote\.php\/webdav\/str%[cC]3%[aA]4ng%[cC]3%[aA]9%20folder                                                                           |
-      | old         | /C++ folder     | remote\.php\/webdav\/C%2[bB]%2[bB]%20folder                                                                                           |
-      | old         | /नेपाली           | remote\.php\/webdav\/%[eE]0%[aA]4%[aA]8%[eE]0%[aA]5%87%[eE]0%[aA]4%[aA]a%[eE]0%[aA]4%be%[eE]0%[aA]4%b2%[eE]0%[aA]5%80                 |
-      | old         | /folder #2.txt  | remote\.php\/webdav\/folder%20%232\.txt                                                                                               |
-      | old         | /folder ?2.txt  | remote\.php\/webdav\/folder%20%3[fF]2\.txt                                                                                            |
-      | old         | /folder &2.txt  | remote\.php\/webdav\/folder%20%262\.txt                                                                                               |
-      | new         | /upload         | remote\.php\/dav\/files\/%username%\/upload                                                                                           |
-      | new         | /strängé folder | remote\.php\/dav\/files\/%username%\/str%[cC]3%[aA]4ng%[cC]3%[aA]9%20folder                                                           |
-      | new         | /C++ folder     | remote\.php\/dav\/files\/%username%\/C%2[bB]%2[bB]%20folder                                                                           |
-      | new         | /नेपाली           | remote\.php\/dav\/files\/%username%\/%[eE]0%[aA]4%[aA]8%[eE]0%[aA]5%87%[eE]0%[aA]4%[aA]a%[eE]0%[aA]4%be%[eE]0%[aA]4%b2%[eE]0%[aA]5%80 |
-      | new         | /folder #2.txt  | remote\.php\/dav\/files\/%username%\/folder%20%232\.txt                                                                               |
-      | new         | /folder ?2.txt  | remote\.php\/dav\/files\/%username%\/folder%20%3[fF]2\.txt                                                                            |
-      | new         | /folder &2.txt  | remote\.php\/dav\/files\/%username%\/folder%20%262\.txt                                                                               |
+      | dav_version | folder_name     | expected_href                                  |
+      | old         | /upload         | remote.php/webdav/upload                       |
+      | old         | /strängé folder | remote.php/webdav/strängé folder              |
+      | old         | /C++ folder     | remote.php/webdav/C++ folder                   |
+      | old         | /नेपाली           | remote.php/webdav/नेपाली                        |
+      | old         | /folder #2.txt  | remote.php/webdav/folder #2.txt                |
+      | old         | /folder ?2.txt  | remote.php/webdav/folder ?2.txt                |
+      | old         | /folder &2.txt  | remote.php/webdav/folder &2.txt                |
+      | new         | /upload         | remote.php/dav/files/%username%/upload         |
+      | new         | /strängé folder | remote.php/dav/files/%username%/strängé folder |
+      | new         | /C++ folder     | remote.php/dav/files/%username%/C++ folder     |
+      | new         | /नेपाली           | remote.php/dav/files/%username%/नेपाली          |
+      | new         | /folder #2.txt  | remote.php/dav/files/%username%/folder #2.txt  |
+      | new         | /folder ?2.txt  | remote.php/dav/files/%username%/folder ?2.txt  |
+      | new         | /folder &2.txt  | remote.php/dav/files/%username%/folder &2.txt  |
 
     @skipOnOcV10 @personalSpace
     Examples:
-      | dav_version | folder_name     | expected_href                                                                                                            |
-      | spaces      | /upload         | dav\/spaces\/%spaceid%\/upload                                                                                           |
-      | spaces      | /strängé folder | dav\/spaces\/%spaceid%\/str%[cC]3%[aA]4ng%[cC]3%[aA]9%20folder                                                           |
-      | spaces      | /C++ folder     | dav\/spaces\/%spaceid%\/C%2[bB]%2[bB]%20folder                                                                           |
-      | spaces      | /नेपाली           | dav\/spaces\/%spaceid%\/%[eE]0%[aA]4%[aA]8%[eE]0%[aA]5%87%[eE]0%[aA]4%[aA]a%[eE]0%[aA]4%be%[eE]0%[aA]4%b2%[eE]0%[aA]5%80 |
-      | spaces      | /folder #2.txt  | dav\/spaces\/%spaceid%\/folder%20%232\.txt                                                                               |
-      | spaces      | /folder ?2.txt  | dav\/spaces\/%spaceid%\/folder%20%3[fF]2\.txt                                                                            |
-      | spaces      | /folder &2.txt  | dav\/spaces\/%spaceid%\/folder%20%262\.txt                                                                               |
+      | dav_version | folder_name     | expected_href                       |
+      | spaces      | /upload         | dav/spaces/%spaceid%/upload         |
+      | spaces      | /strängé folder | dav/spaces/%spaceid%/strängé folder |
+      | spaces      | /C++ folder     | dav/spaces/%spaceid%/C++ folder     |
+      | spaces      | /नेपाली           | dav/spaces/%spaceid%/नेपाली          |
+      | spaces      | /folder #2.txt  | dav/spaces/%spaceid%/folder #2.txt  |
+      | spaces      | /folder ?2.txt  | dav/spaces/%spaceid%/folder ?2.txt  |
+      | spaces      | /folder &2.txt  | dav/spaces/%spaceid%/folder &2.txt  |
 
 
   Scenario Outline: Do a PROPFIND of various files inside various folders
@@ -113,12 +113,12 @@ Feature: get file properties
       | old         | /upload                          | abc.txt                       |
       | old         | /strängé folder                  | strängé file.txt              |
       | old         | /C++ folder                      | C++ file.cpp                  |
-      | old         | /नेपाली                            | नेपाली                          |
+      | old         | /नेपाली                          | नेपाली                        |
       | old         | /folder #2.txt                   | file #2.txt                   |
       | new         | /upload                          | abc.txt                       |
       | new         | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
       | new         | /C++ folder                      | C++ file.cpp                  |
-      | new         | /नेपाली                            | नेपाली                          |
+      | new         | /नेपाली                          | नेपाली                        |
       | new         | /folder #2.txt                   | file #2.txt                   |
 
     @skipOnOcV10 @personalSpace
@@ -127,7 +127,7 @@ Feature: get file properties
       | spaces      | /upload         | abc.txt          |
       | spaces      | /strängé folder | strängé file.txt |
       | spaces      | /C++ folder     | C++ file.cpp     |
-      | spaces      | /नेपाली           | नेपाली             |
+      | spaces      | /नेपाली         | नेपाली           |
       | spaces      | /folder #2.txt  | file #2.txt      |
 
   @issue-ocis-reva-265
@@ -370,7 +370,7 @@ Feature: get file properties
       | spaces      |
 
   @issue-36920
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-reva-217
+    @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-reva-217
   Scenario Outline: add multiple properties to files inside a folder and do a propfind of the parent folder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/TestFolder"

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -812,15 +812,25 @@ class WebDavPropertiesContext implements Context {
 			);
 			$value = $xmlPart[0]->__toString();
 			$decodedValue = \rawurldecode($value);
-			// for folders decoded value will be like: "/owncloud/core/remote.php/webdav/strängé folder/"
+			// for folders, decoded value will be like: "/owncloud/core/remote.php/webdav/strängé folder/"
 			// expected href should be like: "remote.php/webdav/strängé folder/"
-			// for files decoded value will be like: "/owncloud/core/remote.php/ebdav/strängé folder/file.txt"
+			// for files, decoded value will be like: "/owncloud/core/remote.php/webdav/strängé folder/file.txt"
 			// expected href should be like: "remote.php/webdav/strängé folder/file.txt"
 			$explodeDecoded = \explode('/', $decodedValue);
-			$remotePhpIndex = \array_search('remote.php', $explodeDecoded);
+			// get the first item of the expected href.
+			// i.e remote.php from "remote.php/webdav/strängé folder/file.txt"
+			// or dav from "dav/spaces/%spaceid%/C++ file.cpp"
+			$explodeExpected = \explode('/', $expectedHref);
+			$remotePhpIndex = \array_search($explodeExpected[0], $explodeDecoded);
 			if ($remotePhpIndex) {
 				$explodedHrefPartArray = \array_slice($explodeDecoded, $remotePhpIndex);
 				$actualHrefPart = \implode('/', $explodedHrefPartArray);
+				if ($this->featureContext->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES) {
+					// for spaces webdav, space id is included in the href
+					// space id from our helper is returned as d8c029e0\-2bc9\-4b9a\-8613\-c727e5417f05
+					// so we've to remove "\" before every "-"
+					$expectedHref = str_replace('\-', '-', $expectedHref);
+				}
 				if ($actualHrefPart === $expectedHref) {
 					break;
 				}


### PR DESCRIPTION
## Description
- decode href value before making assertions
- do not assert href using regex pattern

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/cs3org/reva/pull/2658

## Motivation and Context
https://github.com/cs3org/reva/pull/2658#issuecomment-1087259710

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
