### PR TITLE
[tests-only] Explicitly use python2 for carddav and caldav tests

### DIFF
--- a/apps/dav/tests/ci/caldav-old-endpoint/script.sh
+++ b/apps/dav/tests/ci/caldav-old-endpoint/script.sh
@@ -13,7 +13,7 @@ sleep 30
 
 # run the tests
 cd "$SCRIPTPATH/CalDAVTester"
-PYTHONPATH="$SCRIPTPATH/pycalendar/src" python testcaldav.py --print-details-onfail --basedir "$SCRIPTPATH/../caldavtest/" -o cdt.txt \
+PYTHONPATH="$SCRIPTPATH/pycalendar/src" python2 testcaldav.py --print-details-onfail --basedir "$SCRIPTPATH/../caldavtest/" -o cdt.txt \
 	"CalDAV/current-user-principal.xml" \
 	"CalDAV/sync-report.xml"
 

--- a/apps/dav/tests/ci/caldav/script.sh
+++ b/apps/dav/tests/ci/caldav/script.sh
@@ -9,7 +9,7 @@ sleep 30
 
 # run the tests
 cd "$SCRIPTPATH/CalDAVTester"
-PYTHONPATH="$SCRIPTPATH/pycalendar/src" python testcaldav.py --print-details-onfail --basedir "$SCRIPTPATH/../caldavtest/" -o cdt.txt \
+PYTHONPATH="$SCRIPTPATH/pycalendar/src" python2 testcaldav.py --print-details-onfail --basedir "$SCRIPTPATH/../caldavtest/" -o cdt.txt \
 	"CalDAV/current-user-principal.xml" \
 	"CalDAV/sync-report.xml" \
 	"CalDAV/sharing-calendars.xml"

--- a/apps/dav/tests/ci/carddav-old-endpoint/script.sh
+++ b/apps/dav/tests/ci/carddav-old-endpoint/script.sh
@@ -13,7 +13,7 @@ sleep 30
 
 # run the tests
 cd "$SCRIPTPATH/CalDAVTester"
-PYTHONPATH="$SCRIPTPATH/pycalendar/src" python testcaldav.py --print-details-onfail --basedir "$SCRIPTPATH/../caldavtest/" -o cdt.txt \
+PYTHONPATH="$SCRIPTPATH/pycalendar/src" python2 testcaldav.py --print-details-onfail --basedir "$SCRIPTPATH/../caldavtest/" -o cdt.txt \
 	"CardDAV/current-user-principal.xml" \
 	"CardDAV/sync-report.xml"
 

--- a/apps/dav/tests/ci/carddav/script.sh
+++ b/apps/dav/tests/ci/carddav/script.sh
@@ -9,7 +9,7 @@ sleep 30
 
 # run the tests
 cd "$SCRIPTPATH/CalDAVTester"
-PYTHONPATH="$SCRIPTPATH/pycalendar/src" python testcaldav.py --print-details-onfail --basedir "$SCRIPTPATH/../caldavtest/" -o cdt.txt \
+PYTHONPATH="$SCRIPTPATH/pycalendar/src" python2 testcaldav.py --print-details-onfail --basedir "$SCRIPTPATH/../caldavtest/" -o cdt.txt \
 	"CardDAV/current-user-principal.xml" \
 	"CardDAV/sync-report.xml" \
 	"CardDAV/sharing-addressbooks.xml"


### PR DESCRIPTION
## Description
The owncloud-ci images for Ubuntu 18.04 currently have `python` being python v2, and `python3` runs python v3. But with Ubuntu 20.04 (and later...) that may or may not be the case - `python` might run python v3, or the `python` command might not exist at all or...

The CalDAV and CardDAV test suites use python and require python v2. They are from GitHub repos like https://github.com/apple/ccs-caldavtester that have not been maintained for years, and so do not support python v3.

I am currently looking at things that fail in CI with Ubuntu 20.04 - issue #38348 - and this is one thing.

All the Ubuntu-based images that we use (should) have a valid `python2`. So use that in the existing CI, and it will "just work" when we want to move to Ubuntu 20.04 and later.

This should also help the (rare) developer who wants to run these scripts locally - they won't have to worry about which version their `python` command is.

## Related Issue

Part of #38348 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
