### PR TITLE
[Not merge] Force a scan before trying to cleanup chunks

### DIFF
--- a/changelog/unreleased/39990
+++ b/changelog/unreleased/39990
@@ -1,0 +1,10 @@
+Bugfix: Upload chunks might not get cleaned up if data is missing from the DB
+
+There might be cases where the upload data has been removed from the DB, but
+the chunks are still present in the FS.
+Previously, those chunks couldn't be cleaned up normally, so you had to remove
+them manually.
+Now, with the help of the "-l" option, a scan will be performed to ensure the
+data is present in the DB before performing the cleanup operation.
+
+https://github.com/owncloud/core/pull/39990


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
There might be cases where the upload data has disappeared from the DB, but the actual chunks are still present in the FS. At the moment, those chunks can't be cleaned even if they're too old, so they have to be removed manually.
This PR forces a scan on the upload folder in order to be able to delete those strayed chunks

## Related Issue
https://github.com/owncloud/enterprise/issues/5125

## Motivation and Context
The chunks can take a lot of space, and there can be a lot of uploads happening to be able to remove the old one manually.

## How Has This Been Tested?
Expected test case is:
1. Having 2 servers behind a load balancer, each server with its own upload folder (not shared)
2. Upload a file from the desktop client and abort the upload halfway through.
3. Check that the chunks are present in the upload folder of one of the server (only one, not both)
4. Wait a couple of days.
5. From the server without the chunks, run `occ dav:cleanup-chunks`. This will remove the info about the uploads in the DB. Note that the chunks will still be present in the FS of the other server
6. From the server with the chunks, run `occ dav:cleanup-chunks -l`. This will force the scan of the upload folder, bring the data back into the DB, and then cleanup the chunks.

Actual test:
1. With only one server
2. Upload a file from the desktop client and abort the upload halfway through
3. Check that the chunks are present in the upload folder
4. Change the mtime of the folder containing the chunks and the chunks in the FS so they're uploaded at least 2 days ago. Do the same for the related DB entries in the oc_filecache table (storage_mtime and mtime columns). This will simulate that more than 2 days have passed since the aborted upload.
5. Remove the DB entries for the upload in the oc_filecache table. This includes the "uploads/<id>" entry and the contents of that folder. This will simulate the "wrong" `occ dav:cleanup-chunk` in the wrong server.
6. Run the `occ dav:cleanup-chunks -l`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
