### PR TITLE
[tests-only][full-ci]Adds API tests for meta endpoint PROPFIND with oc:meta-path-for-user property

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -487,7 +487,7 @@ Feature: dav-versions
 
   Scenario: User can retrieve meta information of a file inside folder
     Given user "Alice" has created folder "testFolder"
-    Given user "Alice" has uploaded file with content "123" to "/testFolder/davtest.txt"
+    And user "Alice" has uploaded file with content "123" to "/testFolder/davtest.txt"
     When user "Alice" retrieves the meta information of file "/testFolder/davtest.txt" using the meta API
     Then the HTTP status code should be "207"
     And the single response should contain a property "oc:meta-path-for-user" with value "/testFolder/davtest.txt"
@@ -501,8 +501,7 @@ Feature: dav-versions
     Then the HTTP status code should be "404"
 
 
-  Scenario Outline: User cannot retrieve meta folder of a file which does not exist
-    Given user "Alice" has uploaded file with content "123" to "/davtest.txt"
+  Scenario Outline: User cannot retrieve meta information of a file that does not exist
     When user "Alice" retrieves the meta information of fileId "<file-id>" using the meta API
     Then the HTTP status code should be "400" or "404"
     Examples:

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -476,3 +476,38 @@ Feature: dav-versions
       | header              | value                                                                |
       | Content-Disposition | attachment; filename*=UTF-8''textfile0.txt; filename="textfile0.txt" |
     And the downloaded content should be "uploaded content"
+
+
+  Scenario: User can retrieve meta information of a file
+    Given user "Alice" has uploaded file with content "123" to "/davtest.txt"
+    When user "Alice" retrieves the meta information of file "/davtest.txt" using the meta API
+    Then the HTTP status code should be "207"
+    And the single response should contain a property "oc:meta-path-for-user" with value "/davtest.txt"
+
+
+  Scenario: User can retrieve meta information of a file inside folder
+    Given user "Alice" has created folder "testFolder"
+    Given user "Alice" has uploaded file with content "123" to "/testFolder/davtest.txt"
+    When user "Alice" retrieves the meta information of file "/testFolder/davtest.txt" using the meta API
+    Then the HTTP status code should be "207"
+    And the single response should contain a property "oc:meta-path-for-user" with value "/testFolder/davtest.txt"
+
+
+  Scenario: User cannot retrieve meta information of a file which is owned by somebody else
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "123" to "/davtest.txt "
+    And we save it into "FILEID"
+    When user "Brian" retrieves the meta information of fileId "<<FILEID>>" using the meta API
+    Then the HTTP status code should be "404"
+
+
+  Scenario Outline: User cannot retrieve meta folder of a file which does not exist
+    Given user "Alice" has uploaded file with content "123" to "/davtest.txt"
+    When user "Alice" retrieves the meta information of fileId "<file-id>" using the meta API
+    Then the HTTP status code should be "400" or "404"
+    Examples:
+      | file-id                                                                                              | decoded-value                                                             | comment            |
+      | MTI4NGQyMzgtYWE5Mi00MmNlLWJkYzQtMGIwMDAwMDA5MTU3PThjY2QyNzUxLTkwYTQtNDBmMi1iOWYzLTYxZWRmODQ0MjFmNA== | 1284d238-aa92-42ce-bdc4-0b0000009157=8ccd2751-90a4-40f2-b9f3-61edf84421f4 | with = sign        |
+      | MTI4NGQyMzgtYWE5Mi00MmNlLWJkYzQtMGIwMDAwMDA5MTU3OGNjZDI3NTEtOTBhNC00MGYyLWI5ZjMtNjFlZGY4NDQyMWY0     | 1284d238-aa92-42ce-bdc4-0b00000091578ccd2751-90a4-40f2-b9f3-61edf84421f4  | no = sign          |
+      | c29tZS1yYW5kb20tZmlsZUlkPWFub3RoZXItcmFuZG9tLWZpbGVJZA==                                             | some-random-fileId=another-random-fileId                                  | some random string |
+      | MTI4NGQyMzgtYWE5Mi00MmNlLWJkxzQtMGIwMDAwMDA5MTU2OjhjY2QyNzUxLTkwYTQtNDBmMi1iOWYzLTYxZWRmODQ0MjFmNA== | 1284d238-aa92-42ce-bd�4-0b0000009156:8ccd2751-90a4-40f2-b9f3-61edf84421f4 | with : and  � sign |

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -355,11 +355,13 @@ class FilesVersionsContext implements Context {
 			$metaPath = "/meta/$path/";
 		}
 
-		$body
-			= "<?xml version='1.0' encoding='utf-8' ?>\n" .
-			"	<a:propfind xmlns:a='DAV:' xmlns:oc='http://owncloud.org/ns' >\n" .
-			"		<a:prop><oc:meta-path-for-user/></a:prop>\n" .
-			"   </a:propfind>\n";
+		$body = '<?xml version="1.0" encoding="utf-8"?>
+			<a:propfind xmlns:a="DAV:" xmlns:oc="http://owncloud.org/ns">
+		    	<a:prop>
+		    		<oc:meta-path-for-user />
+		    	</a:prop>
+			</a:propfind>';
+
 		$response = WebDavHelper::makeDavRequest(
 			$baseUrl,
 			$user,


### PR DESCRIPTION
## Description
Adds API tests for meta endpoint PROPFIND with oc:meta-path-for-user property

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/core/issues/40012

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
