### PR TITLE
Use the same string in the header also in public view

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -58,7 +58,7 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 		 data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
 		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud-public">
 			<h1 class="logo-icon">
-				<?php p($theme->getName()); ?>
+				<?php p($theme->getHTMLName()); ?>
 			</h1>
 		</a>
 

--- a/changelog/unreleased/40032
+++ b/changelog/unreleased/40032
@@ -6,4 +6,4 @@ This can cause problems with branding.
 The string HTMLName from defaults.php is now only used for the header.
 Name is used exclusively for the mail templates.
 
-https://github.com/owncloud/core/pull/40021
+https://github.com/owncloud/core/pull/40032

--- a/changelog/unreleased/40032
+++ b/changelog/unreleased/40032
@@ -1,0 +1,9 @@
+Enhancement: Use the same string in the header also in public view
+
+In the public view, a different string was used next to the logo than in the internal header.
+This can cause problems with branding.
+
+The string HTMLName from defaults.php is now only used for the header.
+Name is used exclusively for the mail templates.
+
+https://github.com/owncloud/core/pull/40021


### PR DESCRIPTION
## Description
In the public view, a different string was used next to the logo than in the internal header. This can cause problems with branding. 

## Motivation and Context
The string `HTMLName` is now only used for the header. `Name` is used exclusively for the mail templates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually testet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
