### PR TITLE
[tests-only][full-ci] Skip @depthInfinityPropfindDisabled tagged tests in oC older than 10.9.1

### DIFF
--- a/tests/acceptance/features/apiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/apiWebdavOperations/listFiles.feature
@@ -388,7 +388,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-  @depthInfinityPropfindDisabled
+  @depthInfinityPropfindDisabled @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Get the list of resources in the root folder with depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
@@ -403,7 +403,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-  @depthInfinityPropfindDisabled
+  @depthInfinityPropfindDisabled @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Get the list of resources in a folder shared through public link with depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     And user "Alice" has created the following folders
@@ -427,8 +427,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-
-  @depthInfinityPropfindDisabled
+  @depthInfinityPropfindDisabled @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: Get the list of files in the trashbin with depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     And user "Alice" has deleted the following resources

--- a/tests/acceptance/features/apiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/apiWebdavOperations/propfind.feature
@@ -28,7 +28,7 @@ Feature: PROPFIND
       | dav_path                    | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/files/alice | 1                      | 0        | 207         |
       | /remote.php/dav/files/alice | 1                      | infinity | 207         |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS @depthInfinityPropfindDisabled
+    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS @depthInfinityPropfindDisabled @skipOnOcV10.9.0 @skipOnOcV10.9.1
     Examples:
       | dav_path                    | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/files/alice | 0                      | 0        | 207         |

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
@@ -113,7 +113,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: list files on root folder with external storage using depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
@@ -123,7 +123,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: list files on external storage when depth infinity is not allowed
     Given using <dav_version> DAV path
     When user "Alice" lists the resources in "/local_storage2" with depth "infinity" using the WebDAV API

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
@@ -55,7 +55,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: list files on external storage that is currently unavailable when depth infinity is not allowed
     Given using <dav_version> DAV path
     When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"
@@ -66,7 +66,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: list files on root folder with depth infinity not allowed when the external storage folder is unavailable
     Given using <dav_version> DAV path
     When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"


### PR DESCRIPTION
## Description
@depthInfinityPropfindDisabled tagged tests are skipped in oC older than version 10.9.1

oC10.9.1 has `dav.propfind.depth_infinity => true` as default
but the latest verson has `dav.propfind.depth_infinity => false` as default

## Related Issue
- Fixes https://github.com/owncloud/QA/issues/740

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
