### PR TITLE
[tests-only][full-ci]Improve then steps in apiShareCreateSpecialToShares2 suite

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
@@ -15,9 +15,9 @@ Feature: shares are received in the default folder for received shares
     And user "Brian" accepts share "/FOLDER" offered by user "Alice" using the sharing API
     And user "Brian" unshares folder "Shares/FOLDER" using the WebDAV API
     And user "Brian" shares folder "/Shares" with user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
+    Then the OCS status code of responses on each endpoint should be "<ocs_status_code>" respectively
+    And the HTTP status code of responses on each endpoint should be "<http_status_code>" respectively
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 404             | 200              |
-      | 2               | 404             | 404              |
+      | ocs_api_version | ocs_status_code | http_status_code   |
+      | 1               | 100, 100, 404   | 200, 200, 204, 200 |
+      | 2               | 200, 200, 404   | 200, 200, 204, 404 |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
@@ -18,11 +18,9 @@ Feature: sharing works when a username and group name are the same
     And user "Alice" has shared file "randomfile.txt" with group "Brian"
     And user "Carol" has accepted share "/randomfile.txt" offered by user "Alice"
     When user "Alice" shares file "randomfile.txt" with user "Brian" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    When user "Brian" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
+    And user "Brian" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
     And user "Brian" should see the following elements
       | /Shares/randomfile.txt |
     And user "Carol" should see the following elements
@@ -42,11 +40,9 @@ Feature: sharing works when a username and group name are the same
     And user "Alice" has shared file "randomfile.txt" with user "Brian"
     And user "Brian" has accepted share "/randomfile.txt" offered by user "Alice"
     When user "Alice" shares file "randomfile.txt" with group "Brian" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    When user "Carol" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
+    And user "Carol" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
     And user "Brian" should see the following elements
       | /Shares/randomfile.txt |
     And user "Carol" should see the following elements
@@ -66,11 +62,9 @@ Feature: sharing works when a username and group name are the same
     And user "Alice" has shared file "randomfile.txt" with group "brian"
     And user "Carol" has accepted share "/randomfile.txt" offered by user "Alice"
     When user "Alice" shares file "randomfile.txt" with user "Brian" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    When user "Brian" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
+    And user "Brian" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
     And user "Brian" should see the following elements
       | /Shares/randomfile.txt |
     And user "Carol" should see the following elements
@@ -90,11 +84,9 @@ Feature: sharing works when a username and group name are the same
     And user "Alice" has shared file "randomfile.txt" with user "Brian"
     And user "Brian" has accepted share "/randomfile.txt" offered by user "Alice"
     When user "Alice" shares file "randomfile.txt" with group "brian" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    When user "Carol" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
+    And user "Carol" accepts share "/randomfile.txt" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "100"
+    And the HTTP status code of responses on all endpoints should be "200"
     And user "Carol" should see the following elements
       | /Shares/randomfile.txt |
     And user "Brian" should see the following elements

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -36,17 +36,15 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "Alice" has been added to group "grp0"
     And user "Alice" has created folder "PARENT"
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    When user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
+    And user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"
+    And the HTTP status code of responses on all endpoints should be "200"
     And as "Brian" folder "/Shares/PARENT" should exist
     But as "Brian" folder "/PARENT" should not exist
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: sharer should be able to share a folder to a group which he/she is member of when share with only member group is enabled
@@ -58,17 +56,15 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "Brian" has been added to group "grp0"
     And user "Alice" has created folder "PARENT"
     When user "Alice" shares folder "/PARENT" with group "grp0" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    When user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
+    And user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"
+    And the HTTP status code of responses on all endpoints should be "200"
     And as "Brian" folder "/Shares/PARENT" should exist
     But as "Brian" folder "/PARENT" should not exist
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   @issue-ocis-1328
   Scenario Outline: sharer should not be able to share a file to a group which he/she is not member of when share with only member group is enabled
@@ -101,17 +97,15 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "Brian" has been added to group "grp0"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/textfile0.txt" with group "grp0" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
+    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"
+    And the HTTP status code of responses on all endpoints should be "200"
     And as "Brian" file "/Shares/textfile0.txt" should exist
     But as "Brian" file "/textfile0.txt" should not exist
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: sharer should be able to share a file to a user who is not a member of sharer group when share with only member group is enabled
@@ -122,14 +116,12 @@ Feature: cannot share resources outside the group when share with membership gro
     And user "Alice" has been added to group "grp0"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     When user "Alice" shares folder "/textfile0.txt" with user "Brian" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
