### PR TITLE
fix: add createSessionToken to Log::$methodsWithSensitiveParameters

### DIFF
--- a/changelog/unreleased/40066
+++ b/changelog/unreleased/40066
@@ -1,0 +1,3 @@
+Bugfix: Filter sensitive data in log for Session::createSessionToken
+
+https://github.com/owncloud/core/pull/40066

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -81,6 +81,7 @@ class Log implements ILogger {
 		'updatePrivateKeyPassword',
 		'validateUserPass',
 		'loginWithPassword',
+		'createSessionToken',
 
 		// TokenProvider
 		'getToken',


### PR DESCRIPTION
## Description
createSessionToken can have sensitive data in the argument list and needs special treatment in logging

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5184

## How Has This Been Tested?
- unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
