### PR TITLE
[tests-only] Refactor status test

### DIFF
--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -1,10 +1,10 @@
-@api @issue-ocis-reva-65 @issue-ocis-reva-97
+@api
 Feature: Status
 
   @smokeTest @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Status.php is correct
     When the administrator requests status.php
-    Then the status.php response should match with
+    Then the status.php response should include
       """
       {"installed":true,"maintenance":false,"needsDbUpgrade":false,"version":"$CURRENT_VERSION","versionstring":"$CURRENT_VERSION_STRING","edition":"$EDITION","productname":"$PRODUCTNAME","product":"$PRODUCT"}
       """


### PR DESCRIPTION
## Description
Other implementations can extend the data items returned by `status.php`. The existing test scenario does not allow for that.

This PR refactors the test for status.php so that it checks that all the data items mention in the test scenario do exist, and have the expected values. The response may have other data items, and those are not required or checked.

This makes the test more flexible, for example for reva and oCIS.

## How Has This Been Tested?
CI and local test runs.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
