### PR TITLE
feat: previews are physically deleted from disk and db in an async ma…

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -22,6 +22,7 @@
 		<job>OCA\Files\BackgroundJob\DeleteOrphanedItems</job>
 		<job>OCA\Files\BackgroundJob\CleanupFileLocks</job>
 		<job>OCA\Files\BackgroundJob\CleanupPersistentFileLocks</job>
+		<job>OCA\Files\BackgroundJob\PreviewCleanupJob</job>
 	</background-jobs>
 
 	<commands>

--- a/apps/files/lib/BackgroundJob/PreviewCleanupJob.php
+++ b/apps/files/lib/BackgroundJob/PreviewCleanupJob.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OCA\Files\BackgroundJob;
+
+use OC\BackgroundJob\TimedJob;
+use OC\PreviewCleanup;
+
+class PreviewCleanupJob extends TimedJob {
+	public function __construct() {
+		$this->setInterval(3600); //execute job every hour
+	}
+
+	public function run($arguments) {
+		$cmd = new PreviewCleanup(\OC::$server->getDatabaseConnection());
+		$count = $cmd->process(false, 10);
+		$logger = \OC::$server->getLogger();
+		$logger->info("$count orphaned previews deleted");
+	}
+}

--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -105,12 +105,8 @@ if ($maxX === 0 || $maxY === 0) {
 	exit;
 }
 
