### PR TITLE
Restore remember me feature

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -103,9 +103,7 @@ class LoginController extends Controller {
 	 */
 	public function logout() {
 		$loginToken = $this->request->getCookie('oc_token');
-		if ($loginToken !== null) {
-			$this->userSession->clearRememberMeTokensForLoggedInUser();
-		}
+		$this->userSession->clearRememberMeTokensForLoggedInUser($loginToken);
 		$this->userSession->logout();
 
 		return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));

--- a/lib/base.php
+++ b/lib/base.php
@@ -971,6 +971,9 @@ class OC {
 		if ($userSession->tryBasicAuthLogin($request)) {
 			return true;
 		}
+		if ($userSession->tryRememberMeLogin($request)) {
+			return true;
+		}
 		return false;
 	}
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -1118,7 +1118,7 @@ class Session implements IUserSession, Emitter {
 
 		// the current token will be deleted regardless success of failure
 		$this->config->deleteUserValue($uid, 'login_token', $hashedToken);
-		$cutoff = \time() - $this->config->getSystemValue('remember_login_cookie_lifetime', 60 * 60 * 24 * 15);
+		$cutoff = $this->timeFactory->getTime() - $this->config->getSystemValue('remember_login_cookie_lifetime', 60 * 60 * 24 * 15);
 		if (\intval($storedTokenTime) < $cutoff) {
 			// expired token already deleted
 			$this->emitFailedLogin($uid);
@@ -1148,7 +1148,7 @@ class Session implements IUserSession, Emitter {
 		$uid = $user->getUID();
 		$newToken = OC::$server->getSecureRandom()->generate(32);
 		$hashedToken = \hash('snefru', $newToken);
-		$this->config->setUserValue($uid, 'login_token', $hashedToken, \time());
+		$this->config->setUserValue($uid, 'login_token', $hashedToken, $this->timeFactory->getTime());
 		$this->setMagicInCookie($uid, $newToken);
 	}
 
@@ -1173,7 +1173,7 @@ class Session implements IUserSession, Emitter {
 				$this->config->deleteUserValue($uid, 'login_token', $key);
 			} else {
 				$storedTokenTime = $this->config->getUserValue($uid, 'login_token', $key, null);
-				$cutoff = \time() - $this->config->getSystemValue('remember_login_cookie_lifetime', 60 * 60 * 24 * 15);
+				$cutoff = $this->timeFactory->getTime() - $this->config->getSystemValue('remember_login_cookie_lifetime', 60 * 60 * 24 * 15);
 				if (\intval($storedTokenTime) < $cutoff) {
 					$this->config->deleteUserValue($uid, 'login_token', $key);
 				}
@@ -1225,7 +1225,7 @@ class Session implements IUserSession, Emitter {
 			$webRoot = '/';
 		}
 		$secureCookie = OC::$server->getRequest()->getServerProtocol() === 'https';
-		$expires = \time() + OC::$server->getConfig()->getSystemValue('remember_login_cookie_lifetime', 60 * 60 * 24 * 15);
+		$expires = $this->timeFactory->getTime() + OC::$server->getConfig()->getSystemValue('remember_login_cookie_lifetime', 60 * 60 * 24 * 15);
 		$cookieOpts = [
 			'expires' => $expires,
 			'path' => $webRoot,
@@ -1254,7 +1254,7 @@ class Session implements IUserSession, Emitter {
 		unset($_COOKIE['oc_username'], $_COOKIE['oc_token'], $_COOKIE['oc_remember_login']); //TODO: DI
 
 		$cookieOpts = [
-			'expires' => \time() - 3600,
+			'expires' => $this->timeFactory->getTime() - 3600,
 			'path' => $webRoot,
 			'domain' => '',
 			'secure' => $secureCookie,

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -1108,7 +1108,7 @@ class Session implements IUserSession, Emitter {
 			throw new LoginException($message);
 		}
 
-		$hashedToken = \sha1($currentToken);
+		$hashedToken = \hash('snefru', $currentToken);
 		// get stored tokens
 		$storedTokenTime = $this->config->getUserValue($uid, 'login_token', $hashedToken, null);
 		if ($storedTokenTime === null) {
@@ -1147,7 +1147,7 @@ class Session implements IUserSession, Emitter {
 		$user = $this->getUser();
 		$uid = $user->getUID();
 		$newToken = OC::$server->getSecureRandom()->generate(32);
-		$hashedToken = \sha1($newToken);
+		$hashedToken = \hash('snefru', $newToken);
 		$this->config->setUserValue($uid, 'login_token', $hashedToken, \time());
 		$this->setMagicInCookie($uid, $newToken);
 	}

--- a/lib/private/legacy/api.php
+++ b/lib/private/legacy/api.php
@@ -402,7 +402,8 @@ class OC_API {
 				self::$logoutRequired = false;
 			} elseif ($userSession->tryTokenLogin($request)
 				|| $userSession->tryAuthModuleLogin($request)
-				|| $userSession->tryBasicAuthLogin($request)) {
+				|| $userSession->tryBasicAuthLogin($request)
+				|| $userSession->tryRememberMeLogin($request)) {
 				self::$logoutRequired = true;
 			} else {
 				return false;

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -98,9 +98,9 @@ class LoginControllerTest extends TestCase {
 			->method('getCookie')
 			->with('oc_token')
 			->willReturn(null);
-		$this->config
+		$this->userSession
 			->expects($this->never())
-			->method('deleteUserValue');
+			->method('clearRememberMeTokensForLoggedInUser');
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToRouteAbsolute')
@@ -117,19 +117,9 @@ class LoginControllerTest extends TestCase {
 			->method('getCookie')
 			->with('oc_token')
 			->willReturn('MyLoginToken');
-		$user = $this->createMock(IUser::class);
-		$user
-			->expects($this->once())
-			->method('getUID')
-			->willReturn('JohnDoe');
 		$this->userSession
 			->expects($this->once())
-			->method('getUser')
-			->willReturn($user);
-		$this->config
-			->expects($this->once())
-			->method('deleteUserValue')
-			->with('JohnDoe', 'login_token', 'MyLoginToken');
+			->method('clearRememberMeTokensForLoggedInUser');
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToRouteAbsolute')

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -99,7 +99,7 @@ class LoginControllerTest extends TestCase {
 			->with('oc_token')
 			->willReturn(null);
 		$this->userSession
-			->expects($this->never())
+			->expects($this->once())
 			->method('clearRememberMeTokensForLoggedInUser');
 		$this->urlGenerator
 			->expects($this->once())

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -663,11 +663,11 @@ class SessionTest extends TestCase {
 		$token = 'goodToken';
 		$this->config->method('getUserValue')
 			->will($this->returnValueMap([
-				['foo', 'login_token', \sha1($token), null, \time()],
+				['foo', 'login_token', \hash('snefru', $token), null, \time()],
 			]));
 		$this->config->expects($this->once())
 			->method('deleteUserValue')
-			->with('foo', 'login_token', \sha1($token));
+			->with('foo', 'login_token', \hash('snefru', $token));
 
 		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->getMockBuilder(Session::class)
@@ -770,11 +770,11 @@ class SessionTest extends TestCase {
 		$token = 'goodToken';
 		$this->config->method('getUserValue')
 			->will($this->returnValueMap([
-				['foo', 'login_token', \sha1($token), null, "50"],
+				['foo', 'login_token', \hash('snefru', $token), null, "50"],
 			]));
 		$this->config->expects($this->once())
 			->method('deleteUserValue')
-			->with('foo', 'login_token', \sha1($token));
+			->with('foo', 'login_token', \hash('snefru', $token));
 
 		$userSession = new Session(
 			$manager,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Restore the "remember me" feature. This will allow auto-login if the session expires and the user has marked the "stay logged in" checkbox in the login page.

Note that this feature relies on all the enabled apps to allow this feature. Some apps such as "files_external" or "encryption" can disable this feature if they're enabled.

## Related Issue
https://github.com/owncloud/core/issues/40170

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Currently tested basic scenario:
1. Set a low `session_lifetime` in the config.php (to test it easier)
2. Ensure that the "stay logged in" checkbox in visible in the login page. You might need to disable some apps (files_external, for example).
3. Log in with any user having marked the "stay logged in" checkbox.
4. Close the tab without login out.
5. Wait until the session expires.
6. Access to ownCloud again

At step 6, you're logged in directly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)


## Notes:
* The feature is expected to work only with the login form. The initial remember-me token is set after a successful login from the login page.
  * Shibboleth, oAuth2 and other authentication methods shouldn't be directly impacted. There are some assumptions here:
    * Those apps should disable the "remember me" feature from their side.
    * An initial remember-me token shouldn't be set from their side (at least it isn't expected). If somehow there is a remember-me token already stored (the user might have access previously through the login form), it's possible that the user is authenticated with such token.
  * Basic authentication from any other place (such as webdav) won't generate a new remember-me token
* After the remember-me token is used, a new one will be generated. The behavior is similar to a one-time token
* Explicitly login out will remove the remember-me token, forcing the user to login again
* Remember-me token is expected to be used only once. After login in with it, regular cookie-based authentication is expected to be used.
* Tokens are hashed in the DB