### PR TITLE
[tests-only][full-ci]Improve then steps usages inside acceptance tests suite `apiFederationToRoot1`

### DIFF
--- a/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
@@ -17,7 +17,8 @@ Feature: propagation of etags between federated and local server
     And user "Alice" has stored etag of element "/PARENT (2)"
     And using server "LOCAL"
     When user "Brian" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
-    Then the etag of element "/PARENT (2)" of user "Alice" on server "REMOTE" should have changed
+    Then the HTTP status code should be "201"
+    And the etag of element "/PARENT (2)" of user "Alice" on server "REMOTE" should have changed
 
   @issue-enterprise-2848
   Scenario: Overwrite a federated shared folder as sharer propagates etag to root folder for recipient

--- a/tests/acceptance/features/apiFederationToRoot1/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federated.feature
@@ -36,10 +36,10 @@ Feature: federated
 
   @smokeTest
   Scenario Outline: Federate share a file with local server
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Alice" from server "REMOTE" shares "/textfile0.txt" with user "Brian" from server "LOCAL" using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -64,11 +64,11 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Federated sharee can see the pending share
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -88,12 +88,12 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Federated sharee requests information of only one share
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" retrieves the information of the last federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -105,7 +105,7 @@ Feature: federated
       | name        | /textfile0.txt           |
       | owner       | %username%               |
       | user        | %username%               |
-      | mountpoint  | /textfile0.txt       |
+      | mountpoint  | /textfile0.txt           |
       | accepted    | 1                        |
       | type        | file                     |
       | permissions | share,read,update,delete |
@@ -116,11 +116,11 @@ Feature: federated
 
   @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
   Scenario Outline: Federated sharee requests information of only one share before accepting it
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" retrieves the information of the last pending federated cloud share using the sharing API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs-status>"
@@ -160,10 +160,10 @@ Feature: federated
       | 2               | 404        | 404         |
 
   Scenario Outline: accept a pending federated share
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" from server "LOCAL" accepts the last pending share using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
@@ -173,105 +173,105 @@ Feature: federated
       | 2               | 200        |
 
   Scenario Outline: Reshare a federated shared file
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
     And user "Carol" has been created with default attributes and small skeleton files
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" creates a share using the sharing API with settings
-      | path        | /textfile0.txt |
-      | shareType   | user               |
-      | shareWith   | Carol              |
-      | permissions | share,read,update  |
+      | path        | /textfile0.txt    |
+      | shareType   | user              |
+      | shareWith   | Carol             |
+      | permissions | share,read,update |
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Brian" sharing with user "Carol" should include
-      | id                     | A_STRING           |
-      | item_type              | file               |
-      | item_source            | A_STRING           |
-      | share_type             | user               |
-      | file_source            | A_STRING           |
-      | path                   | /textfile0.txt |
-      | permissions            | share,read,update  |
-      | stime                  | A_NUMBER           |
-      | storage                | A_STRING           |
-      | mail_send              | 0                  |
-      | uid_owner              | %username%         |
-      | displayname_owner      | %displayname%      |
-      | share_with             | %username%         |
-      | share_with_displayname | %displayname%      |
+      | id                     | A_STRING          |
+      | item_type              | file              |
+      | item_source            | A_STRING          |
+      | share_type             | user              |
+      | file_source            | A_STRING          |
+      | path                   | /textfile0.txt    |
+      | permissions            | share,read,update |
+      | stime                  | A_NUMBER          |
+      | storage                | A_STRING          |
+      | mail_send              | 0                 |
+      | uid_owner              | %username%        |
+      | displayname_owner      | %displayname%     |
+      | share_with             | %username%        |
+      | share_with_displayname | %displayname%     |
     Examples:
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
 
   Scenario Outline: Overwrite a federated shared file as recipient - local server shares - remote server receives
-    Given user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
+    Given using OCS API version "<ocs-api-version>"
+    And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Brian" from server "LOCAL" has shared "/textfile0.txt" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
-    And using OCS API version "<ocs-api-version>"
     When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/textfile0.txt" for user "Brian" on server "LOCAL" should be "BLABLABLA" plus end-of-line
     Examples:
-      | ocs-api-version | ocs-status |
-      | 1               | 100        |
-      | 2               | 200        |
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
   Scenario Outline: Overwrite a federated shared file as recipient - remote server shares - local server receives
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" uploads file "filesForUpload/file_to_overwrite.txt" to "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/textfile0.txt" for user "Alice" on server "REMOTE" should be "BLABLABLA" plus end-of-line
     Examples:
