### PR TITLE
Ignore thumbnails when propagating in home

### DIFF
--- a/changelog/unreleased/39988
+++ b/changelog/unreleased/39988
@@ -1,0 +1,5 @@
+Enhancement: Ignore thumbnails when propagating in home
+
+We no longer needlessly propagate the etag and mtime for thumbnails in the filecache.
+
+https://github.com/owncloud/core/pull/39988

--- a/lib/private/Files/Cache/HomePropagator.php
+++ b/lib/private/Files/Cache/HomePropagator.php
@@ -31,7 +31,7 @@ class HomePropagator extends Propagator {
 	 */
 	public function __construct(\OC\Files\Storage\Storage $storage, IDBConnection $connection) {
 		parent::__construct($storage, $connection);
-		$this->ignoredBaseFolders = ['files_encryption'];
+		$this->ignoredBaseFolders = ['files_encryption', 'thumbnails'];
 	}
 
 	/**


### PR DESCRIPTION
thumbnails don't need to have their mtime propagated as already mentioned in https://github.com/owncloud/core/issues/30320#issuecomment-452358498

however the preview manager also listens on pre deletion hooks to build a list of affected files, so this only part of the problem and might not even be necessary when doing thumbnail eviction in a background cron job.

It might still be useful when generating thumbnails as we then don't have to propagate etag or size changes from the individual thumbnails up to the `thumbnails` folder. A path like `thumbnails/13245/44x44.png` then would not have to do any propagation which helps when lots of pictures need to be thumbnailed, eg. when uploading a photo collection.