### PR TITLE
Allow reuploading a folder after being renamed

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -653,6 +653,12 @@ OC.Uploader.prototype = _.extend({
 			promise = deferred.promise();
 			this._knownDirs[fullPath] = promise;
 
+			// once the promise ends, we'll remove it from the this._knownDirs
+			var that = this;
+			promise.always(function() {
+				delete that._knownDirs[fullPath];
+			});
+
 			// make sure all parents already exist
 			var parentPath = OC.dirname(fullPath);
 			var parentPromise = this._knownDirs[parentPath];

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -654,9 +654,8 @@ OC.Uploader.prototype = _.extend({
 			this._knownDirs[fullPath] = promise;
 
 			// once the promise ends, we'll remove it from the this._knownDirs
-			var that = this;
 			promise.always(function() {
-				delete that._knownDirs[fullPath];
+				delete self._knownDirs[fullPath];
 			});
 
 			// make sure all parents already exist

--- a/changelog/unreleased/39966
+++ b/changelog/unreleased/39966
@@ -1,0 +1,8 @@
+Bugfix: Allow re-uploading the same folder after being renamed
+
+Previously, you couldn't upload a folder, rename it in the web UI and then
+re-upload the same folder.
+
+This behavior is fixed, so you can now re-upload the folder after renaming it
+
+https://github.com/owncloud/core/pull/39966


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Drop an empty folder to the web UI, then, after renaming, you couldn't upload the same empty file. This is fixed in this PR.

## Related Issue
https://github.com/owncloud/enterprise/issues/5025

## Motivation and Context
There is no reason to prevent the upload because the folder doesn't exist any longer. In addition, there wasn't any error message shown to the user. In fact, the expected MKCOL request (after the rename) wasn't happening.

## How Has This Been Tested?
Followed steps described in the issue

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
