### PR TITLE
[full-ci] Convert from utf8_encode to mb_convert_encoding

### DIFF
--- a/changelog/unreleased/40158
+++ b/changelog/unreleased/40158
@@ -1,0 +1,6 @@
+Bugfix: Convert from utf8_encode to mb_convert_encoding
+
+Function `utf8_encode` will be deprecated and removed in future PHP versions.
+It has been replaced with function mb_convert_encoding.
+
+https://github.com/owncloud/core/pull/40158

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -689,15 +689,13 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 
 		$pathInfo = $this->getRawPathInfo();
-		// following is taken from \Sabre\HTTP\URLUtil::decodePathSegment
 		$pathInfo = \rawurldecode($pathInfo);
 		$encoding = \mb_detect_encoding($pathInfo, ['UTF-8', 'ISO-8859-1']);
 
 		switch ($encoding) {
 			case 'ISO-8859-1':
-				$pathInfo = \utf8_encode($pathInfo);
+				$pathInfo = \mb_convert_encoding($pathInfo, 'UTF-8', $encoding);
 		}
-		// end copy
 
 		return $pathInfo;
 	}

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -1280,9 +1280,15 @@ class RequestTest extends TestCase {
 	 * @dataProvider genericPathInfoProvider
 	 * @param string $requestUri
 	 * @param string $scriptName
-	 * @param string $expected
+	 * @param string $expectedGetPathInfo
+	 * @param string $expectedGetRawPathInfo
 	 */
-	public function testGetRawPathInfoWithoutSetEnvGeneric($requestUri, $scriptName, $expected) {
+	public function testGetRawPathInfoWithoutSetEnvGeneric($requestUri, $scriptName, $expectedGetPathInfo, $expectedGetRawPathInfo) {
+		if ($expectedGetRawPathInfo === '') {
+			$expected = $expectedGetPathInfo;
+		} else {
+			$expected = $expectedGetRawPathInfo;
+		}
 		$request = new Request(
 			[
 				'server' => [
@@ -1350,14 +1356,15 @@ class RequestTest extends TestCase {
 	 */
 	public function genericPathInfoProvider() {
 		return [
-			['/core/index.php?XDEBUG_SESSION_START=14600', '/core/index.php', ''],
-			['/index.php/apps/files/', 'index.php', '/apps/files/'],
-			['/index.php/apps/files/../&amp;/&?someQueryParameter=QueryParam', 'index.php', '/apps/files/../&amp;/&'],
-			['/remote.php/漢字編碼方法 / 汉字编码方法', 'remote.php', '/漢字編碼方法 / 汉字编码方法'],
-			['///removeTrailin//gSlashes///', 'remote.php', '/removeTrailin/gSlashes/'],
-			['/remove/multiple/Slashes/In/ScriptName/', '//remote.php', '/remove/multiple/Slashes/In/ScriptName/'],
-			['/', '/', ''],
-			['', '', ''],
+			['/core/index.php?XDEBUG_SESSION_START=14600', '/core/index.php', '', ''],
+			['/index.php/apps/files/', 'index.php', '/apps/files/', ''],
+			['/index.php/apps/files/../&amp;/&?someQueryParameter=QueryParam', 'index.php', '/apps/files/../&amp;/&', ''],
+			['/remote.php/漢字編碼方法 / 汉字编码方法', 'remote.php', '/漢字編碼方法 / 汉字编码方法', ''],
+			['/remote.php/pound-cent-AE-%A3%A2%C6-in-ISO-8859-1', 'remote.php', '/pound-cent-AE-£¢Æ-in-ISO-8859-1', '/pound-cent-AE-%A3%A2%C6-in-ISO-8859-1'],
+			['///removeTrailin//gSlashes///', 'remote.php', '/removeTrailin/gSlashes/', ''],
+			['/remove/multiple/Slashes/In/ScriptName/', '//remote.php', '/remove/multiple/Slashes/In/ScriptName/', ''],
+			['/', '/', '', ''],
+			['', '', '', ''],
 		];
 	}
 


### PR DESCRIPTION
## Description
https://wiki.php.net/rfc/remove_utf8_decode_and_utf8_encode

https://www.php.net/manual/en/function.utf8-encode.php is being deprecated in PHP 8.2 and removed at some time in the future. I happened to notice this while looking at other things. There is an easy change to https://www.php.net/mb_convert_encoding so, IMO, we may as well do it now.

https://github.com/sabre-io/http/blob/master/CHANGELOG.md#500-alpha1-2018-02-16
`Sabre\HTTP\URLUtil` was removed back in 2018 and the code has changed anyway, so I removed the out-dated comment related to that.

I added a unit test case for filename `pound-cent-AE-%A3%A2%C6-in-ISO-8859-1` - that has 3 ISO8859-1 "Latin-1" special characters in it. For that case, the code goes through the changed line and does produce the expected UTF-8 encoding. That unit test case passes with the previous code (I ran it manually), and still passes with the changed code. So there is not any obvious regression.

## Related Issue

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
