### PR TITLE
[full-ci] Make add group error responses consistent

### DIFF
--- a/changelog/unreleased/40165
+++ b/changelog/unreleased/40165
@@ -1,0 +1,7 @@
+Bugfix: Error responses to add group API requests are inconsistent
+
+Some response error messages were contained in a `data` structure. Others were not.
+They have now been made consistent. They are not contained in a `data` structure.
+
+https://github.com/owncloud/core/issues/40164
+https://github.com/owncloud/core/pull/40165

--- a/settings/Controller/GroupsController.php
+++ b/settings/Controller/GroupsController.php
@@ -104,6 +104,7 @@ class GroupsController extends Controller {
 		if ($this->groupManager->groupExists($id)) {
 			return new DataResponse(
 				[
+					'status' => 'error',
 					'message' => (string)$this->l10n->t('Group already exists.')
 				],
 				Http::STATUS_CONFLICT
@@ -121,9 +122,7 @@ class GroupsController extends Controller {
 		return new DataResponse(
 			[
 				'status' => 'error',
-				'data' => [
-					'message' => (string)$this->l10n->t('Unable to add group.')
-				]
+				'message' => (string)$this->l10n->t('Unable to add group.')
 			],
 			Http::STATUS_FORBIDDEN
 		);

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -157,7 +157,7 @@ var GroupList;
 					GroupList.toggleAddGroup();
 				}).fail(function(result) {
 					OC.Notification.showTemporary(t('settings', 'Error creating group: {message}', {
-						message: result.responseJSON.data.message
+						message: result.responseJSON.message
 					}));
 				});
 		},

--- a/tests/Settings/Controller/GroupsControllerTest.php
+++ b/tests/Settings/Controller/GroupsControllerTest.php
@@ -245,6 +245,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 		$expectedResponse = new DataResponse(
 			[
+				'status' => 'error',
 				'message' => 'Group already exists.'
 			],
 			Http::STATUS_CONFLICT
@@ -290,7 +291,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$expectedResponse = new DataResponse(
 			[
 				'status' => 'error',
-				'data' => ['message' => 'Unable to add group.']
+				'message' => 'Unable to add group.'
 			],
 			Http::STATUS_FORBIDDEN
 		);

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -80,3 +80,8 @@ Feature: Add group
   Scenario: Cannot add group with white-space in the name
     When the administrator adds group "whitespace " using the webUI
     Then a notification should be displayed on the webUI with the text "Error creating group: Unable to add group."
+
+  Scenario: Add group with the same name as an existing group
+    Given group "grp1" has been created
+    When the administrator adds group "grp1" using the webUI
+    Then a notification should be displayed on the webUI with the text "Error creating group: Group already exists."


### PR DESCRIPTION
## Description
See the issue for details of what was the problem. This PR makes the error responses to "create group" consistent - the error message text is not enclosed in a `'data'` structure. So the webUI can now find the message consistently.

## Related Issue
- Fixes #40164 

## How Has This Been Tested?
Local run of test scenarios.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