-      | ocs-api-version | ocs-status |
-      | 1               | 100        |
-      | 2               | 200        |
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
-    Given user "Brian" has created folder "PARENT"
+    Given using OCS API version "<ocs-api-version>"
+    And user "Brian" has created folder "PARENT"
     And user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
     And using server "REMOTE"
-    And using OCS API version "<ocs-api-version>"
     When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/PARENT/textfile0.txt" for user "Brian" on server "LOCAL" should be "BLABLABLA" plus end-of-line
     Examples:
-      | ocs-api-version | ocs-status |
-      | 1               | 100        |
-      | 2               | 200        |
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has created folder "PARENT"
     And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/PARENT/textfile0.txt" for user "Alice" on server "REMOTE" should be "BLABLABLA" plus end-of-line
     Examples:
-      | ocs-api-version | ocs-status |
-      | 1               | 100        |
-      | 2               | 200        |
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
   Scenario Outline: Overwrite a federated shared file as recipient using old chunking
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" uploads the following "3" chunks to "/textfile0.txt" with old chunking and using the WebDAV API
       | number | content |
       | 1      | AAAAA   |
@@ -281,17 +281,17 @@ Feature: federated
     And the content of file "/textfile0.txt" for user "Brian" should be "AAAAABBBBBCCCCC"
     And the content of file "/textfile0.txt" for user "Alice" on server "REMOTE" should be "AAAAABBBBBCCCCC"
     Examples:
-      | ocs-api-version | ocs-status |
-      | 1               | 100        |
-      | 2               | 200        |
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient using old chunking
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has created folder "PARENT"
     And user "Alice" from server "REMOTE" has shared "/PARENT" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" uploads the following "3" chunks to "/PARENT/textfile0.txt" with old chunking and using the WebDAV API
       | number | content |
       | 1      | AAAAA   |
@@ -301,26 +301,30 @@ Feature: federated
     And the content of file "/PARENT/textfile0.txt" for user "Brian" should be "AAAAABBBBBCCCCC"
     And the content of file "/PARENT/textfile0.txt" for user "Alice" on server "REMOTE" should be "AAAAABBBBBCCCCC"
     Examples:
-      | ocs-api-version | ocs-status |
-      | 1               | 100        |
-      | 2               | 200        |
+      | ocs-api-version |
+      | 1               |
+      | 2               |
 
   Scenario Outline: Federated sharee deletes an accepted federated share
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last federated cloud share using the sharing API
     Then the OCS status code should be "<ocs-status>"
     And the HTTP status code should be "200"
     And user "Brian" should not see the following elements
       | /textfile0.txt |
     When user "Brian" gets the list of federated cloud shares using the sharing API
-    Then the response should contain 0 entries
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the response should contain 0 entries
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
-    Then the response should contain 0 entries
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the response should contain 0 entries
     Examples:
       | ocs-api-version | ocs-status |
       | 1               | 100        |
@@ -328,12 +332,12 @@ Feature: federated
 
   @issue-31276 @skipOnOcV10
   Scenario Outline: Federated sharee tries to delete an accepted federated share sending wrong password
-    Given using server "REMOTE"
+    Given using OCS API version "<ocs-api-version>"
+    And using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     And user "Alice" from server "REMOTE" has shared "/textfile0.txt" with user "Brian" from server "LOCAL"
     And user "Brian" from server "LOCAL" has accepted the last pending share
     And using server "LOCAL"
-    And using OCS API version "<ocs-api-version>"
     When user "Brian" deletes the last federated cloud share with password "invalid" using the sharing API
     Then the OCS status code should be "401"
     And the HTTP status code should be "401"
@@ -348,7 +352,7 @@ Feature: federated
       | name        | /textfile0.txt           |
       | owner       | %username%               |
       | user        | %username%               |
-      | mountpoint  | /textfile0.txt       |
+      | mountpoint  | /textfile0.txt           |
       | accepted    | 1                        |
       | type        | file                     |
       | permissions | share,delete,update,read |
@@ -371,9 +375,13 @@ Feature: federated
     And user "Brian" should not see the following elements
       | /textfile0.txt |
     When user "Brian" gets the list of federated cloud shares using the sharing API
