### PR TITLE
[tests-only] Allow specifying the expected feature-file path in the expected-failures file

### DIFF
--- a/tests/acceptance/lint-expected-failures.sh
+++ b/tests/acceptance/lint-expected-failures.sh
@@ -24,6 +24,7 @@ then
 	# In most cases the features that are being run are in owncloud/core,
 	# so assume that by default.
 	FEATURE_FILE_REPO="owncloud/core"
+	FEATURE_FILE_PATH="tests/acceptance/features"
 	while read INPUT_LINE
 		do
 			# Ignore comment lines (starting with hash)
@@ -36,9 +37,18 @@ then
 			# "The expected failures in this file are from features in the owncloud/ocis repo."
 			# Write a line near the top of the expected-failures file to "declare" this,
 			# overriding the default "owncloud/core"
+			FEATURE_FILE_SPEC_LINE_FOUND="false"
 			if [[ "${INPUT_LINE}" =~ features[[:blank:]]in[[:blank:]]the[[:blank:]]([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)[[:blank:]]repo ]]; then
 				FEATURE_FILE_REPO="${BASH_REMATCH[1]}"
 				echo "Features are expected to be in the ${FEATURE_FILE_REPO} repo"
+  			FEATURE_FILE_SPEC_LINE_FOUND="true"
+			fi
+			if [[ "${INPUT_LINE}" =~ repo[[:blank:]]in[[:blank:]]the[[:blank:]]([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+)[[:blank:]]folder[[:blank:]]tree ]]; then
+				FEATURE_FILE_PATH="${BASH_REMATCH[1]}"
+				echo "Features are expected to be in the ${FEATURE_FILE_PATH} folder tree"
+  			FEATURE_FILE_SPEC_LINE_FOUND="true"
+			fi
+			if [[ $FEATURE_FILE_SPEC_LINE_FOUND == "true" ]]; then
 				continue
 			fi
 			# Match lines that have [someSuite/someName.feature:n] - the part inside the
@@ -63,7 +73,7 @@ then
 			IFS=${OLD_IFS}
 			SUITE_FEATURE="${FEATURE_PARTS[0]}"
 			FEATURE_LINE="${FEATURE_PARTS[1]}"
-			EXPECTED_LINK="https://github.com/${FEATURE_FILE_REPO}/blob/master/tests/acceptance/features/${SUITE_FEATURE}#L${FEATURE_LINE}"
+			EXPECTED_LINK="https://github.com/${FEATURE_FILE_REPO}/blob/master/${FEATURE_FILE_PATH}/${SUITE_FEATURE}#L${FEATURE_LINE}"
 			if [[ "${ACTUAL_LINK}" != "${EXPECTED_LINK}" ]]; then
 				echo "Link is not correct for ${SUITE_SCENARIO_LINE}"
 				echo "  Actual link: ${ACTUAL_LINK}"


### PR DESCRIPTION
## Description
`lint-expected-failures.sh` currently hard-codes the expected path to acceptance test feature files as `tests/acceptance/features`

For the oCIS parallel-deployment acceptance tests, the feature files are in a different folder - `tests/parallelDeployAcceptance/features' - that causes the expected-failures-file linter to fail, the references are not to the expected place.

This PR adds code so that an expected-failures file can indicate `FEATURE_FILE_PATH` in a similar way to the existing `FEATURE_FILE_REPO`.

The expected-failures file can have a line near the top like:
```
The expected failures in this file are from features in the owncloud/ocis repo in the tests/parallelDeployAcceptance/features folder tree.
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
