### PR TITLE
[tests-only] Make TemplatesTest more flexible

### DIFF
--- a/core/templates/403.php
+++ b/core/templates/403.php
@@ -11,7 +11,7 @@ if (!isset($_)) {//also provide standalone error page
 ?>
 <ul>
 	<li class='error'>
-		<?php p($l->t('Access forbidden')); ?><br>
+		<?php p($l->t('Access forbidden')); ?><br/>
 		<p class='hint'><?php if (isset($_['file'])) {
 	p($_['file']);
 }?></p>

--- a/core/templates/404.php
+++ b/core/templates/404.php
@@ -17,7 +17,7 @@ if (!isset($_)) {//also provide standalone error page
 <?php else: ?>
 	<ul>
 		<li class="error">
-			<?php p($l->t('File not found')); ?><br>
+			<?php p($l->t('File not found')); ?><br/>
 			<p class="hint"><?php p($l->t('The specified document has not been found on the server.')); ?></p>
 			<p class="hint"><a href="<?php p(\OC::$server->getURLGenerator()->linkTo('', 'index.php')) ?>"><?php p($l->t('You can click here to return to %s.', [$theme->getName()])); ?></a></p>
 		</li>

--- a/tests/Core/Templates/TemplatesTest.php
+++ b/tests/Core/Templates/TemplatesTest.php
@@ -5,14 +5,14 @@ namespace Tests\Core\Templates;
 class TemplatesTest extends \Test\TestCase {
 	public function test403() {
 		$template = \OC::$SERVERROOT . '/core/templates/403.php';
-		$expectedHtml = "<ul><li class='error'>\n\t\tAccess forbidden<br><p class='hint'></p></li></ul>";
+		$expectedHtml = "<ul><li class='error'>Access forbidden<br><p class='hint'></p></li></ul>";
 		$this->assertTemplate($expectedHtml, $template);
 	}
 
 	public function test404() {
 		$template = \OC::$SERVERROOT . '/core/templates/404.php';
 		$href = \OC::$server->getURLGenerator()->linkTo('', 'index.php');
-		$expectedHtml = "<ul><li class='error'>\n\t\t\tFile not found<br><p class='hint'>The specified document has not been found on the server.</p>\n<p class='hint'><a href='$href'>You can click here to return to ownCloud.</a></p>\n\t\t</li></ul>";
+		$expectedHtml = "<ul><li class=\"error\">File not found<br><p class=\"hint\">The specified document has not been found on the server.</p><p class=\"hint\"><a href=\"$href\">You can click here to return to ownCloud.</a></p></li></ul>";
 		$this->assertTemplate($expectedHtml, $template);
 	}
 }

--- a/tests/Core/Templates/TemplatesTest.php
+++ b/tests/Core/Templates/TemplatesTest.php
@@ -5,14 +5,14 @@ namespace Tests\Core\Templates;
 class TemplatesTest extends \Test\TestCase {
 	public function test403() {
 		$template = \OC::$SERVERROOT . '/core/templates/403.php';
-		$expectedHtml = "<ul><li class='error'>Access forbidden<br><p class='hint'></p></li></ul>";
+		$expectedHtml = "<ul><li class='error'>Access forbidden<br/><p class='hint'></p></li></ul>";
 		$this->assertTemplate($expectedHtml, $template);
 	}
 
 	public function test404() {
 		$template = \OC::$SERVERROOT . '/core/templates/404.php';
 		$href = \OC::$server->getURLGenerator()->linkTo('', 'index.php');
-		$expectedHtml = "<ul><li class=\"error\">File not found<br><p class=\"hint\">The specified document has not been found on the server.</p><p class=\"hint\"><a href=\"$href\">You can click here to return to ownCloud.</a></p></li></ul>";
+		$expectedHtml = "<ul><li class=\"error\">File not found<br/><p class=\"hint\">The specified document has not been found on the server.</p><p class=\"hint\"><a href=\"$href\">You can click here to return to ownCloud.</a></p></li></ul>";
 		$this->assertTemplate($expectedHtml, $template);
 	}
 }

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -485,7 +485,7 @@ abstract class TestCase extends BaseTestCase {
 
 		$t = new Base($template, $requestToken, $l10n, null, $theme);
 		$buf = $t->fetchPage($vars);
-		$this->assertHtmlStringEqualsHtmlString($expectedHtml, $buf);
+		$this->assertHtmlStringIsEquivalentToHtmlString($expectedHtml, $buf);
 	}
 
 	/**
@@ -493,33 +493,30 @@ abstract class TestCase extends BaseTestCase {
 	 * @param string $actualHtml
 	 * @param string $message
 	 */
-	protected function assertHtmlStringEqualsHtmlString($expectedHtml, $actualHtml, $message = '') {
-		$expected = new DOMDocument();
-		$expected->preserveWhiteSpace = false;
-		$expected->formatOutput = true;
-		$expected->loadHTML($expectedHtml);
-
-		$actual = new DOMDocument();
-		$actual->preserveWhiteSpace = false;
-		$actual->formatOutput = true;
-		$actual->loadHTML($actualHtml);
-		$this->removeWhitespaces($actual);
-
-		$expectedHtml1 = $expected->saveHTML();
-		$actualHtml1 = $actual->saveHTML();
-		self::assertEquals($expectedHtml1, $actualHtml1, $message);
+	protected function assertHtmlStringIsEquivalentToHtmlString($expectedHtml, $actualHtml, $message = '') {
+		self::assertSame(
+			$this->normalizeHTML($expectedHtml),
+			$this->normalizeHTML($actualHtml),
+			$message
+		);
 	}
 
-	private function removeWhitespaces(DOMNode $domNode) {
-		foreach ($domNode->childNodes as $node) {
-			if ($node->hasChildNodes()) {
-				$this->removeWhitespaces($node);
-			} else {
-				if ($node instanceof \DOMText && $node->isWhitespaceInElementContent()) {
-					$domNode->removeChild($node);
-				}
-			}
+	/**
+	 * Takes a string that might be formatted with new-lines and indented with spaces or tabs.
+	 * Returns a one-line string without the new-lines or indenting.
+	 * The returned string has equivalent functionality as HTML.
+	 *
+	 * @param string $inputHtml
+	 *
+	 * @return string
+	 */
+	private function normalizeHTML(string $inputHtml):string {
+		$inputLines = \explode("\n", $inputHtml);
+		$trimmedLines = [];
+		foreach ($inputLines as $inputLine) {
+			$trimmedLines[] = \trim($inputLine);
 		}
+		return \implode("", $trimmedLines);
 	}
 
 	public function getCurrentUser() {

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -485,19 +485,9 @@ abstract class TestCase extends BaseTestCase {
 
 		$t = new Base($template, $requestToken, $l10n, null, $theme);
 		$buf = $t->fetchPage($vars);
-		$this->assertHtmlStringIsEquivalentToHtmlString($expectedHtml, $buf);
-	}
-
-	/**
-	 * @param string $expectedHtml
-	 * @param string $actualHtml
-	 * @param string $message
-	 */
-	protected function assertHtmlStringIsEquivalentToHtmlString($expectedHtml, $actualHtml, $message = '') {
-		self::assertSame(
+		$this->assertXmlStringEqualsXmlString(
 			$this->normalizeHTML($expectedHtml),
-			$this->normalizeHTML($actualHtml),
-			$message
+			$this->normalizeHTML($buf)
 		);
 	}
 


### PR DESCRIPTION
## Description
Unit tests in CI currently run with the owncloud-ci/php image based on Ubuntu 18.04.

On Ubuntu 20.04 some unit tests fail. See the related issue. They are failing in CI and locally on my Ubuntu 20.04 system.

This PR adjusts the 2 failing TemplatesTest tests. For some reason, on Ubuntu 20.04 (with whatever settings we have in CI and on my local system), the HTML output of the templates is "nicely formatted" with new-lines and indenting. That makes the test cases fail, because the test cases currently expect a particular exact formatting.

PHP unit test fails: https://drone.owncloud.com/owncloud/core/35632/9/8
This PR addresses items (3) and (4).
```
There were 4 failures:

1) Test\LargeFileHelperGetFileSizeTest::testGetFileSizeViaCurl with data set #0 ('/drone/src/tests/data/lorem.txt', 446)
Failed asserting that null is identical to 446.

/drone/src/tests/lib/LargeFileHelperGetFileSizeTest.php:53

2) Test\LargeFileHelperGetFileSizeTest::testGetFileSizeViaCurl with data set #1 ('/drone/src/tests/data/strängé...2).txt', 446)
Failed asserting that null is identical to 446.

/drone/src/tests/lib/LargeFileHelperGetFileSizeTest.php:53

3) Tests\Core\Templates\TemplatesTest::test403
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">\n
-<html><body><ul><li class="error">\n
-		Access forbidden<br><p class="hint"></p>\n
-</li></ul></body></html>\n
+<html><body><ul>\n
+<li class="error">\n
+		Access forbidden<br>\n
+		<p class="hint"></p>\n
+	</li>\n
+</ul></body></html>\n
 '

/drone/src/tests/lib/TestCase.php:510
/drone/src/tests/lib/TestCase.php:488
/drone/src/tests/Core/Templates/TemplatesTest.php:9

4) Tests\Core\Templates\TemplatesTest::test404
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
 '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">\n
-<html><body><ul><li class="error">\n
-			File not found<br><p class="hint">The specified document has not been found on the server.</p>\n
-<p class="hint"><a href="/owncloud/">You can click here to return to ownCloud.</a></p>\n
-		</li></ul></body></html>\n
+<html><body><ul>\n
+<li class="error">\n
+			File not found<br>\n
+			<p class="hint">The specified document has not been found on the server.</p>\n
+			<p class="hint"><a href="/owncloud/">You can click here to return to ownCloud.</a></p>\n
+		</li>\n
+	</ul></body></html>\n
 '

/drone/src/tests/lib/TestCase.php:510
/drone/src/tests/lib/TestCase.php:488
/drone/src/tests/Core/Templates/TemplatesTest.php:16
--
```

The changed test code "normalizes" the expected and actual HTML before comparing. That way the test will not be so brittle - it will work even when the formatting of the HTML is a bit different.

## Related Issue
#38348 

## How Has This Been Tested?
CI in this PR (demonstrates that the test still passes on the Ubuntu 18.04 CI image)
Local unit test run on my Ubuntu 20.04 laptop - passes
CI of PR #40006 (demonstrates that these 2 tests pass on the Ubuntu 20.04 CI image)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
