### PR TITLE
Add batch action to allow sharing with multiple users at once

### DIFF
--- a/changelog/unreleased/40155
+++ b/changelog/unreleased/40155
@@ -1,0 +1,7 @@
+Enhancement: Allow sharing with multiple users at once
+
+It is now possible to share resources with multiple users at once
+via the following format: user1;user2;user3.
+
+https://github.com/owncloud/core/pull/40155
+https://github.com/owncloud/enterprise/issues/2865

--- a/changelog/unreleased/40155
+++ b/changelog/unreleased/40155
@@ -1,7 +1,7 @@
 Enhancement: Allow sharing with multiple users at once
 
 It is now possible to share resources with multiple users at once
-via the following format: user1;user2;user3.
+via the following format: user1, user2, user3.
 
 https://github.com/owncloud/core/pull/40155
 https://github.com/owncloud/enterprise/issues/2865

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -277,16 +277,25 @@
 						if (isBatch) {
 							return view._getUsersForBatchAction(trimmedSearch).then(function (res) {
 								if (res.found.length) {
-									suggestions.push({ batch: res.found, failedBatch: res.notFound, label: trimmedSearch, value: {} });
+									var labelArray = [];
+									for (i = 0; i < res.found.length; i++) {
+										labelArray.push(res.found[i].shareWith)
+									}
+
+									suggestions.push({ batch: res.found, failedBatch: res.notFound, label: labelArray.join(', '), value: {} });
 								}
 
 								$loading.addClass('hidden');
 								$loading.removeClass('inlineblock');
 								if (suggestions.length) {
+									$('.shareWithField').removeClass('error')
+										.tooltip('hide')
+										.autocomplete("option", "autoFocus", true);
 									return response(suggestions, result);
 								}
 
 								view._displayError(t('core', 'No users or groups found'));
+								return response(undefined, result);
 							})
 						}
 

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -96,7 +96,7 @@
 		shareeListView: undefined,
 
 		/** @type {string} **/
-		batchActionSeparator: ', ',
+		batchActionSeparator: ',',
 
 		events: {
 			'input .shareWithField': 'onShareWithFieldChanged',
@@ -604,6 +604,8 @@
 			var users = Array.from(new Set(search.split(this.batchActionSeparator)));
 
 			for (var i = 0; i < users.length; i++) {
+				if (!users[i]) continue;
+				var user = users[i].trim();
 				promises.push(
 					$.ajax({
 						url: OC.linkToOCS('apps/files_sharing/api/v1') + 'sharees',
@@ -611,11 +613,11 @@
 						dataType: 'json',
 						data: {
 							format: 'json',
-							search: users[i],
+							search: user,
 							perPage: 200,
 							itemType: view.model.get('itemType')
 						},
-						context: { user: users[i] }
+						context: { user: user }
 					})
 					.done(function (result) {
 						if (result.ocs.data.exact.users.length) {

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -201,7 +201,7 @@
 						return response({osc: {batch: foundUsers, label: trimmedSearch, value: {}}});
 					}
 
-					this._displayError(t('core', 'No users found'));
+					view._displayError(t('core', 'No users found'));
 				})
 			}
 
@@ -309,7 +309,7 @@
 									{chars: suggestStarts}
 								);
 							}
-							this._displayError(title);
+							view._displayError(title);
 							response(undefined, result);
 						}
 					} else {

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -268,12 +268,13 @@
 							}
 						}
 
+						var isBatch = trimmedSearch.indexOf(view.batchActionSeparator) !== -1;
 						var suggestions = users.concat(groups);
