### PR TITLE
[tests-only] [full-ci] Added UI tests for sharing settings guests blockdomains

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -904,6 +904,26 @@ class OccContext implements Context {
 		);
 	}
 
+    /**
+     * @Then /^the command output should be the text ((?:'[^']*')|(?:"[^"]*"))$/
+     *
+     * @param string $text
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function theCommandOutputShouldBeTheText(string $text):void {
+        $text = \trim($text, $text[0]);
+        $commandOutput = \trim($this->featureContext->getStdOutOfOccCommand());
+        Assert::assertEquals(
+            $text,
+            $commandOutput,
+            "The command output did not match the expected text on stdout '$text'\n" .
+            "The command output on stdout was:\n" .
+            $commandOutput
+        );
+    }
+
 	/**
 	 * @Then /^the command output should contain the text ((?:'[^']*')|(?:"[^"]*")) about user "([^"]*)"$/
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -259,6 +259,17 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 		);
 	}
 
+    /**
+     * @When the administrator sets blocked domains sharing from guests to :blockedDomains using webUI
+     *
+     * @param string $blockedDomains
+     *
+     * @return void
+     */
+    public function adminSetsBlockedDomainsSharingFromGuestsTo(string $blockedDomains):void {
+        $this->adminSharingSettingsPage->setBlockedDomainsFromSharingWithGuests($blockedDomains);
+    }
+
 	/**
 	 * @When /^the administrator (enables|disables) mail notification on public link share using the webUI$/
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -228,6 +228,24 @@ class WebUIAdminSharingSettingsContext extends RawMinkContext implements Context
 	}
 
 	/**
+	 * @Then the blocked domains from sharing with guests should set to :blockedDomains on the webUI
+	 *
+	 * @param string $blockedDomains
+	 *
+	 * @return void
+	 */
+	public function blockedDomainsFromSharingWithGuestsShouldBeSetTo(string $blockedDomains):void {
+		$blockedDomainsFromSharingWithGuests = $this->adminSharingSettingsPage->getBlockedDomainsFromSharingWithGuests();
+		Assert::assertEquals(
+			$blockedDomains,
+			$blockedDomainsFromSharingWithGuests,
+			__METHOD__
+			. " The blocked domains from sharing with guests was expected to be set to '$blockedDomains', "
+			. "but was actually set to '$blockedDomainsFromSharingWithGuests'"
+		);
+	}
+
+	/**
 	 * @When /^the administrator (enables|disables) public uploads using the webUI$/
 	 *
 	 * @param string $action

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -101,6 +101,7 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $enforceExpirationDateGroupShareCheckboxId = 'shareapiEnforceExpireDateGroupShare';
 	protected $enforceExpirationDateFederatedShareCheckboxXpath = '//span[@id="setDefaultExpireDateFederatedShare"]//label[contains(text(),"expiration date")]';
 	protected $enforceExpirationDateFederatedShareCheckboxId = 'shareapiEnforceExpireDateFederatedShare';
+	protected $guestSharingBlockDomainsInputFieldId = "guestSharingBlockDomains";
 
 	/**
 	 * toggle the Share API
@@ -851,5 +852,20 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 			$this->shareApiCheckboxXpath,
 			$timeout_msec
 		);
+	}
+
+	/**
+	 * get the blocked domains from sharing with guests
+	 *
+	 * @return string
+	 */
+	public function getBlockedDomainsFromSharingWithGuests(): string {
+		$blockedDomainsSharingWithGuests = $this->findById($this->guestSharingBlockDomainsInputFieldId);
+		$this->assertElementNotNull(
+			$blockedDomainsSharingWithGuests,
+			__METHOD__ .
+			" id $this->guestSharingBlockDomainsInputFieldId could not find input field for blocked domains from sharing with guests"
+		);
+		return $blockedDomainsSharingWithGuests->getValue();
 	}
 }

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -101,7 +101,7 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 	protected $enforceExpirationDateGroupShareCheckboxId = 'shareapiEnforceExpireDateGroupShare';
 	protected $enforceExpirationDateFederatedShareCheckboxXpath = '//span[@id="setDefaultExpireDateFederatedShare"]//label[contains(text(),"expiration date")]';
 	protected $enforceExpirationDateFederatedShareCheckboxId = 'shareapiEnforceExpireDateFederatedShare';
-	protected $guestSharingBlockDomainsInputFieldId = "guestSharingBlockDomains";
+	protected $guestSharingBlockDomainsInputFieldId = 'guestSharingBlockDomains';
 
 	/**
 	 * toggle the Share API
@@ -868,4 +868,22 @@ class AdminSharingSettingsPage extends SharingSettingsPage {
 		);
 		return $blockedDomainsSharingWithGuests->getValue();
 	}
+
+    /**
+     * Set the blocked domains from sharing with guests
+     *
+     * @param string $blockedDomains
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function setBlockedDomainsFromSharingWithGuests(string $blockedDomains): void {
+        $blockedDomainsSharingWithGuests = $this->findById($this->guestSharingBlockDomainsInputFieldId);
+        $this->assertElementNotNull(
+            $blockedDomainsSharingWithGuests,
+            __METHOD__ .
+            " id $this->guestSharingBlockDomainsInputFieldId could not find input field for blocked domains from sharing with guests"
+        );
+        $this->fillField($this->guestSharingBlockDomainsInputFieldId, $blockedDomains);
+    }
 }

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -280,3 +280,12 @@ Feature: admin sharing settings
     When the administrator browses to the admin sharing settings page
     Then the blocked domains from sharing with guests should set to "something.com,qwerty.org" on the webUI
 
+
+  Scenario:  check blocked domains set from webUI for guests in command line
+    Given the administrator browses to the admin sharing settings page
+    When the administrator sets blocked domains sharing from guests to "something.com,qwerty.org,something.gov,hello.au" using webUI
+    And the administrator invokes occ command "config:app:get guests blockdomains"
+    Then the command should have been successful
+    And the command output should be the text "something.com,qwerty.org,something.gov,hello.au"
+
+

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -273,3 +273,10 @@ Feature: admin sharing settings
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "5"
     When the administrator browses to the admin sharing settings page
     Then the expiration date for federated shares should set to "5" days on the webUI
+
+
+  Scenario: check blocked domains set from command line for guests in webUI
+    Given the administrator invokes occ command "config:app:set guests blockdomains --value='something.com,qwerty.org'"
+    When the administrator browses to the admin sharing settings page
+    Then the blocked domains from sharing with guests should set to "something.com,qwerty.org" on the webUI
+


### PR DESCRIPTION
## Description
This PR adds UI tests for sharing settings guests bloackdomains

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/guests/issues/496

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
