### PR TITLE
[tests-only][full-ci]Skip migration status for app test on OC stable

### DIFF
--- a/tests/acceptance/features/cliMain/occMigrationStatus.feature
+++ b/tests/acceptance/features/cliMain/occMigrationStatus.feature
@@ -1,4 +1,4 @@
-@cli
+@cli @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10.0
 Feature: Migration status of apps
   As an admin I want to be able to see the migration status of an app
   So that I can know the current and previous version


### PR DESCRIPTION
### Description

This PR skips the `occ migration status` for app tests for latest stable OC as it is failing on nightly.   
Related issue : https://github.com/owncloud/user_ldap/issues/738