### PR TITLE
Complete apache auth (SAML/SSO) flow with redirect page

### DIFF
--- a/changelog/unreleased/40161
+++ b/changelog/unreleased/40161
@@ -1,0 +1,11 @@
+Bugfix: Apps requiring SAML/SSO session now load correctly at first page
+
+Apps that require session to load some content at request start, could not be loaded due 
+to missing SAML/SSO session objects that could only be obtained after the app loaded or at next visited page
+when that object was correctly persisted. Now, after handling apache backend session, auth success 
+confirmation page is shown that redirects to the owncloud landing page.
+
+https://github.com/owncloud/core/pull/40161
+https://github.com/owncloud/enterprise/issues/4712
+https://github.com/owncloud/enterprise/issues/5225
+https://github.com/owncloud/core/issues/31052

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -130,7 +130,7 @@ class LoginController extends Controller {
 			// initiate login success redirect on client-side
 			//
 			// NOTE: as of https://github.com/owncloud/core/pull/31054 to allow alternative login methods
-			// one needs to setup https://doc.owncloud.com/server/10.10/admin_manual/enterprise/user_management/user_auth_shibboleth.html#other-login-mechanisms
+			// one needs to setup https://doc.owncloud.com/server/next/admin_manual/enterprise/user_management/user_auth_shibboleth.html#other-login-mechanisms
 			// so that on first login there is no valid apache session, and on click to alternative login from config 'login.alternatives'
 			// code reaches handleApacheAuth here after redirect from SSO/SAML provider
 			// NOTE: this redirect page is required to correctly preserve session on client, doing redirect using RedirectResponse could cause

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -29,6 +29,7 @@ use OC\Authentication\TwoFactorAuth\Manager;
 use OC\User\Session;
 use OC_App;
 use OC_Util;
+use OC_User;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -122,10 +123,32 @@ class LoginController extends Controller {
 	 * @return TemplateResponse|RedirectResponse
 	 */
 	public function showLoginForm($user, $redirect_url, $remember_login) {
-		if (\OC_User::handleApacheAuth() || $this->userSession->isLoggedIn()) {
-			return new RedirectResponse($this->getDefaultUrl());
+		// check if there is apache auth backend available and try to obtain session,
+		// if apache backend not registered or failed to login, proceed with show login form
+		if ($this->handleApacheAuth()) {
+			// apache auth was completed server-side and there is active session,
+			// initiate login success redirect on client-side
+			//
+			// NOTE: as of https://github.com/owncloud/core/pull/31054 to allow alternative login methods
+			// one needs to setup https://doc.owncloud.com/server/10.10/admin_manual/enterprise/user_management/user_auth_shibboleth.html#other-login-mechanisms
+			// so that on first login there is no valid apache session, and on click to alternative login from config 'login.alternatives'
+			// code reaches handleApacheAuth here after redirect from SSO/SAML provider
+			// NOTE: this redirect page is required to correctly preserve session on client, doing redirect using RedirectResponse could cause
+			// some apps not being able to load correctly (https://github.com/owncloud/enterprise/issues/5225).
+			return new TemplateResponse(
+				'core',
+				'apacheauthredirect',
+				[],
+				'guest'
+			);
 		}
 
+		// check if user logged in already and has active session
+		if ($this->userSession->isLoggedIn()) {
+			// most likely user manually entered this page, redirect to default url
+			return new RedirectResponse($this->getDefaultUrl());
+		}
+		
 		$parameters = [];
 		$loginMessages = $this->session->get('loginMessages');
 		$errors = [];
@@ -219,6 +242,7 @@ class LoginController extends Controller {
 
 		$parameters['strictLoginEnforced'] = $this->config->getSystemValue('strict_login_enforced', false);
 
+		// start the login flow for auth backends (including alternative logins if registered)
 		return new TemplateResponse(
 			$this->appName,
 			'login',
@@ -300,6 +324,13 @@ class LoginController extends Controller {
 		}
 
 		return new RedirectResponse($this->getDefaultUrl());
+	}
+
+	/**
+	 * @return boolean|null
+	 */
+	protected function handleApacheAuth() {
+		return OC_User::handleApacheAuth();
 	}
 
 	/**

--- a/core/js/apacheauthredirect.js
+++ b/core/js/apacheauthredirect.js
@@ -1,0 +1,23 @@
+/**
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+ (function() {
+
+	window.location = OC.generateUrl('/');
+
+})();

--- a/core/templates/apacheauthredirect.php
+++ b/core/templates/apacheauthredirect.php
@@ -1,0 +1,10 @@
+<?php
+
+script('core', [
+	'apacheauthredirect'
+]);
+?>
+
+<span class="msg">
+	<?php p($l->t('The application was authorized successfully. You can now close this window.'));?>
+</span>

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -449,6 +449,37 @@ class LoginControllerTest extends TestCase {
 		$this->assertEquals($expectedResponse, $this->loginController->showLoginForm('0', '', ''));
 	}
 
+	public function testShowLoginFormWithApacheBackend() {
+		$this->userSession
+			->expects($this->never())
+			->method('isLoggedIn');
+		$this->loginController = $this->getMockBuilder(LoginController::class)
+			->setMethods(['handleApacheAuth'])
+			->setConstructorArgs([
+				'core',
+				$this->request,
+				$this->userManager,
+				$this->config,
+				$this->session,
+				$this->userSession,
+				$this->urlGenerator,
+				$this->twoFactorManager,
+				$this->licenseManager
+			])
+			->getMock();
+		$this->loginController->expects($this->once())
+			->method('handleApacheAuth')
+			->willReturn(true);
+
+		$expectedResponse = new TemplateResponse(
+			'core',
+			'apacheauthredirect',
+			[],
+			'guest'
+		);
+		$this->assertEquals($expectedResponse, $this->loginController->showLoginForm('0', '', ''));
+	}
+
 	public function dataLoginWithInvalidCredentials() {
 		return [
 			[false, 1],


### PR DESCRIPTION
## Description
Without this change, server-side redirect to default page for Apache Auth (e.g. Shibboleth) resulted in session data missing on client side. Flow was incomplete and was missing final redirect page on client side to correctly handle redirect_url and persist the session data on the client.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5225
- Fixes https://github.com/owncloud/enterprise/issues/4712
- Related https://github.com/owncloud/core/pull/31054

## How Has This Been Tested?
- manually in internal oc2.lab test instance

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Base code changes
- [x] Make sure to handle corner cases in login
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
