### PR TITLE
[tests-only] Added then step to check the exact output (assertion)

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -857,6 +857,26 @@ class OccContext implements Context {
 	}
 
 	/**
+	 * @Then /^the command output should be the text ((?:'[^']*')|(?:"[^"]*"))$/
+	 *
+	 * @param string $text
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theCommandOutputShouldBeTheText(string $text):void {
+		$text = \trim($text, $text[0]);
+		$commandOutput = \trim($this->featureContext->getStdOutOfOccCommand());
+		Assert::assertEquals(
+			$text,
+			$commandOutput,
+			"The command output did not match the expected text on stdout '$text'\n" .
+			"The command output on stdout was:\n" .
+			$commandOutput
+		);
+	}
+
+	/**
 	 * @Then /^the command should have failed with exception text "([^"]*)"$/
 	 *
 	 * @param string $exceptionText


### PR DESCRIPTION
## Description
This PR adds an Assertion step to check the output of the command invoked with the provided value.
This PR is related to https://github.com/owncloud/guests/issues/496 issue. 
For the Scenario to set value for the blocked domains sharing from guests input using webUI, the value should be equal after invoking a command  `config:app:get guests blockdomains` An assertion step for strict equal is to be made first in core rather than in the guests app.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- This PR is related to https://github.com/owncloud/guests/issues/496 issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
