### PR TITLE
Fix UI message display when group cannot be created

### DIFF
--- a/changelog/unreleased/40163
+++ b/changelog/unreleased/40163
@@ -1,0 +1,7 @@
+Bugfix: Display error message when a group cannot be created
+
+If a new group could not be created on the user-management UI, the error message
+text was not displayed. This problem has been fixed.
+
+https://github.com/owncloud/core/issues/40162
+https://github.com/owncloud/core/pull/40163

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -156,7 +156,9 @@ var GroupList;
 					}
 					GroupList.toggleAddGroup();
 				}).fail(function(result) {
-					OC.Notification.showTemporary(t('settings', 'Error creating group: {message}', {message: result.responseJSON.message}));
+					OC.Notification.showTemporary(t('settings', 'Error creating group: {message}', {
+						message: result.responseJSON.data.message
+					}));
 				});
 		},
 

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -76,3 +76,7 @@ Feature: Add group
     Then the user count of group "grp1" should display 3 users on the webUI
     When the administrator reloads the users page
     Then the user count of group "grp1" should display 3 users on the webUI
+
+  Scenario: Cannot add group with white-space in the name
+    When the administrator adds group "whitespace " using the webUI
+    Then a notification should be displayed on the webUI with the text "Error creating group: Unable to add group."


### PR DESCRIPTION
## Description
The JS was trying to get the message text from `result.responseJSON.message` but actually it is found in `result.responseJSON.data.message`

## Related Issue
- Fixes #40162 

## How Has This Been Tested?
CI and local use of the User Management UI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
