### PR TITLE
Limit the width of the form on login page

### DIFF
--- a/changelog/unreleased/39962
+++ b/changelog/unreleased/39962
@@ -1,0 +1,5 @@
+Bugfix: Limit the width of the form on login page
+
+The login form breaks if error messages and info messages are longer.
+
+https://github.com/owncloud/core/pull/39962

--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -277,7 +277,7 @@ a.two-factor-cancel {
 #body-login form {
 	position: relative;
 	margin: 32px auto;
-	min-width: 300px;
+	width: 300px;
 }
 
 #body-login form fieldset {


### PR DESCRIPTION
## Description
The login form breaks if error messages and info messages are longer.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39961

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested


## Screenshots:
Before:
<img width="701" alt="image" src="https://user-images.githubusercontent.com/33026403/162200576-75d28df6-6a73-489e-a89a-499230dc95c2.png">

After:
<img width="678" alt="image" src="https://user-images.githubusercontent.com/33026403/162200661-29d3aef8-e379-48e7-9990-e18658a48a86.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
