### PR TITLE
[tests-only] Retry for the etags comparision if the actual value does not match the expected

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -5,27 +5,21 @@ Feature: propagation of etags when copying files or folders
     Given user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file does not change its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -37,27 +31,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -69,27 +58,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -133,24 +118,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -164,92 +149,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file does not change its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -261,27 +254,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -293,27 +281,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -357,24 +341,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -388,60 +372,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -453,27 +477,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -485,27 +504,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -549,24 +564,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -580,60 +595,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -645,27 +700,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -677,27 +727,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -741,24 +787,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -772,60 +818,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -837,27 +923,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -869,27 +950,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -933,24 +1010,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -964,60 +1041,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -1029,27 +1146,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -1061,27 +1173,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -1125,24 +1233,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -1156,28 +1264,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -1189,27 +1369,50 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -1253,24 +1456,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -1284,28 +1487,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -1317,27 +1592,50 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -1381,24 +1679,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -1412,28 +1710,155 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -1477,24 +1902,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -1508,28 +1933,6847 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
+    And these etags should not have changed:
+      | user  | path |
+      | Alice | /src |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -1573,24 +8817,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -1604,60 +8848,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -1669,27 +8953,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -1701,27 +8980,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -1765,24 +9040,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -1796,60 +9071,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -1861,27 +9176,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -1893,27 +9203,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -1957,24 +9263,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -1988,60 +9294,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -2053,27 +9399,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
-    And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -2085,27 +9426,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -2149,24 +9486,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -2180,60 +9517,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -2245,27 +9622,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -2277,27 +9649,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -2341,24 +9709,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -2372,60 +9740,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file does not change its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -2437,27 +9845,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -2469,27 +9872,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -2533,24 +9932,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -2564,60 +9963,127 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
-      | spaces      |
+      | old         |
+      | new         |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file does not change its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
+    And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path             |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file inside a folder changes its etag
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -2629,27 +10095,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -2693,24 +10155,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -2724,92 +10186,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file does not change its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -2821,27 +10291,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -2853,27 +10318,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -2917,24 +10378,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -2948,92 +10409,100 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file does not change its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
       | user  | path             |
-      | Alice | /upload/file.txt |
+      | Alice | /                |
+      | Alice | /renamedFile.txt |
     Examples:
       | dav_version |
       | old         |
@@ -3045,27 +10514,22 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has created folder "/folder"
+    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has stored etag of element "/file.txt"
+    And user "Alice" has stored etag of element "/folder"
+    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
+    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path      |
+      | Alice | /file.txt |
+    And these etags should have changed:
+      | user  | path                    |
+      | Alice | /folder/renamedFile.txt |
+      | Alice | /folder                 |
     Examples:
       | dav_version |
       | old         |
@@ -3077,27 +10541,23 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
-    And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
-    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created folder "/src"
+    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
+    And user "Alice" has created folder "/dst"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/upload"
-    And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/src"
+    And user "Alice" has stored etag of element "/dst"
+    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path |
+      | Alice | /    |
+      | Alice | /dst |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path |
+      | Alice | /src |
     Examples:
       | dav_version |
       | old         |
@@ -3141,24 +10601,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has created a public link share with settings
+      | path        | upload |
+      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
+    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                    |
+      | Alice | /                       |
+      | Alice | /upload                 |
+      | Alice | /upload/renamedFile.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -3172,34 +10632,80 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file into a subfolder changes the etags of all parents
-    Given using <dav_version> DAV path
+  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
-    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
-    And user "Alice" has stored etag of element "/upload/sub"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                 |
-      | Alice | /                    |
-      | Alice | /upload              |
-      | Alice | /upload/sub          |
-      | Alice | /upload/sub/file.txt |
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
     And these etags should not have changed:
