### PR TITLE
[tests-only][full-ci]Added scenarios for profind depth infinity 

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/apiWebdavOperations/listFiles.feature
@@ -73,7 +73,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-
+  @depthInfinityPropfindEnabled
   Scenario Outline: Get the list of resources in the root folder with depth infinity
     Given using <dav_version> DAV path
     And the administrator has set depth_infinity_allowed to 1
@@ -155,7 +155,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-
+  @depthInfinityPropfindEnabled
   Scenario Outline: Get the list of resources in a folder with depth infinity
     Given using <dav_version> DAV path
     And the administrator has set depth_infinity_allowed to 1
@@ -255,7 +255,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-
+  @depthInfinityPropfindEnabled
   Scenario Outline: Get the list of resources in a folder shared through public link with depth infinity
     Given using <dav_version> DAV path
     And the administrator has set depth_infinity_allowed to 1
@@ -356,7 +356,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-
+  @depthInfinityPropfindEnabled
   Scenario Outline: Get the list of files in the trashbin with depth infinity
     Given using <dav_version> DAV path
     And the administrator has set depth_infinity_allowed to 1
@@ -388,7 +388,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-
+  @depthInfinityPropfindDisabled
   Scenario Outline: Get the list of resources in the root folder with depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
@@ -403,7 +403,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-
+  @depthInfinityPropfindDisabled
   Scenario Outline: Get the list of resources in a folder shared through public link with depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     And user "Alice" has created the following folders
@@ -428,6 +428,7 @@ Feature: list files
       | spaces      |
 
 
+  @depthInfinityPropfindDisabled
   Scenario Outline: Get the list of files in the trashbin with depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     And user "Alice" has deleted the following resources

--- a/tests/acceptance/features/apiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/apiWebdavOperations/listFiles.feature
@@ -278,7 +278,6 @@ Feature: list files
       | /simple-folder1/simple-folder2/welcome.txt                   |
       | /simple-folder1/simple-folder2/simple-folder3                |
       | /simple-folder1/simple-folder2/simple-folder3/simple-folder4 |
-
     @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | dav_version |
@@ -379,6 +378,65 @@ Feature: list files
       | simple-folder/simple-folder1/welcome.txt                  |
       | simple-folder/simple-folder1/simple-folder2/textfile0.txt |
       | simple-folder/simple-folder1/simple-folder2/welcome.txt   |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
+  Scenario Outline: Get the list of resources in the root folder with depth infinity when depth infinity is not allowed
+    Given using <dav_version> DAV path
+    When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
+    Then the HTTP status code should be "412"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
+  Scenario Outline: Get the list of resources in a folder shared through public link with depth infinity when depth infinity is not allowed
+    Given using <dav_version> DAV path
+    And user "Alice" has created the following folders
+      | path                                                                       |
+      | /simple-folder/simple-folder1/simple-folder2/simple-folder3                |
+      | /simple-folder/simple-folder1/simple-folder2/simple-folder3/simple-folder4 |
+    And user "Alice" has created a public link share of folder "simple-folder"
+    When the public lists the resources in the last created public link with depth "infinity" using the WebDAV API
+    Then the HTTP status code should be "412"
+    @notToImplementOnOCIS @issue-ocis-2079
+    Examples:
+      | dav_version |
+      | old         |
+
+    Examples:
+      | dav_version |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+
+  Scenario Outline: Get the list of files in the trashbin with depth infinity when depth infinity is not allowed
+    Given using <dav_version> DAV path
+    And user "Alice" has deleted the following resources
+      | path           |
+      | textfile0.txt  |
+      | welcome.txt    |
+      | simple-folder/ |
+    When user "Alice" lists the resources in the trashbin with depth "infinity" using the WebDAV API
+    Then the HTTP status code should be "412"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/apiWebdavOperations/propfind.feature
@@ -23,23 +23,28 @@ Feature: PROPFIND
       | header | value   |
       | depth  | <depth> |
     Then the HTTP status code should be "<http_status>"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS @depthInfinityPropfindEnabled
     Examples:
       | dav_path                    | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/files/alice | 1                      | 0        | 207         |
       | /remote.php/dav/files/alice | 1                      | infinity | 207         |
+    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS @depthInfinityPropfindDisabled
+    Examples:
+      | dav_path                    | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/files/alice | 0                      | 0        | 207         |
       | /remote.php/dav/files/alice | 0                      | infinity | 412         |
-    @skipOnOcV10
+    @skipOnOcV10 @depthInfinityPropfindEnabled
     Examples:
       | dav_path                    | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/files/alice | 1                      | 0        | 207         |
       | /remote.php/dav/files/alice | 1                      | infinity | 207         |
