### PR TITLE
[tests-only] Allow 400 bad request for requests to meta endpoint that do not request meta-path-for-user

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -142,7 +142,7 @@ Feature: dav-versions
     And user "Alice" has uploaded file with content "123" to "/davtest.txt"
     And we save it into "FILEID"
     When user "Brian" sends HTTP method "PROPFIND" to URL "/remote.php/dav/meta/<<FILEID>>"
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "400" or "404"
 
   @files_sharing-app-required @notToImplementOnOCIS
   Scenario: User can access meta folder of a file which is owned by somebody else but shared with that user
@@ -385,16 +385,16 @@ Feature: dav-versions
     And the number of versions should be "3"
 
 
-  Scenario: User cannot access meta folder of a file which does not exists
+  Scenario: User cannot access meta folder of a file which does not exist
     Given user "Brian" has been created with default attributes and without skeleton files
     When user "Brian" sends HTTP method "PROPFIND" to URL "/remote.php/dav/meta/MTI4NGQyMzgtYWE5Mi00MmNlLWJkYzQtMGIwMDAwMDA5MTU2OjhjY2QyNzUxLTkwYTQtNDBmMi1iOWYzLTYxZWRmODQ0MjFmNA=="
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "400" or "404"
 
 
   Scenario Outline: User cannot access meta folder of a file with invalid fileid
     Given user "Brian" has been created with default attributes and without skeleton files
     When user "Brian" sends HTTP method "PROPFIND" to URL "/remote.php/dav/meta/<file-id>/v"
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "400" or "404"
     Examples:
       | file-id                                                                                              | decoded-value                                                             | comment            |
       | MTI4NGQyMzgtYWE5Mi00MmNlLWJkYzQtMGIwMDAwMDA5MTU3PThjY2QyNzUxLTkwYTQtNDBmMi1iOWYzLTYxZWRmODQ0MjFmNA== | 1284d238-aa92-42ce-bdc4-0b0000009157=8ccd2751-90a4-40f2-b9f3-61edf84421f4 | with = sign        |


### PR DESCRIPTION
## Description
There are various test scenarios that check invalid/unauthorised attempts to access `remote.php/dav/meta` API endpoints.
The tests just send a PROPFIND directly to the endpoint, without specifying any request body that mentions `oc:meta-path-for-user`. The documentation https://doc.owncloud.com/server/next/developer_manual/webdav_api/meta.html#meta-files-xml does not mention exactly what should happen if the body is empty.

oC10 returns 404 "not found". But it is also reasonable for an implementation to return 400 "bad request" (and requires that the request has a "proper" XML body in the PROPFIND request.

This PR adjusts the tests so that they will accept either 400 or 404 as the HTTP status of these requests. This will help the tests to pass with reva and oCIS. In particular, see https://github.com/cs3org/reva/pull/2741

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
