### PR TITLE
[tests-only] Bump phpstan 1.7.1 to 1.7.7

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "1.7.1"
+        "phpstan/phpstan": "1.7.7"
     }
 }


### PR DESCRIPTION
## Description
The `phpstan` regressions in 1.7.2 have been fixed in 1.7.7. Bump phpstan to 1.7.7 for now and leave it pinned there for core. core has quite a big set of complex ways that dependencies are located, classes found in core, lib, apps etc., and it seems that `phpstan` quite often releases patch versions that either have accidental regressions for our core usage, or has new and better checks that result in errors "suddenly" being reported. When that happens, CI in core "suddenly" starts to fail, which is not good.

We can manually bump the phpstan version whenever we feel the need in future.

## Related Issue
- Fixes #40105 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
