### PR TITLE
Fix occ migrations:status Executed Unavailable Migrations and New Migrations

### DIFF
--- a/changelog/unreleased/40084
+++ b/changelog/unreleased/40084
@@ -1,0 +1,7 @@
+Bugfix: correct Executed Unavailable Migrations
+
+`occ migrations:status` was reporting an incorrect value for Executed Unavailable Migrations.
+The problem has been corrected.
+
+https://github.com/owncloud/core/issues/40084
+https://github.com/owncloud/core/pull/40085

--- a/changelog/unreleased/40084
+++ b/changelog/unreleased/40084
@@ -1,6 +1,6 @@
-Bugfix: correct Executed Unavailable Migrations
+Bugfix: correct Executed Unavailable Migrations and New Migrations
 
-`occ migrations:status` was reporting an incorrect value for Executed Unavailable Migrations.
+`occ migrations:status` was reporting an incorrect value for these items.
 The problem has been corrected.
 
 https://github.com/owncloud/core/issues/40084

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -67,7 +67,7 @@ class StatusCommand extends Command {
 	public function getMigrationsInfos(MigrationService $ms) {
 		$executedMigrations = $ms->getMigratedVersions();
 		$availableMigrations = $ms->getAvailableVersions();
-		$executedUnavailableMigrations = \array_diff($executedMigrations, \array_keys($availableMigrations));
+		$executedUnavailableMigrations = \array_diff($executedMigrations, $availableMigrations);
 
 		$numExecutedUnavailableMigrations = \count($executedUnavailableMigrations);
 		$numNewMigrations = \count(\array_diff(\array_keys($availableMigrations), $executedMigrations));

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -70,7 +70,7 @@ class StatusCommand extends Command {
 		$executedUnavailableMigrations = \array_diff($executedMigrations, $availableMigrations);
 
 		$numExecutedUnavailableMigrations = \count($executedUnavailableMigrations);
-		$numNewMigrations = \count(\array_diff(\array_keys($availableMigrations), $executedMigrations));
+		$numNewMigrations = \count(\array_diff($availableMigrations, $executedMigrations));
 
 		$infos = [
 			'App'								=> $ms->getApp(),


### PR DESCRIPTION
## Description
`getAvailableVersions()` returns an array with the migration date-timestamps as values. The code incorrectly used the keys of the array. This PR removes the incorrect `array_keys()` in 2 places.

## Related Issue
- Fixes #40084 

## How Has This Been Tested?
Manual run of the command:

Before:
```
$ php occ migrations:status core
    >> App:                                                core
    >> Version Table Name:                                 oc_migrations
    >> Migrations Namespace:                               OC\Migrations
    >> Migrations Directory:                               /home/phil/git/owncloud/core/core/Migrations
    >> Previous Version:                                   20200610110817
    >> Current Version:                                    20210928123126
    >> Next Version:                                       Already at latest migration step
    >> Latest Version:                                     20210928123126
    >> Executed Migrations:                                28
    >> Executed Unavailable Migrations:                    28
    >> Available Migrations:                               28
    >> New Migrations:                                     28
```


After:
```
$ php occ migrations:status core
    >> App:                                                core
    >> Version Table Name:                                 oc_migrations
    >> Migrations Namespace:                               OC\Migrations
    >> Migrations Directory:                               /home/phil/git/owncloud/core/core/Migrations
    >> Previous Version:                                   20200610110817
    >> Current Version:                                    20210928123126
    >> Next Version:                                       Already at latest migration step
    >> Latest Version:                                     20210928123126
    >> Executed Migrations:                                28
    >> Executed Unavailable Migrations:                    0
    >> Available Migrations:                               28
    >> New Migrations:                                     0
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