-    When user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "<http_status_code>"
+    And user "Brian" accepts share "/textfile0.txt" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"
+    And the HTTP status code of responses on all endpoints should be "200"
     And as "Brian" file "/Shares/textfile0.txt" should exist
     But as "Brian" file "/textfile0.txt" should not exist
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 100             | 200              |
-      | 2               | 200             | 200              |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature
@@ -41,15 +41,15 @@ Feature: cannot share resources with invalid permissions
       | shareWith   | Brian         |
       | shareType   | user          |
       | permissions | create        |
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the OCS status code should be "400"
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" entry "textfile0.txt" should not exist
     And as "Brian" entry "/Shares/textfile0.txt" should not exist
     And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 400             | 200              |
-      | 2               | 400             | 400              |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 400              |
 
 
   Scenario Outline: Cannot create a share of a file with a user with only (create,delete) permission
@@ -60,17 +60,17 @@ Feature: cannot share resources with invalid permissions
       | shareWith   | Brian         |
       | shareType   | user          |
       | permissions | <permissions> |
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the OCS status code should be "400"
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" entry "textfile0.txt" should not exist
     And as "Brian" entry "/Shares/textfile0.txt" should not exist
     And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code | permissions   |
-      | 1               | 400             | 200              | delete        |
-      | 2               | 400             | 400              | delete        |
-      | 1               | 400             | 200              | create,delete |
-      | 2               | 400             | 400              | create,delete |
+      | ocs_api_version | http_status_code | permissions   |
+      | 1               | 200              | delete        |
+      | 2               | 400              | delete        |
+      | 1               | 200              | create,delete |
+      | 2               | 400              | create,delete |
 
   @issue-ocis-reva-34
   Scenario Outline: Cannot create a share of a file with a group with only create permission
@@ -83,15 +83,15 @@ Feature: cannot share resources with invalid permissions
       | shareWith   | grp1          |
       | shareType   | group         |
       | permissions | create        |
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the OCS status code should be "400"
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" entry "textfile0.txt" should not exist
     And as "Brian" entry "/Shares/textfile0.txt" should not exist
     And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code |
-      | 1               | 400             | 200              |
-      | 2               | 400             | 400              |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 400              |
 
   @issue-ocis-reva-34
   Scenario Outline: Cannot create a share of a file with a group with only (create,delete) permission
@@ -104,14 +104,14 @@ Feature: cannot share resources with invalid permissions
       | shareWith   | grp1          |
       | shareType   | group         |
       | permissions | <permissions> |
-    Then the OCS status code should be "<ocs_status_code>"
+    Then the OCS status code should be "400"
     And the HTTP status code should be "<http_status_code>"
     And as "Brian" entry "textfile0.txt" should not exist
     And as "Brian" entry "/Shares/textfile0.txt" should not exist
     And the sharing API should report to user "Brian" that no shares are in the pending state
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code | permissions   |
-      | 1               | 400             | 200              | delete        |
-      | 2               | 400             | 400              | delete        |
-      | 1               | 400             | 200              | create,delete |
-      | 2               | 400             | 400              | create,delete |
+      | ocs_api_version | http_status_code | permissions   |
+      | 1               | 200              | delete        |
+      | 2               | 400              | delete        |
+      | 1               | 200              | create,delete |
+      | 2               | 400              | create,delete |

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3387,7 +3387,7 @@ trait WebDav {
 		$this->pauseUploadDelete();
 		$this->response = $this->makeDavRequest($user, 'DELETE', $file, []);
 		$this->lastUploadDeleteTime = \time();
-		$this->pushToLastStatusCodesArrays();
+		$this->pushToLastHttpStatusCodesArray((string) $this->getResponse()->getStatusCode());
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR adds ``` Then ``` steps to existing API test scenarios to better check the results of ``` When ``` steps.

### Suite Covered
- ```apiShareCreateSpecialToShare2```

## Related Issues
- Part of https://github.com/owncloud/core/issues/39512

## How Has This Been Tested?
- Locally
- CI

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
