### PR TITLE
feat: previews are physically deleted from disk and db in an async ma…

### DIFF
--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -105,12 +105,8 @@ if ($maxX === 0 || $maxY === 0) {
 	exit;
 }
 
-// $path is relative to the data directory but Preview expects it to be relative to the user's
-// so strip the first component
-$root = \substr($path, \strpos($path, '/') + 1);
-
 try {
-	$preview = new \OC\Preview($userId, $root);
+	$preview = new \OC\Preview($userId);
 	$preview->setFile($sharedFile);
 	$preview->setMaxX($maxX);
 	$preview->setMaxY($maxY);

--- a/core/Application.php
+++ b/core/Application.php
@@ -41,6 +41,7 @@ use OC\Core\Controller\TokenController;
 use OC\Core\Controller\TwoFactorChallengeController;
 use OC\Core\Controller\UserController;
 use OC\Core\Controller\UserSyncController;
+use OC\Core\Jobs\PreviewCleanupJob;
 use OC\User\AccountMapper;
 use OC\User\SyncService;
 use OC_Defaults;
@@ -242,5 +243,8 @@ class Application extends App {
 		$container->registerService('TwoFactorAuthManager', static function (SimpleContainer $c) {
 			return $c->query('ServerContainer')->getTwoFactorAuthManager();
 		});
+
+		# add preview cleanup job
+		$container->getServer()->getJobList()->add(new PreviewCleanupJob());
 	}
 }

--- a/core/Command/Previews/Cleanup.php
+++ b/core/Command/Previews/Cleanup.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Core\Command\Previews;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use OC\Core\Command\Base;
+use OCP\Files\Folder;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Cleanup extends Base {
+
+	/**
+	 * @var IDBConnection
+	 */
+	private $connection;
+
+	public function __construct(IDBConnection $connection) {
+		parent::__construct();
+		$this->connection = $connection;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('previews:cleanup')
+			->setDescription('Remove unreferenced previews')
+			->addOption('all')
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$all = $input->hasOption('all');
+		$count = $this->process($all);
+		$output->writeln("$count orphaned previews deleted");
+		return 1;
+	}
+
+	public function process(bool $all = false): int {
+		$root = \OC::$server->getLazyRootFolder();
+		$count = 0;
+
+		while (true) {
+			# get 1000 previews to delete
+			$rows = $this->queryPreviewsToDelete();
+			foreach ($rows as $row) {
+				$name = $row['name'];
+				$userId = $row['user_id'];
+
+				$userFiles = $root->getUserFolder($userId);
+				/** @var Folder $thumbnailsFolder */
+				$thumbnailsFolder = $userFiles->getParent()->get('thumbnails');
+				if ($thumbnailsFolder instanceof Folder && $thumbnailsFolder->nodeExists($name)) {
+					$notExistingPreview = $thumbnailsFolder->get($name);
+					$notExistingPreview->delete();
+				}
+			}
+			$count += \count($rows);
+			if (!$all || empty($rows)) {
+				break;
+			}
+		}
+
+		return $count;
+	}
+
+	private function queryPreviewsToDelete(): array {
+		$isMysql = ($this->connection->getDatabasePlatform() instanceof MySqlPlatform);
+		$intDataType = $isMysql ? 'UNSIGNED' : 'INT';
+
+		$sql = "select `name`, `user_id` from `*PREFIX*filecache` `fc`
+		join `*PREFIX*mounts` on `storage` = `storage_id`
+		where `parent` in (select `fileid` from `*PREFIX*filecache` where `storage` in (select `numeric_id` from `oc_storages` where `id` like 'home::%' or `id` like 'object::user:%') and `path` = 'thumbnails')
+		  and not exists(select `fileid` from `*PREFIX*filecache` where CAST(`fc`.`name` as $intDataType) = `*PREFIX*filecache`.`fileid`)
+		  order by `user_id` limit 1000";
+
+		return $this->connection->executeQuery($sql)->fetchAll(\PDO::FETCH_ASSOC);
+	}
+}

