### PR TITLE
[tests-only] [full-ci] More flexible tests for share ids

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
@@ -831,10 +831,9 @@ Feature: a default expiration date can be specified for shares with users or gro
       | path       | /textfile0.txt  |
       | shareWith  | brand-new-group |
       | expireDate | +15 days        |
-    And the administrator has expired the last created share using the testing API
+    And the administrator has expired the last created public link share using the testing API
     When the public accesses the preview of file "textfile0.txt" from the last shared public link using the sharing API
     Then the HTTP status code should be "404"
-    And user "Alice" should not see the share id of the last share
     And as "Alice" file "/textfile0.txt" should exist
 
 

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
@@ -131,7 +131,7 @@ Feature: sharing
     And user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
     And user "Alice" has shared entry "<entry_to_share>" with group "grp1"
-    When user "Brian" deletes the last share using the sharing API
+    When user "Brian" deletes the last share of user "Alice" using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Alice" entry "<entry_to_share>" should exist
@@ -149,7 +149,7 @@ Feature: sharing
     And user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/PARENT/parent.txt"
     And user "Alice" has shared entry "<entry_to_share>" with user "Brian"
-    When user "Brian" deletes the last share using the sharing API
+    When user "Brian" deletes the last share of user "Alice" using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Alice" entry "<entry_to_share>" should exist
@@ -165,7 +165,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "fileToShare.txt"
     And user "Alice" has shared file "fileToShare.txt" with user "Brian"
-    When user "Brian" tries to delete the last share using the sharing API
+    When user "Brian" tries to delete the last share of user "Alice" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
     Examples:

--- a/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -173,7 +173,7 @@ Feature: sharing
     And user "Alice" has shared entry "<entry_to_share>" with group "grp1"
     And user "Brian" has accepted share "<pending_entry>" offered by user "Alice"
     And user "Carol" has accepted share "<pending_entry>" offered by user "Alice"
-    When user "Brian" deletes the last share using the sharing API
+    When user "Brian" deletes the last share of user "Alice" using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Alice" entry "<entry_to_share>" should exist
@@ -201,7 +201,7 @@ Feature: sharing
     And user "Alice" has moved file "/textfile0.txt" to "/shared/shared_file.txt"
     And user "Alice" has shared entry "<entry_to_share>" with user "Brian"
     And user "Brian" has accepted share "<pending_entry>" offered by user "Alice"
-    When user "Brian" deletes the last share using the sharing API
+    When user "Brian" deletes the last share of user "Alice" using the sharing API
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
     And as "Alice" entry "<entry_to_share>" should exist
@@ -242,7 +242,7 @@ Feature: sharing
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"
     And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
-    When user "Brian" tries to delete the last share using the sharing API
+    When user "Brian" tries to delete the last share of user "Alice" using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
     Examples:

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -14,7 +14,7 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT       |
       | permissions | <permissions> |
-    When the public deletes file "parent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public deletes file "parent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
 
@@ -35,7 +35,7 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT            |
       | permissions | read,update,create |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
@@ -55,7 +55,7 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
@@ -114,7 +114,7 @@ Feature: changing a public link share
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "parent.txt" from the last public share using the password "invalid" and <public-webdav-api-version> public WebDAV API
+    When the public deletes file "parent.txt" from the last public link share using the password "invalid" and <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "PARENT/parent.txt" should exist
 
@@ -134,7 +134,7 @@ Feature: changing a public link share
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public deletes file "parent.txt" from the last public share using the password "newpasswd" and <public-webdav-api-version> public WebDAV API
+    When the public deletes file "parent.txt" from the last public link share using the password "newpasswd" and <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
 
@@ -154,7 +154,7 @@ Feature: changing a public link share
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "invalid" and <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "invalid" and <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/newparent.txt" should not exist
     And as "Alice" file "/PARENT/parent.txt" should exist
@@ -175,7 +175,7 @@ Feature: changing a public link share
       | path        | /PARENT   |
       | permissions | change    |
       | password    | newpasswd |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the password "newpasswd" and <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the password "newpasswd" and <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/newparent.txt" should exist
     And as "Alice" file "/PARENT/parent.txt" should not exist
@@ -235,7 +235,7 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public renames file "parent.txt" to "newparent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public renames file "parent.txt" to "newparent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
@@ -255,7 +255,7 @@ Feature: changing a public link share
     Given user "Alice" has created a public link share with settings
       | path        | /PARENT         |
       | permissions | uploadwriteonly |
-    When the public deletes file "parent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public deletes file "parent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/parent.txt" should exist
 

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -25,7 +25,7 @@ Feature: create a public link share
       | uid_file_owner         | %username%      |
       | uid_owner              | %username%      |
       | name                   |                 |
-    When the public downloads the last public shared file using the <public-webdav-api-version> public WebDAV API
+    When the public downloads the last public link shared file using the <public-webdav-api-version> public WebDAV API
     Then the downloaded content should be "Random data"
     And the public upload to the last publicly shared file using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "403"
 
@@ -162,7 +162,7 @@ Feature: create a public link share
       | uid_file_owner         | %username%           |
       | uid_owner              | %username%           |
       | name                   |                      |
-    When the public downloads file "/randomfile.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API
+    When the public downloads file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
     Then the downloaded content should be "Random data"
     And the public upload to the last publicly shared folder using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "403"
 
@@ -201,10 +201,10 @@ Feature: create a public link share
       | uid_file_owner         | %username%           |
       | uid_owner              | %username%           |
       | name                   |                      |
-    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API with password "%public%"
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API with password "%public%"
     And the downloaded content should be "Random data"
-    But the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API without a password
-    And the public should not be able to download file "/randomfile.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API with password "%regular%"
+    But the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API without a password
+    And the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API with password "%regular%"
 
     @notToImplementOnOCIS @issue-ocis-2079
     Examples:
@@ -331,7 +331,7 @@ Feature: create a public link share
       | path        | /afolder |
       | permissions | read     |
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
-    When user "Alice" tries to update the last share using the sharing API with
+    When user "Alice" tries to update the last public link share using the sharing API with
       | permissions | read,create |
     Then the OCS status code should be "<ocs_status_code>"
 
@@ -461,7 +461,7 @@ Feature: create a public link share
       | uid_file_owner         | %username%           |
       | uid_owner              | %username%           |
       | name                   |                      |
-    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
     And the downloaded content should be "Random data"
     And the public upload to the last publicly shared folder using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "403"
 
@@ -508,7 +508,7 @@ Feature: create a public link share
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "/randomfile.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
     And the downloaded content should be "Random data"
 
     @notToImplementOnOCIS @issue-ocis-2079
@@ -541,7 +541,7 @@ Feature: create a public link share
       | permissions | read            |
       | uid_owner   | %username%      |
       | expiration  | +7 days         |
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "<http_status_code>"
     And the fields of the last response to user "Alice" should include
@@ -574,7 +574,7 @@ Feature: create a public link share
       | path        | PARENT |
       | permissions | read   |
     When user "Alice" deletes folder "PARENT" using the WebDAV API
-    And the public download of file "/parent.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "404"
+    And the public download of file "/parent.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "404"
 
     @notToImplementOnOCIS @issue-ocis-2079
     Examples:
@@ -593,7 +593,7 @@ Feature: create a public link share
     And user "Alice" has created a public link share with settings
       | path        | PARENT          |
       | permissions | uploadwriteonly |
-    When the public downloads file "parent.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API
+    When the public downloads file "parent.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
     Then the value of the item "//s:message" in the response should be "<response>"
     And the HTTP status code should be "404"
 
@@ -652,7 +652,7 @@ Feature: create a public link share
     And user "Alice" has created a public link share with settings
       | path        | /testFolder               |
       | permissions | read,update,create,delete |
-    When the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+    When the public uploads file "file.txt" to the last public link shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
@@ -665,7 +665,7 @@ Feature: create a public link share
     And user "Alice" creates a public link share using the sharing API with settings
       | path        | /testFolder               |
       | permissions | read,update,create,delete |
-    And the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+    And the public uploads file "file.txt" to the last public link shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "/testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
@@ -684,7 +684,7 @@ Feature: create a public link share
       | path               | /textfile0.txt |
       | name               | link2          |
       | expireDateAsString | +5 days        |
-    And the administrator expires the last created share using the testing API
+    And the administrator expires the last created public link share using the testing API
     Then the HTTP status code should be "<http_status_code>"
     When user "Alice" gets all the shares from the file "textfile0.txt" using the sharing API
     Then the HTTP status code should be "<http_status_code>"

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
@@ -11,7 +11,7 @@ Feature: create a public link share
 
   @issue-37605
   Scenario: Get the mtime of a file inside a folder shared by public link using new webDAV version
-    When the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+    When the public uploads file "file.txt" to the last public link shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "testFolder/file.txt" should not be "Thu, 08 Aug 2019 04:18:13 GMT"
@@ -22,7 +22,7 @@ Feature: create a public link share
   @issue-37605
   Scenario: overwriting a file changes its mtime (new public webDAV API)
     Given user "Alice" has uploaded file with content "uploaded content for file name ending with a dot" to "testFolder/file.txt"
-    When the public uploads file "file.txt" to the last shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
+    When the public uploads file "file.txt" to the last public link shared folder with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the new public WebDAV API
     Then the HTTP status code should be "204"
     And as "Alice" file "/testFolder/file.txt" should exist
     And as "Alice" the mtime of the file "testFolder/file.txt" should not be "Thu, 08 Aug 2019 04:18:13 GMT"

--- a/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature
@@ -29,7 +29,7 @@ Feature: multilinksharing
       | publicUpload | true        |
       | permissions  | change      |
       | name         | sharedlink3 |
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | permissions | read |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -64,7 +64,7 @@ Feature: multilinksharing
       | expireDate  | +3 days       |
       | permissions | read          |
       | name        | sharedlink3   |
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | permissions | read |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -95,7 +95,7 @@ Feature: multilinksharing
       | publicUpload | true        |
       | permissions  | change      |
       | name         | sharedlink2 |
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | password | %alt1% |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
@@ -36,7 +36,7 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
     And the downloaded content should be "some content"
     But uploading a file should not work using the <public-webdav-api-version> public WebDAV API
 
