### PR TITLE
Add configuration option to bypass proxy settings for some domains

### DIFF
--- a/changelog/unreleased/40148
+++ b/changelog/unreleased/40148
@@ -1,0 +1,6 @@
+Enhancement: Add config option to bypass the proxy setting by domain
+
+The new "proxy_ignore" option allows the admin to set a list of domains
+that won't go through the proxy set via the "proxy" option
+
+https://github.com/owncloud/core/pull/40148

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -562,6 +562,13 @@ $CONFIG = [
 'proxy' => '',
 
 /**
+ * Define a list of hostnames that won't be proxied.
+ * This option only applies if the `proxy` option is used
+ * Example: `['specific.hostname.com', '.sub.domain.com']`.
+ */
+'proxy_ignore' => [],
+
+/**
  * Define proxy authentication
  * The optional authentication for the proxy to use to connect to the internet.
  * The format is: `username:password`.

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -74,7 +74,10 @@ class Client implements IClient {
 			$proxyHost = $this->config->getSystemValue('proxy', null);
 
 			if ($proxyHost !== null && !isset($options[RequestOptions::PROXY])) {
-				$options[RequestOptions::PROXY] = 'tcp://' . $proxyHost;
+				$options[RequestOptions::PROXY] = [
+					'http' => 'tcp://' . $proxyHost,
+					'https' => 'tcp://' . $proxyHost,
+				];
 			}
 
 			if ($proxyHost !== null && !isset($options['config']['stream_context']['http']['request_fulluri'])) {
@@ -111,8 +114,17 @@ class Client implements IClient {
 		}
 
 		$options[RequestOptions::HEADERS]['User-Agent'] = 'ownCloud Server Crawler';
-		if ($this->getProxyUri() !== '') {
-			$options[RequestOptions::PROXY] = $this->getProxyUri();
+		$proxyUri = $this->getProxyUri();
+		if ($proxyUri !== '') {
+			$noProxyList = $this->config->getSystemValue('proxy_ignore', []);
+			if (!\is_array($noProxyList)) {
+				$noProxyList = [];
+			}
+			$options[RequestOptions::PROXY] = [
+				'http' => $proxyUri,
+				'https' => $proxyUri,
+				'no' => $noProxyList,
+			];
 		}
 
 		$this->defaultOptions = $options;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The `proxy` config option allows the admin to set a proxy that will be used for the ownCloud requests. The new `proxy_ignore` option will allow the bypass of that proxy for specific domains

## Related Issue
https://github.com/owncloud/enterprise/issues/4979

## Motivation and Context
Some domains might not need to go through the proxy.

## How Has This Been Tested?
Manually tested
1. Configure mitmproxy and expose a port for it
2. Set the `proxy` setting in ownCloud to use the proxy configured in step 1
3. Go to the market app and try to load the contents

With the proxy active, the proxy should log the request. It might also reject the request due to SSL certificates, but an error should appear in the proxy.
Setting the new `'proxy_ignore' => ['.owncloud.com']` (for example), the market app is expected to load successfully without going through the proxy, so there shouldn't be any activity there.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
