### PR TITLE
Do not overlap the author's comment with other things on small screens

### DIFF
--- a/apps/comments/css/comments.css
+++ b/apps/comments/css/comments.css
@@ -29,6 +29,7 @@
 	width: 28px;
 	height: 28px;
 	line-height: 28px;
+	flex-shrink: 0;
 }
 
 #commentsTabView .comment {
@@ -83,28 +84,41 @@
 	vertical-align: middle;
 }
 
+#commentsTabView .authorRow>* {
+	margin: 0 5px;
+}
+
 #commentsTabView .comment .authorRow {
 	margin-bottom: 5px;
 	position: relative;
+	display: flex;
+	align-items: center;
+	max-height: 30px;
 }
 
 #commentsTabView .comment .author {
+	display: inline;
 	font-weight: bold;
+	flex-grow: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 #commentsTabView .comment .date {
-	position: absolute;
-	right: 0;
+	flex-shrink: 0;
 }
 
 #commentsTabView .comment .action {
 	opacity: 0;
 	vertical-align: middle;
 	display: inline-block;
+	flex-shrink: 0;
 }
 
 #commentsTabView .comment:hover .action {
 	opacity: 0.3;
+	flex-shrink: 0;
 }
 
 #commentsTabView .comment .action:hover {

--- a/changelog/unreleased/40142
+++ b/changelog/unreleased/40142
@@ -1,0 +1,12 @@
+Change: Improve visualization of author's comment in the comments section
+
+Previously, a long display name for the author's comment could overlap
+with the "edit" action and the date. Worst case, the comment might not be
+edited because the "edit" action was below the author's display name, so
+you might not be able to click the action.
+
+Right now, the author's display name won't overlap with the rest of the
+elements. The display name will be cut if needed, but both the "edit"
+action and the date will be clearly visible.
+
+https://github.com/owncloud/core/pull/40142


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
On small screens, the comment section might be too small to hold a long display name for the author of the comment. The display name will overlap with the "edit" button and the date.
This have been adjusted so there is no overlapping of those elements. The display name will be cut to ensure you can edit the comment and see the date. It will be adjusted with the available width.

## Related Issue
https://github.com/owncloud/enterprise/issues/5177

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested using a user with a long display name.

## Screenshots (if appropriate):
![Screenshot from 2022-06-15 12-36-03](https://user-images.githubusercontent.com/1477829/173807594-0eae3823-7f84-45b9-8143-e9e2be11ab52.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