@@ -94,7 +94,7 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
     And the downloaded content should be "some content"
     But uploading a file should not work using the <public-webdav-api-version> public WebDAV API
 
@@ -122,7 +122,7 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the <public-webdav-api-version> public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
     And the downloaded content should be "some content"
     And uploading a file should work using the <public-webdav-api-version> public WebDAV API
 
@@ -164,7 +164,7 @@ Feature: reshare as public link
       | path         | /test |
       | permissions  | read  |
       | publicUpload | false |
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
@@ -192,7 +192,7 @@ Feature: reshare as public link
       | permissions  | read      |
       | publicUpload | false     |
     And uploading a file should not work using the <public-webdav-api-version> public WebDAV API
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -39,7 +39,7 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
     And the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
     Examples:
@@ -91,7 +91,7 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
     And the downloaded content should be "some content"
     But uploading a file should not work using the new public WebDAV API
     Examples:
@@ -112,7 +112,7 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the new public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API
     And the downloaded content should be "some content"
     And uploading a file should work using the new public WebDAV API
     Examples:
@@ -149,7 +149,7 @@ Feature: reshare as public link
       | path         | /Shares/test |
       | permissions  | read         |
       | publicUpload | false        |
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
@@ -171,7 +171,7 @@ Feature: reshare as public link
       | permissions  | read             |
       | publicUpload | false            |
     And uploading a file should not work using the new public WebDAV API
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
@@ -24,7 +24,7 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the old public WebDAV API
     And the downloaded content should be "some content"
     But uploading a file should not work using the old public WebDAV API
     Examples:
@@ -44,7 +44,7 @@ Feature: reshare as public link
       | publicUpload | false        |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the old public WebDAV API
     And the downloaded content should be "some content"
     But uploading a file should not work using the old public WebDAV API
     Examples:
@@ -65,7 +65,7 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public shared folder using the old public WebDAV API
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the old public WebDAV API
     And the downloaded content should be "some content"
     And uploading a file should work using the old public WebDAV API
     Examples:
@@ -84,7 +84,7 @@ Feature: reshare as public link
       | path         | /Shares/test |
       | permissions  | read         |
       | publicUpload | false        |
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
@@ -106,7 +106,7 @@ Feature: reshare as public link
       | permissions  | read             |
       | publicUpload | false            |
     And uploading a file should not work using the old public WebDAV API
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"

--- a/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature
@@ -48,7 +48,7 @@ Feature: public share sharers groups setting
       | permissions | read             |
     And parameter "public_share_sharers_groups_allowlist_enabled" of app "files_sharing" has been set to "yes"
     And parameter "public_share_sharers_groups_allowlist" of app "files_sharing" has been set to '["grp1"]'
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | expireDate | +3 days |
     Then the HTTP status code should be "200"
     And the OCS status code should be "100"

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -11,7 +11,7 @@ Feature: update a public link share
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | expireDate | +3 days |
     Then the OCS status code should be "<ocs_status_code>"
     And the OCS status message should be "Ok"
@@ -51,9 +51,9 @@ Feature: update a public link share
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
-    And user "Alice" has updated the last share with
+    And user "Alice" has updated the last public link share with
       | expireDate | +3 days |
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -86,7 +86,7 @@ Feature: update a public link share
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
     And user "Alice" has moved folder "/FOLDER" to "/RENAMED_FOLDER"
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -129,7 +129,7 @@ Feature: update a public link share
     And user "Alice" has created a public link share with settings
       | path     | randomfile.txt |
       | password | %public%       |
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | expireDate | +3 days |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -153,9 +153,9 @@ Feature: update a public link share
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
-    And user "Alice" has updated the last share with
+    And user "Alice" has updated the last public link share with
       | expireDate | +3 days |
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -186,9 +186,9 @@ Feature: update a public link share
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
-    And user "Alice" has updated the last share with
+    And user "Alice" has updated the last public link share with
       | password | %public% |
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -218,9 +218,9 @@ Feature: update a public link share
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
-    And user "Alice" has updated the last share with
+    And user "Alice" has updated the last public link share with
       | permissions | read,update,create,delete |
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -250,9 +250,9 @@ Feature: update a public link share
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
-    And user "Alice" has updated the last share with
+    And user "Alice" has updated the last public link share with
       | permissions | read,update,create,delete |
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -282,9 +282,9 @@ Feature: update a public link share
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
-    And user "Alice" has updated the last share with
+    And user "Alice" has updated the last public link share with
       | publicUpload | true |
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -320,7 +320,7 @@ Feature: update a public link share
     And user "Brian" has created a public link share with settings
       | path         | /Shares/test |
       | publicUpload | false        |
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | publicUpload | true |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
@@ -350,7 +350,7 @@ Feature: update a public link share
     And user "Brian" has created a public link share with settings
       | path         | /Shares/test |
       | publicUpload | false        |
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | publicUpload | true |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -380,7 +380,7 @@ Feature: update a public link share
     And user "Brian" has created a public link share with settings
       | path        | /Shares/test |
       | permissions | read         |
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
@@ -410,7 +410,7 @@ Feature: update a public link share
     And user "Brian" has created a public link share with settings
       | path        | /Shares/test |
       | permissions | read         |
-    When user "Brian" updates the last share using the sharing API with
+    When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
@@ -437,9 +437,9 @@ Feature: update a public link share
     And user "Alice" has created a public link share with settings
       | path        | /PARENT                   |
       | permissions | read,update,create,delete |
-    And user "Alice" has updated the last share with
+    And user "Alice" has updated the last public link share with
       | permissions | read |
-    When the public deletes file "CHILD/child.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public deletes file "CHILD/child.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/CHILD/child.txt" should exist
 
@@ -465,10 +465,10 @@ Feature: update a public link share
     And user "Alice" has created a public link share with settings
       | path        | /PARENT |
       | permissions | read    |
-    And user "Alice" has updated the last share with
+    And user "Alice" has updated the last public link share with
       | permissions | read,update,create,delete |
-    When the public deletes file "CHILD/child.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
-    And the public deletes file "parent.txt" from the last public share using the <public-webdav-api-version> public WebDAV API
+    When the public deletes file "CHILD/child.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
+    And the public deletes file "parent.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code of responses on all endpoints should be "204"
     And as "Alice" file "PARENT/CHILD/child.txt" should not exist
     And as "Alice" file "PARENT/parent.txt" should not exist
@@ -493,7 +493,7 @@ Feature: update a public link share
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
     And user "Alice" has moved folder "/FOLDER" to "/RENAMED_FOLDER"
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -539,7 +539,7 @@ Feature: update a public link share
     And user "Alice" has created a public link share with settings
       | path | lorem.txt |
     And user "Alice" has moved file "/lorem.txt" to "/new-lorem.txt"
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -583,7 +583,7 @@ Feature: update a public link share
     And user "Alice" has created a public link share with settings
       | path | lorem.txt |
     And user "Alice" has moved file "/lorem.txt" to "/new-lorem.txt"
-    When user "Alice" gets the info of the last share using the sharing API
+    When user "Alice" gets the info of the last public link share using the sharing API
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShareOc10Issue37653.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShareOc10Issue37653.feature
@@ -11,7 +11,7 @@ Feature: update a public link share
     And user "Alice" has created folder "FOLDER"
     And user "Alice" has created a public link share with settings
       | path | FOLDER |
-    When user "Alice" updates the last share using the sharing API with
+    When user "Alice" updates the last public link share using the sharing API with
       | expireDate | +3 days |
     Then the OCS status code should be "<ocs_status_code>"
     And the OCS status message should be ""

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -240,7 +240,7 @@ Feature: propagation of etags when deleting a file or folder
       | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
-    When the public deletes file "file.txt" from the last public share using the new public WebDAV API
+    When the public deletes file "file.txt" from the last public link share using the new public WebDAV API
     Then the HTTP status code should be "204"
     And these etags should have changed:
       | user  | path    |
@@ -265,7 +265,7 @@ Feature: propagation of etags when deleting a file or folder
       | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
-    When the public deletes folder "sub" from the last public share using the new public WebDAV API
+    When the public deletes folder "sub" from the last public link share using the new public WebDAV API
     Then the HTTP status code should be "204"
     And these etags should have changed:
       | user  | path    |

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
@@ -396,7 +396,7 @@ Feature: propagation of etags when moving files or folders
       | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
-    When the public renames file "file.txt" to "renamed.txt" from the last public share using the new public WebDAV API
+    When the public renames file "file.txt" to "renamed.txt" from the last public link share using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
       | user  | path    |
@@ -422,7 +422,7 @@ Feature: propagation of etags when moving files or folders
       | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
