### PR TITLE
[tests-only] [full-ci] Remove special files_primary_s3 guzzle code from CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2558,9 +2558,6 @@ def installExtraApps(phpVersion, extraApps, pathOfServerUnderTest):
     commandArray = []
     for app, command in extraApps.items():
         commandArray.append("ls %s/apps/%s || git clone https://github.com/owncloud/%s.git %s/apps/%s" % (pathOfServerUnderTest, app, app, pathOfServerUnderTest, app))
-        if (app == "files_primary_s3"):
-            commandArray.append("cd /drone/src/apps/%s" % app)
-            commandArray.append("git checkout update-guzzle-6")
         if (command != ""):
             commandArray.append("cd %s/apps/%s" % (pathOfServerUnderTest, app))
             commandArray.append(command)


### PR DESCRIPTION
## Description
These lines were added because the support for Guzzle7 in files_primary_s3 was in a branch called `update-guzzle-6` (originally it was created before Guzzle7 was released). That PR https://github.com/owncloud/files_primary_s3/pull/498 has now been merged to files_primary_s3 master. So we no longer need to checkout the special branch.

## Related Issue
https://github.com/owncloud/core/issues/39387

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
