### PR TITLE
[tests-only] [full-ci] Pin phpstan to 1.7.1 - issue 40105

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^1.0"
+        "phpstan/phpstan": "1.7.1"
     }
 }


### PR DESCRIPTION
## Description
Pin `phpstan` to https://github.com/phpstan/phpstan/releases/tag/1.7.1 - that passes.

"something happened" with `phpstan` 1.7.2, so pin the version for now to get CI  green. Then I can investigate further.

## Related Issue
Part of #40105 

## How Has This Been Tested?
CI and local run of `make test-php-phpstan`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