-// $path is relative to the data directory but Preview expects it to be relative to the user's
-// so strip the first component
-$root = \substr($path, \strpos($path, '/') + 1);
-
 try {
-	$preview = new \OC\Preview($userId, $root);
+	$preview = new \OC\Preview($userId);
 	$preview->setFile($sharedFile);
 	$preview->setMaxX($maxX);
 	$preview->setMaxY($maxY);

--- a/core/Command/Previews/Cleanup.php
+++ b/core/Command/Previews/Cleanup.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Core\Command\Previews;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use OC\Core\Command\Base;
+use OC\PreviewCleanup;
+use OCP\Files\Folder;
+use OCP\IDBConnection;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Cleanup extends Base {
+
+	/**
+	 * @var IDBConnection
+	 */
+	private $connection;
+
+	public function __construct(IDBConnection $connection) {
+		parent::__construct();
+		$this->connection = $connection;
+	}
+
+	protected function configure() {
+		parent::configure();
+
+		$this
+			->setName('previews:cleanup')
+			->setDescription('Remove unreferenced previews')
+			->addOption('all')
+			->addArgument('chunk_size', InputArgument::OPTIONAL, '', 1000)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$all = $input->hasOption('all');
+		$chunk_size = $input->getArgument('chunk_size');
+
+		$pc = new PreviewCleanup($this->connection);
+		$count = $pc->process($all, $chunk_size, static function ($userId, $name, $action) use ($output) {
+			$output->writeln("$name - $userId: $action");
+		});
+
+		$output->writeln("$count orphaned previews deleted");
+		return 0;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -147,6 +147,7 @@ if (\OC::$server->getConfig()->getSystemValue('installed', false)) {
 	$application->add(new OC\Core\Command\Maintenance\Mode(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\SingleUser(\OC::$server->getConfig()));
 	$application->add(new OC\Core\Command\Maintenance\UpdateHtaccess());
+	$application->add(new OC\Core\Command\Previews\Cleanup(\OC::$server->getDatabaseConnection()));
 
 	$application->add(new OC\Core\Command\Upgrade(\OC::$server->getConfig(), \OC::$server->getLogger(), \OC::$server->getMemCacheFactory()));
 	$application->add(

--- a/lib/base.php
+++ b/lib/base.php
@@ -668,7 +668,7 @@ class OC {
 		self::registerCacheHooks();
 		self::registerFilesystemHooks();
 		if ($systemConfig->getValue('enable_previews', true)) {
-			self::registerPreviewHooks();
+			OC_Hook::connect('OC_Filesystem', 'post_write', 'OC\Preview', 'post_write');
 		}
 		self::registerShareHooks();
 		self::registerLogRotate();
@@ -794,20 +794,6 @@ class OC {
 		// Check for blacklisted files
 		OC_Hook::connect('OC_Filesystem', 'write', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
 		OC_Hook::connect('OC_Filesystem', 'rename', 'OC\Files\Filesystem', 'isForbiddenFileOrDir_Hook');
-	}
-
-	/**
-	 * register hooks for previews
-	 */
-	public static function registerPreviewHooks() {
-		OC_Hook::connect('OC_Filesystem', 'post_write', 'OC\Preview', 'post_write');
-		OC_Hook::connect('OC_Filesystem', 'delete', 'OC\Preview', 'prepare_delete_files');
-		OC_Hook::connect('\OCP\Versions', 'preDelete', 'OC\Preview', 'prepare_delete');
-		OC_Hook::connect('\OCP\Trashbin', 'preDelete', 'OC\Preview', 'prepare_delete');
-		OC_Hook::connect('OC_Filesystem', 'post_delete', 'OC\Preview', 'post_delete_files');
-		OC_Hook::connect('\OCP\Versions', 'delete', 'OC\Preview', 'post_delete_versions');
-		OC_Hook::connect('\OCP\Trashbin', 'delete', 'OC\Preview', 'post_delete');
-		OC_Hook::connect('\OCP\Versions', 'rollback', 'OC\Preview', 'post_delete_versions');
 	}
 
 	/**

--- a/lib/private/PreviewCleanup.php
+++ b/lib/private/PreviewCleanup.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC;
+
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use OCP\Files\Folder;
+use OCP\IDBConnection;
+
+class PreviewCleanup {
+
+	/**
+	 * @var IDBConnection
+	 */
+	private $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	public function process(bool $all = false, int $chunkSize = 1000, \Closure $progress = null): int {
+		$root = \OC::$server->getLazyRootFolder();
+		$count = 0;
+
+		$lastFileId = 0;
+		while (true) {
+			$rows = $this->queryPreviewsToDelete($lastFileId, $chunkSize);
+			foreach ($rows as $row) {
+				$name = $row['name'];
+				$userId = $row['user_id'];
+				$lastFileId = $row['fileid'];
+
+				$userFiles = $root->getUserFolder($userId);
+				if ($userFiles->getParent()->nodeExists('thumbnails')) {
+					/** @var Folder $thumbnailsFolder */
+					$thumbnailsFolder = $userFiles->getParent()->get('thumbnails');
+					if ($thumbnailsFolder instanceof Folder && $thumbnailsFolder->nodeExists($name)) {
+						$notExistingPreview = $thumbnailsFolder->get($name);
+						$notExistingPreview->delete();
+						if ($progress) {
+							$progress($userId, $name, 'deleted');
+						}
+					} else {
+						# cleanup cache
+						$this->cleanFileCache($name, $thumbnailsFolder->getStorage()->getCache()->getNumericStorageId());
+						if ($progress) {
+							$progress($userId, $name, 'cache cleared');
+						}
+					}
+				}
+			}
+			$count += \count($rows);
+			if (!$all || empty($rows)) {
+				break;
+			}
+		}
+
+		return $count;
+	}
+
+	private function queryPreviewsToDelete(int $startFileId = 0, int $chunkSize = 1000): array {
+		$isOracle = ($this->connection->getDatabasePlatform() instanceof OraclePlatform);
+
+		$sql = "select `fileid`, `name`, `user_id` from `*PREFIX*filecache` `fc`
+join `*PREFIX*mounts` on `storage` = `storage_id`
+where `parent` in (select `fileid` from `*PREFIX*filecache` where `storage` in (select `numeric_id` from `oc_storages` where `id` like 'home::%' or `id` like 'object::user:%') and `path` = 'thumbnails')
+  and not exists(select `fileid` from `*PREFIX*filecache` where `fc`.`name` = CAST(`*PREFIX*filecache`.`fileid` as CHAR(24)))
+  and `fc`.`fileid` > ?
+  order by `user_id`, `fileid`";
+
+		if ($isOracle) {
+			$sql = "select * from ($sql) where ROWNUM <= $chunkSize";
+
+			# Oracle might have issues with new lines ......
+			$sql = trim(preg_replace('/\s+/', ' ', $sql));
+		} else {
+			$sql .= " limit $chunkSize";
+		}
+
+		return $this->connection->executeQuery($sql, [$startFileId])->fetchAll(\PDO::FETCH_ASSOC);
+	}
+
+	private function cleanFileCache($name, int $storageId): void {
+		$sql = "delete from `*PREFIX*filecache` where (path like 'thumbnails/$name/%' or path = 'thumbnails/$name') and storage = ?";
+		$this->connection->executeQuery($sql, [$storageId])->rowCount();
+	}
+}

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -141,7 +141,7 @@ class PreviewManager implements IPreview {
 			throw new NotLoggedInException();
 		}
 		$file = $this->rootFolder->getUserFolder($user->getUID())->getParent()->get($file);
-		$preview = new Preview('', '/', $file, $maxX, $maxY, $scaleUp);
+		$preview = new Preview('', '', $file, $maxX, $maxY, $scaleUp);
 		return $preview->getPreview();
 	}
 

--- a/tests/lib/PreviewCleanupTest.php
+++ b/tests/lib/PreviewCleanupTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test;
+
+use OC\Core\Command\Previews\Cleanup;
+use OC\Files\Filesystem;
+use OC\Files\Node\File;
+use OC\PreviewCleanup;
+use OCP\Files\Folder;
+use OCP\Share;
+use Test\Traits\UserTrait;
+
+/**
+ * Class PreviewCleanupTest
+ *
+ * @group DB
+ *
+ * @package Test
+ */
+class PreviewCleanupTest extends TestCase {
+	use UserTrait;
+
+	public const TEST_PREVIEW_USER1 = "test-preview-cleanup-user1";
+	public const TEST_PREVIEW_USER2 = "test-preview-cleanup-user2";
+	private $trashWasEnabled;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		# disable trashbin
+		$this->trashWasEnabled = \OC::$server->getAppManager()->isEnabledForUser('files_trashbin');
+		if ($this->trashWasEnabled) {
+			\OC::$server->getAppManager()->disableApp('files_trashbin');
+		}
+
+		# create test user 2
+		$this->createUser(self::TEST_PREVIEW_USER2, self::TEST_PREVIEW_USER2);
+
+		# create test user 1
+		$this->createUser(self::TEST_PREVIEW_USER1, self::TEST_PREVIEW_USER1);
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		if ($this->trashWasEnabled) {
+			$this->trashWasEnabled = \OC::$server->getAppManager()->enableApp('files_trashbin');
+		}
+	}
+
+	public function test(): void {
+		# user 1
+		$this->login(self::TEST_PREVIEW_USER1);
+
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1);
+
+		# create test file
+		/** @var File $textFile */
+		$textFile = $rootFolder->newFile('welcome.txt');
+		$textFile->putContent('1234567890');
+		$textFileId = (string)$textFile->getId();
+		$thumbnailFolderUser1 = $this->createPreview($textFile, $rootFolder, $textFileId);
+
+		# file is shared with another user
+		$share = \OC::$server->getShareManager()->newShare();
+		$share->setNode($textFile);
+		$share->setSharedWith(self::TEST_PREVIEW_USER2);
+		$share->setShareType(Share::SHARE_TYPE_USER);
+		$share->setSharedBy(self::TEST_PREVIEW_USER1);
+		$share->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$share = \OC::$server->getShareManager()->createShare($share);
+
+		# login as user 2
+		$this->login(self::TEST_PREVIEW_USER2);
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_PREVIEW_USER1);
+		/** @var File $sharedTextFile */
+		$sharedTextFile = $rootFolder->get('welcome.txt');
+		$sharedTextFileId = (string)$sharedTextFile->getId();
+		# create preview
+		$thumbnailFolderUser2 = $this->createPreview($sharedTextFile, $rootFolder, $sharedTextFileId);
+
+		# delete file
+		$textFile->delete();
+
+		# assert thumbnail still exists - no hooks are triggered
+		self::assertTrue($thumbnailFolderUser1->nodeExists($textFileId));
+		self::assertTrue($thumbnailFolderUser2->nodeExists($sharedTextFileId));
+
+		# run cleanup command
+		$cmd = new PreviewCleanup(\OC::$server->getDatabaseConnection());
+		$cmd->process();
+
+		# assert thumbnail NO LONGER exists
+		self::assertFalse($thumbnailFolderUser1->nodeExists($textFileId));
+		self::assertFalse($thumbnailFolderUser2->nodeExists($sharedTextFileId));
+	}
+
+	/**
+	 * @throws \OC\User\NoUserException
+	 */
+	private function login(string $user): void {
+		self::logout();
+		self::loginAsUser($user);
+
+		# properly initialize the file system
+		Filesystem::clearMounts();
+		Filesystem::initMountPoints($user);
+	}
+
+	/**
+	 * @throws \OCP\Files\NotFoundException
+	 */
+	private function createPreview(File $textFile, ?Folder $rootFolder, string $textFileId): Folder {
+		$textFile->getThumbnail([]);
+
+		# assert thumbnail exists
+		/** @var Folder $thumbnailFolder */
+		$thumbnailFolder = $rootFolder->getParent()->get('thumbnails');
+		self::assertTrue($thumbnailFolder->nodeExists($textFileId));
+		return $thumbnailFolder;
+	}
+}


### PR DESCRIPTION
…nner

## ToDos
- [x] background job for automation
- [x] occ command for cron on bigger installations
- [x] define occ command printout
- [x] add tests for cleanup procedure
- [x] implement cleanup logic for objectstore - requires different sql queries
- [x] invalidate previews if a file is upldated
- [x] kills gallery because of https://github.com/owncloud/gallery/blob/0d980ea3fd7858f27e9096c9f2c0c71e1fb160ed/preview/preview.php#L105 :vomiting_face: :vomiting_face: :vomiting_face: :vomiting_face: :vomiting_face: 


## Description
All preview hooks are gone now. Previews are cleaned up on disk and db in a background job (alternative occ command)

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5164

## How Has This Been Tested?
### Scenario I
- disable trashbin
- upload file which can have previews (e.g. image)
- wait for the preview to be generated
- note the fileid (e.g.query filecache)
- look up the thumbnails for this file (data/$user/thumbnails/$fileid)
- delete the file
- make sure the thumbnail is still there
- run occ p:c --all
- make sure thumbnail got removed from disk and failcache

### Scenario II
- same as Scenario II - but with trashbin enabled
- file needs to be deleted from trashbin

### Scenario III
- create new test file
- enter some text via texteditor
- see the text on the preview
- edit the file again aka change the contents
- make sure the preview holds the new file contents

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
