### PR TITLE
[tests-only] skip new 'add group' test on older oC10

### DIFF
--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -77,6 +77,7 @@ Feature: Add group
     When the administrator reloads the users page
     Then the user count of group "grp1" should display 3 users on the webUI
 
+  @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10
   Scenario: Cannot add group with white-space in the name
     When the administrator adds group "whitespace " using the webUI
     Then a notification should be displayed on the webUI with the text "Error creating group: Unable to add group."


### PR DESCRIPTION
## Description
This test was added yesterday, along with the related fix. See PR #40163 

The test will not pass against Oc10.10 and earlier, so skip it in that case.

## Related Issue
- Fixes https://github.com/owncloud/encryption/issues/349

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