-    Then the response should contain 0 entries
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the response should contain 0 entries
     When user "Brian" gets the list of pending federated cloud shares using the sharing API
-    Then the response should contain 0 entries
+    Then the OCS status code should be "<ocs-status>"
+    And the HTTP status code should be "200"
+    And the response should contain 0 entries
     Examples:
       | ocs-api-version | ocs-status |
       | 1               | 100        |
@@ -527,8 +535,10 @@ Feature: federated
     And user "Carol" from server "LOCAL" accepts the last pending share using the sharing API
     And user "Brian" shares folder "zzzfolder" with user "Carol" using the sharing API
     And user "Brian" shares folder "randomfile.txt" with user "Carol" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
     # local shares are taking priority at the moment
-    Then as "Carol" folder "zzzfolder (2)/remote" should exist
+    And as "Carol" folder "zzzfolder (2)/remote" should exist
     And as "Carol" folder "zzzfolder/local" should exist
     And the content of file "/randomfile (2).txt" for user "Carol" on server "LOCAL" should be "remote content"
     And the content of file "/randomfile.txt" for user "Carol" on server "LOCAL" should be "local content"
@@ -549,7 +559,9 @@ Feature: federated
     And user "Carol" from server "LOCAL" accepts the last pending share using the sharing API
     And user "Alice" from server "REMOTE" shares "randomfile.txt" with user "Carol" from server "LOCAL" using the sharing API
     And user "Carol" from server "LOCAL" accepts the last pending share using the sharing API
-    Then as "Carol" folder "zzzfolder/local" should exist
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
+    And as "Carol" folder "zzzfolder/local" should exist
     And as "Carol" folder "zzzfolder (2)/remote" should exist
     And the content of file "/randomfile.txt" for user "Carol" on server "LOCAL" should be "local content"
     And the content of file "/randomfile (2).txt" for user "Carol" on server "LOCAL" should be "remote content"

--- a/tests/acceptance/features/apiFederationToRoot1/savePublicShare.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/savePublicShare.feature
@@ -31,8 +31,9 @@ Feature: Save public shares created by oC users
     And as "Brian" folder "/PARENT" should not exist
 
 
-  Scenario: Mount public share and sharer unshares the share (local server share)
-    Given user "Brian" has been created with default attributes and without skeleton files
+  Scenario Outline: Mount public share and sharer unshares the share (local server share)
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created a public link share with settings
       | path        | /PARENT    |
@@ -40,8 +41,13 @@ Feature: Save public shares created by oC users
       | name        | sharedlink |
     And user "Brian" has added the public share created from server "LOCAL" using the sharing API
     When user "Alice" deletes public link share named "sharedlink" in file "/PARENT" using the sharing API
-    Then the HTTP status code should be "200"
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
     And as "Brian" folder "/PARENT" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Mount public share and try to reshare (local server share)
@@ -91,8 +97,9 @@ Feature: Save public shares created by oC users
     And as "Alice" folder "/PARENT" should not exist
 
 
-  Scenario: Mount public share and sharer unshares the share (remote server share)
-    Given using server "REMOTE"
+  Scenario Outline: Mount public share and sharer unshares the share (remote server share)
+    Given using OCS API version "<ocs_api_version>"
+    And using server "REMOTE"
     And user "RemoteAlice" has been created with default attributes and without skeleton files
     And user "RemoteAlice" has created folder "/PARENT"
     And user "RemoteAlice" has created a public link share with settings
@@ -103,8 +110,15 @@ Feature: Save public shares created by oC users
     And user "Alice" has added the public share created from server "REMOTE" using the sharing API
     And using server "REMOTE"
     When user "RemoteAlice" deletes public link share named "sharedlink" in file "/PARENT" using the sharing API
-    And using server "LOCAL"
-    Then as "Alice" folder "/PARENT" should not exist
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    When using server "LOCAL"
+    Then the HTTP status code should be "200"
+    And as "Alice" folder "/PARENT" should not exist
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Mount public share and try to reshare (remote server share)

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -75,6 +75,7 @@ class FederationContext implements Context {
 			null,
 			$expireDate
 		);
+		$this->featureContext->pushToLastStatusCodesArrays();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adds `Then` steps to existing API test scenarios to better check the results of `When` steps.

**Suites covered:**
- `apiFederationToRoot1`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/core/issues/39512


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
