### PR TITLE
[tests-only] [full-ci] Revert "workaround trashbin href difference on oCIS"

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -322,3 +322,20 @@ Feature: files and folders can be deleted from the trashbin
     Examples:
       | dav-path |
       | spaces   |
+
+
+  Scenario: temp test - delete a folder that contains a file from the trashbin
+    Given using new DAV path
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has created folder "FOLDER/CHILD"
+    And user "Alice" has uploaded file with content "to delete" to "/FOLDER/parent.txt"
+    And user "Alice" has uploaded file with content "to delete" to "/FOLDER/CHILD/child.txt"
+    And user "Alice" has deleted folder "/PARENT"
+    And user "Alice" has deleted folder "/FOLDER"
+    When user "Alice" deletes the folder with original path "/PARENT" from the trashbin using the trashbin API
+    Then the HTTP status code should be "204"
+    And as "Alice" the file with original path "/PARENT/parent.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should not exist in the trashbin
+    And as "Alice" the folder with original path "/PARENT/CHILD/" should not exist in the trashbin
+    But as "Alice" the file with original path "/FOLDER/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/FOLDER/CHILD/child.txt" should exist in the trashbin

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -587,7 +587,7 @@ class TrashbinContext implements Context {
 	public function tryToDeleteFileFromTrashbin(?string $user, ?string $originalPath, ?string $asUser = null, ?string $password = null):int {
 		$user = $this->featureContext->getActualUsername($user);
 		$asUser = $asUser ?? $user;
-		$listing = $this->listTrashbinFolder($user, 1, true);
+		$listing = $this->listTrashbinFolder($user, "1", true);
 		$originalPath = \trim($originalPath, '/');
 		$numItemsDeleted = 0;
 

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -195,15 +195,17 @@ class TrashbinContext implements Context {
 	 *
 	 * @param string|null $user user
 	 * @param string $depth
+	 * @param bool $debug
 	 *
 	 * @return array of all the items in the trashbin of the user
 	 * @throws Exception
 	 */
-	public function listTrashbinFolder(?string $user, string $depth = "1"):array {
+	public function listTrashbinFolder(?string $user, string $depth = "1", bool $debug = false):array {
 		return $this->listTrashbinFolderCollection(
 			$user,
 			"",
-			$depth
+			$depth,
+			$debug
 		);
 	}
 
@@ -213,11 +215,12 @@ class TrashbinContext implements Context {
 	 * @param string|null $user user
 	 * @param string|null $collectionPath the string of ids of the folder and sub-folders
 	 * @param string $depth
+	 * @param bool $debug
 	 *
 	 * @return array response
 	 * @throws Exception
 	 */
-	public function listTrashbinFolderCollection(?string $user, ?string $collectionPath = "", string $depth = "1"):array {
+	public function listTrashbinFolderCollection(?string $user, ?string $collectionPath = "", string $depth = "1", bool $debug = false):array {
 		// $collectionPath should be some list of file-ids like 2147497661/2147497662
 		// or the empty string, which will list the whole trashbin from the top.
 		$collectionPath = \trim($collectionPath, "/");
@@ -246,6 +249,10 @@ class TrashbinContext implements Context {
 		);
 
 		$files = $this->getTrashbinContentFromResponseXml($responseXml);
+		if ($debug) {
+			echo "listFolder for collectionPath '$collectionPath' returned:\n";
+			\var_dump($files);
+		}
 		// filter out the collection itself, we only want to return the members
 		$files = \array_filter(
 			$files,
@@ -580,7 +587,7 @@ class TrashbinContext implements Context {
 	public function tryToDeleteFileFromTrashbin(?string $user, ?string $originalPath, ?string $asUser = null, ?string $password = null):int {
 		$user = $this->featureContext->getActualUsername($user);
 		$asUser = $asUser ?? $user;
-		$listing = $this->listTrashbinFolder($user);
+		$listing = $this->listTrashbinFolder($user, 1, true);
 		$originalPath = \trim($originalPath, '/');
 		$numItemsDeleted = 0;
 

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -250,17 +250,6 @@ class TrashbinContext implements Context {
 		$files = \array_filter(
 			$files,
 			static function ($element) use ($user, $collectionPath) {
-				if (\trim($element['href'], "/") === "remote.php/dav/trash-bin") {
-					// This is a bug in oCIS. The root-level trashbin href should be like:
-					// /remote.php/dav/trash-bin/Alice/
-					// But it is missing the username, so is like:
-					// /remote.php/dav/trash-bin/
-					// We don't want to fail almost every trashbin test because of this.
-					// We filter out this entry here, and just echo a warning that this
-					// problem has happened, so that it can be seen in the test log output.
-					echo __METHOD__ . "Warning: unexpected href in trashbin propfind: " . $element['href'] . "\n";
-					return false;
-				}
 				$path = $collectionPath;
 				if ($path !== "") {
 					$path = $path . "/";

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -261,6 +261,7 @@ class TrashbinContext implements Context {
 		foreach ($files as $file) {
 			if ($file["collection"]) {
 				$trashbinRef = $file["href"];
+				echo "TrashbinTestInfo: collection has href: '$trashbinRef'\n";
 				$trimmedHref = \trim($trashbinRef, "/");
 				$explodedHref = \explode("/", $trimmedHref);
 				$trashbinId = $collectionPath . "/" . end($explodedHref);


### PR DESCRIPTION
## Description
This reverts commit e8662957514202c36ba6b80ea39ab4873ab9c120.

## Related Issue
Part of https://github.com/owncloud/ocis/issues/1846

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
