### PR TITLE
[tests-only] [full-ci] Adjust testPutSingleFileLegalMtime unit test cases

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -570,21 +570,32 @@ class FileTest extends TestCase {
 					'HTTP_X_OC_MTIME' => -34.43,
 					'expected result' => -34
 			],
+			/*
+			 * The ext4 file system supports file time stamps up to 0x3fffffff
+			 * which is a time on date 2446-05-10. So test that maximum case.
+			 * We want to know that time stamps work a "reasonable" time into
+			 * the future, but we know that different file system implementations
+			 * support different maximum time stamps.
+			 *
+			 * See issue https://github.com/owncloud/core/issues/40098 for
+			 * related discussion.
+			 */
 			"long int" => [
-					'HTTP_X_OC_MTIME' => PHP_INT_MAX,
-					'expected result' => PHP_INT_MAX
+					'HTTP_X_OC_MTIME' => 0x3fffffff,
+					'expected result' => 0x3fffffff
 			],
-			"too long int" => [
-					'HTTP_X_OC_MTIME' => PHP_INT_MAX + 1,
-					'expected result' => PHP_INT_MAX
-			],
+			/*
+			 * The ext4 file system supports negative file time stamps up to -0x80000000
+			 * which is a time on date 1901-12-13. So test that maximum negative case.
+			 * Negative values allow time stamps to be recorded for times before the
+			 * "zero"  time of 1970-01-01.
+			 * We want to know that time stamps work a "reasonable" time into
+			 * the past, but we know that different file system implementations
+			 * support different maximum negative time stamps.
+			 */
 			"long negative int" => [
-					'HTTP_X_OC_MTIME' => PHP_INT_MAX * - 1,
-					'expected result' => (PHP_INT_MAX * - 1)
-			],
-			"too long negative int" => [
-					'HTTP_X_OC_MTIME' => (PHP_INT_MAX * - 1) - 1,
-					'expected result' => (PHP_INT_MAX * - 1)
+					'HTTP_X_OC_MTIME' => -0x80000000,
+					'expected result' => -0x80000000
 			],
 		];
 	}


### PR DESCRIPTION
## Description
See the comment blocks that I added to the test code - they explain the new maximum positive and negative values being tested.

The "too long" test cases have been removed. Some file system implementations might support storing time stamps outside of the ext4-supported time stamp ranges (positive and/or negative). We don't require that an implementation does or does not support such time stamps - the results might (and are) different on different file system implementations. So don't try to test those.

## Related Issue
- Fixes #40098 

## How Has This Been Tested?
Local unit test run on Ubuntu 22.04 with PHP 7.4.29
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
