### PR TITLE
Add flexibility to getFileSizeViaCurl

### DIFF
--- a/changelog/unreleased/40065
+++ b/changelog/unreleased/40065
@@ -1,0 +1,7 @@
+Bugfix: get file size using cURL on Ubuntu 20.04 and 22.04
+
+Local file size using the php-curl functions did not work on Ubuntu 20.04 or 22.04.
+The code has been enhanced so that the file size can be determined using php-curl
+on these operating system releases.
+
+https://github.com/owncloud/core/pull/40065


### PR DESCRIPTION
## Description
See discussion in the related issue, and the code comments in this PR.

`CURLOPT_HEADER` is not always causing the headers to actually be returned. That is a bug somewhere in php-curl and/or libcurl and their "integration" on Ubuntu 20.04 and 22.04.

This PR adds to the code of `getFileSizeViaCurl` so that it uses `CURLOPT_HEADERFUNCTION` and finds the Content-Length from there, if the data is not returned by `CURLOPT_HEADER`.

I have confirmed that this works on Ubuntu 20.04 - see PR #40006 which now passes. And locally on Ubuntu 22.04 in a VM.

## Related Issue
#38348 

## How Has This Been Tested?
CI with Ubuntu 18.04 (this PR) and 20.04 (PR #40006 )

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
