### PR TITLE
[tests-only] full-ci] Fix path calculation in listTrashbinFolderCollection

### DIFF
--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -250,6 +250,17 @@ class TrashbinContext implements Context {
 		$files = \array_filter(
 			$files,
 			static function ($element) use ($user, $collectionPath) {
+				if (\trim($element['href'], "/") === "remote.php/dav/trash-bin") {
+					// This is a bug in oCIS. The root-level trashbin href should be like:
+					// /remote.php/dav/trash-bin/Alice/
+					// But it is missing the username, so is like:
+					// /remote.php/dav/trash-bin/
+					// We don't want to fail almost every trashbin test because of this.
+					// We filter out this entry here, and just echo a warning that this
+					// problem has happened, so that it can be seen in the test log output.
+					echo __METHOD__ . "Warning: unexpected href in trashbin propfind: " . $element['href'] . "\n";
+					return false;
+				}
 				$path = $collectionPath;
 				if ($path !== "") {
 					$path = $path . "/";

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -250,7 +250,11 @@ class TrashbinContext implements Context {
 		$files = \array_filter(
 			$files,
 			static function ($element) use ($user, $collectionPath) {
-				return ($element['href'] !== "/remote.php/dav/trash-bin/$user/$collectionPath/");
+				$path = $collectionPath;
+				if ($path !== "") {
+					$path = $path . "/";
+				}
+				return ($element['href'] !== "/remote.php/dav/trash-bin/$user/$path");
 			}
 		);
 


### PR DESCRIPTION
## Description
1) fix test code problem in `listTrashbinFolderCollection`
```
	static function ($element) use ($user, $collectionPath) {
		$path = $collectionPath;
		if ($path !== "") {
			$path = $path . "/";
		}
		return ($element['href'] !== "/remote.php/dav/trash-bin/$user/$path");
	}
```

Before this change, when `$collectionPath` was empty, the code would end up with 2 `/` on the end for the comparison with `$element['href']`. It would try to match a string like `/remote.php/dav/trash-bin/Alice//` - and that would never match. That caused the top-level trash-bin root itself to end up in the list of items in the trash-bin for consideration by later steps.

Later code was then trying to traverse down into an invalid trashbin "folder" like `/remote.php/dav/trash-bin/Alice/Alice/` which is an incorrect thing to even try to do (and looks like it might be part of the cause of trouble when running against oCIS)

2) Handle trashbin PROPFIND href problem that happens in oCIS

When doing a PROPFIND to the root of the empty trashbin in oC10, you get a response like:
```
<?xml version="1.0"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
  <d:response>
    <d:href>/remote.php/dav/trash-bin/admin/</d:href>
    <d:propstat>
      <d:prop>
        <d:resourcetype><d:collection/></d:resourcetype>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
    <d:propstat>
      <d:prop>
        <oc:trashbin-original-filename/>
        <oc:trashbin-original-location/>
        <oc:trashbin-delete-datetime/>
        <d:getcontentlength/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```

But on oCIS the response is like:
```
<?xml version="1.0" encoding="utf-8"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
  <d:response>
    <d:href>/remote.php/dav/trash-bin/</d:href>
    <d:propstat>
      <d:prop>
        <d:resourcetype><d:collection/></d:resourcetype>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
    <d:propstat>
      <d:prop>
        <oc:trashbin-original-filename></oc:trashbin-original-filename>
        <oc:trashbin-original-location></oc:trashbin-original-location>
        <oc:trashbin-delete-datetime></oc:trashbin-delete-datetime>
        <d:getcontentlength></d:getcontentlength>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```

The "href" is missing the username at the end of the string `/remote.php/dav/trash-bin/` - it should be something like `/remote.php/dav/trash-bin/Alice/`.

And that creates a problem for any client code that tries to use the "href" value.

## How Has This Been Tested?
CI and local test runs.

oCIS CI is tested in https://github.com/owncloud/ocis/pull/3638 - that gets the regular trashbin test scenarios passing like they previously did. There are other issues with using the spaces endpoint and trying to access the trashbin - those are a separate thing.

https://drone.owncloud.com/owncloud/ocis/11191/31/6
```
    Examples:
      | dav-path | filename1     | filename2     |
      | new      | textfile0.txt | textfile1.txt |
        │ {closure}Warning: unexpected href in trashbin propfind: /remote.php/dav/trash-bin/
        │ 
        │ {closure}Warning: unexpected href in trashbin propfind: /remote.php/dav/trash-bin/
        │ 
```

The test code works-around the problem, and actually the rest of the test passes. We can see in the log output that the problem is there, so that will help when fixing it. After it is fixed in reva and oCIS we then need to go back and remove the work-around from the test code. I would rather do this than have every trashbin test scenario added to expected-failures because of this newly-discovered problem.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
