### PR TITLE
[tests-only] [full-ci] Remove pushToLastStatusCodesArrays from AppConfigurationContext

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -4,7 +4,7 @@ Feature: CORS headers
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
+  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
@@ -48,7 +48,7 @@ Feature: CORS headers
       | 1               | /apps/files_sharing/api/v1/shares                | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/shares                | 200      | 200       |
 
-  @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
+  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
     And the administrator has added "https://aphno.badal" to the list of personal CORS domains

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given user "Alice" has been created with default attributes and without skeleton files
 
   @smokeTest
-  @skipOnEncryptionType:user-keys @issue-32322
+  @skipOnEncryptionType:user-keys @issue-32322 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -6,7 +6,7 @@ Feature: sharing
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   @skipOnEncryptionType:user-keys @issue-32322
   Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
@@ -69,7 +69,7 @@ Feature: Display notifications when receiving a share
     When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "no"
     And the administrator creates user "David" using the provisioning API
     And the administrator adds user "David" to group "grp1" using the provisioning API
-    Then the OCS status code of responses on each endpoint should be "100, 200, 100" respectively
+    Then the OCS status code of responses on each endpoint should be "200, 100" respectively
     And the HTTP status code of responses on all endpoints should be "200"
     And user "Brian" should have 0 notifications
     And user "Carol" should have 0 notifications
@@ -113,7 +113,7 @@ Feature: Display notifications when receiving a share
     When the administrator sets parameter "shareapi_auto_accept_share" of app "core" to "yes"
     And the administrator creates user "David" using the provisioning API
     And the administrator adds user "David" to group "grp1" using the provisioning API
-    Then the OCS status code of responses on each endpoint should be "100, 200, 100" respectively
+    Then the OCS status code of responses on each endpoint should be "200, 100" respectively
     And the HTTP status code of responses on all endpoints should be "200"
     And user "Brian" should have 1 notification
     And the last notification of user "Brian" should match these regular expressions about user "Alice"

--- a/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToShares/sharingNotifications.feature
@@ -101,7 +101,7 @@ Feature: Display notifications when receiving a share
     And the administrator creates user "David" using the provisioning API
     And the administrator adds user "David" to group "grp1" using the provisioning API
     Then the HTTP status code of responses on all endpoints should be "200"
-    And the OCS status code of responses on each endpoint should be "100,200,100" respectively
+    And the OCS status code of responses on each endpoint should be "200,100" respectively
     And user "Brian" should have 1 notification
     And the last notification of user "Brian" should match these regular expressions about user "Alice"
       | key         | regex                                            |

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -59,7 +59,6 @@ class AppConfigurationContext implements Context {
 		// end of the captured string, so trim them.
 		$value = \trim($value, $value[0]);
 		$this->modifyAppConfig($app, $parameter, $value);
-		$this->featureContext->pushToLastStatusCodesArrays();
 	}
 
 	/**


### PR DESCRIPTION
## Description
https://drone.owncloud.com/owncloud/admin_audit/2419/22/10
```
  Scenario: change a core-app config via testing app                                  # /var/www/owncloud/testrunner/apps/admin_audit/tests/acceptance/features/apiConfig/setConfig.feature:12
    When the administrator sets parameter "shareapi_enabled" of app "core" to "no"    # AppConfigurationContext::adminSetsServerParameterToUsingAPI()
      Fatal error: Call to a member function getStatusCode() on null (Behat\Testwork\Call\Exception\FatalThrowableError)
```

```
runsh: Total unexpected failed scenarios throughout the test run:
apiConfig/setConfig.feature:12
apiConfig/setConfig.feature:18
apiConfig/setConfig.feature:26
apiConfig/setConfig.feature:32
```

The function `adminSetsServerParameterToUsingAPI()` was calling `pushToLastStatusCodesArrays()`. But that function does not return the status codes, so there are no new status codes to push. If that step is used before any other step that has returned HTTP/OCS status codes, then `pushToLastStatusCodesArrays()` will fail because there is no response with status codes at that point.

Remove the call to `pushToLastStatusCodesArrays()`

## How Has This Been Tested?
CI and local run of the failing admin_audit test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