-
-    @skipOnOcV10 @personalSpace
+    @skipOnOcV10 @personalSpace @depthInfinityPropfindDisabled
     Examples:
       | dav_path                         | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/spaces/%spaceid% | 0                      | 0        | 207         |
       | /remote.php/dav/spaces/%spaceid% | 0                      | infinity | 207         |
+    @skipOnOcV10 @personalSpace @depthInfinityPropfindEnabled
+    Examples:
+      | dav_path                         | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/spaces/%spaceid% | 1                      | 0        | 207         |
       | /remote.php/dav/spaces/%spaceid% | 1                      | infinity | 207         |

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
@@ -112,3 +112,23 @@ Feature: get file info using PROPFIND
       | dav_version |
       | old         |
       | new         |
+
+  @skipOnEncryptionType:user-keys @issue-encryption-320
+  Scenario Outline: list files on root folder with external storage using depth infinity when depth infinity is not allowed
+    Given using <dav_version> DAV path
+    When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
+    Then the HTTP status code should be "412"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnEncryptionType:user-keys @issue-encryption-320
+  Scenario Outline: list files on external storage when depth infinity is not allowed
+    Given using <dav_version> DAV path
+    When user "Alice" lists the resources in "/local_storage2" with depth "infinity" using the WebDAV API
+    Then the HTTP status code should be "412"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
@@ -31,7 +31,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @skipOnEncryptionType:user-keys @issue-encryption-320
+  @skipOnEncryptionType:user-keys @issue-encryption-320 @depthInfinityPropfindEnabled
   Scenario Outline: list files on root folder with external storage using depth infinity
     Given using <dav_version> DAV path
     And the administrator has set depth_infinity_allowed to 1
@@ -67,7 +67,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @skipOnEncryptionType:user-keys @issue-encryption-320
+  @skipOnEncryptionType:user-keys @issue-encryption-320 @depthInfinityPropfindEnabled
   Scenario Outline: list files on external storage with depth infinity
     Given using <dav_version> DAV path
     And the administrator has set depth_infinity_allowed to 1
@@ -113,7 +113,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @skipOnEncryptionType:user-keys @issue-encryption-320
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on root folder with external storage using depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
@@ -123,7 +123,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @skipOnEncryptionType:user-keys @issue-encryption-320
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on external storage when depth infinity is not allowed
     Given using <dav_version> DAV path
     When user "Alice" lists the resources in "/local_storage2" with depth "infinity" using the WebDAV API

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
@@ -54,3 +54,25 @@ Feature: get file info using PROPFIND
       | dav_version |
       | old         |
       | new         |
+
+  @skipOnEncryptionType:user-keys @issue-encryption-320
+  Scenario Outline: list files on external storage that is currently unavailable when depth infinity is not allowed
+    Given using <dav_version> DAV path
+    When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"
+    And user "Alice" lists the resources in "/local_storage2" with depth "infinity" using the WebDAV API
+    Then the HTTP status code should be "412"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnEncryptionType:user-keys @issue-encryption-320
+  Scenario Outline: list files on root folder with depth infinity not allowed when the external storage folder is unavailable
+    Given using <dav_version> DAV path
+    When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"
+    And user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
+    Then the HTTP status code should be "412"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
@@ -15,7 +15,7 @@ Feature: get file info using PROPFIND
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/local_storage3/PARENT/PARENT.txt"
 
-  @skipOnEncryptionType:user-keys @issue-encryption-320
+  @skipOnEncryptionType:user-keys @issue-encryption-320 @depthInfinityPropfindEnabled
   Scenario Outline: list files on external storage that is currently unavailable
     Given using <dav_version> DAV path
     And the administrator has set depth_infinity_allowed to 1
@@ -32,7 +32,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @skipOnEncryptionType:user-keys @issue-encryption-320
+  @depthInfinityPropfindEnabled @skipOnEncryptionType:user-keys @issue-encryption-320 @depthInfinityPropfindEnabled
   Scenario Outline: list files on root folder with depth infinity when the external storage folder is unavailable
     Given using <dav_version> DAV path
     And the administrator has set depth_infinity_allowed to 1
@@ -55,7 +55,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @skipOnEncryptionType:user-keys @issue-encryption-320
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on external storage that is currently unavailable when depth infinity is not allowed
     Given using <dav_version> DAV path
     When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"
@@ -66,7 +66,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @skipOnEncryptionType:user-keys @issue-encryption-320
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on root folder with depth infinity not allowed when the external storage folder is unavailable
     Given using <dav_version> DAV path
     When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"


### PR DESCRIPTION
## Description
This PR adds acceptance tests (Scenarios) for default for propfind depth infinity being false as in past.
As there is no config option to enable or disable depth infinity PROPFIND in `OCIS`, the added scenarios have to be on expected to failure or we have to skip as per this https://github.com/owncloud/ocis/issues/3720 issue

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- This PR is related to https://github.com/owncloud/core/issues/40035

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally 
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
