### PR TITLE
[tests-only] Ensure that path is a string in makeDavRequest

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -556,6 +556,12 @@ class WebDavHelper {
 	):ResponseInterface {
 		$baseUrl = self::sanitizeUrl($baseUrl, true);
 
+		// We need to manipulate and use path as a string.
+		// So ensure that it is a string to avoid any type-conversion errors.
+		if ($path === null) {
+			$path = "";
+		}
+
 		$spaceId = null;
 		// get space id if testing with spaces dav
 		if ($davPathVersionToUse === self::DAV_VERSION_SPACES) {


### PR DESCRIPTION
## Description
When running the test-runner with PHP 8.1 (against an oC10 system running PHP 7.4) we get:
https://drone.owncloud.com/owncloud/core/36003/82/13
```
runsh: Total unexpected failed scenarios throughout the test run:
apiWebdavOperations/search.feature:273
apiWebdavOperations/search.feature:289
apiWebdavOperations/search.feature:314
```

```
    When user "Alice" searches for resources tagged with tag "JustARegularTag1" using the webDAV API # TagsContext::userSearchesForTagUsingWebDavAPI()
      Type error: str_replace(): Argument #3 ($subject) must be of type array|string, null given (Behat\Testwork\Call\Exception\FatalThrowableError)
```

Some code passes path=null to `WebDavHelper::makeDavRequest`, which is allowed. If path is null, then set it to the empty string, so that later uses of path, like `str_replace` will not complain about a type error.


## How Has This Been Tested?
CI - PR #40127 demonstrates that this code fixed the problem.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
