### PR TITLE
Do not invalidate app tokens in case LDAP connection is temporary una…

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -851,6 +851,13 @@ class Session implements IUserSession, Emitter {
 			$this->tokenProvider->updateToken($dbToken);
 			return true;
 		}
+                
+                // in case LDAP connection is temporary unavailable we do not want to invalidate the token
+                $uid = $dbToken->getUID();
+                $user = $this->manager->get($uid);
+                if ($user->getBackendClassName() === 'LDAP' && $this->activeUser == null) {
+                        return true;
+                }
 
 		if ($this->manager->checkPassword($dbToken->getLoginName(), $pwd) === false
 			|| ($this->activeUser !== null && !$this->activeUser->isEnabled())) {

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -123,14 +123,15 @@ class SessionTest extends TestCase {
 		$expectedUser->expects($this->once())
 			->method('isEnabled')
 			->will($this->returnValue(true));
+                
 
 		$this->tokenProvider->expects($this->once())
 			->method('updateTokenActivity')
 			->with($token);
 
-		$manager->expects($this->any())
+		$manager
 			->method('get')
-			->with($expectedUser->getUID())
+			//->with($expectedUser->getUID())
 			->will($this->returnValue($expectedUser));
 
 		$userSession = new Session(
@@ -1053,6 +1054,11 @@ class SessionTest extends TestCase {
 			->with('APP-PASSWORD');
 		$userSession->expects($this->once())
 			->method('logout');
+               
+                $user->method('getBackendClassName')
+                        ->will($this->returnValue('LDAP'));
+                $userManager->method('get')
+                        ->will($this->returnValue($user));
 
 		$userSession->setUser($user);
 		$userSession->validateSession();

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -123,8 +123,7 @@ class SessionTest extends TestCase {
 		$expectedUser->expects($this->once())
 			->method('isEnabled')
 			->will($this->returnValue(true));
-                
-
+				
 		$this->tokenProvider->expects($this->once())
 			->method('updateTokenActivity')
 			->with($token);
@@ -1054,11 +1053,11 @@ class SessionTest extends TestCase {
 			->with('APP-PASSWORD');
 		$userSession->expects($this->once())
 			->method('logout');
-               
-                $user->method('getBackendClassName')
-                        ->will($this->returnValue('LDAP'));
-                $userManager->method('get')
-                        ->will($this->returnValue($user));
+			   
+		$user->method('getBackendClassName')
+						->will($this->returnValue('LDAP'));
+		$userManager->method('get')
+						->will($this->returnValue($user));
 
 		$userSession->setUser($user);
 		$userSession->validateSession();


### PR DESCRIPTION
…vailable

## Description

App tokens are getting deleted in case LDAP connection is temporary not available.

## Related Issue

- https://github.com/owncloud/enterprise/issues/5221

## Motivation and Context

Whenever connection to the LDAP server becomes unavailable app tokens are getting deleted after some minutes causing disconnection of connected clients.

## How Has This Been Tested?

1. Create an app token over /settings/personal?sectionid=security and use it to connect a desktop client
2. Deliberately cutting connection to the LDAP server;
--> without this fix: app token is getting deleted after some minutes causing disconnection of the desktop client
--> with this fix: app token is still valid till connection is back.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised