### PR TITLE
[tests-only] Remove useless owncloudLog drone steps

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1152,7 +1152,6 @@ def dav():
                              installServer(phpVersion, db, params["logLevel"]) +
                              davInstall(phpVersion, scriptPath) +
                              fixPermissions(phpVersion, False) +
-                             owncloudLog("server", "src") +
                              [
                                  {
                                      "name": "dav-test",
@@ -1456,7 +1455,6 @@ def phpTests(ctx, testType, withCoverage):
                                  setupScality(phpVersion, needScality) +
                                  params["extraSetup"] +
                                  fixPermissions(phpVersion, False) +
-                                 owncloudLog("server", "src") +
                                  [
                                      {
                                          "name": "%s-tests" % testType,


### PR DESCRIPTION
## Description
The caldav/carddav tests run a PHP dev server in-line with the tests. Errors logged will be seen inline in the test step of the pipeline.

The PHP unit tests do not have a "server" running. They hook in to the individual PHP classes to test them. The "server log file" is not useful/does not exist. If a unit test has a problem then that should be reported in the unit test output.

Remove the `owncloudLog` step from each of these pipelines.

I noticed this just now while looking at some PHP unit test failures and realised that the owncloud log step output is empty.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
