### PR TITLE
Allow partial initialization of the FS

### DIFF
--- a/apps/dav/lib/Command/CleanupChunks.php
+++ b/apps/dav/lib/Command/CleanupChunks.php
@@ -60,8 +60,8 @@ class CleanupChunks extends Command {
 				'local',
 				'l',
 				InputOption::VALUE_NONE,
-				'only delete chunks that exist on the local filesystem, 
-				this applies to setups with multiple servers connected to the same database and 
+				'only delete chunks that exist on the local filesystem,
+				this applies to setups with multiple servers connected to the same database and
 				chunk folder is not shared among'
 			);
 	}
@@ -74,7 +74,7 @@ class CleanupChunks extends Command {
 		$output->writeln("Cleaning chunks older than $d days({$cutOffTime->format('c')})");
 		$this->userManager->callForSeenUsers(function (IUser $user) use ($output, $cutOffTime, $checkUploadExistsLocal) {
 			\OC_Util::tearDownFS();
-			\OC_Util::setupFS($user->getUID());
+			\OC_Util::setupFS($user->getUID(), true);
 
 			$view = new View('/' . $user->getUID() . '/uploads');
 			$home = new UploadHome(['user' => $user]);

--- a/apps/dav/lib/Command/CleanupChunks.php
+++ b/apps/dav/lib/Command/CleanupChunks.php
@@ -74,7 +74,7 @@ class CleanupChunks extends Command {
 		$output->writeln("Cleaning chunks older than $d days({$cutOffTime->format('c')})");
 		$this->userManager->callForSeenUsers(function (IUser $user) use ($output, $cutOffTime, $checkUploadExistsLocal) {
 			\OC_Util::tearDownFS();
-			\OC_Util::setupFS($user->getUID(), true);
+			\OC_Util::setupFS($user->getUID(), false);
 
 			$view = new View('/' . $user->getUID() . '/uploads');
 			$home = new UploadHome(['user' => $user]);

--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -141,7 +141,7 @@ class ExpireTrash extends TimedJob {
 	 */
 	protected function setupFS($user) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($user);
+		\OC_Util::setupFS($user, true);
 
 		// Check if this user has a trashbin directory
 		$view = new \OC\Files\View('/' . $user);

--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -141,7 +141,7 @@ class ExpireTrash extends TimedJob {
 	 */
 	protected function setupFS($user) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($user, true);
+		\OC_Util::setupFS($user, false);
 
 		// Check if this user has a trashbin directory
 		$view = new \OC\Files\View('/' . $user);

--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -106,7 +106,7 @@ class CleanUp extends Command {
 	 */
 	protected function removeDeletedFiles($uid) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($uid, true);
+		\OC_Util::setupFS($uid, false);
 		if ($this->rootFolder->nodeExists('/' . $uid . '/files_trashbin')) {
 			$this->rootFolder->get('/' . $uid . '/files_trashbin')->delete();
 			$query = $this->dbConnection->getQueryBuilder();

--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -106,7 +106,7 @@ class CleanUp extends Command {
 	 */
 	protected function removeDeletedFiles($uid) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($uid);
+		\OC_Util::setupFS($uid, true);
 		if ($this->rootFolder->nodeExists('/' . $uid . '/files_trashbin')) {
 			$this->rootFolder->get('/' . $uid . '/files_trashbin')->delete();
 			$query = $this->dbConnection->getQueryBuilder();

--- a/apps/files_trashbin/lib/Command/Expire.php
+++ b/apps/files_trashbin/lib/Command/Expire.php
@@ -60,7 +60,7 @@ class Expire implements ICommand {
 		}
 
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($this->user, true);
+		\OC_Util::setupFS($this->user, false);
 
 		$trashExpiryManager->expireTrash($this->user);
 

--- a/apps/files_trashbin/lib/Command/Expire.php
+++ b/apps/files_trashbin/lib/Command/Expire.php
@@ -60,7 +60,7 @@ class Expire implements ICommand {
 		}
 
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($this->user);
+		\OC_Util::setupFS($this->user, true);
 
 		$trashExpiryManager->expireTrash($this->user);
 

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -115,7 +115,7 @@ class ExpireTrash extends Command {
 	 */
 	protected function setupFS($user) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($user);
+		\OC_Util::setupFS($user, true);
 
 		// Check if this user has a trashbin directory
 		$view = new \OC\Files\View('/' . $user);

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -115,7 +115,7 @@ class ExpireTrash extends Command {
 	 */
 	protected function setupFS($user) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($user, true);
+		\OC_Util::setupFS($user, false);
 
 		// Check if this user has a trashbin directory
 		$view = new \OC\Files\View('/' . $user);

--- a/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
+++ b/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
@@ -82,7 +82,7 @@ class ExpireVersions extends \OC\BackgroundJob\TimedJob {
 	 */
 	protected function setupFS($user) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($user, true);
+		\OC_Util::setupFS($user, false);
 
 		// Check if this user has a versions directory
 		$view = new \OC\Files\View('/' . $user);

--- a/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
+++ b/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
@@ -82,7 +82,7 @@ class ExpireVersions extends \OC\BackgroundJob\TimedJob {
 	 */
 	protected function setupFS($user) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($user);
+		\OC_Util::setupFS($user, true);
 
 		// Check if this user has a versions directory
 		$view = new \OC\Files\View('/' . $user);

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -115,7 +115,7 @@ class ExpireVersions extends Command {
 	 */
 	protected function setupFS($user) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($user);
+		\OC_Util::setupFS($user, true);
 
 		// Check if this user has a version directory
 		$view = new \OC\Files\View('/' . $user);

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -115,7 +115,7 @@ class ExpireVersions extends Command {
 	 */
 	protected function setupFS($user) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($user, true);
+		\OC_Util::setupFS($user, false);
 
 		// Check if this user has a version directory
 		$view = new \OC\Files\View('/' . $user);

--- a/changelog/unreleased/40031
+++ b/changelog/unreleased/40031
@@ -1,0 +1,17 @@
+Bugfix: Allow partial initialization of the FS
+
+Previously, when the FS was initialized, we needed to make a request
+to the LDAP server in order to fetch the possible group shares of the
+user. Some commands only accessed to the trashbin or versions, and
+operated for a target user, so accessing to the LDAP server to fetch
+groups that wouldn't be used doesn't make much sense.
+
+Now, the commands have the ability to initialize the FS partially,
+meaning that no additional mount point other than the home one will
+be mounted. In particular, this affects shares and external storages.
+Anyway, the commands that have been modified don't need such access. The
+main advantage is that now, those commands can operate without a working
+connection to the LDAP server because the users will be fetched from the
+DB and they don't operate with groups.
+
+https://github.com/owncloud/core/pull/40031

--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -173,7 +173,7 @@ class ChangeKeyStorageRoot extends Command {
 	 */
 	protected function setupUserFS($uid) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($uid, true);
+		\OC_Util::setupFS($uid, false);
 	}
 
 	/**

--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -173,7 +173,7 @@ class ChangeKeyStorageRoot extends Command {
 	 */
 	protected function setupUserFS($uid) {
 		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($uid);
+		\OC_Util::setupFS($uid, true);
 	}
 
 	/**

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -359,7 +359,7 @@ class Filesystem {
 		}
 	}
 
-	public static function init($user, $root) {
+	public static function init($user, $root, $partial = false) {
 		if (self::$defaultInstance) {
 			return false;
 		}
@@ -371,7 +371,7 @@ class Filesystem {
 		}
 
 		//load custom mount config
-		self::initMountPoints($user);
+		self::initMountPoints($user, $partial);
 
 		self::$loaded = true;
 
@@ -390,7 +390,7 @@ class Filesystem {
 	 * @param string $user
 	 * @throws \OC\User\NoUserException if the user is not available
 	 */
-	public static function initMountPoints($user = '') {
+	public static function initMountPoints($user = '', $partial = false) {
 		if ($user == '') {
 			$user = \OC_User::getUser();
 		}
@@ -441,16 +441,18 @@ class Filesystem {
 
 		\OC\Files\Filesystem::getStorage($user);
 
-		// Chance to mount for other storages
-		if ($userObject) {
-			$mounts = $mountConfigManager->getMountsForUser($userObject);
-			\array_walk($mounts, [self::$mounts, 'addMount']);
-			$mounts[] = $homeMount;
-			$mountConfigManager->registerMounts($userObject, $mounts);
-		}
+		if (!$partial) {
+			// Chance to mount for other storages
+			if ($userObject) {
+				$mounts = $mountConfigManager->getMountsForUser($userObject);
+				\array_walk($mounts, [self::$mounts, 'addMount']);
+				$mounts[] = $homeMount;
+				$mountConfigManager->registerMounts($userObject, $mounts);
+			}
 
-		self::listenForNewMountProviders($mountConfigManager, $userManager);
-		\OC_Hook::emit('OC_Filesystem', 'post_initMountPoints', ['user' => $user]);
+			self::listenForNewMountProviders($mountConfigManager, $userManager);
+			\OC_Hook::emit('OC_Filesystem', 'post_initMountPoints', ['user' => $user]);
+		}
 	}
 
 	/**

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -359,7 +359,7 @@ class Filesystem {
 		}
 	}
 
-	public static function init($user, $root, $partial = false) {
+	public static function init($user, $root, $fullInit = true) {
 		if (self::$defaultInstance) {
 			return false;
 		}
@@ -371,7 +371,7 @@ class Filesystem {
 		}
 
 		//load custom mount config
-		self::initMountPoints($user, $partial);
+		self::initMountPoints($user, $fullInit);
 
 		self::$loaded = true;
 
@@ -390,7 +390,7 @@ class Filesystem {
 	 * @param string $user
 	 * @throws \OC\User\NoUserException if the user is not available
 	 */
-	public static function initMountPoints($user = '', $partial = false) {
+	public static function initMountPoints($user = '', $fullInit = true) {
 		if ($user == '') {
 			$user = \OC_User::getUser();
 		}
@@ -441,7 +441,7 @@ class Filesystem {
 
 		\OC\Files\Filesystem::getStorage($user);
 
-		if (!$partial) {
+		if ($fullInit) {
 			// Chance to mount for other storages
 			if ($userObject) {
 				$mounts = $mountConfigManager->getMountsForUser($userObject);

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -131,7 +131,7 @@ class OC_Util {
 	 * @return boolean
 	 * @description configure the initial filesystem based on the configuration
 	 */
-	public static function setupFS($user = '') {
+	public static function setupFS($user = '', $partial = false) {
 		//setting up the filesystem twice can only lead to trouble
 		if (self::$fsSetup) {
 			return false;
@@ -308,7 +308,7 @@ class OC_Util {
 			$userDir = '/' . $user . '/files';
 
 			//jail the user into his "home" directory
-			\OC\Files\Filesystem::init($user, $userDir);
+			\OC\Files\Filesystem::init($user, $userDir, $partial);
 
 			OC_Hook::emit('OC_Filesystem', 'setup', ['user' => $user, 'user_dir' => $userDir]);
 		}

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -131,7 +131,7 @@ class OC_Util {
 	 * @return boolean
 	 * @description configure the initial filesystem based on the configuration
 	 */
-	public static function setupFS($user = '', $partial = false) {
+	public static function setupFS($user = '', $fullInit = true) {
 		//setting up the filesystem twice can only lead to trouble
 		if (self::$fsSetup) {
 			return false;
@@ -308,7 +308,7 @@ class OC_Util {
 			$userDir = '/' . $user . '/files';
 
 			//jail the user into his "home" directory
-			\OC\Files\Filesystem::init($user, $userDir, $partial);
+			\OC\Files\Filesystem::init($user, $userDir, $fullInit);
 
 			OC_Hook::emit('OC_Filesystem', 'setup', ['user' => $user, 'user_dir' => $userDir]);
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Using LDAP, setting up the whole FS causes a connection to the LDAP server because we need to mount the shares of any group the user belongs to. This is confusing with some commands that don't expect a connection to the LDAP server since the users are fetched from the DB.

In order to solve this, the commands will setup the FS partially. This means that no mounts will be added other than the home one. This is expected to affect access to shares and external storages. However, the touched commands should need to access to those locations.

Note that, by default, the whole FS will be initialized. For web access, this is done pretty early (in "lib/base.php"), meaning that this feature is mostly limited to CLI.

The main goal of this feature is to prevent hitting the LDAP server. In case the LDAP server isn't accessible, the modified commands will still run instead of crashing. As side effect, there is a minor performance improvement due to the initialization skip (a few ms per FS setup)

## Related Issue
https://github.com/owncloud/enterprise/issues/5081

## Motivation and Context
Some commands crash due to hitting the LDAP server, although they shouldn't hit the LDAP server in the first place.

## How Has This Been Tested?
1. Setup LDAP connection
2. Set `'trashbin_retention_obligation' => '0, 0',` in the config.php file to remove the files from the trashbin without waiting.
3. Add some files in a LDAP account
4. Remove some files from the LDAP account
5. Stop the LDAP server
5. Run the `occ trashbin:expire` command

The command runs without crashing.

The rest of the touched commands and brackground jobs should behave the same way, although they haven't tested yet.

Note that the `occ trashbin:cleanup` command might still crash because it gets the users from the backend directly, not through the account.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
