### PR TITLE
Add missing js file

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -21,6 +21,7 @@ OCP\Util::addScript('files', 'newfilemenu');
 OCP\Util::addScript('files', 'files');
 OCP\Util::addScript('files', 'filelist');
 OCP\Util::addScript('files', 'keyboardshortcuts');
+OCP\Util::addScript('files', 'fileactionsapplicationselectmenu');
 
 // OpenGraph Support: http://ogp.me/
 OCP\Util::addHeader('meta', ['property' => "og:title", 'content' => $theme->getName() . ' - ' . $theme->getSlogan()]);

--- a/changelog/unreleased/40143
+++ b/changelog/unreleased/40143
@@ -1,0 +1,7 @@
+Bugfix: Application selection menu now appears on shared folders
+
+An app selection menu will appear on public folder links when you click
+in a file that could be opened with multiple apps. The behavior is the
+same as in the regular file listing.
+
+https://github.com/owncloud/core/pull/40143


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The missing js file was causing a crash in the js thread, preventing showing the action menu in public links. The crash is fixed and the menu shows up now.

## Related Issue
https://github.com/owncloud/enterprise/issues/5166

## Motivation and Context
The crash happen when the file is clicked, but before the expected popup menu is shown (https://github.com/owncloud/core/blob/45c9aa5e86f06601c7e5e6cf92d3595e376afaac/apps/files/js/filelist.js#L701). I guess the "click" wasn't prevented due to the crash, which instead of showing the popup menu, the browser acted as if the file was clicked normally, redirecting the user to the first app that could handle the file type (or maybe downloading the file)

## How Has This Been Tested?
Install the pdf viewer and the collabora apps, and then follow the steps in the issue. A popup menu appears now.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
