### PR TITLE
[tests-only] [full-ci] Add tests to demonstrate attempted trashbin access combinations

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -252,6 +252,36 @@ Feature: files and folders exist in the trashbin after being deleted
       | dav-path |
       | spaces   |
 
+  @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore
+  Scenario Outline: Listing other user's empty unused trashbin is prohibited
+    Given using <dav-path> DAV path
+    And user "testtrashbinempty" has been created with default attributes and without skeleton files
+    And user "testtrashbinempty" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
+    When user "Alice" tries to list the trashbin content for user "testtrashbinempty"
+    Then the HTTP status code should be "401"
+    Examples:
+      | dav-path |
+      | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+
+  @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore
+  Scenario Outline: Listing non-existent user's trashbin is prohibited
+    Given using <dav-path> DAV path
+    When user "Alice" tries to list the trashbin content for user "testtrashbinnotauser"
+    Then the HTTP status code should be "404"
+    Examples:
+      | dav-path |
+      | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+
   @smokeTest
   Scenario Outline: Get trashbin content with wrong password
     Given using <dav-path> DAV path


### PR DESCRIPTION
## Description
Add test scenarios to demonstrate:
- a user attempts to access the trashbin of another user (whose trashbin is currently empty - never been used) - gets HTTP status 401
- a user attempts to access the trashbin of a non-existent user- gets HTTP status 404

Note: see discussion in https://github.com/owncloud/ocis/issues/3561 - the same 404 status should probably be returned in all these kind of situations.

I have written the tests so that they pass on oC10. If the behavior should be different on oC10 then when need a developer to adjust the tests and correct the behavior.

## Related Issue
https://github.com/owncloud/ocis/issues/3561

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