-      | user  | path             |
-      | Alice | /upload/file.txt |
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
+  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
+    Given user "Brian" has been created with default attributes and without skeleton files
+    And the administrator has set the default folder for received shares to "Shares"
+    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
+    And using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has shared folder "/upload" with user "Brian"
+    And user "Brian" has accepted share "/upload" offered by user "Alice"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
+    And user "Brian" has stored etag of element "/"
+    And user "Brian" has stored etag of element "/Shares"
+    And user "Brian" has stored etag of element "/Shares/upload"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
+    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                       |
+      | Alice | /                          |
+      | Alice | /upload                    |
+      | Alice | /upload/renamed.txt        |
+      | Brian | /                          |
+      | Brian | /Shares                    |
+      | Brian | /Shares/upload             |
+      | Brian | /Shares/upload/renamed.txt |
+    And these etags should not have changed:
+      | user  | path                    |
+      | Alice | /upload/file.txt        |
+      | Brian | /Shares/upload/file.txt |
     Examples:
       | dav_version |
-      | spaces      |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -5,76 +5,27 @@ Feature: propagation of etags when copying files or folders
     Given user "Alice" has been created with default attributes and without skeleton files
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file does not change its etag
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
     Given using <dav_version> DAV path
-    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
     And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/file.txt"
-    And user "Alice" has stored etag of element "/file.txt" on path "/renamedFile.txt"
-    When user "Alice" copies file "/file.txt" to "/renamedFile.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
-    And these etags should not have changed:
-      | user  | path      |
-      | Alice | /file.txt |
     And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
       | user  | path             |
-      | Alice | /                |
-      | Alice | /renamedFile.txt |
-    Examples:
-      | dav_version |
-      | old         |
-      | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file inside a folder changes its etag
-    Given using <dav_version> DAV path
-    And user "Alice" has created folder "/folder"
-    And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
-    And user "Alice" has stored etag of element "/file.txt"
-    And user "Alice" has stored etag of element "/folder"
-    And user "Alice" has stored etag of element "/file.txt" on path "/folder/renamedFile.txt"
-    When user "Alice" copies file "/file.txt" to "/folder/renamedFile.txt" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And these etags should not have changed:
-      | user  | path      |
-      | Alice | /file.txt |
-    And these etags should have changed:
-      | user  | path                    |
-      | Alice | /folder/renamedFile.txt |
-      | Alice | /folder                 |
-    Examples:
-      | dav_version |
-      | old         |
-      | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
-  @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file from one folder to an other changes the etags of destination
-    Given using <dav_version> DAV path
-    And user "Alice" has created folder "/src"
-    And user "Alice" has uploaded file with content "uploaded content" to "/src/file.txt"
-    And user "Alice" has created folder "/dst"
-    And user "Alice" has stored etag of element "/"
-    And user "Alice" has stored etag of element "/src"
-    And user "Alice" has stored etag of element "/dst"
-    When user "Alice" copies folder "/src/file.txt" to "/dst/file.txt" using the WebDAV API
-    Then the HTTP status code should be "201"
-    And these etags should have changed:
-      | user  | path |
-      | Alice | /    |
-      | Alice | /dst |
-    And these etags should not have changed:
-      | user  | path |
-      | Alice | /src |
+      | Alice | /upload/file.txt |
     Examples:
       | dav_version |
       | old         |
@@ -118,24 +69,24 @@ Feature: propagation of etags when copying files or folders
       | spaces      |
 
   @skipOnOcis-OC-Storage @issue-product-280
-  Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | upload |
-      | permissions | change |
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamedFile.txt"
-    When the public copies file "file.txt" to "/renamedFile.txt" using the new public WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                    |
-      | Alice | /                       |
-      | Alice | /upload                 |
-      | Alice | /upload/renamedFile.txt |
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
@@ -149,80 +100,3106 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-  Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
-    Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has set the default folder for received shares to "Shares"
-    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-    And using <dav_version> DAV path
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has shared folder "/upload" with user "Brian"
-    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
-    And user "Brian" has stored etag of element "/"
-    And user "Brian" has stored etag of element "/Shares"
-    And user "Brian" has stored etag of element "/Shares/upload"
-    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
-    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
-    When user "Brian" copies file "/Shares/upload/file.txt" to "/Shares/upload/renamed.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                       |
-      | Alice | /                          |
-      | Alice | /upload                    |
-      | Alice | /upload/renamed.txt        |
-      | Brian | /                          |
-      | Brian | /Shares                    |
-      | Brian | /Shares/upload             |
-      | Brian | /Shares/upload/renamed.txt |
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path                    |
-      | Alice | /upload/file.txt        |
-      | Brian | /Shares/upload/file.txt |
+      | user  | path             |
+      | Alice | /upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-  Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
-    Given user "Brian" has been created with default attributes and without skeleton files
-    And the administrator has set the default folder for received shares to "Shares"
-    And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
-    And using <dav_version> DAV path
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
-    And user "Alice" has shared folder "/upload" with user "Brian"
-    And user "Brian" has accepted share "/upload" offered by user "Alice"
     And user "Alice" has stored etag of element "/"
     And user "Alice" has stored etag of element "/upload"
     And user "Alice" has stored etag of element "/upload/file.txt"
