### PR TITLE
Default for propfind depth infinity should be false as in the past

### DIFF
--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -45,7 +45,7 @@ class Capabilities implements ICapability {
 					'search-files',
 				],
 				'propfind' => [
-					'depth_infinity' => $this->config->getSystemValue('dav.propfind.depth_infinity', true),
+					'depth_infinity' => $this->config->getSystemValue('dav.propfind.depth_infinity', false),
 				]
 			]
 		];

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -140,7 +140,7 @@ class ServerFactory {
 		$server->on('beforeMethod:PROPFIND', function (Request $request) use ($config) {
 			$depthHeader = strtolower($request->getHeader('depth'));
 
-			if ($depthHeader === 'infinity' && !$config->getSystemValue('dav.propfind.depth_infinity', true)) {
+			if ($depthHeader === 'infinity' && !$config->getSystemValue('dav.propfind.depth_infinity', false)) {
 				throw new PreconditionFailed('Depth infinity not supported');
 			}
 		}, 0);

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -244,7 +244,7 @@ class Server {
 		$this->server->on('beforeMethod:PROPFIND', function (Request $request) use ($config) {
 			$depthHeader = strtolower($request->getHeader('depth'));
 
-			if ($depthHeader === 'infinity' && !$config->getSystemValue('dav.propfind.depth_infinity', true)) {
+			if ($depthHeader === 'infinity' && !$config->getSystemValue('dav.propfind.depth_infinity', false)) {
 				throw new Exception\PreconditionFailed('Depth infinity not supported');
 			}
 		}, 0);

--- a/changelog/unreleased/40016
+++ b/changelog/unreleased/40016
@@ -1,0 +1,7 @@
+Bugfix: default for propfind depth infinity adjusted
+
+Fixed potential cause for performance issues under certain conditions 
+with infinite propfind being enabled by default. 
+
+https://github.com/owncloud/core/pull/40016
+https://github.com/owncloud/enterprise/issues/5154

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1717,11 +1717,12 @@ $CONFIG = [
 /**
  * Allow propfind depth infinity
  *
- * With this setting that defaults to true, propfind requests will now be streamed to reduce memory usage
- * with large responses. It tells the clients whether `depth=infinity` is allowed for propfind requests.
+ * It tells the clients whether `depth=infinity` is allowed for propfind requests.
+ * Streamed infinite depth propfind requests can reduce memory usage
+ * with large responses.
  * For details see: https://datatracker.ietf.org/doc/html/rfc4918#section-10.2
  */
-'dav.propfind.depth_infinity' => true,
+'dav.propfind.depth_infinity' => false,
 
 /**
  * Show the grace period popup

--- a/tests/acceptance/features/apiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/apiWebdavOperations/listFiles.feature
@@ -76,6 +76,7 @@ Feature: list files
 
   Scenario Outline: Get the list of resources in the root folder with depth infinity
     Given using <dav_version> DAV path
+    And the administrator has set depth_infinity_allowed to 1
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should contain these nodes
@@ -157,6 +158,7 @@ Feature: list files
 
   Scenario Outline: Get the list of resources in a folder with depth infinity
     Given using <dav_version> DAV path
+    And the administrator has set depth_infinity_allowed to 1
     When user "Alice" lists the resources in "/simple-folder" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the last DAV response for user "Alice" should contain these nodes
@@ -256,6 +258,7 @@ Feature: list files
 
   Scenario Outline: Get the list of resources in a folder shared through public link with depth infinity
     Given using <dav_version> DAV path
+    And the administrator has set depth_infinity_allowed to 1
     And user "Alice" has created the following folders
       | path                                                                       |
       | /simple-folder/simple-folder1/simple-folder2/simple-folder3                |
@@ -291,14 +294,14 @@ Feature: list files
       | spaces      |
 
 
-  Scenario Outline: Get the list of files in a folder in the trashbin with depth 0
+  Scenario Outline: Get the list of files in the trashbin with depth 0
     Given using <dav_version> DAV path
     And user "Alice" has deleted the following resources
       | path           |
       | textfile0.txt  |
       | welcome.txt    |
       | simple-folder/ |
-    When user "Alice" lists the resources in the trashbin path "/" with depth "0" using the WebDAV API
+    When user "Alice" lists the resources in the trashbin with depth "0" using the WebDAV API
     Then the HTTP status code should be "207"
     And the trashbin DAV response should not contain these nodes
       | name                                                      |
@@ -322,14 +325,14 @@ Feature: list files
       | spaces      |
 
 
-  Scenario Outline: Get the list of files in a folder in the trashbin with depth 1
+  Scenario Outline: Get the list of files in the trashbin with depth 1
     Given using <dav_version> DAV path
     And user "Alice" has deleted the following resources
       | path           |
       | textfile0.txt  |
       | welcome.txt    |
       | simple-folder/ |
-    When user "Alice" lists the resources in the trashbin path "/" with depth "1" using the WebDAV API
+    When user "Alice" lists the resources in the trashbin with depth "1" using the WebDAV API
     Then the HTTP status code should be "207"
     And the trashbin DAV response should contain these nodes
       | name           |
@@ -355,14 +358,15 @@ Feature: list files
       | spaces      |
 
 
-  Scenario Outline: Get the list of files in a folder in the trashbin with depth infinity
+  Scenario Outline: Get the list of files in the trashbin with depth infinity
     Given using <dav_version> DAV path
+    And the administrator has set depth_infinity_allowed to 1
     And user "Alice" has deleted the following resources
       | path           |
       | textfile0.txt  |
       | welcome.txt    |
       | simple-folder/ |
-    When user "Alice" lists the resources in the trashbin path "/" with depth "infinity" using the WebDAV API
+    When user "Alice" lists the resources in the trashbin with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the trashbin DAV response should contain these nodes
       | name                                                      |

--- a/tests/acceptance/features/bootstrap/CommentsContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsContext.php
@@ -529,6 +529,7 @@ class CommentsContext implements Context {
 		$responseXmlObject = $this->featureContext->getResponseXmlObject();
 		$responses = $responseXmlObject->xpath("//d:response");
 		$found = false;
+		$savedResponseXml = "UNKNOWN";
 		foreach ($responses as $response) {
 			foreach ($expectedProperties as $expectedProperty) {
 				$expectedProperty['propertyValue'] = $this->featureContext->substituteInLineCodes(
@@ -548,8 +549,9 @@ class CommentsContext implements Context {
 			if ($found) {
 				break;
 			}
+			$savedResponseXml = $response->asXML();
 		}
-		Assert::assertTrue($found, "Could not find expected properties in" . $response->asXML());
+		Assert::assertTrue($found, "Could not find expected properties in response " . $savedResponseXml);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1040,16 +1040,22 @@ class OccContext implements Context {
 	/**
 	 * @When the administrator has set depth_infinity_allowed to :depth_infinity_allowed
 	 *
-	 * @param int $depth_infinity_allowed
+	 * @param int $depthInfinityAllowed
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function theAdministratorHasSetDepthInfinityAllowedTo($depth_infinity_allowed) {
+	public function theAdministratorHasSetDepthInfinityAllowedTo($depthInfinityAllowed) {
+		$depthInfinityAllowedString = (string) $depthInfinityAllowed;
 		$this->addSystemConfigKeyUsingTheOccCommand(
 			"dav.propfind.depth_infinity",
-			(string) $depth_infinity_allowed
+			$depthInfinityAllowedString
 		);
+		if ($depthInfinityAllowedString === "0") {
+			$this->featureContext->davPropfindDepthInfinityDisabled();
+		} else {
+			$this->featureContext->davPropfindDepthInfinityEnabled();
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -104,6 +104,36 @@ trait WebDav {
 	private $chunkingToUse = null;
 
 	/**
+	 * The ability to do requests with depth infinity is disabled by default.
+	 * This remembers when the setting dav.propfind.depth_infinity has been
+	 * enabled, so that test code can make use of it as appropriate.
+	 *
+	 * @var bool
+	 */
+	private $davPropfindDepthInfinityEnabled = false;
+
+	/**
+	 * @return void
+	 */
+	public function davPropfindDepthInfinityEnabled():void {
+		$this->davPropfindDepthInfinityEnabled = true;
+	}
+
+	/**
+	 * @return void
+	 */
+	public function davPropfindDepthInfinityDisabled():void {
+		$this->davPropfindDepthInfinityEnabled = false;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function davPropfindDepthInfinityIsEnabled():bool {
+		return $this->davPropfindDepthInfinityEnabled;
+	}
+
+	/**
 	 * @param int $lastUploadDeleteTime
 	 *
 	 * @return void
@@ -1996,7 +2026,7 @@ trait WebDav {
 	}
 
 	/**
-	 * asserts that a the user can or cannot see a list of files/folders by propfind
+	 * asserts that the user can or cannot see a list of files/folders by propfind
 	 *
 	 * @param string $user
 	 * @param TableNode $elements
@@ -2014,34 +2044,73 @@ trait WebDav {
 	):void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeColumnsCount($elements, 1);
-		$responseXmlObject = $this->listFolderAndReturnResponseXml(
-			$user,
-			"/",
-			"infinity"
-		);
 		$elementRows = $elements->getRows();
 		$elementsSimplified = $this->simplifyArray($elementRows);
-		foreach ($elementsSimplified as $expectedElement) {
-			// Allow the table of expected elements to have entries that do
-			// not have to specify the "implied" leading slash, or have multiple
-			// leading slashes, to make scenario outlines more flexible
-			$expectedElement = $this->encodePath($expectedElement);
-			$expectedElement = "/" . \ltrim($expectedElement, "/");
-			$webdavPath = "/" . $this->getFullDavFilesPath($user) . $expectedElement;
-			$element = $responseXmlObject->xpath(
-				"//d:response/d:href[text() = \"$webdavPath\"]"
+		if ($this->davPropfindDepthInfinityIsEnabled()) {
+			// get a full "infinite" list of the user's root folder in one request
+			// and process that to check the elements (resources)
+			$responseXmlObject = $this->listFolderAndReturnResponseXml(
+				$user,
+				"/",
+				"infinity"
 			);
-			if ($expectedToBeListed
-				&& (!isset($element[0]) || $element[0]->__toString() !== $webdavPath)
-			) {
-				Assert::fail(
-					"$webdavPath is not in propfind answer but should be"
+			foreach ($elementsSimplified as $expectedElement) {
+				// Allow the table of expected elements to have entries that do
+				// not have to specify the "implied" leading slash, or have multiple
+				// leading slashes, to make scenario outlines more flexible
+				$expectedElement = $this->encodePath($expectedElement);
+				$expectedElement = "/" . \ltrim($expectedElement, "/");
+				$webdavPath = "/" . $this->getFullDavFilesPath($user) . $expectedElement;
+				$element = $responseXmlObject->xpath(
+					"//d:response/d:href[text() = \"$webdavPath\"]"
 				);
-			} elseif (!$expectedToBeListed && isset($element[0])
-			) {
-				Assert::fail(
-					"$webdavPath is in propfind answer but should not be"
+				if ($expectedToBeListed
+					&& (!isset($element[0]) || $element[0]->__toString() !== $webdavPath)
+				) {
+					Assert::fail(
+						"$webdavPath is not in propfind answer but should be"
+					);
+				} elseif (!$expectedToBeListed && isset($element[0])
+				) {
+					Assert::fail(
+						"$webdavPath is in propfind answer but should not be"
+					);
+				}
+			}
+		} else {
+			// do a PROPFIND for each element
+			foreach ($elementsSimplified as $elementToRequest) {
+				// Allow the table of expected elements to have entries that do
+				// not have to specify the "implied" leading slash, or have multiple
+				// leading slashes, to make scenario outlines more flexible
+				$elementToRequest = "/" . \ltrim($elementToRequest, "/");
+				// Note: in the request we ask to do a PROPFIND on a resource like:
+				//       /some-folder with spaces/sub-folder
+				// but the response has encoded values for the special characters like:
+				//       /some-folder%20with%20spaces/sub-folder
+				// So we need both $elementToRequest and $expectedElement
+				$expectedElement = $this->encodePath($elementToRequest);
+				$responseXmlObject = $this->listFolderAndReturnResponseXml(
+					$user,
+					$elementToRequest,
+					"1"
 				);
+				$webdavPath = "/" . $this->getFullDavFilesPath($user) . $expectedElement;
+				$element = $responseXmlObject->xpath(
+					"//d:response/d:href[text() = \"$webdavPath\"]"
+				);
+				if ($expectedToBeListed
+					&& (!isset($element[0]) || $element[0]->__toString() !== $webdavPath)
+				) {
+					Assert::fail(
+						"$webdavPath is not in propfind answer but should be"
+					);
+				} elseif (!$expectedToBeListed && isset($element[0])
+				) {
+					Assert::fail(
+						"$webdavPath is in propfind answer but should not be"
+					);
+				}
 			}
 		}
 	}

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -117,10 +117,7 @@ class WebDavPropertiesContext implements Context {
 				$properties[] = $row["propertyName"];
 			}
 		}
-		$depth = '0';
-		if (\count($properties) > 1) {
-			$depth = 'infinity';
-		}
+		$depth = "1";
 		$this->featureContext->setResponseXmlObject(
 			$this->featureContext->listFolderAndReturnResponseXml(
 				$user,
@@ -136,11 +133,17 @@ class WebDavPropertiesContext implements Context {
 	 * @param string $user
 	 * @param string $path
 	 * @param TableNode $propertiesTable
+	 * @param string $depth
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function getFollowingCommentPropertiesOfFileUsingWebDAVPropfindApi(string $user, string $path, TableNode $propertiesTable):void {
+	public function getFollowingCommentPropertiesOfFileUsingWebDAVPropfindApi(
+		string $user,
+		string $path,
+		TableNode $propertiesTable,
+		string $depth = "1"
+	):void {
 		$properties = null;
 		$this->featureContext->verifyTableNodeColumns($propertiesTable, ["propertyName"]);
 		$this->featureContext->verifyTableNodeColumnsCount($propertiesTable, 1);
@@ -149,15 +152,10 @@ class WebDavPropertiesContext implements Context {
 				$properties[] = $row["propertyName"];
 			}
 		}
-		$depth = 0;
 
 		$user = $this->featureContext->getActualUsername($user);
 		$fileId = $this->featureContext->getFileIdForPath($user, $path);
 		$commentsPath = "/comments/files/$fileId/";
-		if (\count($properties) > 1) {
-			$depth = 'infinity';
-			$this->featureContext->usingNewDavPath();
-		}
 		$this->featureContext->setResponseXmlObject(
 			$this->featureContext->listFolderAndReturnResponseXml(
 				$user,

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
@@ -34,6 +34,7 @@ Feature: get file info using PROPFIND
   @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on root folder with external storage using depth infinity
     Given using <dav_version> DAV path
+    And the administrator has set depth_infinity_allowed to 1
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the propfind result of user "Alice" should contain only these entries:
@@ -69,6 +70,7 @@ Feature: get file info using PROPFIND
   @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on external storage with depth infinity
     Given using <dav_version> DAV path
+    And the administrator has set depth_infinity_allowed to 1
     When user "Alice" lists the resources in "/local_storage2" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
     And the propfind result of user "Alice" should contain only these entries:

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
@@ -18,6 +18,7 @@ Feature: get file info using PROPFIND
   @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on external storage that is currently unavailable
     Given using <dav_version> DAV path
+    And the administrator has set depth_infinity_allowed to 1
     When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"
     And user "Alice" lists the resources in "/local_storage2" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"
@@ -34,6 +35,7 @@ Feature: get file info using PROPFIND
   @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on root folder with depth infinity when the external storage folder is unavailable
     Given using <dav_version> DAV path
+    And the administrator has set depth_infinity_allowed to 1
     When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"
     And user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "207"


### PR DESCRIPTION
Change in https://github.com/owncloud/core/pull/38583/files#diff-efe547293d3c10c67f8014fd439977f1c8f1073dcb65a1a83dc33e7d266dec70R48 release for oc10.9 set dav.propfind.depth_infinity' => true as default and caused some performance issues on some setups. This PR brings back the default as in the past, as discussed in https://github.com/owncloud/core/pull/38583#issuecomment-937842124. 

- [x] review unit tests for potential adjustments

fixes https://github.com/owncloud/enterprise/issues/5154 