-						if (suggestions.length < 1 && !trimmedSearch.includes(view.batchActionSeparator)) {
+						if (suggestions.length < 1 && !isBatch) {
 							suggestions = suggestions.concat(remotes);
 						}
 
-						if (trimmedSearch.includes(view.batchActionSeparator)) {
+						if (isBatch) {
 							return view._getUsersForBatchAction(trimmedSearch).then(function (res) {
 								if (res.found.length) {
 									suggestions.push({ batch: res.found, failedBatch: res.notFound, label: trimmedSearch, value: {} });
@@ -544,7 +545,7 @@
 		 * @private
 		 */
 		_showFailedBatchSharees: function(users) {
-			var failedUsersStr = users.join(', ')
+			var failedUsersStr = users.join(', ');
 			OC.Notification.show(
 				t('core', 'Could not be shared with the following users: {users}', {users: failedUsersStr}),
 				{type: 'error'}
@@ -590,7 +591,7 @@
 			var view = this;
 			var foundUsers = [];
 			var notFound = [];
-			var promises= [];
+			var promises = [];
 			var users = Array.from(new Set(search.split(this.batchActionSeparator)));
 
 			for (var i = 0; i < users.length; i++) {

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -748,6 +748,16 @@ describe('OC.Share.ShareDialogView', function() {
 				expect(el.is('li')).toEqual(true);
 				expect(el.hasClass('user')).toEqual(true);
 			});
+
+			it('renders a batch element', function() {
+				dialog.render();
+				var el = dialog.autocompleteRenderItem(
+						$("<ul></ul>"),
+						{label: "1", batch: [], value: { shareType: OC.Share.SHARE_TYPE_USER }}
+				);
+				expect(el.is('li')).toEqual(true);
+				expect(el.hasClass('user')).toEqual(true);
+			});
 		});
 
 		it('calls addShare after selection', function() {

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -344,8 +344,11 @@ describe('OC.Share.ShareDialogView', function() {
 
 		it('fetches multiple users for batch action', function () {
 			dialog.render();
-			dialog._getUsersForBatchAction('user01;user02').then(function(users) {
-				var expected = [{'shareType': 0, 'shareWith': 'user01'}, {'shareType': 0, 'shareWith': 'user02'}];
+			dialog._getUsersForBatchAction('user01, user02').then(function(users) {
+				var expected = {
+					found: [{'shareType': 0, 'shareWith': 'user01'}, {'shareType': 0, 'shareWith': 'user02'}],
+					notFound: []
+				};
 				expect(users).toEqual(expected);
 			});
 

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -344,10 +344,9 @@ describe('OC.Share.ShareDialogView', function() {
 
 		it('fetches multiple users for batch action', function () {
 			dialog.render();
-			var response = sinon.stub();
-			dialog.autocompleteHandler({term: 'user01;user02'}, response).then(function() {
+			dialog._getUsersForBatchAction('user01;user02').then(function(users) {
 				var expected = [{'shareType': 0, 'shareWith': 'user01'}, {'shareType': 0, 'shareWith': 'user02'}];
-				expect(response.getCall(0).args[0].osc.batch).toEqual(expected);
+				expect(users).toEqual(expected);
 			});
 
 			var getRequestResponse = function(user) {

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -342,6 +342,39 @@ describe('OC.Share.ShareDialogView', function() {
 			expect(autocompleteStub.calledWith("option", "autoFocus", true)).toEqual(true);
 		});
 
+		it('fetches multiple users for batch action', function () {
+			dialog.render();
+			var response = sinon.stub();
+			dialog.autocompleteHandler({term: 'user01;user02'}, response).then(function() {
+				var expected = [{'shareType': 0, 'shareWith': 'user01'}, {'shareType': 0, 'shareWith': 'user02'}];
+				expect(response.getCall(0).args[0].osc.batch).toEqual(expected);
+			});
+
+			var getRequestResponse = function(user) {
+				return JSON.stringify({
+					'ocs' : {
+						'meta' : {
+							'status' : 'success',
+							'statuscode' : 100,
+							'message' : null
+						},
+						'data' : {
+							'exact' : {
+								'users'  : [{'label': 'user01', 'value': {'shareType': 0, 'shareWith': user}}],
+								'groups' : [],
+								'remotes': []
+							},
+							'users'  : [],
+							'groups' : [],
+							'remotes': []
+						}
+					}
+				});
+			}
+			fakeServer.requests[0].respond(200, {'Content-Type': 'application/json'}, getRequestResponse('user01'));
+			fakeServer.requests[1].respond(200, {'Content-Type': 'application/json'}, getRequestResponse('user02'));
+		});
+
 		describe('filter out', function() {
 			it('the current user', function () {
 				dialog.render();


### PR DESCRIPTION
## Description
This feature allows sharing resources with multiple users at once via the following format: *user1, user2, user3*

If you have the `guest` app installed and active, https://github.com/owncloud/guests/pull/506 is required to properly use this feature. Unfortunately, there is no way to overcome this as the `guest` app extends the sharing functionality in a very bad way by re-implementing it. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Works towards https://github.com/owncloud/enterprise/issues/2865

## Screenshot

![image](https://user-images.githubusercontent.com/50302941/174735571-2b814e01-8c6e-4d4d-92ed-e0c4a768891d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
