### PR TITLE
Display each app only once in app:list --minimal

### DIFF
--- a/changelog/unreleased/39930
+++ b/changelog/unreleased/39930
@@ -1,0 +1,7 @@
+Bugfix: List apps only once
+
+`occ app:list --minimal`
+could display apps twice in the listing. Each app is now displayed only once.
+
+https://github.com/owncloud/core/issues/39930
+https://github.com/owncloud/core/pull/40081

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -122,7 +122,7 @@ class ListApps extends Base {
 				$appDetailRecord = [];
 
 				if ($minimalView) {
-					$apps['enabled'][] = sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
+					$apps['enabled'][$app] = sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
 					continue;
 				}
 
@@ -141,7 +141,7 @@ class ListApps extends Base {
 				$appDetailRecord = [];
 
 				if ($minimalView) {
-					$apps['disabled'][] = sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
+					$apps['disabled'][$app] = sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
 					continue;
 				}
 
@@ -152,6 +152,14 @@ class ListApps extends Base {
 				$appDetailRecord['Path'] = \OC_App::getAppPath($app);
 				$apps['disabled'][$app] = $appDetailRecord;
 			}
+		}
+
+		if ($minimalView) {
+			// For minimal view we do not want writeArrayInOutputFormat to write a key-value format
+			// The app name and version are already formatted in the string that is the array value.
+			// So just keep the array values.
+			$apps['enabled'] = \array_values($apps['enabled']);
+			$apps['disabled'] = \array_values($apps['disabled']);
 		}
 
 		$this->writeAppList($input, $output, $apps);


### PR DESCRIPTION
## Description
Use the app name as an array key when building the lists of enabled and disabled apps in minimal view. That way each app can only end up once in the array.

## Related Issue
- Fixes #39930 

## How Has This Been Tested?
Put an app in both `apps` and `apps-external` folders. Then:
`php occ app:list --minimal`

Observe that the app is only listed once.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
