### PR TITLE
[tests-only][full-ci] Added webdav spaces in apiTrashbin suite

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -54,10 +54,10 @@ class WebDavHelper {
 	 * @return void
 	 * @throws Exception
 	 */
-	public static function removeSpaceIdForUser(
+	public static function removeSpaceIdReferenceForUser(
 		?string $user
 	):void {
-		if (\array_key_exists($user, self::$spacesIdRef) && \array_key_exists("personal", self::$spacesIdRef[$user])) {
+		if (\array_key_exists($user, self::$spacesIdRef)) {
 			unset(self::$spacesIdRef[$user]);
 		}
 	}
@@ -644,6 +644,7 @@ class WebDavHelper {
 		?string $type = "files",
 		?string $spaceId = null
 	):string {
+		$newTrashbinDavPath = "remote.php/dav/trash-bin/$user/";
 		if ($type === "public-files" || $type === "public-files-old") {
 			return "public.php/webdav/";
 		}
@@ -669,7 +670,8 @@ class WebDavHelper {
 		} else {
 			if ($davPathVersionToUse === self::DAV_VERSION_OLD) {
 				if ($type === "trash-bin") {
-					return "remote.php/dav/trash-bin/" . $user . '/';
+					// Since there is no trash bin endpoint for old dav version, new dav version's endpoint is used here.
+					return $newTrashbinDavPath;
 				}
 				return "remote.php/webdav/";
 			} elseif ($davPathVersionToUse === self::DAV_VERSION_NEW) {
@@ -677,7 +679,7 @@ class WebDavHelper {
 					$path = 'remote.php/dav/files/';
 					return $path . $user . '/';
 				} elseif ($type === "trash-bin") {
-					return "remote.php/dav/trash-bin/" . $user . '/';
+					return $newTrashbinDavPath;
 				} else {
 					return "remote.php/dav";
 				}

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -534,7 +534,11 @@ class WebDavHelper {
 		$spaceId = null;
 		// get space id if testing with spaces dav
 		if ($davPathVersionToUse === self::DAV_VERSION_SPACES) {
-			$spaceId = self::getPersonalSpaceIdForUser($baseUrl, $user, $password, $xRequestId);
+			if ($doDavRequestAsUser === null) {
+				$spaceId = self::getPersonalSpaceIdForUser($baseUrl, $user, $password, $xRequestId);
+			} else {
+				$spaceId = self::getPersonalSpaceIdForUser($baseUrl, $doDavRequestAsUser, $password, $xRequestId);
+			}
 		}
 
 		if ($doDavRequestAsUser === null) {
@@ -633,15 +637,19 @@ class WebDavHelper {
 					__METHOD__ . " A spaceId must be passed when using DAV path version 3 (spaces)"
 				);
 			}
+			if ($type === "trash-bin") {
+				return "/remote.php/dav/spaces/trash-bin/" . $spaceId . '/';
+			}
 			return "dav/spaces/" . $spaceId . '/';
 		} else {
 			if ($davPathVersionToUse === self::DAV_VERSION_OLD) {
-				$path = "remote.php/webdav/";
-				return $path;
+				return "remote.php/webdav/";
 			} elseif ($davPathVersionToUse === self::DAV_VERSION_NEW) {
 				if ($type === "files") {
 					$path = 'remote.php/dav/files/';
 					return $path . $user . '/';
+				} elseif ($type === "trash-bin") {
+					return "remote.php/dav/trash-bin/" . $user . '/';
 				} else {
 					return "remote.php/dav";
 				}

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -668,6 +668,9 @@ class WebDavHelper {
 			return "dav/spaces/" . $spaceId . '/';
 		} else {
 			if ($davPathVersionToUse === self::DAV_VERSION_OLD) {
+				if ($type === "trash-bin") {
+					return "remote.php/dav/trash-bin/" . $user . '/';
+				}
 				return "remote.php/webdav/";
 			} elseif ($davPathVersionToUse === self::DAV_VERSION_NEW) {
 				if ($type === "files") {

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -47,6 +47,22 @@ class WebDavHelper {
 	public static $spacesIdRef = [];
 
 	/**
+	 * clear space id reference for user
+	 *
+	 * @param string|null $user
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public static function removeSpaceIdForUser(
+		?string $user
+	):void {
+		if (\array_key_exists($user, self::$spacesIdRef) && \array_key_exists("personal", self::$spacesIdRef[$user])) {
+			unset(self::$spacesIdRef[$user]);
+		}
+	}
+
+	/**
 	 * returns the id of a file
 	 *
 	 * @param string|null $baseUrl
@@ -118,6 +134,7 @@ class WebDavHelper {
 	 * @param string|null $folderDepth
 	 * @param string|null $type
 	 * @param int|null $davPathVersionToUse
+	 * @param string|null $doDavRequestAsUser
 	 *
 	 * @return ResponseInterface
 	 */
@@ -130,7 +147,8 @@ class WebDavHelper {
 		?string $xRequestId = '',
 		?string $folderDepth = '0',
 		?string $type = "files",
-		?int $davPathVersionToUse = self::DAV_VERSION_NEW
+		?int $davPathVersionToUse = self::DAV_VERSION_NEW,
+		?string $doDavRequestAsUser = null
 	):ResponseInterface {
 		$propertyBody = "";
 		$extraNamespaces = "";
@@ -178,7 +196,14 @@ class WebDavHelper {
 			$xRequestId,
 			$body,
 			$davPathVersionToUse,
-			$type
+			$type,
+			null,
+			null,
+			false,
+			null,
+			null,
+			[],
+			$doDavRequestAsUser
 		);
 	}
 

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -102,7 +102,7 @@ Feature: files and folders can be deleted from the trashbin
       | dav-path |
       | new      |
 
-    @issue-ocis-3544 @skipOnOcV10 @personalSpace
+    @skipOnOcV10 @personalSpace
     Examples:
       | dav-path |
       | spaces   |

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -15,9 +15,9 @@ Feature: files and folders can be deleted from the trashbin
 
   @smokeTest
   Scenario Outline: Trashbin can be emptied
-    Given user "Alice" has uploaded file with content "file with comma" to "sample,0.txt"
+    Given using <dav-path> DAV path
+    And user "Alice" has uploaded file with content "file with comma" to "sample,0.txt"
     And user "Alice" has uploaded file with content "file with comma" to "sample,1.txt"
-    And using <dav-path> DAV path
     And user "Alice" has deleted file "<filename1>"
     And user "Alice" has deleted file "<filename2>"
     When user "Alice" empties the trashbin using the trashbin API
@@ -26,14 +26,19 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "<filename2>" should not exist in the trashbin
     Examples:
       | dav-path | filename1     | filename2     |
-      | old      | textfile0.txt | textfile1.txt |
       | new      | textfile0.txt | textfile1.txt |
-      | old      | sample,0.txt  | sample,1.txt  |
       | new      | sample,0.txt  | sample,1.txt  |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path | filename1     | filename2     |
+      | spaces   | textfile0.txt | textfile1.txt |
+      | spaces   | sample,0.txt  | sample,1.txt  |
+
   @smokeTest
-  Scenario: delete a single file from the trashbin
-    Given user "Alice" has deleted file "/textfile0.txt"
+  Scenario Outline: delete a single file from the trashbin
+    Given using <dav-path> DAV path
+    And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
     And user "Alice" has deleted file "/PARENT/parent.txt"
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
@@ -43,10 +48,19 @@ Feature: files and folders can be deleted from the trashbin
     But as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @smokeTest
-  Scenario: delete multiple files from the trashbin and make sure the correct ones are gone
-    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/textfile0.txt"
+  Scenario Outline: delete multiple files from the trashbin and make sure the correct ones are gone
+    Given using <dav-path> DAV path
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/textfile0.txt"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/child.txt"
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
@@ -61,10 +75,19 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should not exist in the trashbin
     But as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/child.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @skipOnOcV10.3
-  Scenario: User tries to delete another user's trashbin
-    Given user "Brian" has been created with default attributes and without skeleton files
+  Scenario Outline: User tries to delete another user's trashbin
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
     And user "Alice" has deleted file "/PARENT/parent.txt"
@@ -75,9 +98,18 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | new      |
 
-  Scenario: User tries to delete trashbin file using invalid password
-    Given user "Brian" has been created with default attributes and without skeleton files
+    @issue-ocis-3544 @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+
+  Scenario Outline: User tries to delete trashbin file using invalid password
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
     And user "Alice" has deleted file "/PARENT/parent.txt"
@@ -88,9 +120,18 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | new      |
 
-  Scenario: User tries to delete trashbin file using no password
-    Given user "Brian" has been created with default attributes and without skeleton files
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+
+  Scenario Outline: User tries to delete trashbin file using no password
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     And user "Alice" has deleted file "/textfile1.txt"
     And user "Alice" has deleted file "/PARENT/parent.txt"
@@ -101,10 +142,19 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
-  Scenario: delete a folder that contains a file from the trashbin
-    Given user "Alice" has created folder "FOLDER"
+  Scenario Outline: delete a folder that contains a file from the trashbin
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created folder "FOLDER/CHILD"
     And user "Alice" has uploaded file with content "to delete" to "/FOLDER/parent.txt"
     And user "Alice" has uploaded file with content "to delete" to "/FOLDER/CHILD/child.txt"
@@ -117,10 +167,19 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the folder with original path "/PARENT/CHILD/" should not exist in the trashbin
     But as "Alice" the file with original path "/FOLDER/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/FOLDER/CHILD/child.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
-  Scenario: delete a subfolder from a deleted folder from the trashbin
-    Given user "Alice" has created folder "FOLDER"
+  Scenario Outline: delete a subfolder from a deleted folder from the trashbin
+    Given using <dav-path> DAV path
+    And user "Alice" has created folder "FOLDER"
     And user "Alice" has created folder "FOLDER/CHILD"
     And user "Alice" has uploaded file with content "to delete" to "/FOLDER/parent.txt"
     And user "Alice" has uploaded file with content "to delete" to "/FOLDER/CHILD/child.txt"
@@ -133,6 +192,14 @@ Feature: files and folders can be deleted from the trashbin
     But as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     But as "Alice" the file with original path "/FOLDER/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/FOLDER/CHILD/child.txt" should exist in the trashbin
+    Examples:
+      | dav-path |
+      | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: delete files with special characters from the trashbin
@@ -164,8 +231,12 @@ Feature: files and folders can be deleted from the trashbin
       | # %ab ab?=ed.txt |
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: delete folders with special characters from the trashbin
@@ -197,11 +268,16 @@ Feature: files and folders can be deleted from the trashbin
       | # %ab ab?=ed |
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
-  Scenario: delete folders with dot in the name from the trashbin
-    Given user "Alice" has created the following folders
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+
+  Scenario Outline: delete folders with dot in the name from the trashbin
+    Given using <dav-path> DAV path
+    And user "Alice" has created the following folders
       | path      |
       | /fo.      |
       | /fo.1     |
@@ -238,3 +314,11 @@ Feature: files and folders can be deleted from the trashbin
       | /..fo     |
       | /fo.xyz   |
       | /fo.exe   |
+    Examples:
+      | dav-path |
+      | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -17,8 +17,12 @@ Feature: files and folders exist in the trashbin after being deleted
     But as "Alice" file "/textfile0.txt" should not exist
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @smokeTest
   Scenario Outline: deleting a folder moves it to trashbin
@@ -29,8 +33,12 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" folder "/tmp" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   Scenario Outline: deleting a file in a folder moves it to the trashbin root
     Given using <dav-path> DAV path
@@ -43,8 +51,12 @@ Feature: files and folders exist in the trashbin after being deleted
     But as "Alice" file "/new-folder/new-file.txt" should not exist
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @files_sharing-app-required
   Scenario Outline: deleting a file in a shared folder moves it to the trashbin root
@@ -60,8 +72,12 @@ Feature: files and folders exist in the trashbin after being deleted
     But as "Alice" file "/shared/shared_file.txt" should not exist
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @files_sharing-app-required
   Scenario Outline: deleting a shared folder moves it to trashbin
@@ -75,8 +91,12 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" the folder with original path "/shared" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @skipOnOcV10 @issue-23151
   # This scenario deletes many files as close together in time as the test can run.
@@ -107,8 +127,12 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   # Note: the underlying acceptance test code ensures that each delete step is separated by a least 1 second
   Scenario Outline: trashbin can store two files with the same name but different origins when the deletes are separated by at least 1 second
@@ -126,8 +150,12 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @local_storage @files_external-app-required
   @skipOnEncryptionType:user-keys @encryption-issue-42
@@ -142,10 +170,14 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" the folder with original path "/local_storage/tmp" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
-  @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+
+  @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "testtrashbin100" has been created with default attributes and without skeleton files
@@ -159,10 +191,14 @@ Feature: files and folders exist in the trashbin after being deleted
       | textfile1.txt | testtrashbin100 |
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
-  @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+
+  @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited with multiple files on trashbin
     Given using <dav-path> DAV path
     And user "testtrashbin101" has been created with default attributes and without skeleton files
@@ -179,10 +215,14 @@ Feature: files and folders exist in the trashbin after being deleted
       | textfile2.txt | testtrashbin101 |
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
-  @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+
+  @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited for newly recreated user with same name
     Given using <dav-path> DAV path
     And user "testtrashbin102" has been created with default attributes and without skeleton files
@@ -205,8 +245,12 @@ Feature: files and folders exist in the trashbin after being deleted
       | textfile3.txt | testtrashbin102 |
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @smokeTest
   Scenario Outline: Get trashbin content with wrong password
@@ -220,8 +264,12 @@ Feature: files and folders exist in the trashbin after being deleted
       | /textfile0.txt | Alice |
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @smokeTest
   Scenario Outline: Get trashbin content without password
@@ -235,31 +283,39 @@ Feature: files and folders exist in the trashbin after being deleted
       | /textfile0.txt | Alice |
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+
   Scenario Outline: user with unusual username deletes a file
-    Given user "<username>" has been created with default attributes and without skeleton files
+    Given using <dav-path> DAV path
+    And user "<username>" has been created with default attributes and without skeleton files
     And user "<username>" has uploaded file with content "to delete" to "/textfile0.txt"
-    And using <dav-path> DAV path
     When user "<username>" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And as "<username>" file "/textfile0.txt" should exist in the trashbin
     But as "<username>" file "/textfile0.txt" should not exist
     Examples:
       | dav-path | username |
-      | old      | dash-123 |
-      | old      | null     |
-      | old      | nil      |
-      | old      | 123      |
-      | old      | -123     |
-      | old      | 0.0      |
       | new      | dash-123 |
       | new      | null     |
       | new      | nil      |
       | new      | 123      |
       | new      | -123     |
       | new      | 0.0      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path | username |
+      | spaces   | dash-123 |
+      | spaces   | null     |
+      | spaces   | nil      |
+      | spaces   | 123      |
+      | spaces   | -123     |
+      | spaces   | 0.0      |
 
   Scenario Outline: deleting a file with comma in the filename moves it to trashbin
     Given using <dav-path> DAV path
@@ -270,8 +326,12 @@ Feature: files and folders exist in the trashbin after being deleted
     But as "Alice" file "sample,1.txt" should not exist
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: deleting a folder moves all its content to the trashbin
@@ -286,8 +346,12 @@ Feature: files and folders exist in the trashbin after being deleted
     But as "Alice" file "/new-folder/new-file.txt" should not exist
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @issue-ocis-541
   Scenario Outline: deleted file has appropriate deletion time information
@@ -299,8 +363,12 @@ Feature: files and folders exist in the trashbin after being deleted
     And the deleted file "file.txt" should have the correct deletion mtime in the response
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @issue-ocis-1547
   Scenario Outline: deleting files with special characters moves it to trashbin
@@ -332,8 +400,12 @@ Feature: files and folders exist in the trashbin after being deleted
       | # %ab ab?=ed.txt |
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
   @issue-ocis-1547
   Scenario Outline: deleting folders with special characters moves it to trashbin
@@ -344,7 +416,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | !@tester$^   |
       | %file *?2    |
       | # %ab ab?=ed |
-    When user "Alice" deletes the following files
+    When user "Alice" deletes the following folders
       | path         |
       | qa&dev       |
       | !@tester$^   |
@@ -365,5 +437,9 @@ Feature: files and folders exist in the trashbin after being deleted
       | # %ab ab?=ed |
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
@@ -40,5 +40,4 @@ Feature: files and folders exist in the trashbin after being deleted
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -18,7 +18,6 @@ Feature: using trashbin together with sharing
     And as "Brian" the folder with original path "/renamed_shared" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -35,7 +34,6 @@ Feature: using trashbin together with sharing
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -56,7 +54,6 @@ Feature: using trashbin together with sharing
     And as "Carol" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -77,7 +74,6 @@ Feature: using trashbin together with sharing
     And as "Carol" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -99,7 +95,6 @@ Feature: using trashbin together with sharing
     And as "Carol" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -121,7 +116,6 @@ Feature: using trashbin together with sharing
     And as "Carol" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -144,11 +138,10 @@ Feature: using trashbin together with sharing
     And the content of file "/renamed_shared/shared_file.txt" for user "Brian" should be "to delete"
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-  Scenario Outline: restoring a file to a read-only folder
+  Scenario Outline: restoring a file to a read-only folder is not allowed
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "shareFolderParent"
@@ -163,11 +156,10 @@ Feature: using trashbin together with sharing
     And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-  Scenario Outline: restoring a file to a read-only sub-folder
+  Scenario Outline: restoring a file to a read-only sub-folder is not allowed
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "shareFolderParent"
@@ -183,5 +175,4 @@ Feature: using trashbin together with sharing
     And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     Examples:
       | dav-path |
-      | old      |
       | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -21,8 +21,12 @@ Feature: using trashbin together with sharing
     And as "Brian" the folder with original path "/Shares/renamed_shared" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: deleting a file in a received folder moves it to trashbin of both users
@@ -39,8 +43,12 @@ Feature: using trashbin together with sharing
     And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: sharee deleting a file in a group-shared folder moves it to the trashbin of sharee and sharer only
@@ -62,8 +70,12 @@ Feature: using trashbin together with sharing
     And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: sharer deleting a file in a group-shared folder moves it to the trashbin of sharer only
@@ -85,8 +97,12 @@ Feature: using trashbin together with sharing
     And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: sharee deleting a folder in a group-shared folder moves it to the trashbin of sharee and sharer only
@@ -109,8 +125,12 @@ Feature: using trashbin together with sharing
     And as "Carol" the file with original path "/Shares/sub/shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: sharer deleting a folder in a group-shared folder moves it to the trashbin of sharer only
@@ -133,8 +153,12 @@ Feature: using trashbin together with sharing
     And as "Carol" the file with original path "/Shares/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: deleting a file in a received folder when restored it comes back to the original path
@@ -157,8 +181,12 @@ Feature: using trashbin together with sharing
     And the content of file "/Shares/renamed_shared/shared_file.txt" for user "Brian" should be "file to delete"
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: restoring a file to a read-only folder
@@ -176,8 +204,12 @@ Feature: using trashbin together with sharing
     And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
 
 
   Scenario Outline: restoring a file to a read-only sub-folder
@@ -196,5 +228,9 @@ Feature: using trashbin together with sharing
     And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     Examples:
       | dav-path |
-      | old      |
       | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |

--- a/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
@@ -38,7 +38,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "/sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -69,7 +68,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "/PARENT/sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -115,7 +113,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "/sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
   Scenario Outline: Skip trashbin based on extensions when deleting the parent folder - skip-by-extension rules should not be applied
@@ -139,7 +136,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "PARENT/sample.go" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -169,7 +165,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "simple-folder/sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -190,7 +185,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     But as "Alice" the file with original path "simple-folder/s.txt" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -206,7 +200,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "/PARENT/sample.dat" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -221,7 +214,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "skipFile" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -236,7 +228,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "PARENT/lorem.txt" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -252,7 +243,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     But as "Alice" the file with original path "lorem.dat" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -268,7 +258,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     But as "Alice" the file with original path "PARENT/lorem.dat" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -283,7 +272,6 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "PARENT/lorem.dat" should exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |
 
 
@@ -331,5 +319,4 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
     Examples:
       | dav-path |
-      | old      |
       | new      |

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -29,6 +29,7 @@ use TestHelpers\SetupHelper;
 use TestHelpers\UserHelper;
 use TestHelpers\HttpRequestHelper;
 use TestHelpers\OcisHelper;
+use TestHelpers\WebDavHelper;
 use Laminas\Ldap\Exception\LdapException;
 use Laminas\Ldap\Ldap;
 
@@ -2001,6 +2002,7 @@ trait Provisioning {
 	public function theAdministratorHasDeletedUserUsingTheProvisioningApi(?string $user):void {
 		$user = $this->getActualUsername($user);
 		$this->deleteTheUserUsingTheProvisioningApi($user);
+		WebDavHelper::removeSpaceIdForUser($user);
 		$this->userShouldNotExist($user);
 	}
 

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -2002,7 +2002,7 @@ trait Provisioning {
 	public function theAdministratorHasDeletedUserUsingTheProvisioningApi(?string $user):void {
 		$user = $this->getActualUsername($user);
 		$this->deleteTheUserUsingTheProvisioningApi($user);
-		WebDavHelper::removeSpaceIdForUser($user);
+		WebDavHelper::removeSpaceIdReferenceForUser($user);
 		$this->userShouldNotExist($user);
 	}
 

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -301,11 +301,12 @@ class TrashbinContext implements Context {
 	public function sendTrashbinListRequest(string $user, ?string $asUser = null, ?string $password = null):void {
 		$asUser = $asUser ?? $user;
 		$password = $password ?? $this->featureContext->getPasswordForUser($asUser);
+		$davPathVersion = $this->featureContext->getDavPathVersion();
 		$response = WebDavHelper::propfind(
 			$this->featureContext->getBaseUrl(),
 			$asUser,
 			$password,
-			"/trash-bin/$user/",
+			null,
 			[
 				'oc:trashbin-original-filename',
 				'oc:trashbin-original-location',
@@ -315,14 +316,19 @@ class TrashbinContext implements Context {
 			$this->featureContext->getStepLineRef(),
 			'1',
 			'trash-bin',
-			2
+			$davPathVersion,
+			$user
 		);
 		$this->featureContext->setResponse($response);
-		$responseXmlObject = HttpRequestHelper::getResponseXml(
-			$response,
-			__METHOD__
-		);
-		$this->featureContext->setResponseXmlObject($responseXmlObject);
+		try {
+			$responseXmlObject = HttpRequestHelper::getResponseXml(
+				$response,
+				__METHOD__
+			);
+			$this->featureContext->setResponseXmlObject($responseXmlObject);
+		} catch (Exception $e) {
+			$this->featureContext->clearResponseXmlObject();
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -695,7 +695,9 @@ class TrashbinContext implements Context {
 			'trash-bin',
 			'2',
 			false,
-			$password
+			$password,
+			[],
+			$user
 		);
 		$this->featureContext->setResponse($response);
 		return $response;

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -136,6 +136,13 @@ trait WebDav {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function clearResponseXmlObject():void {
+		$this->responseXmlObject = null;
+	}
+
+	/**
 	 *
 	 * @return string the etag or an empty string if the getetag property does not exist
 	 */


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Added Spaces examples for features inside suite apiTrashbin
Files covered:
- [x] trashbinDelete.feature
- [x] trashbinFilesFolders.feature
- [x] trashbinFilesFoldersOc10Issue23151.feature
- [x] trashbinSharingToRoot.feature
- [x] trashbinSharingToShares.feature
- [x] trashbinSkip.feature
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/3065

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- CI
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