-    When the public renames folder "sub" to "renamed" from the last public share using the new public WebDAV API
+    When the public renames folder "sub" to "renamed" from the last public link share using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
       | user  | path    |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -99,7 +99,7 @@ Feature: persistent-locking in case of a public link
   @smokeTest @skipOnOcV10.3
   Scenario Outline: Public locking is not supported
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
-    When the public locks "/CHILD" in the last public shared folder using the <public-webdav-api-version> public WebDAV API setting the following properties
+    When the public locks "/CHILD" in the last public link shared folder using the <public-webdav-api-version> public WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "405"
     And the value of the item "//s:message" in the response should be "Locking not allowed from public endpoint"

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -577,20 +577,35 @@ class AppConfigurationContext implements Context {
 	}
 
 	/**
-	 * Expires last created share using the testing API
+	 * Expires last created public link share using the testing API
 	 *
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function expireLastCreatedUserShare():void {
+	public function expireLastCreatedPublicLinkShare():void {
+		$shareId = $this->featureContext->getLastPublicLinkShareId();
+		$this->expireShare($shareId);
+	}
+
+	/**
+	 * Expires a share using the testing API
+	 *
+	 * @param string|null $shareId optional share id, if null then expire the last share that was created.
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function expireShare(string $shareId = null):void {
 		$adminUser = $this->featureContext->getAdminUsername();
-		$share_id = $this->featureContext->getLastShareId();
+		if ($shareId === null) {
+			$shareId = $this->featureContext->getLastShareId();
+		}
 		$response = OcsApiHelper::sendRequest(
 			$this->featureContext->getBaseUrl(),
 			$adminUser,
 			$this->featureContext->getAdminPassword(),
 			'POST',
-			"/apps/testing/api/v1/expire-share/{$share_id}",
+			"/apps/testing/api/v1/expire-share/{$shareId}",
 			$this->featureContext->getStepLineRef(),
 			[],
 			$this->featureContext->getOcsApiVersion()
@@ -605,11 +620,26 @@ class AppConfigurationContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function theAdministratorHasExpiredTheLastCreatedShare():void {
-		$this->expireLastCreatedUserShare();
+		$this->expireShare();
 		Assert::assertSame(
 			200,
 			$this->featureContext->getResponse()->getStatusCode(),
 			"Request to expire last share failed."
+		);
+	}
+
+	/**
+	 * @Given the administrator has expired the last created public link share using the testing API
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorHasExpiredTheLastCreatedPublicLinkShare():void {
+		$this->expireLastCreatedPublicLinkShare();
+		Assert::assertSame(
+			200,
+			$this->featureContext->getResponse()->getStatusCode(),
+			"Request to expire last public link share failed."
 		);
 	}
 
@@ -620,7 +650,17 @@ class AppConfigurationContext implements Context {
 	 * @throws GuzzleException
 	 */
 	public function theAdministratorExpiresTheLastCreatedShare():void {
-		$this->expireLastCreatedUserShare();
+		$this->expireShare();
+	}
+
+	/**
+	 * @When the administrator expires the last created public link share using the testing API
+	 *
+	 * @return void
+	 * @throws GuzzleException
+	 */
+	public function theAdministratorExpiresTheLastCreatedPublicLinkShare():void {
+		$this->expireLastCreatedPublicLinkShare();
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3176,10 +3176,10 @@ class FeatureContext extends BehatVariablesContext {
 				"parameter" => []
 			],
 			[
-				"code" => "%last_share_token%",
+				"code" => "%last_public_share_token%",
 				"function" => [
 					$this,
-					"getLastSharetoken"
+					"getLastPublicShareToken"
 				],
 				"parameter" => []
 			]

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -924,7 +924,6 @@ trait Provisioning {
 	 * @throws Exception
 	 */
 	public function deleteLdapUsersAndGroups():void {
-		// pdd
 		$isOcisOrReva = OcisHelper::isTestingOnOcisOrReva();
 		foreach ($this->ldapCreatedUsers as $user) {
 			if ($isOcisOrReva) {

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -45,7 +45,7 @@ class PublicWebDavContext implements Context {
 	private $occContext;
 
 	/**
-	 * @When /^the public downloads the last public shared file with range "([^"]*)" using the (old|new) public WebDAV API$/
+	 * @When /^the public downloads the last public link shared file with range "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $range ignore if empty
 	 * @param string $publicWebDAVAPIVersion
@@ -55,7 +55,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function downloadPublicFileWithRange(string $range, string $publicWebDAVAPIVersion, ?string $password = ""):void {
 		if ($publicWebDAVAPIVersion === "new") {
-			$path = (string)$this->featureContext->getLastShareData()->data->file_target;
+			$path = (string)$this->featureContext->getLastPublicShareData()->data->file_target;
 		} else {
 			$path = "";
 		}
@@ -68,7 +68,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads the last public shared file with range "([^"]*)" and password "([^"]*)" using the (old|new) public WebDAV API$/
+	 * @When /^the public downloads the last public link shared file with range "([^"]*)" and password "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $range ignore if empty
 	 * @param string $password
@@ -78,7 +78,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function downloadPublicFileWithRangeAndPassword(string $range, string $password, string $publicWebDAVAPIVersion):void {
 		if ($publicWebDAVAPIVersion === "new") {
-			$path = $this->featureContext->getLastShareData()->data->file_target;
+			$path = $this->featureContext->getLastPublicShareData()->data->file_target;
 		} else {
 			$path = "";
 		}
@@ -91,7 +91,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads the last public shared file using the (old|new) public WebDAV API$/
+	 * @When /^the public downloads the last public link shared file using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $publicWebDAVAPIVersion
 	 *
@@ -102,7 +102,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads the last public shared file with password "([^"]*)" using the (old|new) public WebDAV API$/
+	 * @When /^the public downloads the last public link shared file with password "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $password
 	 * @param string $publicWebDAVAPIVersion
@@ -114,7 +114,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public deletes (?:file|folder|entry) "([^"]*)" from the last public share using the (old|new) public WebDAV API$/
+	 * @When /^the public deletes (?:file|folder|entry) "([^"]*)" from the last public link share using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 * @param string $publicWebDAVAPIVersion
@@ -123,7 +123,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function deleteFileFromPublicShare(string $fileName, string $publicWebDAVAPIVersion, string $password = ""):void {
-		$token = (string) $this->featureContext->getLastShareData()->data->token;
+		$token = $this->featureContext->getLastPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -151,7 +151,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public deletes file "([^"]*)" from the last public share using the password "([^"]*)" and (old|new) public WebDAV API$/
+	 * @When /^the public deletes file "([^"]*)" from the last public link share using the password "([^"]*)" and (old|new) public WebDAV API$/
 	 *
 	 * @param string $file
 	 * @param string $password
@@ -164,7 +164,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public renames (?:file|folder|entry) "([^"]*)" to "([^"]*)" from the last public share using the (old|new) public WebDAV API$/
+	 * @When /^the public renames (?:file|folder|entry) "([^"]*)" to "([^"]*)" from the last public link share using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 * @param string $toFileName
@@ -174,7 +174,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function renameFileFromPublicShare(string $fileName, string $toFileName, string $publicWebDAVAPIVersion, ?string $password = ""):void {
-		$token = (string)$this->featureContext->getLastShareData()->data->token;
+		$token = $this->featureContext->getLastPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -204,7 +204,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public renames file "([^"]*)" to "([^"]*)" from the last public share using the password "([^"]*)" and (old|new) public WebDAV API$/
+	 * @When /^the public renames file "([^"]*)" to "([^"]*)" from the last public link share using the password "([^"]*)" and (old|new) public WebDAV API$/
 	 *
 	 * @param string $fileName
 	 * @param string $toName
@@ -218,7 +218,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $publicWebDAVAPIVersion
@@ -235,7 +235,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" using the (old|new) public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public link shared folder with password "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string|null $password
@@ -257,7 +257,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with range "([^"]*)" using the (old|new) public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public link shared folder with range "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $range
@@ -275,7 +275,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When /^the public downloads file "([^"]*)" from inside the last public shared folder with password "([^"]*)" with range "([^"]*)" using the (old|new) public WebDAV API$/
+	 * @When /^the public downloads file "([^"]*)" from inside the last public link shared folder with password "([^"]*)" with range "([^"]*)" using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $password
@@ -292,7 +292,7 @@ class PublicWebDavContext implements Context {
 	):void {
 		$path = \ltrim($path, "/");
 		$password = $this->featureContext->getActualPassword($password);
-		$token = (string) $this->featureContext->getLastShareData()->data->token;
+		$token = $this->featureContext->getLastPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -403,7 +403,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicCopiesFileUsingTheWebDAVApi(string $source, string $destination, string $publicWebDAVAPIVersion):void {
-		$token = (string) $this->featureContext->getLastShareData()->data->token;
+		$token = $this->featureContext->getLastPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -782,7 +782,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API$/
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API$/
 	 *
 	 * @param string $path
 	 * @param string $publicWebDAVAPIVersion
@@ -802,8 +802,8 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API without a password$/
-	 * @Then /^the public download of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API should fail with HTTP status code "([^"]*)"$/
+	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API without a password$/
+	 * @Then /^the public download of file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $publicWebDAVAPIVersion
@@ -826,7 +826,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $publicWebDAVAPIVersion
@@ -848,7 +848,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)" and the content should be "([^"]*)" plus end-of-line$/
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)" and the content should be "([^"]*)" plus end-of-line$/
 	 *
 	 * @param string $path
 	 * @param string $publicWebDAVAPIVersion
@@ -885,8 +885,8 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
-	 * @Then /^the public download of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
+	 * @Then /^the public should not be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
+	 * @Then /^the public download of file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $path
 	 * @param string $publicWebDAVAPIVersion
@@ -911,7 +911,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)""$/
+	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)""$/
 	 *
 	 * @param string $range
 	 * @param string $path
@@ -943,7 +943,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
+	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $range
 	 * @param string $path
@@ -989,7 +989,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API and the content should be "([^"]*)"$/
+	 * @Then /^the public should be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API and the content should be "([^"]*)"$/
 	 *
 	 * @param string $range
 	 * @param string $path
@@ -1015,7 +1015,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public shared folder using the (old|new) public WebDAV API without a password$/
+	 * @Then /^the public should not be able to download the range "([^"]*)" of file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API without a password$/
 	 *
 	 * @param string $range
 	 * @param string $path
@@ -1053,7 +1053,7 @@ class PublicWebDavContext implements Context {
 		$filename = "";
 
 		if ($publicWebDAVAPIVersion === "new") {
-			$filename = (string)$this->featureContext->getLastShareData()->data[0]->file_target;
+			$filename = (string)$this->featureContext->getLastPublicShareData()->data[0]->file_target;
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -1120,7 +1120,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to upload file "([^"]*)" into the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
+	 * @Then /^the public should be able to upload file "([^"]*)" into the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $filename
 	 * @param string $publicWebDAVAPIVersion
@@ -1146,7 +1146,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public upload of file "([^"]*)" into the last public shared folder using the (old|new) public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
+	 * @Then /^the public upload of file "([^"]*)" into the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $filename
 	 * @param string $publicWebDAVAPIVersion
@@ -1222,7 +1222,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @When the public uploads file :fileName to the last shared folder with mtime :mtime using the :davVersion public WebDAV API
+	 * @When the public uploads file :fileName to the last public link shared folder with mtime :mtime using the :davVersion public WebDAV API
 	 *
 	 * @param String $fileName
 	 * @param String $mtime
@@ -1259,7 +1259,7 @@ class PublicWebDavContext implements Context {
 		string $destination,
 		string $password
 	):void {
-		$token = $this->featureContext->getLastShareToken();
+		$token = $this->featureContext->getLastPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -1301,7 +1301,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public should be able to create folder "([^"]*)" in the last public shared folder using the new public WebDAV API with password "([^"]*)"$/
+	 * @Then /^the public should be able to create folder "([^"]*)" in the last public link shared folder using the new public WebDAV API with password "([^"]*)"$/
 	 *
 	 * @param string $foldername
 	 * @param string $password
@@ -1317,7 +1317,7 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
-	 * @Then /^the public creation of folder "([^"]*)" in the last public shared folder using the new public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
+	 * @Then /^the public creation of folder "([^"]*)" in the last public link shared folder using the new public WebDAV API with password "([^"]*)" should fail with HTTP status code "([^"]*)"$/
 	 *
 	 * @param string $foldername
 	 * @param string $password
@@ -1351,8 +1351,7 @@ class PublicWebDavContext implements Context {
 		string $fileName,
 		string $mtime
 	):void {
-		$tokenArray = $this->featureContext->getLastShareData()->data->token;
-		$token = (string)$tokenArray[0];
+		$token = $this->featureContext->getLastPublicShareToken();
 		$baseUrl = $this->featureContext->getBaseUrl();
 		if (\TestHelpers\OcisHelper::isTestingOnOcisOrReva()) {
 			$mtime = \explode(" ", $mtime);
@@ -1393,8 +1392,7 @@ class PublicWebDavContext implements Context {
 		string $fileName,
 		string $mtime
 	):void {
-		$tokenArray = $this->featureContext->getLastShareData()->data->token;
-		$token = (string)$tokenArray[0];
+		$token = $this->featureContext->getLastPublicShareToken();
 		$baseUrl = $this->featureContext->getBaseUrl();
 		Assert::assertNotEquals(
 			$mtime,
@@ -1428,7 +1426,7 @@ class PublicWebDavContext implements Context {
 		string $publicWebDAVAPIVersion = "old"
 	):void {
 		$password = $this->featureContext->getActualPassword($password);
-		$token = $this->featureContext->getLastShareToken();
+		$token = $this->featureContext->getLastPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -44,9 +44,47 @@ trait Sharing {
 	private $sharingApiVersion = 1;
 
 	/**
+	 * Contains the API response to the last share that was created by each user
+	 * using the Sharing API. Shares created on the webUI do not have an entry.
+	 *
+	 * @var SimpleXMLElement[]
+	 */
+	private $lastShareDataByUser = [];
+
+	/**
+	 * Contains the share id of the last share that was created by each user,
+	 * either using the Sharing API or on the web UI.
+	 *
+	 * @var string[]
+	 */
+	private $lastShareIdByUser = [];
+
+	/**
+	 * @var string
+	 */
+	private $userWhoCreatedLastShare = null;
+
+	/**
+	 * @var string
+	 */
+	private $userWhoCreatedLastPublicShare = null;
+
+	/**
+	 * Contains the API response to the last public link share that was created
+	 * by the test-runner using the Sharing API.
+	 * Shares created on the webUI do not have an entry.
+	 *
 	 * @var SimpleXMLElement
 	 */
-	private $lastShareData = null;
+	private $lastPublicShareData = null;
+
+	/**
+	 * Contains the share id of the last public link share that was created by
+	 * the test-runner, either using the Sharing API or on the web UI.
+	 *
+	 * @var string
+	 */
+	private $lastPublicShareId = null;
 
 	/**
 	 * @var int
@@ -95,10 +133,37 @@ trait Sharing {
 	}
 
 	/**
+	 * @return SimpleXMLElement|null
+	 */
+	public function getLastPublicShareData():?SimpleXMLElement {
+		return $this->lastPublicShareData;
+	}
+
+	/**
 	 * @return SimpleXMLElement
+	 * @throws Exception
 	 */
 	public function getLastShareData():SimpleXMLElement {
-		return $this->lastShareData;
+		return $this->getLastShareDataForUser($this->userWhoCreatedLastShare);
+	}
+
+	/**
+	 * @param string|null $user
+	 *
+	 * @return SimpleXMLElement
+	 * @throws Exception
+	 */
+	public function getLastShareDataForUser(?string $user):SimpleXMLElement {
+		if ($user === null) {
+			throw new Exception(
+				__METHOD__ . " user not specified. Probably no user or group shares have been created yet in the test scenario."
+			);
+		}
+		if (isset($this->lastShareDataByUser[$user])) {
+			return $this->lastShareDataByUser[$user];
+		} else {
+			throw new Exception(__METHOD__ . " last share data for user '$user' was not found");
+		}
 	}
 
 	/**
@@ -111,8 +176,24 @@ trait Sharing {
 	/**
 	 * @return void
 	 */
-	public function resetLastShareData():void {
-		$this->lastShareData = null;
+	public function resetLastPublicShareData():void {
+		$this->lastPublicShareData = null;
+		$this->lastPublicShareId = null;
+		$this->userWhoCreatedLastPublicShare = null;
+	}
+
+	/**
+	 * @param string $user
+	 *
+	 * @return void
+	 */
+	public function resetLastShareInfoForUser(string $user):void {
+		if (isset($this->lastShareDataByUser[$user])) {
+			unset($this->lastShareDataByUser[$user]);
+		}
+		if (isset($this->lastShareIdByUser[$user])) {
+			unset($this->lastShareIdByUser[$user]);
+		}
 	}
 
 	/**
@@ -126,7 +207,7 @@ trait Sharing {
 	 * @return int
 	 */
 	public function getServerLastShareTime():int {
-		return (int) $this->lastShareData->data->stime;
+		return (int) $this->getLastShareData()->data->stime;
 	}
 
 	/**
@@ -752,7 +833,7 @@ trait Sharing {
 	 * @return string
 	 */
 	public function getMimeTypeOfLastSharedFile():string {
-		return \json_decode(\json_encode($this->lastShareData->data->mimetype), true)[0];
+		return \json_decode(\json_encode($this->getLastShareData()->data->mimetype), true)[0];
 	}
 
 	/**
@@ -873,17 +954,27 @@ trait Sharing {
 	 * @param string $user
 	 * @param TableNode|null $body
 	 * @param string|null $shareOwner
+	 * @param bool $updateLastPublicLink
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function updateLastShareWithSettings(string $user, ?TableNode $body, ?string $shareOwner = null):void {
+	public function updateLastShareWithSettings(
+		string $user,
+		?TableNode $body,
+		?string $shareOwner = null,
+		?bool $updateLastPublicLink = false
+	):void {
 		$user = $this->getActualUsername($user);
 
-		if ($shareOwner === null) {
-			$share_id = $this->lastShareData->data[0]->id;
+		if ($updateLastPublicLink) {
+			$share_id = $this->getLastPublicLinkShareId();
 		} else {
-			$share_id = $this->getLastShareIdOf($shareOwner);
+			if ($shareOwner === null) {
+				$share_id = $this->getLastShareId();
+			} else {
+				$share_id = $this->getLastShareIdForUser($shareOwner);
+			}
 		}
 
 		$this->verifyTableNodeRows(
@@ -935,6 +1026,20 @@ trait Sharing {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" updates the last public link share using the sharing API with$/
+	 *
+	 * @param string $user
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userUpdatesTheLastPublicLinkShareWith(string $user, ?TableNode $body):void {
+		$this->updateLastShareWithSettings($user, $body, null, true);
+		$this->pushToLastStatusCodesArrays();
+	}
+
+	/**
 	 * @Given /^user "([^"]*)" has updated the last share with$/
 	 *
 	 * @param string $user
@@ -945,6 +1050,20 @@ trait Sharing {
 	 */
 	public function userHasUpdatedTheLastShareWith(string $user, ?TableNode $body):void {
 		$this->updateLastShareWithSettings($user, $body);
+		$this->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
+	 * @Given /^user "([^"]*)" has updated the last public link share with$/
+	 *
+	 * @param string $user
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userHasUpdatedTheLastPublicLinkShareWith(string $user, ?TableNode $body):void {
+		$this->updateLastShareWithSettings($user, $body, null, true);
 		$this->theHTTPStatusCodeShouldBeSuccess();
 	}
 
@@ -1030,15 +1149,37 @@ trait Sharing {
 			$this->sharingApiVersion,
 			$sharingApp
 		);
-		// In case of HTTP status code 204, there is no content in response payload body.
-		if ($this->response->getStatusCode() === 204) {
-			$this->lastShareData = null;
+		$httpStatusCode = $this->response->getStatusCode();
+		// In case of HTTP status code 204 "no content", or a failure code like 4xx
+		// in the HTTP or OCS status there is no useful content in response payload body.
+		// Clear the test-runner's memory of "last share data" to avoid later steps
+		// accidentally using some previous share data.
+		if (($httpStatusCode === 204)
+			|| !$this->theHTTPStatusCodeWasSuccess()
+			|| (($httpStatusCode === 200) && ($this->ocsContext->getOCSResponseStatusCode($this->response) > 299))
+		) {
+			if ($shareType === 'public_link') {
+				$this->lastPublicShareData = null;
+				$this->lastPublicShareId = null;
+				$this->userWhoCreatedLastPublicShare = null;
+			} else {
+				$this->resetLastShareInfoForUser($user);
+			}
 		} else {
-			$this->lastShareData = $this->getResponseXml(null, __METHOD__);
-			if ($shareType === 'public_link' && isset($this->lastShareData->data)) {
-				$linkName = (string) $this->lastShareData->data[0]->name;
-				$linkUrl = (string) $this->lastShareData->data[0]->url;
-				$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+			if ($shareType === 'public_link') {
+				$this->lastPublicShareData = $this->getResponseXml(null, __METHOD__);
+				$this->setLastPublicLinkShareId((string) $this->lastPublicShareData->data[0]->id);
+				$this->userWhoCreatedLastPublicShare = $user;
+				if (isset($this->lastPublicShareData->data)) {
+					$linkName = (string) $this->lastPublicShareData->data[0]->name;
+					$linkUrl = (string) $this->lastPublicShareData->data[0]->url;
+					$this->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+				}
+			} else {
+				$shareData = $this->getResponseXml(null, __METHOD__);
+				$this->lastShareDataByUser[$user] = $shareData;
+				$shareId = (string) $shareData->data[0]->id;
+				$this->setLastShareIdOf($user, $shareId);
 			}
 		}
 		$this->localLastShareTime = \microtime(true);
@@ -1747,6 +1888,19 @@ trait Sharing {
 	}
 
 	/**
+	 * @When /^user "([^"]*)" tries to update the last public link share using the sharing API with$/
+	 *
+	 * @param string $user
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userTriesToUpdateTheLastPublicLinkShareUsingTheSharingApiWith(string $user, ?TableNode $body):void {
+		$this->updateLastShareWithSettings($user, $body, null, true);
+	}
+
+	/**
 	 * @Then /^user "([^"]*)" should not be able to share (file|folder|entry) "([^"]*)" with (user|group) "([^"]*)"(?: with permissions (\d+))? using the sharing API$/
 	 * @Then /^user "([^"]*)" should not be able to share (file|folder|entry) "([^"]*)" with (user|group) "([^"]*)" with permissions "([^"]*)" using the sharing API$/
 	 *
@@ -1850,13 +2004,17 @@ trait Sharing {
 
 	/**
 	 * @param string $user
+	 * @param string|null $sharer
 	 *
 	 * @return void
 	 */
-	public function deleteLastShareUsingSharingApi(string $user):void {
+	public function deleteLastShareUsingSharingApi(string $user, string $sharer = null):void {
 		$user = $this->getActualUsername($user);
-		$share_id = $this->lastShareData->data[0]->id;
-		$url = $this->getSharesEndpointPath("/$share_id");
+		if ($sharer === null) {
+			$sharer = $user;
+		}
+		$shareId = $this->getLastShareIdForUser($sharer);
+		$url = $this->getSharesEndpointPath("/$shareId");
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$user,
 			"DELETE",
@@ -1882,6 +2040,20 @@ trait Sharing {
 	 */
 	public function userDeletesLastShareUsingTheSharingApi(string $user):void {
 		$this->deleteLastShareUsingSharingApi($user);
+		$this->pushToLastStatusCodesArrays();
+	}
+
+	/**
+	 * @When /^user "([^"]*)" deletes the last share of user "([^"]*)" using the sharing API$/
+	 * @When /^user "([^"]*)" tries to delete the last share of user "([^"]*)" using the sharing API$/
+	 *
+	 * @param string $user
+	 * @param string $sharer
+	 *
+	 * @return void
+	 */
+	public function userDeletesLastShareOfUserUsingTheSharingApi(string $user, string $sharer):void {
+		$this->deleteLastShareUsingSharingApi($user, $sharer);
 		$this->pushToLastStatusCodesArrays();
 	}
 
@@ -1918,13 +2090,42 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function userGetsInfoOfLastShareUsingTheSharingApi(string $user, ?string $language = null):void {
-		if (isset($this->lastShareData->data[0]->id)) {
-			$share_id = $this->lastShareData->data[0]->id;
+		$shareId = $this->getLastShareId();
+		$language = TranslationHelper::getLanguage($language);
+		$this->getShareData($user, $shareId, $language);
+		$this->pushToLastStatusCodesArrays();
+	}
+
+	/**
+	 * @When /^the user gets the info of the last public link share using the sharing API$/
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theUserGetsInfoOfLastPublicLinkShareUsingTheSharingApi():void {
+		$this->userGetsInfoOfLastPublicLinkShareUsingTheSharingApi($this->userWhoCreatedLastPublicShare);
+	}
+
+	/**
+	 * @When /^user "([^"]*)" gets the info of the last public link share in language "([^"]*)" using the sharing API$/
+	 * @When /^user "([^"]*)" gets the info of the last public link share using the sharing API$/
+	 *
+	 * @param string $user username that requests the information (might not be the user that has initiated the share)
+	 * @param string|null $language
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function userGetsInfoOfLastPublicLinkShareUsingTheSharingApi(string $user, ?string $language = null):void {
+		if ($this->lastPublicShareId !== null) {
+			$shareId = $this->lastPublicShareId;
 		} else {
-			$share_id = $this->getLastShareIdOf($user);
+			throw new Exception(
+				__METHOD__ . " last public link share data was not found"
+			);
 		}
 		$language = TranslationHelper::getLanguage($language);
-		$this->getShareData($user, (string)$share_id, $language);
+		$this->getShareData($user, $shareId, $language);
 		$this->pushToLastStatusCodesArrays();
 	}
 
@@ -1969,26 +2170,36 @@ trait Sharing {
 	}
 
 	/**
-	 * Get id of the last share of the user
-	 *
-	 * If lastShareData was not of $user, it fetches all shares for that user,
-	 * and extracts the id for last share from the response
+	 * Sets the id of the last shared file
 	 *
 	 * @param string $user
+	 * @param string $shareId
+	 *
+	 * @return void
+	 */
+	public function setLastShareIdOf(string $user, string $shareId):void {
+		$this->lastShareIdByUser[$user] = $shareId;
+		$this->userWhoCreatedLastShare = $user;
+	}
+
+	/**
+	 * Sets the id of the last public link shared file
+	 *
+	 * @param string $shareId
+	 *
+	 * @return void
+	 */
+	public function setLastPublicLinkShareId(string $shareId):void {
+		$this->lastPublicShareId = $shareId;
+	}
+
+	/**
+	 * Retrieves the id of the last public link shared file
 	 *
 	 * @return string|null
-	 * @throws Exception
 	 */
-	public function getLastShareIdOf(string $user):?string {
-		$user = $this->getActualUsername($user);
-
-		$this->getListOfShares($user);
-		$id = $this->extractLastSharedIdFromLastResponse();
-		Assert::assertNotNull(
-			$id,
-			__METHOD__ . " Could not find id in the last response."
-		);
-		return $id;
+	public function getLastPublicLinkShareId():?string {
+		return $this->lastPublicShareId;
 	}
 
 	/**
@@ -1997,13 +2208,24 @@ trait Sharing {
 	 * @return string|null
 	 */
 	public function getLastShareId():?string {
-		if ($this->lastShareData && $this->lastShareData->data) {
-			// id is a SimpleXMLElement object that contains the share id
-			// which is a string.
-			// (It might be a numeric string or might not, either is fine.)
-			return (string) $this->lastShareData->data[0]->id;
+		return $this->getLastShareIdForUser($this->userWhoCreatedLastShare);
+	}
+
+	/**
+	 * @param string $user
+	 *
+	 * @return string|null
+	 */
+	public function getLastShareIdForUser(string $user):?string {
+		if ($user === null) {
+			throw new Exception(
+				__METHOD__ . " user not specified. Probably no user or group shares have been created yet in the test scenario."
+			);
+		}
+		if (isset($this->lastShareIdByUser[$user])) {
+			return $this->lastShareIdByUser[$user];
 		} else {
-			return null;
+			throw new Exception(__METHOD__ . " last share id for user '$user' was not found");
 		}
 	}
 
@@ -2027,21 +2249,6 @@ trait Sharing {
 			$this->ocsApiVersion
 		);
 		return $this->response;
-	}
-
-	/**
-	 * Extracts `id` from responseXml
-	 *
-	 * @return string|null
-	 */
-	public function extractLastSharedIdFromLastResponse():?string {
-		// extract max id
-		$xpath = '/ocs/data/element/id[not (. < ../../element/id)][1]';
-		$id = $this->getResponseXml(null, __METHOD__)->xpath($xpath);
-		if ((bool) $id) {
-			return (string) $id[0];
-		}
-		return null;
 	}
 
 	/**
@@ -2286,7 +2493,7 @@ trait Sharing {
 	):void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeRows($body, [], $this->shareResponseFields);
-		$this->getShareData($user, (string)$this->lastShareData->data[0]->id);
+		$this->getShareData($user, (string)$this->getLastShareData()->data[0]->id);
 		$this->theHTTPStatusCodeShouldBe(
 			200,
 			"Error getting info of last share for user $user"
@@ -2315,16 +2522,11 @@ trait Sharing {
 		TableNode $body
 	):void {
 		$user = $this->getActualUsername($user);
-		$this->getListOfShares($user);
-		$share_id = $this->extractLastSharedIdFromLastResponse();
-		Assert::assertNotNull(
-			$share_id,
-			__METHOD__ . " Could not find id in the last response."
-		);
-		$this->getShareData($user, $share_id);
+		$shareId = $this->getLastShareIdForUser($user);
+		$this->getShareData($user, $shareId);
 		$this->theHTTPStatusCodeShouldBe(
 			200,
-			"Error getting info of last share for user $user"
+			"Error getting info of last share for user $user with share id $shareId"
 		);
 		$this->verifyTableNodeRows($body, [], $this->shareResponseFields);
 		$this->checkFields($user, $body);
@@ -2396,10 +2598,10 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function checkingLastShareIDIsIncluded():void {
-		$share_id = (string)$this->lastShareData->data[0]->id;
-		if (!$this->isFieldInResponse('id', $share_id)) {
+		$shareId = $this->getLastShareId();
+		if (!$this->isFieldInResponse('id', $shareId)) {
 			Assert::fail(
-				"Share id $share_id not found in response"
+				"Share id $shareId not found in response"
 			);
 		}
 	}
@@ -2411,10 +2613,10 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function checkLastShareIDIsNotIncluded():void {
-		$share_id = (string) $this->lastShareData->data[0]->id;
-		if ($this->isFieldInResponse('id', $share_id, false)) {
+		$shareId = $this->getLastShareId();
+		if ($this->isFieldInResponse('id', $shareId, false)) {
 			Assert::fail(
-				"Share id $share_id has been found in response"
+				"Share id $shareId has been found in response"
 			);
 		}
 	}
@@ -2786,7 +2988,14 @@ trait Sharing {
 	}
 
 	/**
-	 * Returns shares of a file or folders as an array of elements
+	 * Returns shares of a file or folder as a SimpleXMLElement
+	 *
+	 * Note: the "single" SimpleXMLElement may contain one or more actual
+	 * shares (to users, groups or public links etc). If you access an item directly,
+	 * for example, getShares()->id, then the value of "id" for the first element
+	 * will be returned. To access all the elements, you can loop through the
+	 * returned SimpleXMLElement with "foreach" - it will act like a PHP array
+	 * of elements.
 	 *
 	 * @param string $user
 	 * @param string $path
@@ -3387,12 +3596,12 @@ trait Sharing {
 	/**
 	 * @return string authorization token
 	 */
-	public function getLastShareToken():string {
-		if (\count($this->lastShareData->data->element) > 0) {
-			return (string)$this->lastShareData->data[0]->token;
+	public function getLastPublicShareToken():string {
+		if (\count($this->lastPublicShareData->data->element) > 0) {
+			return (string)$this->lastPublicShareData->data[0]->token;
 		}
 
-		return (string)$this->lastShareData->data->token;
+		return (string)$this->lastPublicShareData->data->token;
 	}
 
 	/**
@@ -3422,7 +3631,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function thePublicAccessesThePreviewOfTheSharedFileUsingTheSharingApi(string $path):void {
-		$shareData = $this->getLastShareData();
+		$shareData = $this->getLastPublicShareData();
 		$token = (string) $shareData->data->token;
 		$this->getPublicPreviewOfFile($path, $token);
 		$this->pushToLastStatusCodesArrays();
@@ -3444,7 +3653,7 @@ trait Sharing {
 		$this->emptyLastHTTPStatusCodesArray();
 		$this->emptyLastOCSStatusCodesArray();
 		foreach ($paths as $path) {
-			$shareData = $this->getLastShareData();
+			$shareData = $this->getLastPublicShareData();
 			$token = (string) $shareData->data->token;
 			$this->getPublicPreviewOfFile($path["path"], $token);
 			$this->pushToLastStatusCodesArrays();
@@ -3466,7 +3675,7 @@ trait Sharing {
 		$user = $this->getActualUsername($user);
 		$userPassword = $this->getPasswordForUser($user);
 
-		$shareData = $this->getLastShareData();
+		$shareData = $this->getLastPublicShareData();
 		$owner = (string) $shareData->data->uid_owner;
 		$name = $this->encodePath((string) $shareData->data->file_target);
 		$name = \trim($name, "/");

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1566,7 +1566,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function publicGetsSizeOfLastSharedPublicLinkUsingTheWebdavApi():void {
-		$tokenArray = $this->getLastShareData()->data->token;
+		$tokenArray = $this->getLastPublicShareData()->data->token;
 		$token = (string)$tokenArray[0];
 		$url = $this->getBaseUrl() . "/remote.php/dav/public-files/{$token}";
 		$this->response = HttpRequestHelper::sendRequest(
@@ -5123,7 +5123,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function theLastPublicDavResponseShouldContainTheseNodes(TableNode $table):void {
-		$user = (string) $this->getLastShareData()->data->token;
+		$user = $this->getLastPublicShareToken();
 		$this->verifyTableNodeColumns($table, ["name"]);
 		$type = $this->usingOldDavPath ? "public-files" : "public-files-new";
 		foreach ($table->getHash() as $row) {
@@ -5142,7 +5142,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function theLastPublicDavResponseShouldNotContainTheseNodes(TableNode $table):void {
-		$user = (string) $this->getLastShareData()->data->token;
+		$user = $this->getLastPublicShareToken();
 		$this->verifyTableNodeColumns($table, ["name"]);
 		$type = $this->usingOldDavPath ? "public-files" : "public-files-new";
 		foreach ($table->getHash() as $row) {
@@ -5161,7 +5161,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function thePublicListsTheResourcesInTheLastCreatedPublicLinkWithDepthUsingTheWebdavApi(string $depth):void {
-		$user = (string) $this->getLastShareData()->data->token;
+		$user = $this->getLastPublicShareToken();
 		$response = $this->listFolder(
 			$user,
 			'/',

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -150,7 +150,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given the public has locked the last public shared file/folder setting the following properties
+	 * @Given the public has locked the last public link shared file/folder setting the following properties
 	 *
 	 * @param TableNode $properties
 	 *
@@ -158,7 +158,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicHasLockedLastSharedFile(TableNode $properties) {
 		$this->lockFile(
-			(string) $this->featureContext->getLastShareData()->data->token,
+			$this->featureContext->getLastPublicShareToken(),
 			"/",
 			$properties,
 			true
@@ -166,7 +166,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When the public locks the last public shared file/folder using the WebDAV API setting the following properties
+	 * @When the public locks the last public link shared file/folder using the WebDAV API setting the following properties
 	 *
 	 * @param TableNode $properties
 	 *
@@ -174,7 +174,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicLocksLastSharedFile(TableNode $properties) {
 		$this->lockFile(
-			(string) $this->featureContext->getLastShareData()->data->token,
+			$this->featureContext->getLastPublicShareToken(),
 			"/",
 			$properties,
 			true,
@@ -183,7 +183,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @Given the public has locked :file in the last public shared folder setting the following properties
+	 * @Given the public has locked :file in the last public link shared folder setting the following properties
 	 *
 	 * @param string $file
 	 * @param TableNode $properties
@@ -195,7 +195,7 @@ class WebDavLockingContext implements Context {
 		TableNode $properties
 	) {
 		$this->lockFile(
-			(string) $this->featureContext->getLastShareData()->data->token,
+			$this->featureContext->getLastPublicShareToken(),
 			$file,
 			$properties,
 			true
@@ -203,7 +203,7 @@ class WebDavLockingContext implements Context {
 	}
 
 	/**
-	 * @When /^the public locks "([^"]*)" in the last public shared folder using the (old|new) public WebDAV API setting the following properties$/
+	 * @When /^the public locks "([^"]*)" in the last public link shared folder using the (old|new) public WebDAV API setting the following properties$/
 	 *
 	 * @param string $file
 	 * @param string $publicWebDAVAPIVersion
@@ -217,7 +217,7 @@ class WebDavLockingContext implements Context {
 		TableNode $properties
 	) {
 		$this->lockFile(
-			(string) $this->featureContext->getLastShareData()->data->token,
+			$this->featureContext->getLastPublicShareToken(),
 			$file,
 			$properties,
 			true,
@@ -278,7 +278,7 @@ class WebDavLockingContext implements Context {
 		$itemToUnlock,
 		$itemToUseLockOf
 	) {
-		$lockOwner = (string) $this->featureContext->getLastShareData()->data->token;
+		$lockOwner = $this->featureContext->getLastPublicShareToken();
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
@@ -429,7 +429,7 @@ class WebDavLockingContext implements Context {
 		$lockOwner,
 		$itemToUseLockOf
 	) {
-		$user = (string) $this->featureContext->getLastShareData()->data->token;
+		$user = $this->featureContext->getLastPublicShareToken();
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
@@ -447,7 +447,7 @@ class WebDavLockingContext implements Context {
 	 * @return void
 	 */
 	public function unlockItemAsPublicUsingWebDavAPI($itemToUnlock) {
-		$user = (string) $this->featureContext->getLastShareData()->data->token;
+		$user = $this->featureContext->getLastPublicShareToken();
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
@@ -602,7 +602,7 @@ class WebDavLockingContext implements Context {
 		$itemToUseLockOf,
 		$publicWebDAVAPIVersion
 	) {
-		$lockOwner = (string) $this->featureContext->getLastShareData()->data->token;
+		$lockOwner = $this->featureContext->getLastPublicShareToken();
 		$this->publicUploadFileSendingLockTokenOfUser(
 			$filename,
 			$content,

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -298,7 +298,7 @@ class WebDavPropertiesContext implements Context {
 	 * @throws Exception
 	 */
 	public function publicGetsThePropertiesOfFolder(string $path, TableNode $propertiesTable):void {
-		$user = (string) $this->featureContext->getLastShareData()->data->token;
+		$user = $this->featureContext->getLastPublicShareToken();
 		$properties = null;
 		if ($propertiesTable instanceof TableNode) {
 			foreach ($propertiesTable->getRows() as $row) {

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -145,6 +145,13 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	private $currentFile = "";
 
 	/**
+	 * variable to remember the path of a received share that has been moved
+	 *
+	 * @var string
+	 */
+	private $pathOfMovedReceivedShare = "";
+
+	/**
 	 *
 	 * @var FeatureContext
 	 */
@@ -225,6 +232,15 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	private function getCurrentFolderFilePath():string {
 		return \rtrim($this->currentFolder, '/') . '/' . $this->currentFile;
+	}
+
+	/**
+	 * get the new path of a moved received share (if any, it might be an empty string)
+	 *
+	 * @return string
+	 */
+	public function getPathOfMovedReceivedShare():string {
+		return $this->pathOfMovedReceivedShare;
 	}
 
 	/**
@@ -888,6 +904,22 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theUserMovesFileFolderIntoFolderUsingTheWebUI($name, $destination):void {
 		$pageObject = $this->getCurrentPageObject();
 		$pageObject->moveFileTo($name, $destination, $this->getSession());
+	}
+
+	/**
+	 * @When the user moves received file/folder :name into folder :destination using the webUI
+	 *
+	 * @param string|array $name
+	 * @param string|array $destination
+	 *
+	 * @return void
+	 */
+	public function theUserMovesReceivedFileFolderIntoFolderUsingTheWebUI($name, $destination):void {
+		$pageObject = $this->getCurrentPageObject();
+		$pageObject->moveFileTo($name, $destination, $this->getSession());
+		// A received share has been moved. Remember that this exists as a new share path,
+		// so that other steps can be aware of it.
+		$this->pathOfMovedReceivedShare = "$destination/$name";
 	}
 
 	/**
@@ -2683,7 +2715,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function publicLinkWithLastShareTokenShouldBeListedAsShareReceiverViaOnTheWebUI(string $item):void {
-		$token = (string)$this->featureContext->getLastShareData()->data->token;
+		$token = $this->featureContext->getLastPublicShareToken();
 		$sharingDialog = $this->filesPage->getSharingDialog();
 		$shareTreeItem = $sharingDialog->getShareTreeItem("public link", $token, $item);
 		Assert::assertTrue(

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -178,5 +178,5 @@ Feature: admin storage settings
     And the administrator has enabled read-only for the last created local storage mount using the webUI
     And the administrator has enabled sharing for the last created local storage mount using the webUI
     And the user has re-logged in as "Alice" using the webUI
-    When the user shares folder "local_storage1" with user "Brian" using the webUI
+    When the user tries to share folder "local_storage1" with user "Brian" using the webUI
     And as "Brian" folder "local_storage1" should exist

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
@@ -18,7 +18,7 @@ Feature: admin storage settings
     And the administrator has enabled read-only for the last created local storage mount using the webUI
     And the administrator has enabled sharing for the last created local storage mount using the webUI
     And the user has re-logged in as "Alice" using the webUI
-    When the user shares folder "local_storage1" with user "Brian" using the webUI
+    When the user tries to share folder "local_storage1" with user "Brian" using the webUI
     Then notifications should be displayed on the webUI with the text
       | Cannot set the requested share permissions for local_storage1 |
    # And as "Brian" folder "local_storage1" should exist

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
@@ -264,8 +264,7 @@ Feature: Sharing files and folders with internal groups with expiration date set
       | permissions | read,share     |
       | expireDate  | +15 days       |
     And user "Alice" has logged in using the webUI
-    When the user opens folder "simple-folder" using the webUI
-    And the user shares file "simple-empty-folder" with group "grp1" using the webUI without closing the share dialog
+    When the user shares file "simple-folder/simple-empty-folder" with group "grp1" using the webUI without closing the share dialog
     Then the expiration date input field should be "+30 days" for the group "grp1" in the share dialog
     When the user changes expiration date for share of group "grp1" to "+20 days" in the share dialog
     And the information of the last share of user "Alice" should include

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -366,8 +366,7 @@ Feature: Sharing files and folders with internal groups
     And user "Carol" has shared folder "/simple-folder" with group "grp1"
     And user "Alice" has logged in using the webUI
     When the user shares folder "simple-folder" with group "grp2" using the webUI
-    And the user opens folder "simple-folder" using the webUI
-    And the user shares folder "simple-empty-folder" with group "grp2" using the webUI
+    And the user shares folder "simple-folder/simple-empty-folder" with group "grp2" using the webUI
     Then as "Alice" folder "/simple-folder" should exist
     And user "Alice" should be able to upload file "filesForUpload/textfile.txt" to "simple-folder/textfile.txt"
     And as "Alice" folder "/simple-empty-folder" should not exist
@@ -389,8 +388,7 @@ Feature: Sharing files and folders with internal groups
     And the user sets the sharing permissions of group "grp2" for "simple-folder" using the webUI to
       | edit   | no |
       | create | no |
-    And the user opens folder "simple-folder" using the webUI
-    And the user shares folder "simple-empty-folder" with group "grp2" using the webUI
+    And the user shares folder "simple-folder/simple-empty-folder" with group "grp2" using the webUI
     And the user sets the sharing permissions of group "grp2" for "simple-empty-folder" using the webUI to
       | edit   | no |
       | create | no |
@@ -438,8 +436,7 @@ Feature: Sharing files and folders with internal groups
     And user "Alice" has been added to group "grp1"
     And user "Carol" has uploaded file with content "some data" to "/simple-folder/simple-inner-folder/simple-inner-inner-folder/textfile-1.txt"
     And user "Carol" has logged in using the webUI
-    And the user opens folder "/simple-folder/simple-inner-folder/simple-inner-inner-folder" using the webUI
-    When the user shares file "textfile-1.txt" with group "grp1" using the webUI
+    When the user shares file "simple-folder/simple-inner-folder/simple-inner-inner-folder/textfile-1.txt" with group "grp1" using the webUI
     Then the following permissions are seen for "textfile-1.txt" in the sharing dialog for group "grp1"
       | edit   | yes |
       | change | yes |
@@ -470,8 +467,7 @@ Feature: Sharing files and folders with internal groups
     And user "Alice" has shared file "/simple-folder/simple-inner-folder" with group "grp1" with permissions "read"
     And user "Alice" has shared file "/simple-folder/simple-inner-folder/simple-inner-inner-folder" with group "grp2" with permissions "read,share,delete"
     And user "Brian" has logged in using the webUI
-    And the user opens folder "/simple-folder/simple-inner-folder/simple-inner-inner-folder" using the webUI
-    When the user shares file "textfile-2.txt" with group "grp3" using the webUI
+    When the user shares file "simple-folder/simple-inner-folder/simple-inner-inner-folder/textfile-2.txt" with group "grp3" using the webUI
     Then the following permissions are seen for "textfile-2.txt" in the sharing dialog for group "grp3"
       | edit   | yes |
       | change | yes |
@@ -501,8 +497,7 @@ Feature: Sharing files and folders with internal groups
     And user "Alice" has shared file "/simple-folder" with group "grp2" with permissions "all"
     And user "Alice" has shared file "/simple-folder/simple-inner-folder" with group "grp1" with permissions "read"
     And user "Alice" has logged in using the webUI
-    And the user opens folder "/simple-folder" using the webUI
-    When the user shares folder "simple-inner-folder" with group "grp3" using the webUI
+    When the user shares folder "simple-folder/simple-inner-folder" with group "grp3" using the webUI
     Then the following permissions are seen for "simple-inner-folder" in the sharing dialog for group "grp3"
       | edit   | yes |
       | change | yes |
@@ -530,19 +525,23 @@ Feature: Sharing files and folders with internal groups
     And user "Carol" has shared folder "/simple-folder" with user "Alice" with permissions "all"
     And user "Alice" has shared folder "/simple-folder" with group "grp2" with permissions "all"
     And user "Alice" has shared folder "/simple-folder/simple-inner-folder" with group "grp1" with permissions "read"
-    And user "Brian" has created folder "/renamed-simple-folder"
+    And user "Brian" has created folder "/other-folder"
     And user "Brian" has logged in using the webUI
     When the user opens the sharing tab from the file action menu of folder "simple-inner-folder" using the webUI
     Then the user should see an error message on the share dialog saying "Sharing is not allowed"
     # now move received simple-inner-folder into some folder
-    And the user moves folder "simple-inner-folder" into folder "renamed-simple-folder" using the webUI
-    And the user opens folder "/renamed-simple-folder" using the webUI
+    # this effectively moves the read-only share of this folder with grp1
+    # and so sharing is not allowed for /other-folder/simple-inner-folder
+    And the user moves received folder "simple-inner-folder" into folder "other-folder" using the webUI
+    And the user opens folder "/other-folder" using the webUI
     When the user opens the sharing tab from the file action menu of folder "simple-inner-folder" using the webUI
     Then the user should see an error message on the share dialog saying "Sharing is not allowed"
-    # after move, sharing folder simple-inner-folder again but with different group should be possible
+    # simple-inner-folder is also still shown in simple-folder. In that view, it is just a sub-folder
+    # of the share of simple-folder with grp2 with all permissions.
+    # So that "view" of simple-inner-folder can be reshared.
+    # This is an unusual edge case combination. The test scenario demonstrates the current behavior.
     And the user browses to the home page
-    And the user opens folder "/simple-folder" using the webUI
-    When the user shares folder "simple-inner-folder" with group "grp3" using the webUI
+    When the user shares folder "simple-folder/simple-inner-folder" with group "grp3" using the webUI
     Then the following permissions are seen for "simple-inner-folder" in the sharing dialog for group "grp3"
       | edit   | yes |
       | change | yes |

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -190,7 +190,10 @@ Feature: Sharing files and folders with internal users
     When the user uploads file "textfile.txt" using the webUI
     Then as "Alice" file "simple-folder/textfile.txt" should not exist
     And file "textfile.txt" should not be listed on the webUI
-    When the user shares file "lorem.txt" with user "Carol" using the webUI
+    # Go back to the home page so that the "user shares file" step can navigate its own way
+    # into simple-folder and will "know where it is"
+    When the user browses to the home page
+    And the user shares file "simple-folder/lorem.txt" with user "Carol" using the webUI
     Then as "Carol" file "lorem.txt" should exist
 
   @skipOnOcV10.3

--- a/tests/acceptance/features/webUISharingInternalUsers2/adminDisablesSharePermissions.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/adminDisablesSharePermissions.feature
@@ -27,7 +27,10 @@ Feature: Sharing files and folders with internal users where admin disables diff
     And the option to rename file "lorem.txt" should be available on the webUI
     And the option to delete file "lorem.txt" should not be available on the webUI
     And the option to upload file should be available on the webUI
-    When the user shares file "lorem.txt" with user "Carol" using the webUI
+    # Go back to the home page so that the "user shares file" step can navigate its own way
+    # into simple-folder and will "know where it is"
+    When the user browses to the home page
+    And the user shares file "simple-folder/lorem.txt" with user "Carol" using the webUI
     Then as "Carol" file "lorem.txt" should exist
 
   @skipOnOcV10.3
@@ -52,7 +55,10 @@ Feature: Sharing files and folders with internal users where admin disables diff
     And the user opens folder "simple-folder" using the webUI
     And the option to rename file "lorem.txt" should not be available on the webUI
     And the option to upload file should be available on the webUI
-    When the user shares file "lorem.txt" with user "Carol" using the webUI
+    # Go back to the home page so that the "user shares file" step can navigate its own way
+    # into simple-folder and will "know where it is"
+    When the user browses to the home page
+    And the user shares file "simple-folder/lorem.txt" with user "Carol" using the webUI
     Then as "Carol" file "lorem.txt" should exist
     And the option to delete file "lorem.txt" should be available on the webUI
 
@@ -123,5 +129,8 @@ Feature: Sharing files and folders with internal users where admin disables diff
     Then the option to rename file "lorem.txt" should be available on the webUI
     And the option to upload file should be available on the webUI
     And the option to delete file "lorem.txt" should not be available on the webUI
-    When the user shares file "lorem.txt" with user "Carol" using the webUI
+    # Go back to the home page so that the "user shares file" step can navigate its own way
+    # into simple-folder and will "know where it is"
+    When the user browses to the home page
+    When the user shares file "simple-folder/lorem.txt" with user "Carol" using the webUI
     Then as "Carol" file "lorem.txt" should exist

--- a/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
@@ -253,8 +253,7 @@ Feature: Sharing files and folders with internal users with expiration date set/
       | permissions | read,share     |
       | expireDate  | +15 days       |
     And user "Alice" has logged in using the webUI
-    When the user opens folder "simple-folder" using the webUI
-    And the user shares file "simple-empty-folder" with user "Brian" using the webUI without closing the share dialog
+    When the user shares file "simple-folder/simple-empty-folder" with user "Brian" using the webUI without closing the share dialog
     Then the expiration date input field should be "+30 days" for the user "Brian" in the share dialog
     When the user changes expiration date for share of user "Brian" to "+20 days" in the share dialog
     And the information of the last share of user "Alice" should include

--- a/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
+++ b/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
@@ -236,7 +236,7 @@ Feature: Share by public link
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI with
       | expiration |  |
-    And user "Alice" gets the info of the last share using the sharing API
+    And user "Alice" gets the info of the last public link share using the sharing API
     Then the fields of the last response to user "Alice" should include
       | expiration |  |
 
@@ -256,7 +256,7 @@ Feature: Share by public link
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI
-    And user "Alice" gets the info of the last share using the sharing API
+    And user "Alice" gets the info of the last public link share using the sharing API
     Then the fields of the last response to user "Alice" should include
       | expiration | +7 days |
 

--- a/tests/acceptance/features/webUISharingPublic2/reShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/reShareByPublicLink.feature
@@ -32,8 +32,7 @@ Feature: Reshare by public link
     And user "Alice" has uploaded file with content "some content" to "/simple-folder/sub-folder/randomfile.txt"
     And user "Alice" has shared folder "/simple-folder" with user "Brian" with permissions "share,read"
     And user "Brian" has logged in using the webUI
-    When the user opens folder "simple-folder" using the webUI
-    And the user creates a new public link for folder "sub-folder" using the webUI
+    When the user creates a new public link for folder "simple-folder/sub-folder" using the webUI
     And the public accesses the last created public link using the webUI
     Then file "randomfile.txt" should be listed on the webUI
 
@@ -42,8 +41,7 @@ Feature: Reshare by public link
     And user "Alice" has uploaded file with content "some content" to "/simple-folder/randomfile.txt"
     And user "Alice" has shared folder "/simple-folder" with user "Brian" with permissions "share,read"
     And user "Brian" has logged in using the webUI
-    When the user opens folder "simple-folder" using the webUI
-    And the user creates a new public link for file "randomfile.txt" using the webUI
+    When the user creates a new public link for file "simple-folder/randomfile.txt" using the webUI
     And the public accesses the last created public link using the webUI
     Then the text preview of the public link should contain "some content"
 
@@ -68,8 +66,7 @@ Feature: Reshare by public link
     And user "Alice" has shared folder "/simple-folder" with user "Brian" with permissions "share,read"
     And parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     And user "Brian" has logged in using the webUI
-    When the user opens folder "simple-folder" using the webUI
-    And the user creates a new public link for file "randomfile.txt" using the webUI with
+    When the user creates a new public link for file "simple-folder/randomfile.txt" using the webUI with
       | email | foo@bar.co |
     Then the email address "foo@bar.co" should have received an email from user "Brian" with the body containing
       """

--- a/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
@@ -138,7 +138,7 @@ Feature: Share by public link
       | shareType  | public_link |
     And user "Alice" has logged in using the webUI
     When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "21-07-2038"
-    And the user gets the info of the last share using the sharing API
+    And the user gets the info of the last public link share using the sharing API
     Then the fields of the last response to user "Alice" should include
       | expiration | 21-07-2038 |
 
@@ -151,20 +151,19 @@ Feature: Share by public link
       | shareType  | public_link |
     And user "Alice" has logged in using the webUI
     When the user changes the expiration of the public link named "Public link" of file "lorem.txt" to "14-09-2017"
-    And the user gets the info of the last share using the sharing API
+    And the user gets the info of the last public link share using the sharing API
     Then the user should see an error message on the public link share dialog saying "Expiration date is in the past"
     And the fields of the last response to user "Alice" should include
       | expiration | 14-10-2038 |
 
-  Scenario: share two file with same name but different paths by public link
+  Scenario: share two files with the same name but different paths by public link
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "Alice" has created folder "/simple-folder"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/lorem.txt"
     And user "Alice" has logged in using the webUI
     When the user creates a new public link for file "lorem.txt" using the webUI
     And the user closes the details dialog
-    And the user opens folder "simple-folder" using the webUI
-    And the user creates a new public link for file "lorem.txt" using the webUI
+    And the user creates a new public link for file "simple-folder/lorem.txt" using the webUI
     And the user browses to the shared-by-link page
     Then file "lorem.txt" with path "" should be listed in the shared with others page on the webUI
     And file "lorem.txt" with path "/simple-folder" should be listed in the shared with others page on the webUI
@@ -232,7 +231,7 @@ Feature: Share by public link
     And user "Alice" has logged in using the webUI
     And the user changes the expiration of the public link named "Public link" of file "lorem.txt" to " "
     Then the user should see an error message on the public link popup saying "Expiration date is required"
-    And the user gets the info of the last share using the sharing API
+    And the user gets the info of the last public link share using the sharing API
     And the fields of the last response to user "Alice" should include
       | expiration | + 5 days |
 
@@ -246,7 +245,7 @@ Feature: Share by public link
       | shareType  | public_link |
     And user "Alice" has logged in using the webUI
     And the user changes the expiration of the public link named "Public link" of file "lorem.txt" to " "
-    And the user gets the info of the last share using the sharing API
+    And the user gets the info of the last public link share using the sharing API
     And the fields of the last response to user "Alice" should include
       | expiration |  |
 


### PR DESCRIPTION
## Description
The core acceptance test steps often refer to "the last created share". Most of the time, the existing code would do an API request to get a list of shares for the user, then choose the returned element that had the largest share id (and I think was usually last in the list). This logic assumed that share id is an ever-increasing value, and/or that the returned response was in some ffirst-to-last order. Those assumptions/heuristics are not valid in all implementations. An implementation (like oCIS or reva) can have share id as some alpha-numeric string that is not "increasing". The list of shares in a response does not have to be in any date-time first-to-last order.

This PR removes that logic from the acceptance test suite.

The new code remembers:
- the response to the last share by user, which contains the share id.
- the share id of that last share by user (this allows finding the last share that was shared by a particular user in the scenario)
- the user name of the user that last created a share (this helps for finding the very last share that was created in a scenario)
- the response to the last creation of a public link share (not by user)
- the share id of the last created public link share

Test steps that actually reference a public link share have been refactored to be like:
```
Given the administrator has expired the last created public link share using the testing API
When user "Alice" tries to update the last public link share using the sharing API with
```
They mention "the last created public link share". Corresponding test step code implementation makes use of the remember last public link share id.

We also have to remember shares that were created in webUI test scenarios.

For public link shares, the webUI has the full link to the new public link share. That has the public-link-token on the end. After creating a public link in the webUI, the test code now uses the API  to get the shares of the user, and finds the share that has the just-created token. It remembers that share data and share id as the "last created public link share".

For shares to users and groups, the webUI has no easy "hook" to the share id of the just-created share. But the test code knows where the user has navigated to in the webUI, and the name of the resource that was just shared. So the test code uses the API to get the shares of the user, and finds the share that has the expected path. It remembers that share data and share id as the "last created share" for the user.

This way, and `Then` steps later in either an API or a webUI test scenario can mention the "last created share" or "last created public link share", and the remembered data will already be up-to-date in the test-runner.

There are some edge cases handled. For example, if a share action is tried, but not expected to work (should give a 4xx response, or the webUI should give some error notification...), and so the share actually will not exist, that is passed through the test-runner code so that it does not try to get and remember the "last created share" in that case.

## Related Issue
#40093 

## How Has This Been Tested?
CI passed here in core
oCIS https://github.com/owncloud/ocis/pull/3906 - passed
reva https://github.com/cs3org/reva/pull/2912 - passed except see comment https://github.com/cs3org/reva/pull/2912#issuecomment-1143564584 - I can look into that later.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