--- a/core/Command/Previews/Cleanup.php
+++ b/core/Command/Previews/Cleanup.php
@@ -63,7 +63,6 @@ class Cleanup extends Base {
 		$lastFileId = 0;
 		while (true) {
 			# get 1000 previews to delete
-			echo 'Next 1000:' . PHP_EOL;
 			$rows = $this->queryPreviewsToDelete($lastFileId);
 			foreach ($rows as $row) {
 				$name = $row['name'];

--- a/core/Jobs/PreviewCleanupJob.php
+++ b/core/Jobs/PreviewCleanupJob.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OC\Core\Jobs;
+
+use OC\BackgroundJob\TimedJob;
+use OC\Core\Command\Previews\Cleanup;
+use OCA\Windriver\AppInfo\Application;
+use OCA\Windriver\Db\ShareMapper;
+
+class PreviewCleanupJob extends TimedJob {
+	public function __construct() {
+		$this->setInterval(3600); //execute job every hour
+	}
+
+	public function run($arguments) {
+		$cmd = new Cleanup(\OC::$server->getDatabaseConnection());
+		$count = $cmd->process();
+		$logger = \OC::$server->getLogger();
+		$logger->info("$count orphaned previews deleted");
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -147,6 +147,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\SingleUser(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
+	$application->add(new OC\Core\Command\Previews\Cleanup(\OC::$server->getDatabaseConnection()));
 
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger(), \OC::$server->getMemCacheFactory()));
 	$application->add(

--- a/lib/base.php
+++ b/lib/base.php
@@ -667,9 +667,6 @@ class OC {
 
 		self::registerCacheHooks();
 		self::registerFilesystemHooks();
-		if ($systemConfig->getValue('enable_previews', true)) {
-			self::registerPreviewHooks();
-		}
 		self::registerShareHooks();
 		self::registerLogRotate();
 		if ($systemConfig->getValue("installed", false)) {
@@ -794,20 +791,6 @@ class OC {
 		// Check for blacklisted files
 		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
 		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
-	}
-
-	/**
-	 * register hooks for previews
-	 */
-	public static function registerPreviewHooks() {
-		OC_Hook::connect('OC_Filesystem', 'post_write', 'OC\Preview', 'post_write');
-		OC_Hook::connect('OC_Filesystem', 'delete', 'OC\Preview', 'prepare_delete_files');
-		OC_Hook::connect('\OCP\Versions', 'preDelete', 'OC\Preview', 'prepare_delete');
-		OC_Hook::connect('\OCP\Trashbin', 'preDelete', 'OC\Preview', 'prepare_delete');
-		OC_Hook::connect('OC_Filesystem', 'post_delete', 'OC\Preview', 'post_delete_files');
-		OC_Hook::connect('\OCP\Versions', 'delete', 'OC\Preview', 'post_delete_versions');
-		OC_Hook::connect('\OCP\Trashbin', 'delete', 'OC\Preview', 'post_delete');
-		OC_Hook::connect('\OCP\Versions', 'rollback', 'OC\Preview', 'post_delete_versions');
 	}
 
 	/**

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -102,6 +102,7 @@ class Preview {
 	 */
 	public function __construct(
 		$user = '',
+		$root = '/',
 		Node $file = null,
 		$maxX = 1,
 		$maxY = 1,

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -31,11 +31,9 @@
  */
 namespace OC;
 
-use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Files_Sharing\SharedMount;
 use OCP\Files\FileInfo;
-use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IImage;
@@ -58,8 +56,7 @@ class Preview {
 	private $configMaxHeight;
 
 	//fileview object
-	private $fileView = null;
-	private $userView = null;
+	private $userView;
 
 	//vars
 	/** @var Node | null */
@@ -81,11 +78,6 @@ class Preview {
 	/** @var int $previewHeight calculated height of the preview we're looking for */
 	private $previewHeight;
 
-	// filemapper used for deleting previews
-	// index is path, value is fileinfo
-	public static $deleteFileMapper = [];
-	public static $deleteChildrenMapper = [];
-
 	/**
 	 * preview images object
 	 *
@@ -99,8 +91,7 @@ class Preview {
 	 * check if thumbnail or bigger version of thumbnail of file is cached
 	 *
 	 * @param string $user userid - if no user is given, OC_User::getUser will be used
-	 * @param string $root path of root
-	 * @param Node $file The path to the file where you want a thumbnail from
+	 * @param Node|null $file The path to the file where you want a thumbnail from
 	 * @param int $maxX The maximum X size of the thumbnail. It can be smaller depending on the
 	 *     shape of the image
 	 * @param int $maxY The maximum Y size of the thumbnail. It can be smaller depending on the
@@ -111,7 +102,6 @@ class Preview {
 	 */
 	public function __construct(
 		$user = '',
-		$root = '/',
 		Node $file = null,
 		$maxX = 1,
 		$maxY = 1,
@@ -122,7 +112,6 @@ class Preview {
 		if ($user === '') {
 			$user = \OC_User::getUser();
 		}
-		$this->fileView = new View('/' . $user . '/' . $root);
 		$this->userView = new View('/' . $user);
 
 		//set config
@@ -138,8 +127,6 @@ class Preview {
 		$this->setMaxX((int)$maxX);
 		$this->setMaxY((int)$maxY);
 		$this->setScalingup($scalingUp);
-
-		$this->preview = null;
 
 		//check if there are preview backends
 		if (!\OC::$server->getPreviewManager()
@@ -222,20 +209,6 @@ class Preview {
 	 */
 	public function getConfigMaxY() {
 		return $this->configMaxHeight;
-	}
-
-	/**
-	 * @return array|null
-	 */
-	private function getChildren() {
-		$absPath = $this->file->getPath();
-		$absPath = Files\Filesystem::normalizePath($absPath);
-
-		if (\array_key_exists($absPath, self::$deleteChildrenMapper)) {
-			return self::$deleteChildrenMapper[$absPath];
-		}
-
-		return null;
 	}
 
 	/**
@@ -400,40 +373,6 @@ class Preview {
 	}
 
 	/**
-	 * Deletes all previews of a file including version previews
-	 *
-	 * @param int|null $versionId (optional) - delete all previews of the specified versionId
-	 */
-	public function deleteAllPreviews($versionId = null) {
-		$thumbnailMount = $this->userView->getMount($this->getThumbnailsFolder());
-		$propagator = $thumbnailMount->getStorage()->getPropagator();
-		$propagator->beginBatch();
-
-		$toDelete = $this->getChildren();
-		$toDelete[] = $this->getFile();
-
-		foreach ($toDelete as $delete) {
-			if ($delete instanceof FileInfo) {
-				/** @var \OCP\Files\FileInfo $delete */
-				$fileId = $delete->getId();
-
-				// getId() might return null, e.g. when the file is a
-				// .ocTransferId*.part file from chunked file upload.
-				if (!empty($fileId)) {
-					$previewPath = $this->getPreviewPath($fileId);
-					if ($versionId !== null) {
-						$versionId = \intval($versionId);
-						$previewPath = "$previewPath/$versionId";
-					}
-					$this->userView->rmdir($previewPath);
-				}
-			}
-		}
-
-		$propagator->commitBatch();
-	}
-
-	/**
 	 * Checks if a preview matching the asked dimensions or a bigger version is already cached
 	 *
 	 *    * We first retrieve the size of the max preview since this is what we be used to create
@@ -496,11 +435,11 @@ class Preview {
 				// The preview we-re looking for is the exact size or larger than the max preview,
 				// so return that
 				return $this->buildCachePath($maxPreviewWidth, $maxPreviewHeight);
-			} else {
-				// The last resort is to look for something bigger than what we've calculated,
-				// but still smaller than the max preview
-				return $this->isCachedBigger($allThumbnails);
 			}
+
+			// The last resort is to look for something bigger than what we've calculated,
+			// but still smaller than the max preview
+			return $this->isCachedBigger($allThumbnails);
 		}
 
 		return false;
@@ -659,9 +598,9 @@ class Preview {
 		foreach ($possibleThumbnails as $width => $path) {
 			if ($width < $maxX) {
 				continue;
-			} else {
-				return $path;
 			}
+
+			return $path;
 		}
 
 		// At this stage, we didn't find a preview, so we return the max preview
@@ -877,8 +816,8 @@ class Preview {
 
 			return;
 		}
-		$previewWidth = (int)$image->width();
-		$previewHeight = (int)$image->height();
+		$previewWidth = $image->width();
+		$previewHeight = $image->height();
 		$askedWidth = $this->getMaxX();
 		$askedHeight = $this->getMaxY();
 
@@ -1274,149 +1213,5 @@ class Preview {
 		}
 
 		return $dim;
-	}
-
-	/**
-	 * @param array $args
-	 */
-	public static function post_write($args) {
-		self::post_delete(
-			\array_merge($args, ['keep_versions' => true]),
-			'files/'
-		);
-	}
-
-	/**
-	 * @param array $args
-	 */
-	public static function prepare_delete_files($args) {
-		self::prepare_delete($args, 'files/');
-	}
-
-	/**
-	 * @param array $args
-	 * @param string $prefix
-	 */
-	public static function prepare_delete(array $args, $prefix = '') {
-		// override path for versions
-		if (isset($args['original_path'])) {
-			$args['path'] = $args['original_path'];
-		}
-		$path = Files\Filesystem::normalizePath($args['path']);
-		$userFolder = self::getUserFolder($args);
-		if ($userFolder === false) {
-			return;
-		}
-		if (\strpos($path, '/files_trashbin/') === 0) {
-			$node = $userFolder->getParent()->get($path);
-		} else {
-			$node = $userFolder->get($path);
-		}
-
-		self::addPathToDeleteFileMapper($path, $node);
-		if ($node->getType() === FileInfo::TYPE_FOLDER) {
-			$children = self::getAllChildren($node);
-			self::$deleteChildrenMapper[$node->getPath()] = $children;
-		}
-	}
-
-	/**
-	 * @param string $absolutePath
-	 * @param \OCP\Files\FileInfo $info
-	 */
-	private static function addPathToDeleteFileMapper($absolutePath, $info) {
-		self::$deleteFileMapper[$absolutePath] = $info;
-	}
-
-	/**
-	 * @param Folder $node
-	 *
-	 * @return array
-	 */
-	private static function getAllChildren($node) {
-		$children = $node->getDirectoryListing();
-		$childrenFiles = [];
-
-		foreach ($children as $child) {
-			if ($child->getType() === FileInfo::TYPE_FOLDER) {
-				$childrenFiles = \array_merge(
-					$childrenFiles,
-					self::getAllChildren($child)
-				);
-			} else {
-				$childrenFiles[] = $child;
-			}
-		}
-
-		return $childrenFiles;
-	}
-
-	/**
-	 * @param array $args
-	 */
-	public static function post_delete_files($args) {
-		self::post_delete($args, 'files/');
-	}
-
-	/**
-	 * @param array $args
-	 */
-	public static function post_delete_versions($args) {
-		if (isset($args['original_path'])) {
-			$args['path'] = $args['original_path'];
-		}
-		self::post_delete($args, 'files/');
-	}
-
-	/**
-	 * @param array $args
-	 * @param string $prefix
-	 */
-	public static function post_delete($args, $prefix = '') {
-		$path = Files\Filesystem::normalizePath($args['path']);
-
-		if (!isset(self::$deleteFileMapper[$path])) {
-			$userFolder = self::getUserFolder($args);
-			if ($userFolder === false) {
-				return;
-			}
-			if (\strpos($path, '/files_trashbin/') === 0) {
-				$node = $userFolder->getParent()->get($path);
-			} else {
-				$node = $userFolder->get($path);
-			}
-		} else {
-			/** @var FileInfo $node */
-			$node = self::$deleteFileMapper[$path];
-		}
-
-		$preview = new Preview($node->getOwner()->getUID(), $prefix, $node);
-		$versionId = isset($args['deleted_revision']) ? $args['deleted_revision'] : null;
-		if (isset($args['keep_versions'])) {
-			// PostWrite hook - delete main preview keeping versions previews
-			$preview->deletePreview(false);
-		} else {
-			// "true" PostDelete
-			$preview->deleteAllPreviews($versionId);
-		}
-		unset(self::$deleteFileMapper[$path], self::$deleteChildrenMapper[$node->getPath()]);
-	}
-
-	/**
-	 * @param string[] $args
-	 * @return Folder|bool
-	 */
-	private static function getUserFolder($args) {
-		$user = isset($args['user']) ? $args['user'] : \OC_User::getUser();
-		if ($user === false) {
-			try {
-				$path = Files\Filesystem::normalizePath($args['path']);
-				$user = Filesystem::getOwner($path);
-			} catch (NotFoundException $e) {
-				return false;
-			}
-		}
-		$userFolder = \OC::$server->getUserFolder($user);
-		return $userFolder === null ? false : $userFolder;
 	}
 }

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -141,7 +141,7 @@ class PreviewManager implements IPreview {
 			throw new NotLoggedInException();
 		}
 		$file = $this->rootFolder->getUserFolder($user->getUID())->getParent()->get($file);
-		$preview = new Preview('', '/', $file, $maxX, $maxY, $scaleUp);
+		$preview = new Preview('', $file, $maxX, $maxY, $scaleUp);
 		return $preview->getPreview();
 	}
 

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -141,7 +141,7 @@ class PreviewManager implements IPreview {
 			throw new NotLoggedInException();
 		}
 		$file = $this->rootFolder->getUserFolder($user->getUID())->getParent()->get($file);
-		$preview = new Preview('', $file, $maxX, $maxY, $scaleUp);
+		$preview = new Preview('', '', $file, $maxX, $maxY, $scaleUp);
 		return $preview->getPreview();
 	}
 

--- a/tests/lib/PreviewCleanupTest.php
+++ b/tests/lib/PreviewCleanupTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test;
+
+use OC\Core\Command\Previews\Cleanup;
+use OC\Files\Filesystem;
+use OC\Files\ObjectStore\ObjectStoreStorage;
+use OCP\Files\Folder;
+use Test\Traits\UserTrait;
+
+/**
+ * Class PreviewCleanupTest
+ *
+ * @group DB
+ *
+ * @package Test
+ */
+class PreviewCleanupTest extends TestCase {
+	use UserTrait;
+
+	public const TEST_PREVIEW_USER1 = "test-preview-cleanup-user1";
+	private $trashWasEnabled;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		# disable trashbin
+		$this->trashWasEnabled = \OC::$server->getAppManager()->isEnabledForUser('files_trashbin');
+		if ($this->trashWasEnabled) {
+			\OC::$server->getAppManager()->disableApp('files_trashbin');
+		}
+
+		# create test user
+		$this->createUser(self::TEST_PREVIEW_USER1, self::TEST_PREVIEW_USER1);
+		self::loginAsUser(self::TEST_PREVIEW_USER1);
+
+		# properly initialize the file system
+		Filesystem::clearMounts();
+		Filesystem::initMountPoints(self::TEST_PREVIEW_USER1);
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		if ($this->trashWasEnabled) {
+			$this->trashWasEnabled = \OC::$server->getAppManager()->enableApp('files_trashbin');
+		}
+	}
+
+	public function test(): void {
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1);
+
+		# create test file
+		/** @var \OC\Files\Node\File $textFile */
+		$textFile = $rootFolder->newFile('welcome.txt');
+		$textFile->putContent('1234567890');
+		$textFileId = (string)$textFile->getId();
+
+		# create preview
+		$textFile->getThumbnail([]);
+
+		# assert thumbnail exists
+		/** @var Folder $thumbnailFolder */
+		$thumbnailFolder = $rootFolder->getParent()->get('thumbnails');
+		self::assertTrue($thumbnailFolder->nodeExists($textFileId));
+
+		# delete file
+		$textFile->delete();
+
+		# assert thumbnail still exists - no hooks are triggered
+		self::assertTrue($thumbnailFolder->nodeExists($textFileId));
+
+		# run cleanup command
+		$cmd = new Cleanup(\OC::$server->getDatabaseConnection());
+		$cmd->process();
+
+		# assert thumbnail NO LONGER exists
+		self::assertFalse($thumbnailFolder->nodeExists($textFileId));
+	}
+}

--- a/tests/lib/PreviewTest.php
+++ b/tests/lib/PreviewTest.php
@@ -82,7 +82,7 @@ class PreviewTest extends TestCase {
 		parent::setUp();
 
 		$this->createUser(self::TEST_PREVIEW_USER1, self::TEST_PREVIEW_USER1);
-		$this->loginAsUser(self::TEST_PREVIEW_USER1);
+		self::loginAsUser(self::TEST_PREVIEW_USER1);
 
 		$storage = new Temporary([]);
 		Filesystem::mount($storage, [], '/' . self::TEST_PREVIEW_USER1 . '/');
@@ -129,7 +129,7 @@ class PreviewTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->logout();
+		self::logout();
 
 		parent::tearDown();
 	}
@@ -146,7 +146,7 @@ class PreviewTest extends TestCase {
 		$y = 50;
 
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('test.txt');
-		$preview = new Preview(self::TEST_PREVIEW_USER1, 'files/', $file, $x, $y);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, $file, $x, $y);
 		$preview->getPreview();
 
 		$fileInfo = $this->rootView->getFileInfo($sampleFile);
@@ -159,106 +159,6 @@ class PreviewTest extends TestCase {
 		$preview->deletePreview();
 
 		$this->assertFalse($this->rootView->file_exists($thumbCacheFile));
-	}
-
-	/**
-	 * Tests if all previews can be deleted
-	 *
-	 * We test this first to make sure we'll be able to cleanup after each preview generating test
-	 */
-	public function testAreAllPreviewsDeleted() {
-		$sampleFile = '/' . self::TEST_PREVIEW_USER1 . '/files/test.txt';
-
-		$this->rootView->file_put_contents($sampleFile, 'dummy file data');
-
-		$x = 50;
-		$y = 50;
-
-		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('test.txt');
-		$preview = new Preview(self::TEST_PREVIEW_USER1, 'files/', $file, $x, $y);
-		$preview->getPreview();
-
-		$fileInfo = $this->rootView->getFileInfo($sampleFile);
-		/** @var int $fileId */
-		$fileId = $fileInfo['fileid'];
-
-		$thumbCacheFolder = '/' . self::TEST_PREVIEW_USER1 . '/' . Preview::THUMBNAILS_FOLDER .
-			'/' . $fileId . '/';
-
-		$this->assertTrue($this->rootView->is_dir($thumbCacheFolder), "$thumbCacheFolder \n");
-
-		$preview->deleteAllPreviews();
-
-		$this->assertFalse($this->rootView->is_dir($thumbCacheFolder));
-	}
-
-	public function testVersionPreviewsDeleted() {
-		$x = 50;
-		$y = 50;
-		$sampleFile = '/' . self::TEST_PREVIEW_USER1 . '/files/test.txt';
-		$versionPath = '/' . self::TEST_PREVIEW_USER1 . '/files_versions/test.txt';
-		$timestamp1 = 12345678;
-		$timestamp2 = 22222222;
-		$timestamp3 = 45678901;
-
-		$this->rootView->file_put_contents($sampleFile, "dummy data");
-		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('test.txt');
-		$preview = new Preview(
-			self::TEST_PREVIEW_USER1,
-			'files/',
-			$file,
-			$x,
-			$y,
-			null
-		);
-		$preview->getPreview();
-		$this->rootView->mkdir(self::TEST_PREVIEW_USER1 . '/files_versions');
-		foreach ([$timestamp1, $timestamp2, $timestamp3] as $versionId) {
-			$this->rootView->file_put_contents("$versionPath.v$versionId", "file data $versionId");
-			$versionPreview = new Preview(
-				self::TEST_PREVIEW_USER1,
-				'files/',
-				$file,
-				$x,
-				$y,
-				null,
-				$versionId
-			);
-			$versionPreview->getPreview();
-		}
-
-		$thumbCacheFolder = '/' . self::TEST_PREVIEW_USER1 . '/' . Preview::THUMBNAILS_FOLDER .
-			'/' . $file->getId() . '/';
-
-		foreach ([$timestamp1, $timestamp2, $timestamp3] as $versionId) {
-			$this->assertTrue(
-				$this->rootView->is_dir("$thumbCacheFolder/$versionId"),
-				"version preview $versionId was not created \n"
-			);
-		}
-
-		// Delete  preview for one version and check that others still exist
-		Preview::post_delete_versions(
-			[
-				'user' => self::TEST_PREVIEW_USER1,
-				'path' => '/test.txt.v' . $timestamp2,
-				'original_path' => '/test.txt',
-				'deleted_revision' => $timestamp2
-			]
-		);
-
-		$this->assertFalse(
-			$this->rootView->is_dir("$thumbCacheFolder/$timestamp2"),
-			"version preview $timestamp2 still exists \n"
-		);
-		foreach ([$timestamp1, $timestamp3] as $versionId) {
-			$this->assertTrue(
-				$this->rootView->is_dir("$thumbCacheFolder/$versionId"),
-				"version preview $versionId was deleted \n"
-			);
-		}
-
-		$preview->deleteAllPreviews();
 	}
 
 	public function txtBlacklist() {
@@ -285,7 +185,6 @@ class PreviewTest extends TestCase {
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get("test.$extension");
 		$preview = new Preview(
 			self::TEST_PREVIEW_USER1,
-			'files/',
 			$file,
 			$x,
 			$y
@@ -316,7 +215,7 @@ class PreviewTest extends TestCase {
 		$this->rootView->file_put_contents($imgPath, $imgData);
 
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('testimage.odt');
-		$preview = new Preview(self::TEST_PREVIEW_USER1, 'files/', $file, $width, $height);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, $file, $width, $height);
 		$preview->getPreview();
 		$image = $preview->getPreview();
 
@@ -396,7 +295,7 @@ class PreviewTest extends TestCase {
 		$heightAdjustment,
 		$keepAspect = false,
 		$scalingUp = false
-	) {
+	): void {
 		// Get the right sample for the experiment
 		$this->getSample($sampleId);
 		$sampleWidth = $this->sampleWidth;
@@ -452,8 +351,6 @@ class PreviewTest extends TestCase {
 
 		// And it should be cached
 		$this->checkCache($sampleFileId, $limitedPreviewWidth, $limitedPreviewHeight);
-
-		$preview->deleteAllPreviews();
 	}
 
 	/**
@@ -503,27 +400,6 @@ class PreviewTest extends TestCase {
 			'-max'
 		);
 		$this->assertSame($cachedMaxPreview, $isCached);
-	}
-
-	/**
-	 * Make sure that the max preview can never be deleted
-	 *
-	 * For this test to work, the preview we generate first has to be the size of max preview
-	 */
-	public function testMaxPreviewCannotBeDeleted() {
-		//$this->markTestSkipped('Not testing this at this time');
-
-		$this->keepAspect = true;
-		$this->getSample(0);
-
-		//Creates the Max preview which we will try to delete
-		$preview = $this->createMaxPreview();
-
-		// We try to deleted the preview
-		$preview->deletePreview();
-		$this->assertNotFalse($preview->isCached());
-
-		$preview->deleteAllPreviews();
 	}
 
 	public static function aspectDataProvider() {
@@ -598,8 +474,6 @@ class PreviewTest extends TestCase {
 			$postfix
 		);
 		$this->assertFalse($this->rootView->file_exists($thumbCacheFile), "$thumbCacheFile \n");
-
-		$preview->deleteAllPreviews();
 	}
 
 	/**
@@ -658,7 +532,6 @@ class PreviewTest extends TestCase {
 
 		// We create a preview in order to be able to delete the cache
 		$preview = $this->createPreview(\rand(), \rand());
-		$preview->deleteAllPreviews();
 		$this->cachedBigger = [];
 	}
 
@@ -674,7 +547,6 @@ class PreviewTest extends TestCase {
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get($this->sampleFilename);
 		$preview = new Preview(
 			self::TEST_PREVIEW_USER1,
-			'files/',
 			$file,
 			$width,
 			$height
@@ -999,7 +871,6 @@ class PreviewTest extends TestCase {
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('testimage.jpg');
 		$preview = new Preview(
 			self::TEST_PREVIEW_USER1,
-			'files/',
 			$file,
 			150,
 			150
@@ -1022,7 +893,6 @@ class PreviewTest extends TestCase {
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('testimage.jpg');
 		$preview = new Preview(
 			self::TEST_PREVIEW_USER1,
-			'files/',
 			$file,
 			150,
 			150
@@ -1040,7 +910,7 @@ class PreviewTest extends TestCase {
 
 	public function testIsCached() {
 		$sourceFile = __DIR__ . '/../data/testimage.png';
-		$userId = $this->getUniqueID();
+		$userId = self::getUniqueID();
 		$this->createUser($userId, 'pass');
 
 		$storage = new Temporary();
@@ -1049,7 +919,7 @@ class PreviewTest extends TestCase {
 
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($userId);
-		$preview = new Preview($userId, 'files');
+		$preview = new Preview($userId);
 		$view = new View('/' . $userId . '/files');
 		$view->file_put_contents('test.png', \file_get_contents($sourceFile));
 		$file = \OC::$server->getUserFolder($userId)->get('test.png');
@@ -1068,14 +938,14 @@ class PreviewTest extends TestCase {
 	public function testPreviewReGenerationForSharee() {
 		$x = 50;
 		$y = 50;
-		$shareeeUserId = $this->getUniqueID();
+		$shareeeUserId = self::getUniqueID();
 		$this->createUser($shareeeUserId, 'pass');
 
 		// Create preview for share owner and sharee
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('testimage.jpg');
-		$preview = new Preview(self::TEST_PREVIEW_USER1, 'files/', $file, $x, $y);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, $file, $x, $y);
 		$preview->getPreview();
-		$preview = new Preview($shareeeUserId, 'files/', $file, $x, $y);
+		$preview = new Preview($shareeeUserId, $file, $x, $y);
 		$shareePreview = $preview->getPreview();
 
 		// Update file for share owner
@@ -1084,7 +954,7 @@ class PreviewTest extends TestCase {
 		$shareOwnerView->file_put_contents($file->getInternalPath(), $newFileContent);
 
 		// Re-generate new preview for share owner
-		$preview = new Preview(self::TEST_PREVIEW_USER1, 'files/', $file, $x, $y);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, $file, $x, $y);
 		$preview->deletePreview();
 		$preview->getPreview();
 
@@ -1102,7 +972,7 @@ class PreviewTest extends TestCase {
 		$fileMock->expects($this->any())->method('getOwner')->willReturn($ownerMock);
 
 		// Get preview for sharee -> should be re-generated although it already exists
-		$preview = new Preview(self::TEST_PREVIEW_USER1, 'files/', $fileMock, $x, $y);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, $fileMock, $x, $y);
 		$updatedShareePreview = $preview->getPreview();
 
 		$this->assertNotFalse($updatedShareePreview);

--- a/tests/lib/PreviewTest.php
+++ b/tests/lib/PreviewTest.php
@@ -146,7 +146,7 @@ class PreviewTest extends TestCase {
 		$y = 50;
 
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('test.txt');
-		$preview = new Preview(self::TEST_PREVIEW_USER1, $file, $x, $y);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, '', $file, $x, $y);
 		$preview->getPreview();
 
 		$fileInfo = $this->rootView->getFileInfo($sampleFile);
@@ -185,6 +185,7 @@ class PreviewTest extends TestCase {
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get("test.$extension");
 		$preview = new Preview(
 			self::TEST_PREVIEW_USER1,
+			'',
 			$file,
 			$x,
 			$y
@@ -215,7 +216,7 @@ class PreviewTest extends TestCase {
 		$this->rootView->file_put_contents($imgPath, $imgData);
 
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('testimage.odt');
-		$preview = new Preview(self::TEST_PREVIEW_USER1, $file, $width, $height);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, '', $file, $width, $height);
 		$preview->getPreview();
 		$image = $preview->getPreview();
 
@@ -547,6 +548,7 @@ class PreviewTest extends TestCase {
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get($this->sampleFilename);
 		$preview = new Preview(
 			self::TEST_PREVIEW_USER1,
+			'',
 			$file,
 			$width,
 			$height
@@ -871,6 +873,7 @@ class PreviewTest extends TestCase {
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('testimage.jpg');
 		$preview = new Preview(
 			self::TEST_PREVIEW_USER1,
+			'',
 			$file,
 			150,
 			150
@@ -893,6 +896,7 @@ class PreviewTest extends TestCase {
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('testimage.jpg');
 		$preview = new Preview(
 			self::TEST_PREVIEW_USER1,
+			'',
 			$file,
 			150,
 			150
@@ -943,9 +947,9 @@ class PreviewTest extends TestCase {
 
 		// Create preview for share owner and sharee
 		$file = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1)->get('testimage.jpg');
-		$preview = new Preview(self::TEST_PREVIEW_USER1, $file, $x, $y);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, '', $file, $x, $y);
 		$preview->getPreview();
-		$preview = new Preview($shareeeUserId, $file, $x, $y);
+		$preview = new Preview($shareeeUserId, '', $file, $x, $y);
 		$shareePreview = $preview->getPreview();
 
 		// Update file for share owner
@@ -954,7 +958,7 @@ class PreviewTest extends TestCase {
 		$shareOwnerView->file_put_contents($file->getInternalPath(), $newFileContent);
 
 		// Re-generate new preview for share owner
-		$preview = new Preview(self::TEST_PREVIEW_USER1, $file, $x, $y);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, '', $file, $x, $y);
 		$preview->deletePreview();
 		$preview->getPreview();
 
@@ -972,7 +976,7 @@ class PreviewTest extends TestCase {
 		$fileMock->expects($this->any())->method('getOwner')->willReturn($ownerMock);
 
 		// Get preview for sharee -> should be re-generated although it already exists
-		$preview = new Preview(self::TEST_PREVIEW_USER1, $fileMock, $x, $y);
+		$preview = new Preview(self::TEST_PREVIEW_USER1, '', $fileMock, $x, $y);
 		$updatedShareePreview = $preview->getPreview();
 
 		$this->assertNotFalse($updatedShareePreview);


### PR DESCRIPTION
…nner

## ToDos
- [x] background job for automation
- [x] occ command for cron on bigger installations
- [x] define occ command printout
- [x] add tests for cleanup procedure
- [x] implement cleanup logic for objectstore - requires different sql queries
- [ ] invalidate previews if a file is upldated
- [x] kills gallery because of https://github.com/owncloud/gallery/blob/0d980ea3fd7858f27e9096c9f2c0c71e1fb160ed/preview/preview.php#L105 :vomiting_face: :vomiting_face: :vomiting_face: :vomiting_face: :vomiting_face: 


## Description
All preview hooks are gone now. Previews are cleaned up on disk and db in a background job (alternative occ command)

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5164

## How Has This Been Tested?
### Scenario I
- disable trashbin
- upload file which can have previews (e.g. image)
- wait for the preview to be generated
- note the fileid (e.g.query filecache)
- look up the thumbnails for this file (data/$user/thumbnails/$fileid)
- delete the file
- make sure the thumbnail is still there
- run occ p:c --all
- make sure thumbnail got removed from disk and failcache

### Scenario II
- same as Scenario II - but with trashbin enabled
- file needs to be deleted from trashbin

### Scenario III
- create new test file
- enter some text via texteditor
- see the text on the preview
- edit the file again aka change the contents
- make sure the preview holds the new file contents

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
