### PR TITLE
[tests-only] [full-ci] Fix deleteLastShareUsingSharingApi

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2003,8 +2003,8 @@ trait Sharing {
 	}
 
 	/**
-	 * @param string $user
-	 * @param string|null $sharer
+	 * @param string $user the user who will do the delete request
+	 * @param string|null $sharer the specific user whose share will be deleted (if specified)
 	 * @param bool $deleteLastPublicLink
 	 *
 	 * @return void
@@ -2015,9 +2015,10 @@ trait Sharing {
 			$shareId = $this->getLastPublicLinkShareId();
 		} else {
 			if ($sharer === null) {
-				$sharer = $user;
+				$shareId = $this->getLastShareId();
+			} else {
+				$shareId = $this->getLastShareIdForUser($sharer);
 			}
-			$shareId = $this->getLastShareIdForUser($sharer);
 		}
 		$url = $this->getSharesEndpointPath("/$shareId");
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(


### PR DESCRIPTION
## Description
If a test scenario creates a few shares, then has steps like:
```
    Given user "Alice" has created folder "folder"
    And user "Alice" has shared folder "folder" with user "Brian" with permissions "31"
    And user "Brian" has accepted share "/folder" offered by user "Alice"
    And user "Brian" has shared folder "Shares/folder" with user "Carol" with permissions "31"
    And user "Carol" has accepted share "/folder" offered by user "Brian"
    And user "Carol" has shared folder "Shares/folder" with user "Gina" with permissions "17"
    And user "Gina" has accepted share "/folder" offered by user "Carol"
    When user "Alice" deletes the last share using the sharing API
```

The code would delete the last share that Alice that Alice had created. That was wrong. The test code should delete the very last share - the share from Carol to Gina. And in a test like this, Alice can delete that share, because Alice is the original sharer of the folder.

This PR fixes the test code. It regressed when I did the recent refactoring of all the test code that refers to "the last share".

## How Has This Been Tested?
CI and local run of an example test from oCIS where this had a problem

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