-    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/renamed.txt"
-    And user "Brian" has stored etag of element "/"
-    And user "Brian" has stored etag of element "/Shares"
-    And user "Brian" has stored etag of element "/Shares/upload"
-    And user "Brian" has stored etag of element "/Shares/upload/file.txt"
-    And user "Brian" has stored etag of element "/Shares/upload/file.txt" on path "/Shares/upload/renamed.txt"
-    When user "Alice" copies file "/upload/file.txt" to "/upload/renamed.txt" using the WebDAV API
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And these etags should have changed:
-      | user  | path                       |
-      | Alice | /                          |
-      | Alice | /upload                    |
-      | Alice | /upload/renamed.txt        |
-      | Brian | /                          |
-      | Brian | /Shares                    |
-      | Brian | /Shares/upload             |
-      | Brian | /Shares/upload/renamed.txt |
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
     And these etags should not have changed:
-      | user  | path                    |
-      | Alice | /upload/file.txt        |
-      | Brian | /Shares/upload/file.txt |
+      | user  | path             |
+      | Alice | /upload/file.txt |
     Examples:
       | dav_version |
       | old         |
       | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |
+
+  @skipOnOcis-OC-Storage @issue-product-280
+  Scenario Outline: copying a file into a subfolder changes the etags of all parents
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/upload"
+    And user "Alice" has created folder "/upload/sub"
+    And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
+    And user "Alice" has stored etag of element "/"
+    And user "Alice" has stored etag of element "/upload"
+    And user "Alice" has stored etag of element "/upload/file.txt"
+    And user "Alice" has stored etag of element "/upload/file.txt" on path "/upload/sub/file.txt"
+    And user "Alice" has stored etag of element "/upload/sub"
+    When user "Alice" copies file "/upload/file.txt" to "/upload/sub/file.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And these etags should have changed:
+      | user  | path                 |
+      | Alice | /                    |
+      | Alice | /upload              |
+      | Alice | /upload/sub          |
+      | Alice | /upload/sub/file.txt |
+    And these etags should not have changed:
+      | user  | path             |
+      | Alice | /upload/file.txt |
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -1,4 +1,4 @@
-@api
+@api @focus
 Feature: propagation of etags when copying files or folders
 
   Background:

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -1260,7 +1260,9 @@ class WebDavPropertiesContext implements Context {
 			$storedEtag = $this->getStoredEtagOfElement($path, $user, __METHOD__);
 			do {
 				// wait for a second before retrying
-				if($sentRequestsCount > 0) \sleep(1);
+				if ($sentRequestsCount > 0) {
+					\sleep(1);
+				}
 				$actualEtag = $this->getCurrentEtagOfElement($path, $user);
 				$loopAgain = $storedEtag !== $actualEtag && ++$sentRequestsCount < $maxRetries;
 			} while ($loopAgain);
@@ -1289,7 +1291,7 @@ class WebDavPropertiesContext implements Context {
 		$sentRequestsCount = 0;
 		do {
 			$actualEtag = $this->getCurrentEtagOfElement($path, $user);
-		} while($actualEtag !== $storedEtag && ++$sentRequestsCount < $maxRetries);
+		} while ($actualEtag !== $storedEtag && ++$sentRequestsCount < $maxRetries);
 		Assert::assertEquals(
 			$storedEtag,
 			$actualEtag,
@@ -1321,11 +1323,13 @@ class WebDavPropertiesContext implements Context {
 			$storedEtag = $this->getStoredEtagOfElement($path, $user, __METHOD__);
 			do {
 				// wait for second before retrying
-				if ($sentRequestsCount > 0) \sleep(1);
+				if ($sentRequestsCount > 0) {
+					\sleep(1);
+				}
 				$actualEtag = $this->getCurrentEtagOfElement($path, $user);
 				// loop again if the etag has not changed and we have not exceeded the max retries
 				$loopAgain = $actualEtag === $storedEtag && ++$sentRequestsCount < $maxRetries ;
-			} while($loopAgain);
+			} while ($loopAgain);
 			if ($actualEtag === $storedEtag) {
 				$unchangedEtagCount = $unchangedEtagCount + 1;
 				$unchangedEtagMessage
@@ -1351,7 +1355,7 @@ class WebDavPropertiesContext implements Context {
 		$sentRequestsCount = 0;
 		do {
 			$actualEtag = $this->getCurrentEtagOfElement($path, $user);
-		} while($actualEtag === $storedEtag && ++$sentRequestsCount < $maxRetries);
+		} while ($actualEtag === $storedEtag && ++$sentRequestsCount < $maxRetries);
 
 		Assert::assertNotEquals(
 			$storedEtag,

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -1106,7 +1106,7 @@ class WebDavPropertiesContext implements Context {
 			$storePath = $path;
 		}
 		if ($this->storedETAG[$user][$storePath] === null || $this->storedETAG[$user][$path] === "") {
-			throw new Exception("Expected stored etag to be some string but found null!");
+			throw new Exception("Expected stored etag for user $user at $path to be some string but found null!");
 		}
 	}
 
@@ -1126,7 +1126,7 @@ class WebDavPropertiesContext implements Context {
 			$path
 		);
 		if ($this->storedETAG[$user][$path] === "" || $this->storedETAG[$user][$path] === null) {
-			throw new Exception("Expected stored etag to be some string but found null!");
+			throw new Exception("Expected stored etag for user $user at $path to be some string but found null!");
 		}
 	}
 
@@ -1257,13 +1257,16 @@ class WebDavPropertiesContext implements Context {
 			$path = $row["path"];
 			$user = $this->featureContext->getActualUsername($user);
 			$storedEtag = $this->getStoredEtagOfElement($path, $user, __METHOD__);
+
 			do {
 				// wait for a second before retrying
 				if ($sentRequestsCount > 0) {
+					echo "waiting for a second before retrying\n";
 					\sleep(1);
 				}
 				$actualEtag = $this->getCurrentEtagOfElement($path, $user);
 			} while ($storedEtag !== $actualEtag && ++$sentRequestsCount < HttpRequestHelper::numRetriesOnHttpTooEarly());
+
 			if ($actualEtag !== $storedEtag) {
 				$changedEtagCount = $changedEtagCount + 1;
 				$changedEtagMessage
@@ -1289,6 +1292,7 @@ class WebDavPropertiesContext implements Context {
 		do {
 			// wait for a second before retrying
 			if ($sentRequestsCount > 0) {
+				echo "waiting for a second before retrying\n";
 				\sleep(1);
 			}
 			$actualEtag = $this->getCurrentEtagOfElement($path, $user);
@@ -1324,6 +1328,7 @@ class WebDavPropertiesContext implements Context {
 			do {
 				// wait for second before retrying
 				if ($sentRequestsCount > 0) {
+					echo "waiting for a second before retrying\n";
 					\sleep(1);
 				}
 				$actualEtag = $this->getCurrentEtagOfElement($path, $user);
@@ -1353,6 +1358,7 @@ class WebDavPropertiesContext implements Context {
 		do {
 			// wait for second before retrying
 			if ($sentRequestsCount > 0) {
+				echo "waiting for a second before retrying\n";
 				\sleep(1);
 			}
 			$actualEtag = $this->getCurrentEtagOfElement($path, $user);


### PR DESCRIPTION
## Description
The etag propagation can be async. So, it's better to retry the ETag assertions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/4091

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- :robot:
- https://github.com/owncloud/ocis/pull/4137

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
