### PR TITLE
Include tab communication for the forced logout config

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -248,7 +248,8 @@ $CONFIG = [
  * might cause unwanted logouts for the users.
  * Also note that this feature works properly if the user uses only one
  * tab. If a user uses multiple tabs, closing one of them will likely
- * force the rest to re-authenticate.
+ * force the rest to re-authenticate in IE11 and Safari < 15.4 (other browsers
+ * work fine)
  */
 'session_forced_logout_timeout' => 0,
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Possible solution to the issue with multiple tabs in https://github.com/owncloud/core/pull/39916.

When the tab closes, a message is sent to the rest of the tabs so they sent a heartbeat request to update the cookie. This will prevent the tabs from logging out since the cookie won't expire soon.
It's expected that only one tab sends the heartbeat request, although it isn't fully guaranteed.

Note that this solution **WON'T work in IE11**, and for Safari it will only work in 15.4 but not for previous versions. We should consider whether we want to use this solution as it is, ignoring IE11, or if we want to provide a configuration option in order to try to keep the same behavior in all the browsers.

## Related Issue
Part of https://github.com/owncloud/core/pull/39916

## Motivation and Context
Right now, the `session_forced_logout_timeout` works with only one tab. Using multiple tabs will cause a logout in all the tabs when any of them closes. This is an unwanted behavior.

## How Has This Been Tested?
Checked with firefox:
1. Setup `session_forced_logout_timeout => 10` in the config.php file
2. Open 3 tabs with ownCloud. Note that you have logged in with just one of them.
3. Close one of them
4. Wait 10 secs before performing any action

You can perform the action without any problem because you haven't been logged out. You can check that one of the ownCloud tab has sent a heartbeat request to refresh the cookie.

As said, **IE11 and Safari < 15.4** fails due to the lack of support for broadcast channels. (https://caniuse.com/broadcastchannel)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
