### PR TITLE
[tests-only] [full-ci] Add test step for 'the info of the last public link share should include

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2509,6 +2509,36 @@ trait Sharing {
 	}
 
 	/**
+	 * @Then /^the response when user "([^"]*)" gets the info of the last public link share should include$/
+	 *
+	 * @param string $user
+	 * @param TableNode|null $body
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theResponseWhenUserGetsInfoOfLastPublicLinkShareShouldInclude(
+		string $user,
+		?TableNode $body
+	):void {
+		$user = $this->getActualUsername($user);
+		$this->verifyTableNodeRows($body, [], $this->shareResponseFields);
+		$this->getShareData($user, (string)$this->getLastPublicLinkShareId());
+		$this->theHTTPStatusCodeShouldBe(
+			200,
+			"Error getting info of last public link share for user $user"
+		);
+		$this->ocsContext->assertOCSResponseIndicatesSuccess(
+			__METHOD__ .
+			' Error getting info of last public link share for user $user\n' .
+			$this->ocsContext->getOCSResponseStatusMessage(
+				$this->getResponse()
+			) . '"'
+		);
+		$this->checkFields($user, $body);
+	}
+
+	/**
 	 * @Then the information of the last share of user :user should include
 	 *
 	 * @param string $user


### PR DESCRIPTION
## Description
In files_classifier (and possibly other oC10 apps)  we have test steps like:
```
    When user "Alice" creates a public link share of file "confidential.docx" using the sharing API
    Then the HTTP status code should be "200"
    And the OCS status code should be "<ocs-status>"
    And the response when user "Alice" gets the info of the last share should include
      | item_type   | file                                                                    |
      | share_type  | public_link                                                             |
      | file_target | /confidential.docx                                                      |
      | path        | /confidential.docx                                                      |
      | permissions | read                                                                    |
      | uid_owner   | Alice                                                                   |
      | mimetype    | application/vnd.openxmlformats-officedocument.wordprocessingml.document |
      | expiration  | +42 days                                                                |
```

After recent refactoring in core test code, we need a `Then` step that checks the response for a public link share:
```
    And the response when user "Alice" gets the info of the last public link share should include
...
```

And that step will use `getLastPublicLinkShareId()` to work out which share id to check.

This PR adds that test step code.

## Related Issue
https://github.com/owncloud/files_classifier/issues/631

## How Has This Been Tested?
Local test run of the failing test scenario.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
